### PR TITLE
Minor improvements to data collection script

### DIFF
--- a/positronic/cfg/dataset.py
+++ b/positronic/cfg/dataset.py
@@ -10,12 +10,8 @@ def local(path: str):
     return LocalDataset(Path(path))
 
 
-@cfn.config(transforms=[
-                observation.franka_mujoco_stackcubes,
-                action.absolute_position,
-            ],
-            pass_through=False)
-def transformed(path, transforms, pass_through):
+@cfn.config(observation=observation.franka_mujoco_stackcubes, action=action.absolute_position, pass_through=False)
+def transformed(path, observation, action, pass_through):
     from positronic.dataset.local_dataset import LocalDataset
     from positronic.dataset.transforms import TransformedDataset
-    return TransformedDataset(LocalDataset(Path(path)), *transforms, pass_through=pass_through)
+    return TransformedDataset(LocalDataset(Path(path)), observation, action, pass_through=pass_through)

--- a/positronic/cfg/policy/observation.py
+++ b/positronic/cfg/policy/observation.py
@@ -40,15 +40,11 @@ def end_effector_mem15():
     )
 
 
-@cfn.config()
-def franka_mujoco_stackcubes():
+@cfn.config(state=['robot_position_quaternion', 'robot_position_translation', 'grip'])
+def franka_mujoco_stackcubes(state):
     from positronic.policy.observation import ObservationEncoder
     return ObservationEncoder(
-        state_features=[
-            'robot_position_quaternion',
-            'robot_position_translation',
-            'grip',
-        ],
+        state_features=state,
         left=('image.handcam_left', (224, 224)),
         side=('image.back_view', (224, 224)),
     )

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -183,7 +183,7 @@ def _wire(world: pimm.World, cameras: Dict[str, pimm.ControlSystem] | None, data
 
     ds_agent = None
     if dataset_writer is not None:
-        signals_spec = {v: None for v in camera_mappings.values()}
+        signals_spec = {v: Serializers.image for v in camera_mappings.values()}
         signals_spec['target_grip'] = None
         signals_spec['robot_commands'] = Serializers.robot_command
         signals_spec['controller_positions'] = controller_positions_serializer

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -263,14 +263,13 @@ def main_sim(mujoco_model_path: str,
 
     sim = MujocoSim(mujoco_model_path, loaders)
     robot_arm = MujocoFranka(sim, suffix='_ph')
+
     cameras = {
         'handcam_left': MujocoCamera(sim.model, sim.data, 'handcam_left_ph', (320, 240), fps=fps),
         'handcam_right': MujocoCamera(sim.model, sim.data, 'handcam_right_ph', (320, 240), fps=fps),
+        'back_view': MujocoCamera(sim.model, sim.data, 'back_view_ph', (320, 240), fps=fps),
+        'agent_view': MujocoCamera(sim.model, sim.data, 'agentview', (320, 240), fps=fps),
     }
-    vis_cameras = [
-        MujocoCamera(sim.model, sim.data, 'agentview', (320, 240), fps=fps),
-        MujocoCamera(sim.model, sim.data, 'birdview', (320, 240), fps=fps)
-    ]
     gui = DearpyguiUi()
     gripper = MujocoGripper(sim, actuator_name='actuator8_ph', joint_name='finger_joint1_ph')
 
@@ -292,10 +291,7 @@ def main_sim(mujoco_model_path: str,
         for camera_name, camera in cameras.items():
             world.connect(camera.frame, gui.cameras[camera_name])
 
-        for camera in vis_cameras:
-            world.connect(camera.frame, gui.cameras[camera.camera_name])
-
-        sim_iter = world.start([sim, *cameras.values(), robot_arm, gripper, data_collection, *vis_cameras], bg_cs)
+        sim_iter = world.start([sim, *cameras.values(), robot_arm, gripper, data_collection], bg_cs)
         sim_iter = iter(sim_iter)
 
         start_time = pimm.world.SystemClock().now_ns()

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -103,6 +103,10 @@ class Serializers:
             case roboarm.command.Reset():
                 return {'.reset': 1}
 
+    @staticmethod
+    def image(input: dict[str, np.ndarray], key: str = 'image'):
+        return input[key]
+
 
 def _extract_names(serializer: Callable[[Any], Any]) -> dict[str, list[str]] | None:
     names = getattr(serializer, 'names', None)

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -220,7 +220,11 @@ class DsWriterAgent(pimm.ControlSystem):
                 yield pimm.Sleep(limiter.wait_time())
         finally:
             if ep_writer is not None:
-                ep_writer.__exit__(None, None, None)
+                try:
+                    ep_writer.abort()
+                finally:
+                    ep_writer.__exit__(None, None, None)
+                    print(f"DsWriterAgent: [ABORT] Episode {ep_counter}")
 
     def _handle_command(self, cmd: DsWriterCommand, ep_writer: EpisodeWriter | None,
                         ep_counter: int) -> tuple[EpisodeWriter | None, int]:

--- a/positronic/run_inference.py
+++ b/positronic/run_inference.py
@@ -184,7 +184,7 @@ class Driver(pimm.ControlSystem):
             yield pimm.Sleep(self.simulation_time)
             self.ds_commands.emit(DsWriterCommand(type=DsWriterCommandType.STOP_EPISODE))
             self.inf_commands.emit(InferenceCommand.RESET())
-            yield pimm.Sleep(0.1)  # Let the tnings to propagate
+            yield pimm.Sleep(0.05)  # Let the tnings to propagate
 
 
 def main_sim(


### PR DESCRIPTION
* switch positronic/cfg/dataset.py:10 to configure observation/action components directly so transformed datasets match the new serializer API
* refactor positronic/cfg/policy/observation.py:40 to accept configurable state feature names, keeping camera shapes intact
* adjust positronic/data_collection.py:183 so dataset writer emits camera frames through Serializers.image and register the back/agent views as primary cameras instead of mirrored viewer feeds
* extend positronic/dataset/ds_writer_agent.py:103 with an image serializer and ensure episode writers abort cleanly when data collection stops
* tighten the post-reset pause in positronic/run_inference.py:184 to shorten inference turnaround


