### PR TITLE
Refactor shared memory handling

### DIFF
--- a/pimm/README.md
+++ b/pimm/README.md
@@ -144,13 +144,13 @@ loop, or plug it into different schedulers without rewriting it.
 
 ## Moving Large Blobs
 
-Some signals (camera frames, robot state vectors) benefit from zero-copy sharing.
-`world.shared_memory()` returns an emitter/receiver pair backed by shared memory.
-Payloads implement the `SMCompliant` protocol—`pimm.shared_memory.NumpySMAdapter`
-handles numpy arrays—so emitters know how big the buffer should be and receivers
-can view the data without copying. Currently you have to set shared-memory channels
-up manually, though we will modify the `pimm.World` scheduler to do it
-automatically, when data allows it.
+Some signals (camera frames, robot state vectors) require a large bandwidth and/or
+small latency, and hence benefit from communication channels that avoid serialisation.
+`world.mp_pipe(transport=pimm.world.TransportMode.SHARED_MEMORY)` returns an emitter/receiver pair backed by shared memory. Payloads implement the `SMCompliant` protocol—
+`pimm.shared_memory.NumpySMAdapter` handles numpy arrays—so emitters know how big
+the buffer should be and receivers can view the data without copying. If your data
+implements `SMCompliant` protocol, the shared memory communication will be used
+automatcially without your explicit request.
 
 ## Learn from Real Pipelines
 

--- a/pimm/shared_memory.py
+++ b/pimm/shared_memory.py
@@ -1,11 +1,7 @@
-import multiprocessing as mp
-import multiprocessing.shared_memory
 from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
-
-from pimm.core import Clock, Message, SignalEmitter, SignalReceiver
 
 
 class SMCompliant(ABC):
@@ -55,89 +51,3 @@ class NumpySMAdapter(SMCompliant):
 
     def read_from_buffer(self, buffer: memoryview | bytes) -> None:
         self.array[:] = np.frombuffer(buffer[:self.array.nbytes], dtype=self.array.dtype).reshape(self.array.shape)
-
-
-class SharedMemoryEmitter(SignalEmitter):
-    def __init__(self, lock: mp.Lock, ts_value: mp.Value, sm_queue: mp.Queue, clock: Clock):
-        self._data_type: type[SMCompliant] | None = None
-        self._lock = lock
-        self._ts_value = ts_value
-        self._sm_queue = sm_queue
-
-        self._sm = None
-        self._expected_buf_size = None
-        self._clock = clock
-
-    def emit(self, data: Any, ts: int = -1) -> bool:
-        ts = ts if ts >= 0 else self._clock.now_ns()
-        if self._data_type is None:
-            self._data_type = type(data)
-            assert issubclass(self._data_type, SMCompliant), f"Data type {self._data_type} is not SMCompliant"
-        else:
-            assert isinstance(data, self._data_type), f"Data type mismatch: {type(data)} != {self._data_type}"
-
-        buf_size = data.buf_size()
-
-        if self._sm is None:  # First emit - create shared memory with the size from this instance
-            self._expected_buf_size = buf_size
-            # Note that size of shared_memory could be larger than the requested size depending on the platform
-            self._sm = mp.shared_memory.SharedMemory(create=True, size=buf_size)
-            self._sm_queue.put((self._sm, self._data_type, data.instantiation_params()))
-        else:  # Subsequent emits - validate buffer size matches
-            assert buf_size == self._expected_buf_size, \
-                f"Buffer size mismatch: expected {self._expected_buf_size}, got {buf_size}. " \
-                "All data instances must have the same buffer size for a given channel."
-
-        with self._lock:
-            data.set_to_buffer(self._sm.buf)
-            self._ts_value.value = ts
-
-        return True
-
-    def close(self):
-        """Release references to shared memory to allow proper cleanup."""
-        if self._sm is not None:
-            self._sm.close()
-            self._sm.unlink()
-            self._sm = None
-
-
-class SharedMemoryReceiver(SignalReceiver):
-    def __init__(self, lock: mp.Lock, ts_value: mp.Value, sm_queue: mp.Queue):
-        self._lock = lock
-        self._ts_value = ts_value
-        self._sm_queue = sm_queue
-
-        self._out_value = None
-        self._return_value = None
-        self._readonly_buffer = None
-        self._sm = None
-
-    def read(self) -> Message | None:
-        with self._lock:
-            if self._ts_value.value == -1:
-                return None
-
-        if self._out_value is None:
-            self._sm, data_type, instantiation_params = self._sm_queue.get_nowait()
-            self._readonly_buffer = self._sm.buf.toreadonly()
-            self._out_value = data_type(*instantiation_params)
-
-        with self._lock:
-            if self._ts_value.value == -1:
-                return None
-
-            self._out_value.read_from_buffer(self._readonly_buffer)
-
-            return Message(data=self._out_value, ts=self._ts_value.value)
-
-    def close(self):
-        """Release references to shared memory to allow proper cleanup."""
-        if self._readonly_buffer is not None:
-            self._readonly_buffer.release()
-            self._readonly_buffer = None
-
-        if self._sm is not None:
-            # Don't call unlink here, it will be called by the emitter
-            self._sm.close()
-            self._sm = None

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -3,15 +3,16 @@
 import heapq
 import logging
 import multiprocessing as mp
-import multiprocessing.managers as mp_managers
 import multiprocessing.shared_memory
 import sys
 import time
 import traceback
+import weakref
 from collections import deque
+from enum import IntEnum
 from multiprocessing.synchronize import Event as EventClass
 from queue import Empty, Full
-from typing import Callable, Iterator, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Iterator, Sequence, Tuple, TypeVar
 
 from .core import (
     Clock,
@@ -24,10 +25,15 @@ from .core import (
     SignalReceiver,
     Sleep,
 )
-from .shared_memory import SharedMemoryEmitter, SharedMemoryReceiver, SMCompliant
+from .shared_memory import SMCompliant
 
 T = TypeVar('T')
-T_SM = TypeVar('T_SM', bound=SMCompliant)
+
+
+class TransportMode(IntEnum):
+    UNDECIDED = 0
+    QUEUE = 1
+    SHARED_MEMORY = 2
 
 
 class QueueEmitter(SignalEmitter[T]):
@@ -80,6 +86,293 @@ class QueueReceiver(SignalReceiver[T]):
         except Empty:
             pass
         return self._last_value
+
+
+class MultiprocessEmitter(SignalEmitter[T]):
+    """Signal emitter that transparently bridges processes.
+
+    The emitter owns both the queue transport and (when selected) a
+    shared-memory buffer. It defers the transport choice until the first payload
+    unless ``forced_mode`` pins the decision.
+
+    Weak references link the emitter and its paired receiver so that whichever
+    side closes first can tell the other to release shared-memory views before
+    unlinking the underlying buffer. Full references would create reference cycles
+    and break pickling when ``multiprocessing`` spawns child processes, hence
+    the indirection via ``weakref``.
+    """
+
+    def __init__(self,
+                 clock: Clock,
+                 queue: mp.Queue,
+                 mode_value: mp.Value,
+                 lock: mp.Lock,
+                 ts_value: mp.Value,
+                 sm_queue: mp.Queue,
+                 *,
+                 forced_mode: TransportMode | None = None):
+        self._clock = clock
+        self._queue = queue
+        self._mode_value = mode_value
+        self._forced_mode = forced_mode
+        self._mode = forced_mode or TransportMode.UNDECIDED
+
+        # Shared memory state
+        self._data_type: type[SMCompliant] | None = None
+        self._lock = lock
+        self._ts_value = ts_value
+        self._sm_queue = sm_queue
+        self._sm: multiprocessing.shared_memory.SharedMemory | None = None
+        self._expected_buf_size: int | None = None
+        self._receiver_ref: weakref.ReferenceType['MultiprocessReceiver[Any]'] | None = None
+        self._closed = False
+        if forced_mode is not None:
+            self._mode_value.value = int(forced_mode)
+
+    @property
+    def transport_mode(self) -> TransportMode:
+        if self._mode is TransportMode.UNDECIDED:
+            self._mode = TransportMode(self._mode_value.value)
+        return self._mode
+
+    @property
+    def uses_shared_memory(self) -> bool:
+        return self.transport_mode is TransportMode.SHARED_MEMORY
+
+    def _set_mode(self, mode: TransportMode) -> None:
+        self._mode = mode
+        self._mode_value.value = int(mode)
+
+    def _attach_receiver(self, receiver: 'MultiprocessReceiver[Any]') -> None:
+        self._receiver_ref = weakref.ref(receiver)
+
+    def _ensure_mode(self, data: T) -> TransportMode:
+        if self._mode is not TransportMode.UNDECIDED:
+            return self._mode
+
+        if isinstance(data, SMCompliant):
+            self._set_mode(TransportMode.SHARED_MEMORY)
+        else:
+            self._set_mode(TransportMode.QUEUE)
+        return self._mode
+
+    def _emit_queue(self, data: T, ts: int) -> bool:
+        try:
+            self._queue.put_nowait(Message(data, ts))
+            return True
+        except Full:
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(Message(data, ts))
+                return True
+            except (Empty, Full):
+                return False
+
+    def _emit_shared_memory(self, data: SMCompliant, ts: int) -> bool:
+        if self._data_type is None:
+            self._data_type = type(data)
+        elif not isinstance(data, self._data_type):
+            raise TypeError(f"Data type mismatch: {type(data)} != {self._data_type}")
+
+        buf_size = data.buf_size()
+
+        if self._sm is None:
+            self._expected_buf_size = buf_size
+            self._sm = multiprocessing.shared_memory.SharedMemory(create=True, size=buf_size)
+            self._sm_queue.put((self._sm, self._data_type, data.instantiation_params()))
+        else:
+            assert self._expected_buf_size == buf_size, (
+                f"Buffer size mismatch: expected {self._expected_buf_size}, got {buf_size}. "
+                "All data instances must have the same buffer size for a given channel.")
+
+        with self._lock:
+            data.set_to_buffer(self._sm.buf)
+            self._ts_value.value = ts
+        return True
+
+    def emit(self, data: T, ts: int = -1) -> bool:
+        ts = ts if ts >= 0 else self._clock.now_ns()
+        mode = self._ensure_mode(data)
+
+        if mode is TransportMode.SHARED_MEMORY:
+            if not isinstance(data, SMCompliant):
+                raise TypeError("Shared memory transport selected; data must implement SMCompliant")
+            return self._emit_shared_memory(data, ts)
+
+        return self._emit_queue(data, ts)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._receiver_ref is not None:
+            receiver = self._receiver_ref()
+            if receiver is not None:
+                receiver.close()
+
+        if self._sm is not None:
+            try:
+                self._sm.close()
+            except BufferError:
+                # Receiver may still hold a view; let GC handle once released.
+                pass
+            else:
+                self._sm.unlink()
+            self._sm = None
+
+    def __getstate__(self):
+        # Drop weakrefs so multiprocessing can pickle the emitter state.
+        state = self.__dict__.copy()
+        state['_receiver_ref'] = None
+        return state
+
+    def __setstate__(self, state):
+        # Recreate weakref slot after unpickling in a child process.
+        self.__dict__.update(state)
+        self._receiver_ref = None
+
+    def __del__(self):
+        # Last-resort cleanup when user code forgets to close the emitter.
+        self.close()
+
+
+class MultiprocessReceiver(SignalReceiver[T]):
+    """Signal receiver companion for :class:`MultiprocessEmitter`.
+
+    The receiver lazily initialises shared-memory views when the transport mode
+    switches and keeps the last queue message as a fallback. Weak references
+    back to the emitter let the receiver clear the emitter's cleanup hook on
+    close without introducing cycles or non-picklable state.
+    """
+
+    def __init__(self,
+                 queue: mp.Queue,
+                 mode_value: mp.Value,
+                 lock: mp.Lock,
+                 ts_value: mp.Value,
+                 sm_queue: mp.Queue,
+                 *,
+                 forced_mode: TransportMode | None = None):
+        self._queue = queue
+        self._mode_value = mode_value
+        self._forced_mode = forced_mode
+        self._mode = forced_mode or TransportMode.UNDECIDED
+
+        # Shared memory state
+        self._lock = lock
+        self._ts_value = ts_value
+        self._sm_queue = sm_queue
+        self._sm: multiprocessing.shared_memory.SharedMemory | None = None
+        self._out_value: SMCompliant | None = None
+        self._readonly_buffer: memoryview | None = None
+
+        self._last_queue_message: Message[T] | None = None
+        self._closed = False
+        self._emitter_ref: weakref.ReferenceType['MultiprocessEmitter[Any]'] | None = None
+        if forced_mode is not None:
+            self._mode_value.value = int(forced_mode)
+
+    @property
+    def transport_mode(self) -> TransportMode:
+        if self._mode is TransportMode.UNDECIDED:
+            self._mode = TransportMode(self._mode_value.value)
+        return self._mode
+
+    @property
+    def uses_shared_memory(self) -> bool:
+        return self.transport_mode is TransportMode.SHARED_MEMORY
+
+    def _attach_emitter(self, emitter: 'MultiprocessEmitter[Any]') -> None:
+        self._emitter_ref = weakref.ref(emitter)
+
+    def _read_queue(self) -> Message[T] | None:
+        try:
+            self._last_queue_message = self._queue.get_nowait()
+        except Empty:
+            pass
+        else:
+            if self._mode is TransportMode.UNDECIDED:
+                self._mode = TransportMode.QUEUE
+        return self._last_queue_message
+
+    def _ensure_shared_memory_initialized(self) -> bool:
+        if self._out_value is not None:
+            return True
+
+        try:
+            self._sm, data_type, instantiation_params = self._sm_queue.get_nowait()
+        except Empty:
+            return False
+
+        self._readonly_buffer = self._sm.buf.toreadonly()
+        self._out_value = data_type(*instantiation_params)
+        return True
+
+    def _read_shared_memory(self) -> Message[T] | None:
+        with self._lock:
+            if self._ts_value.value == -1:
+                return None
+
+        if not self._ensure_shared_memory_initialized():
+            return None
+
+        with self._lock:
+            if self._ts_value.value == -1:
+                return None
+
+            assert self._readonly_buffer is not None
+            assert self._out_value is not None
+            self._out_value.read_from_buffer(self._readonly_buffer)
+            return Message(data=self._out_value, ts=self._ts_value.value)
+
+    def read(self) -> Message[T] | None:
+        mode = self.transport_mode
+
+        if mode is TransportMode.SHARED_MEMORY:
+            return self._read_shared_memory()
+
+        message = self._read_queue()
+        if message is not None:
+            return message
+
+        if mode is TransportMode.UNDECIDED:
+            # No data yet; underlying transport still undecided.
+            return None
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._readonly_buffer is not None:
+            self._readonly_buffer.release()
+            self._readonly_buffer = None
+
+        if self._sm is not None:
+            self._sm.close()
+            self._sm = None
+
+        if self._emitter_ref is not None:
+            emitter = self._emitter_ref()
+            if emitter is not None:
+                emitter._receiver_ref = None
+
+    def __del__(self):
+        # Ensure shared-memory buffers are released on GC.
+        self.close()
+
+    def __getstate__(self):
+        # Weakrefs are not picklable; strip them before multiprocessing serialises us.
+        state = self.__dict__.copy()
+        state['_emitter_ref'] = None
+        return state
+
+    def __setstate__(self, state):
+        # Restore weakref slot once deserialised in the target process.
+        self.__dict__.update(state)
+        self._emitter_ref = None
 
 
 class LocalQueueEmitter(SignalEmitter[T]):
@@ -170,13 +463,11 @@ class World:
         self._stop_event = mp.Event()
         self.background_processes = []
         self._manager = mp.Manager()
-        self._sm_manager = mp_managers.SharedMemoryManager()
-        self._sm_emitters_readers = []
+        self._cleanup_emitters_readers = []
         self.entered = False
         self._connections = []
 
     def __enter__(self):
-        self._sm_manager.__enter__()
         self.entered = True
         return self
 
@@ -199,11 +490,9 @@ class World:
             print(f'Process {process.name} (pid {process.pid}) finished', flush=True)
             process.close()
 
-        for emitter, reader in self._sm_emitters_readers:
+        for emitter, reader in self._cleanup_emitters_readers:
             reader.close()
             emitter.close()
-
-        self._sm_manager.__exit__(exc_type, exc_value, traceback)
 
     def local_pipe(self, maxsize: int = 1) -> Tuple[SignalEmitter[T], SignalReceiver[T]]:
         """Create a queue-based communication channel within the same process.
@@ -217,17 +506,55 @@ class World:
         q = deque(maxlen=maxsize)
         return LocalQueueEmitter(q, self._clock), LocalQueueReceiver(q)
 
-    def mp_pipe(self, maxsize: int = 1, clock: Clock | None = None) -> Tuple[SignalEmitter[T], SignalReceiver[T]]:
-        """Create a queue-based communication channel between processes.
+    def mp_pipe(self,
+                maxsize: int = 1,
+                clock: Clock | None = None,
+                *,
+                transport: TransportMode = TransportMode.UNDECIDED) -> Tuple[SignalEmitter[T], SignalReceiver[T]]:
+        """Create an inter-process channel with optional transport override.
+
+        ``transport`` defaults to ``TransportMode.UNDECIDED`` so the first emitted
+        payload decides between queue and shared memory. Passing
+        :class:`TransportMode.QUEUE` or :class:`TransportMode.SHARED_MEMORY`
+        forces a specific transport upfront.
 
         Args:
-            maxsize: (int) Maximum queue size (0 for unlimited). Default is 1.
+            maxsize: Maximum queue size (0 for unlimited). Default is 1.
+            clock: Optional clock override for timestamp generation when the
+                emitter lives in another process.
+            transport: Transport override. ``TransportMode.UNDECIDED`` enables
+                adaptive selection; ``TransportMode.QUEUE`` or
+                ``TransportMode.SHARED_MEMORY`` pins the transport.
 
         Returns:
-            Tuple of (emitter, reader) for inter-process communication
+            Tuple of (emitter, reader) suitable for inter-process communication.
         """
-        q = self._manager.Queue(maxsize=maxsize)
-        return QueueEmitter(q, clock or self._clock), QueueReceiver(q)  # type: ignore
+        if transport is TransportMode.SHARED_MEMORY and not self.entered:
+            raise AssertionError("Shared memory transport is only available after entering the world context.")
+
+        forced_mode: TransportMode | None
+        forced_mode = transport if transport in (TransportMode.QUEUE, TransportMode.SHARED_MEMORY) else None
+
+        message_queue = self._manager.Queue(maxsize=maxsize)
+        lock = self._manager.Lock()
+        ts_value = self._manager.Value('Q', -1)
+        sm_queue = self._manager.Queue()
+        initial_mode = forced_mode or TransportMode.UNDECIDED
+        mode_value = self._manager.Value('i', int(initial_mode))
+
+        emitter_clock = clock or self._clock
+        emitter = MultiprocessEmitter(emitter_clock,
+                                      message_queue,
+                                      mode_value,
+                                      lock,
+                                      ts_value,
+                                      sm_queue,
+                                      forced_mode=forced_mode)
+        receiver = MultiprocessReceiver(message_queue, mode_value, lock, ts_value, sm_queue, forced_mode=forced_mode)
+        emitter._attach_receiver(receiver)
+        receiver._attach_emitter(emitter)
+        self._cleanup_emitters_readers.append((emitter, receiver))
+        return emitter, receiver
 
     def local_one_to_many_pipe(self,
                                n_readers: int,
@@ -261,26 +588,6 @@ class World:
             readers.append(reader)
             emitters.append(emiter)
         return BroadcastEmitter(emitters), readers
-
-    def shared_memory(self) -> Tuple[SignalEmitter[T_SM], SignalReceiver[T_SM]]:
-        """Create shared memory channel for efficient data sharing.
-
-        Message data must be a SMCompliant type and have the same buffer size as the first message emitted.
-
-        Args:
-            data_type: SMCompliant type that defines the shared data structure
-
-        Returns:
-            Tuple of (emitter, reader) for shared memory inter-process communication
-        """
-        assert self.entered, "Shared memory is only available after entering the world context."
-        lock = self._manager.Lock()
-        ts_value = self._manager.Value('Q', -1)
-        sm_queue = self._manager.Queue()
-        emitter = SharedMemoryEmitter(lock, ts_value, sm_queue, SystemClock())
-        reader = SharedMemoryReceiver(lock, ts_value, sm_queue)
-        self._sm_emitters_readers.append((emitter, reader))
-        return emitter, reader
 
     def start_in_subprocess(self, *background_loops: ControlLoop):
         """Starts background control loops. Can be called multiple times for different control loops."""
@@ -360,7 +667,10 @@ class World:
                 case _:
                     raise ValueError(f"Unknown command: {command}")
 
-    def connect(self, emitter: ControlSystemEmitter[T], receiver: ControlSystemReceiver[T], *,
+    def connect(self,
+                emitter: ControlSystemEmitter[T],
+                receiver: ControlSystemReceiver[T],
+                *,
                 emitter_wrapper: Callable[[SignalEmitter[T]], SignalEmitter[T]] = lambda x: x,
                 receiver_wrapper: Callable[[SignalReceiver[T]], SignalReceiver[T]] = lambda x: x):
         """Declare a logical connection between Emitter and Receiver of two control systems.

--- a/positronic/robot_controller.py
+++ b/positronic/robot_controller.py
@@ -1,6 +1,7 @@
 import configuronic as cfn
 import positronic.cfg.hardware.roboarm
 import pimm
+from pimm.world import TransportMode
 from positronic import geom
 from positronic.drivers.roboarm import command
 
@@ -9,7 +10,7 @@ from positronic.drivers.roboarm import command
 def main(robot):
     with pimm.World() as world:
         command_emmiter, robot.commands = world.mp_pipe()
-        robot.state, state_receiver = world.shared_memory()
+        robot.state, state_receiver = world.mp_pipe(transport=TransportMode.SHARED_MEMORY)
 
         world.start_in_subprocess(robot.run)
 

--- a/positronic/run_inference.py
+++ b/positronic/run_inference.py
@@ -7,6 +7,7 @@ import torch
 import tqdm
 
 import pimm
+from pimm.world import TransportMode
 import positronic.cfg.hardware.camera
 import positronic.cfg.hardware.gripper
 import positronic.cfg.hardware.roboarm
@@ -158,7 +159,8 @@ def main(
         world.start_in_subprocess(*[camera.run for camera in cameras.values()])
 
         if robot_arm is not None:
-            robot_arm.state, inference.robot_state = world.shared_memory()
+            robot_arm.state, inference.robot_state = world.mp_pipe(
+                transport=TransportMode.SHARED_MEMORY)
             inference.robot_commands, robot_arm.commands = world.mp_pipe()
             world.start_in_subprocess(robot_arm.run)
 


### PR DESCRIPTION
Refactor shared memory handling in `World` class to support adaptive transport selection. Replace `SharedMemoryEmitter` and `SharedMemoryReceiver` with `MultiprocessEmitter` and `MultiprocessReceiver` for improved inter-process communication. Modify tests to validate new transport behavior.