### PR TITLE
Align dataset transforms and policy wiring with LeRobot updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ Clone the repository and set up a local `uv` environment (recommended) or use Do
 
 ### Option 1: Local via uv (recommended)
 
-Prerequisites: Python 3.11 and [uv](https://docs.astral.sh/uv/) and `libturbojpeg`
-(`sudo apt install libturbojpeg` on Linux or `brew install jpeg-turbo` on Mac)
+Prerequisites: Python 3.11, [uv](https://docs.astral.sh/uv/), `libturbojpeg`, and FFmpeg
+```
+sudo apt install libturbojpeg ffmpeg   # Linux
+brew install jpeg-turbo ffmpeg         # macOS
+```
 
 ```bash
 git clone git@github.com:Positronic-Robotics/positronic.git
@@ -131,7 +134,7 @@ Both sim and real robots can be controlled by position tracking devices, such as
 
 Here's how to do it with your phone:
 
-1. Launch data collection with `--webxr=.iphone` or `--webxr=android` (frontend defined in [WebXR config](positronic/cfg/webxr.py)).
+1. Launch data collection with `--webxr=.iphone` or `--webxr=.android` (frontend defined in [WebXR config](positronic/cfg/webxr.py)).
 2. On iPhone, you need to use any WebXR-capable browser, such as **XR Browser**. On Android, the your default Chrome should support WebXR out of the box.
 3. On iPhone visit `http://<host-ip>:5005` (note **http**), on Android you will need to use `https://<host-ip>:5005`. WebXR module will print its address in the console.
 4. Tap **Enter AR**, grant camera/gyroscope access, and hold the phone upright; the reticle represents the virtual controller. If you don't see **Enter AR**, it means that either your browser does not support WebXR or you should try with/without https (`--webxr.use_https=True`).
@@ -241,7 +244,7 @@ Run the [LeRobot training driver](positronic/training/lerobot_train.py) with Pos
 Train an ACT policy using LeRobot’s pipeline configured for Positronic observations and actions:
 
 ```bash
-uv run --with-editable . -s positronic/training/lerobot_train.py \
+python -m positronic.training.lerobot_train \
     --dataset_root=~/datasets/lerobot/stack_cubes \
     --base_config=positronic/training/train_config.json
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install hardware extras only when you need physical robot drivers (Linux only):
 uv sync --frozen --extra hardware
 ```
 
-All runtime commands in the sections below assume either an activated virtual environment or `uv run --with-editable . -s …`.
+All runtime commands in the sections below assume either an activated virtual environment or `uv run python -m …`.
 
 ### Option 2: Docker
 
@@ -217,7 +217,7 @@ Use the [LeRobot conversion helper](positronic/training/to_lerobot.py) until nat
 Until training scripts consume Positronic datasets directly, convert curated runs into LeRobot format:
 
 ```bash
-uv run --with-editable . -s positronic/training/to_lerobot.py convert \
+python -m positronic.training.to_lerobot convert \
     --dataset.path=~/datasets/stack_cubes_raw \
     --output_dir=~/datasets/lerobot/stack_cubes \
     --task="pick up the green cube and place it on the red cube" \
@@ -227,7 +227,7 @@ uv run --with-editable . -s positronic/training/to_lerobot.py convert \
 The converter reads your data through `positronic.cfg.dataset.transformed` (see [Dataset config module](positronic/cfg/dataset.py)), applies the same observation/action transforms used at inference time, and writes a `LeRobotDataset`. Re-run the command whenever you tweak transforms or add new episodes. To extend an existing LeRobot dataset:
 
 ```bash
-uv run --with-editable . -s positronic/training/to_lerobot.py append \
+python -m positronic.training.to_lerobot append \
     --dataset_dir=~/datasets/lerobot/stack_cubes \
     --dataset.path=~/datasets/stack_cubes_new
 ```

--- a/positronic/cfg/policy/action.py
+++ b/positronic/cfg/policy/action.py
@@ -2,19 +2,18 @@ import configuronic as cfn
 
 from positronic import geom
 
-
-@cfn.config(rotation_representation=geom.Rotation.Representation.ROTVEC, offset=1)
-def relative_robot_position(rotation_representation: geom.Rotation.Representation, offset: int):
-    from positronic.policy.action import RelativeRobotPositionAction
-
-    return RelativeRobotPositionAction(offset=offset, rotation_representation=rotation_representation)
+RotRep = geom.Rotation.Representation
 
 
-@cfn.config(rotation_representation=geom.Rotation.Representation.QUAT)
-def absolute_position(rotation_representation: geom.Rotation.Representation):
+@cfn.config(rotation_representation=RotRep.QUAT, tgt_ee_pose_key='robot_commands.pose', tgt_grip_key='target_grip')
+def absolute_position(rotation_representation: RotRep, tgt_ee_pose_key: str, tgt_grip_key: str):
     from positronic.policy.action import AbsolutePositionAction
 
-    return AbsolutePositionAction(rotation_representation=rotation_representation)
+    return AbsolutePositionAction(
+        tgt_ee_pose_key,
+        tgt_grip_key,
+        rotation_representation=rotation_representation,
+    )
 
 
 @cfn.config()

--- a/positronic/cfg/policy/observation.py
+++ b/positronic/cfg/policy/observation.py
@@ -43,7 +43,7 @@ def end_effector_mem15():
     )
 
 
-@cfn.config(state=['robot_position_quaternion', 'robot_position_translation', 'grip'])
+@cfn.config(state=['robot_state.ee_pose', 'grip'])
 def franka_mujoco_stackcubes(state):
     from positronic.policy.observation import ObservationEncoder
 

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -415,7 +415,7 @@ class EpisodeTransform(ABC):
         ...
 ```
 
-`TransformedEpisode` applies one or more `EpisodeTransform`s to an existing episode (all in lazy model). When `pass_through=True`, all original keys are preserved, unless they are overwritten by transforms. `TransformedDataset` lifts the same idea to the dataset level so that every retrieved episode exposes the transformed view.
+`TransformedEpisode` applies one or more `EpisodeTransform`s to an existing episode (all in lazy model). When `pass_through=True`, all original keys are preserved, unless they are overwritten by transforms. You can also provide a list of key names to `pass_through` so that only the listed originals remain visible. `TransformedDataset` lifts the same idea to the dataset level so that every retrieved episode exposes the transformed view.
 
 ### Example
 
@@ -439,7 +439,7 @@ class Features(transforms.EpisodeTransform):
           return image.resize(width=224, height=224, signal=episode["rgb_camera"])
 
 
-dataset = transforms.TransformedDataset(raw_dataset, Features(), pass_through=True)
+dataset = transforms.TransformedDataset(raw_dataset, Features(), pass_through=['robot.ee_pose'])
 episode = dataset[0]
 # resized view; original imagery untouched
 frame0, _ts = episode['resized_image'].time[episode.start_ts]

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -53,7 +53,7 @@ Signal implements `Sequence[(T, int)]` (iterable, indexable). We support three k
 ```python
 T = TypeVar('T')  # The type of the data we manage
 
-IndicesLike = Sequence[int] | np.ndarray
+IndicesLike = slice | Sequence[int] | np.ndarray
 RealNumericArrayLike = Sequence[int] | Sequence[float] | np.ndarray
 
 class Signal[T]:
@@ -166,7 +166,7 @@ class Dataset:
         pass
 
     # Indexing returns an Episode; slices and index arrays return lists of Episodes
-    def __getitem__(self, index_or_slice: int | slice | Sequence[int] | np.ndarray) -> `Episode` | list[Episode]:
+    def __getitem__(self, index_or_slice: int | IndicesLike) -> `Episode` | list[Episode]:
         pass
 
     @property

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -395,6 +395,7 @@ Common utilities stack the building blocks to cover frequent needs:
 - `astype(signal, dtype)`: cast vector signals on the fly via `Elementwise`.
 - `pairwise(a, b, op)`: join two signals and apply a custom binary operator to every aligned pair.
 - `recode_rotation(rep_from, rep_to, signal)`: convert rotation representations using `positronic.geom` utilities.
+- `view(signal, slice_obj)`: create a zero-copy view that slices each frame (e.g., select quaternion components from a pose vector) while preserving timestamps.
 
 Typical use cases include building model-ready tensors, normalizing values, resizing video streams, or deriving velocities. Because every helper is a view, you can stack them freely and continue to use standard access patterns (`signal.time[...]`, indexing, slicing) without materializing intermediate results.
 

--- a/positronic/dataset/dataset.py
+++ b/positronic/dataset/dataset.py
@@ -1,12 +1,11 @@
 import collections.abc
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
 from contextlib import AbstractContextManager
 
 import numpy as np
 
 from .episode import Episode, EpisodeWriter
-from .signal import SignalMeta
+from .signal import IndicesLike, SignalMeta
 
 
 class DatasetWriter(AbstractContextManager, ABC):
@@ -35,7 +34,7 @@ class Dataset(ABC, collections.abc.Sequence[Episode]):
         """Return the episode at a single, already-normalized index."""
         pass
 
-    def __getitem__(self, index_or_slice: int | slice | Sequence[int] | np.ndarray) -> Episode | list[Episode]:
+    def __getitem__(self, index_or_slice: int | IndicesLike) -> Episode | list[Episode]:
         """Return an Episode or list of Episodes after normalizing integer-based indices."""
         length = len(self)
 

--- a/positronic/dataset/episode.py
+++ b/positronic/dataset/episode.py
@@ -462,7 +462,8 @@ class DiskEpisode(Episode):
             return self._ensure_signal(name)
         if name in self._static_data:
             return self._static_data[name]
-        raise KeyError(name)
+        available = list(self._signal_factories.keys()) + list(self._static_data.keys())
+        raise KeyError(f"'{name}' not found in episode. Available keys: {', '.join(available)}")
 
     @property
     def meta(self) -> dict:

--- a/positronic/dataset/episode.py
+++ b/positronic/dataset/episode.py
@@ -5,7 +5,7 @@ import sys
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, suppress
 from functools import lru_cache, partial
 from importlib import metadata as importlib_metadata
 from pathlib import Path
@@ -310,6 +310,11 @@ class DiskEpisodeWriter(EpisodeWriter):
 
     def __exit__(self, exc_type, exc, tb) -> None:
         """Finalize all signal writers and persist static items on context exit."""
+        if exc_type is not None and not self._aborted:
+            with suppress(Exception):
+                self.abort()
+            return
+
         # Always try to close all signal writers
         for writer in self._writers.values():
             try:

--- a/positronic/dataset/signal.py
+++ b/positronic/dataset/signal.py
@@ -11,7 +11,7 @@ import numpy as np
 
 T = TypeVar('T')
 
-IndicesLike: TypeAlias = Sequence[int] | np.ndarray
+IndicesLike: TypeAlias = slice | Sequence[int] | np.ndarray
 RealNumericArrayLike: TypeAlias = Sequence[int] | Sequence[float] | np.ndarray
 
 
@@ -145,9 +145,7 @@ class Signal(Sequence[tuple[T, int]], ABC, Generic[T]):
         return _SignalViewTime(self)
 
     @final
-    def __getitem__(
-        self, index_or_slice: int | slice | Sequence[int] | np.ndarray
-    ) -> Union[tuple[T, int], 'Signal[T]']:
+    def __getitem__(self, index_or_slice: int | IndicesLike) -> Union[tuple[T, int], 'Signal[T]']:
         match index_or_slice:
             case int() | np.integer() as idx:
                 if idx < 0:
@@ -179,9 +177,7 @@ class _SignalViewTime(TimeIndexerLike[T], Generic[T]):
     def __init__(self, signal: Signal[T]):
         self._signal = signal
 
-    def __getitem__(
-        self, ts_or_array: int | float | Sequence[int] | np.ndarray | slice
-    ) -> Union[tuple[T, int], 'Signal[T]']:
+    def __getitem__(self, ts_or_array: int | IndicesLike) -> Union[tuple[T, int], 'Signal[T]']:
         match ts_or_array:
             case int() | float() | np.floating() as ts:
                 idx = int(self._signal._search_ts([ts])[0])

--- a/positronic/dataset/tests/test_episode.py
+++ b/positronic/dataset/tests/test_episode.py
@@ -240,6 +240,15 @@ def test_episode_writer_abort_cleans_up_and_blocks_further_use(tmp_path):
             w.set_static('z', 2)
 
 
+def test_episode_writer_context_aborts_on_exception(tmp_path):
+    ep_dir = tmp_path / 'ep_context_abort'
+    with pytest.raises(RuntimeError, match='boom'):
+        with DiskEpisodeWriter(ep_dir) as w:
+            w.append('a', 1, 1000)
+            raise RuntimeError('boom')
+    assert not ep_dir.exists()
+
+
 def test_episode_writer_set_static_twice_raises(tmp_path):
     ep_dir = tmp_path / 'ep_static_dup'
     with DiskEpisodeWriter(ep_dir) as w:

--- a/positronic/dataset/transforms/__init__.py
+++ b/positronic/dataset/transforms/__init__.py
@@ -1,7 +1,7 @@
 """Dataset transformation utilities."""
 
 from .dataset import TransformedDataset
-from .episode import EpisodeTransform, TransformedEpisode
+from .episode import EpisodeTransform, KeyFuncEpisodeTransform, TransformedEpisode
 from .signals import (
     Elementwise,
     IndexOffsets,
@@ -29,6 +29,7 @@ __all__ = [
     'view',
     # Episode transforms
     'EpisodeTransform',
+    'KeyFuncEpisodeTransform',
     'TransformedEpisode',
     # Dataset transforms
     'TransformedDataset',

--- a/positronic/dataset/transforms/__init__.py
+++ b/positronic/dataset/transforms/__init__.py
@@ -12,6 +12,7 @@ from .signals import (
     concat,
     pairwise,
     recode_rotation,
+    view,
 )
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     'astype',
     'pairwise',
     'recode_rotation',
+    'view',
     # Episode transforms
     'EpisodeTransform',
     'TransformedEpisode',

--- a/positronic/dataset/transforms/dataset.py
+++ b/positronic/dataset/transforms/dataset.py
@@ -7,10 +7,12 @@ from .episode import EpisodeTransform, TransformedEpisode
 class TransformedDataset(Dataset):
     """Transform a dataset into a new view of the dataset."""
 
-    def __init__(self, dataset: Dataset, *transforms: EpisodeTransform, pass_through: bool = False) -> None:
+    def __init__(self, dataset: Dataset, *transforms: EpisodeTransform, pass_through: bool | list[str] = False):
         self._dataset = dataset
         self._transforms = transforms
         self._pass_through = pass_through
+        if not isinstance(pass_through, bool):
+            self._pass_through = tuple(pass_through)
         self._meta = None
 
     def __len__(self) -> int:

--- a/positronic/dataset/transforms/episode.py
+++ b/positronic/dataset/transforms/episode.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from ..episode import Episode
@@ -19,6 +19,22 @@ class EpisodeTransform(ABC):
     def transform(self, name: str, episode: Episode) -> Signal[Any] | Any:
         """For given output key, return the transformed signal or static value."""
         ...
+
+
+class KeyFuncEpisodeTransform(EpisodeTransform):
+    """Transform an episode using a dictionary of key-function pairs."""
+
+    def __init__(self, **transforms: Callable[[Episode], Any]):
+        self._transforms = transforms
+
+    @property
+    def keys(self) -> Sequence[str]:
+        return list(self._transforms.keys())
+
+    def transform(self, name: str, episode: Episode) -> Signal[Any] | Any:
+        if name not in self._transforms:
+            raise KeyError(f'Unknown key: {name}, expected one of {self._transforms.keys()}')
+        return self._transforms[name](episode)
 
 
 class TransformedEpisode(Episode):

--- a/positronic/dataset/transforms/episode.py
+++ b/positronic/dataset/transforms/episode.py
@@ -25,16 +25,16 @@ class KeyFuncEpisodeTransform(EpisodeTransform):
     """Transform an episode using a dictionary of key-function pairs."""
 
     def __init__(self, **transforms: Callable[[Episode], Any]):
-        self._transforms = transforms
+        self._transform_fns = transforms
 
     @property
     def keys(self) -> Sequence[str]:
-        return list(self._transforms.keys())
+        return self._transform_fns.keys()
 
     def transform(self, name: str, episode: Episode) -> Signal[Any] | Any:
-        if name not in self._transforms:
-            raise KeyError(f'Unknown key: {name}, expected one of {self._transforms.keys()}')
-        return self._transforms[name](episode)
+        if name not in self._transform_fns:
+            raise KeyError(f'Unknown key: {name}, expected one of {self._transform_fns.keys()}')
+        return self._transform_fns[name](episode)
 
 
 class TransformedEpisode(Episode):

--- a/positronic/dataset/transforms/tests/test_episode.py
+++ b/positronic/dataset/transforms/tests/test_episode.py
@@ -65,6 +65,23 @@ def test_transform_episode_keys_and_getitem_pass_through(sig_simple):
         _ = te['missing']
 
 
+def test_transform_episode_pass_through_selected_keys(sig_simple):
+    ep = EpisodeContainer(
+        signals={'s': sig_simple},
+        static={'id': 7, 'note': 'ok', 'skip': 'nope'},
+    )
+    tf = _DummyTransform()
+    te = TransformedEpisode(ep, tf, pass_through=['note'])
+
+    assert list(te.keys) == ['a', 's', 'note']
+    assert [v for v, _ in te['a']] == [x * 10 for x, _ in ep['s']]
+    assert te['note'] == 'ok'
+    with pytest.raises(KeyError):
+        _ = te['id']
+    with pytest.raises(KeyError):
+        _ = te['skip']
+
+
 def test_transform_episode_no_pass_through(sig_simple):
     ep = EpisodeContainer(signals={'s': sig_simple}, static={'id': 7})
     tf = _DummyTransform()

--- a/positronic/dataset/video.py
+++ b/positronic/dataset/video.py
@@ -259,7 +259,7 @@ class VideoSignal(Signal[np.ndarray]):
         all frames up front.
         """
 
-        def __init__(self, parent: 'VideoSignal', indices: Sequence[int] | np.ndarray):
+        def __init__(self, parent: 'VideoSignal', indices: IndicesLike):
             self._parent = parent
             # Store as numpy int64 array for efficient indexing/slicing
             self._indices = np.asarray(indices, dtype=np.int64)

--- a/positronic/policy/action.py
+++ b/positronic/policy/action.py
@@ -25,15 +25,9 @@ def _relative_rot_vec(q_current: np.ndarray, q_target: np.ndarray, representatio
     return _convert_quat_to_array(rel, representation)
 
 
-class ActionDecoder(transforms.EpisodeTransform):
-    @property
-    def keys(self) -> list[str]:
-        return ['action']
-
-    def transform(self, name: str, episode: Episode) -> Signal[Any] | Any:
-        if name != 'action':
-            raise ValueError(f'Unknown action key: {name}')
-        return self.encode_episode(episode)
+class ActionDecoder(transforms.KeyFuncEpisodeTransform):
+    def __init__(self):
+        super().__init__(action=self.encode_episode)
 
     @abstractmethod
     def encode_episode(self, episode: Episode) -> Signal[Any]:

--- a/positronic/policy/action.py
+++ b/positronic/policy/action.py
@@ -40,8 +40,8 @@ class ActionDecoder(transforms.KeyFuncEpisodeTransform):
 
 class RotationTranslationGripAction(ActionDecoder, abc.ABC):
     def __init__(self, rotation_representation: RotRep | str = RotRep.QUAT):
+        super().__init__()
         self.rot_rep = RotRep(rotation_representation)
-        # self.rotation_shape = self.rot_rep.shape
 
 
 class AbsolutePositionAction(RotationTranslationGripAction):

--- a/positronic/policy/observation.py
+++ b/positronic/policy/observation.py
@@ -33,8 +33,8 @@ class ObservationEncoder(transforms.EpisodeTransform):
             )
         elif name.startswith('observation.images.'):
             key = name[len('observation.images.') :]
-            input_key, (widht, height) = self._image_configs[key]
-            return image.resize_with_pad(widht, height, episode[input_key])
+            input_key, (width, height) = self._image_configs[key]
+            return image.resize_with_pad(width, height, episode[input_key])
         else:
             raise ValueError(f'Unknown observation key: {name}')
 

--- a/positronic/policy/observation.py
+++ b/positronic/policy/observation.py
@@ -31,7 +31,7 @@ class ObservationEncoder(transforms.KeyFuncEpisodeTransform):
 
     def encode_image(self, name: str, episode: Episode) -> Signal[Any]:
         input_key, (width, height) = self._image_configs[name]
-        return episode[input_key].resize_with_pad(width, height)
+        return image.resize_with_pad(width, height, signal=episode[input_key])
 
     def encode(self, images: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
         """Encode a single inference observation from raw images and input dict.

--- a/positronic/policy/observation.py
+++ b/positronic/policy/observation.py
@@ -20,7 +20,7 @@ class ObservationEncoder(transforms.KeyFuncEpisodeTransform):
                            The output key will be 'observation.images.{name}'.
         """
         image_fns = {f'observation.images.{k}': partial(self.encode_image, k) for k in image_configs.keys()}
-        super().__init__(observation_state=self.encode_state, **image_fns)
+        super().__init__(**{'observation.state': self.encode_state}, **image_fns)
         self._state_features = state_features
         self._image_configs = image_configs
 

--- a/positronic/policy/observation.py
+++ b/positronic/policy/observation.py
@@ -38,21 +38,6 @@ class ObservationEncoder(transforms.EpisodeTransform):
         else:
             raise ValueError(f'Unknown observation key: {name}')
 
-    def get_features(self):
-        features = {}
-        for key, (_, (width, height)) in self._image_configs.items():
-            features['observation.images.' + key] = {
-                'dtype': 'video',
-                'shape': (height, width, 3),
-                'names': ['height', 'width', 'channel'],
-            }
-        features['observation.state'] = {
-            'dtype': 'float64',
-            'shape': (8,),  # TODO: Invent the way to compute it dynamically
-            'names': list(self._state_features),
-        }
-        return features
-
     def encode(self, images: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
         """Encode a single inference observation from raw images and input dict.
 

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -46,9 +46,10 @@ class ReplayController(pimm.ControlSystem):
 
 class RestoreCommand(transforms.KeyFuncEpisodeTransform):
     def __init__(self):
-        super().__init__(robot_commands=self.transform)
+        super().__init__(robot_commands=self._commands_from_episode)
 
-    def transform(self, episode: Episode) -> Any:
+    @staticmethod
+    def _commands_from_episode(episode: Episode) -> Any:
         pose = episode['robot_commands.pose']
         return transforms.Elementwise(pose, RestoreCommand.command_from_pose, names=['robot_commands'])
 

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -15,7 +15,6 @@ from positronic.dataset import Dataset, Episode, transforms
 from positronic.dataset.ds_player_agent import DsPlayerAgent, DsPlayerCommand, DsPlayerStartCommand
 from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, Serializers, TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
-from positronic.dataset.transforms import EpisodeTransform
 from positronic.drivers import roboarm
 from positronic.gui.dpg import DearpyguiUi
 from positronic.simulator.mujoco.sim import MujocoCamera, MujocoFranka, MujocoGripper, MujocoSim
@@ -45,12 +44,11 @@ class ReplayController(pimm.ControlSystem):
                 yield pimm.Sleep(1)
 
 
-class RestoreCommand(EpisodeTransform):
-    @property
-    def keys(self) -> Sequence[str]:
-        return ['robot_commands']
+class RestoreCommand(transforms.KeyFuncEpisodeTransform):
+    def __init__(self):
+        super().__init__(robot_commands=self.transform)
 
-    def transform(self, name: str, episode: Episode) -> Any:
+    def transform(self, episode: Episode) -> Any:
         pose = episode['robot_commands.pose']
         return transforms.Elementwise(pose, RestoreCommand.command_from_pose, names=['robot_commands'])
 

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -124,7 +124,7 @@ def _collect_signal_groups(ep: Episode) -> tuple[list[str], list[str], dict[str,
 
 
 def _build_blueprint(video_names: list[str], signal_names: list[str], signal_dims: dict[str, int]) -> rrb.Blueprint:
-    image_views = [rrb.Spatial2DView(name=k.replace('_', ' ').title(), origin=f'/{k}') for k in video_names]
+    image_views = [rrb.Spatial2DView(name=k, origin=f'/{k}') for k in video_names]
 
     per_signal_views = []
     for sig in signal_names:
@@ -132,7 +132,7 @@ def _build_blueprint(video_names: list[str], signal_names: list[str], signal_dim
         show_legend = signal_dims.get(sig, 1) > 1
         per_signal_views.append(
             rrb.TimeSeriesView(
-                name=sig.replace('_', ' ').title(),
+                name=sig,
                 origin=f'/signals/{sig}',
                 plot_legend=rrb.PlotLegend(visible=show_legend),
             )
@@ -148,7 +148,7 @@ def _build_blueprint(video_names: list[str], signal_names: list[str], signal_dim
         rrb.BlueprintPanel(state=rrb.PanelState.Hidden),
         rrb.SelectionPanel(state=rrb.PanelState.Hidden),
         rrb.TopPanel(state=rrb.PanelState.Expanded),
-        rrb.TimePanel(state=rrb.PanelState.Expanded),
+        rrb.TimePanel(state=rrb.PanelState.Collapsed),
         rrb.Grid(*grid_items, column_shares=[1, 2]),
     )
 

--- a/positronic/training/lerobot_train.py
+++ b/positronic/training/lerobot_train.py
@@ -1,25 +1,6 @@
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#     "lerobot>=0.3.3",
-#     "torch",
-#     "configuronic",
-# ]
-# ///
 """
-PEP 723 standalone script
--------------------------
-
-This script is intentionally decoupled from the core library’s dependencies so
-that `lerobot` does not become a hard requirement of `positronic`.
-
-How to run (recommended):
-- Use uv to run the script in an isolated env that also installs the local
-  project and its dependencies, while adding only the script-specific deps
-  (like `lerobot`) as declared above.
-
-Examples:
-`uv run -s positronic/training/lerobot_train.py --dataset_root=/tmp/datasets/`
+Example:
+`python -m positronic.training.lerobot_train --dataset_root=~/datasets/lerobot/stack_cubes`
 """
 
 from dataclasses import dataclass, field
@@ -65,7 +46,7 @@ def train(dataset_root: str, base_config: str = 'positronic/training/train_confi
     assert Path(base_config).is_file(), f'Base config file {base_config} does not exist.'
     cfg = TrainPipelineConfig.from_pretrained(base_config)
     cfg.env = PositronicEnvConfig()
-    cfg.dataset.root = dataset_root
+    cfg.dataset.root = Path(dataset_root).expanduser().absolute()
     cfg.dataset.repo_id = 'local'
     cfg.eval_freq = 0
     cfg.policy.push_to_hub = False

--- a/positronic/training/to_lerobot.py
+++ b/positronic/training/to_lerobot.py
@@ -1,39 +1,18 @@
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#     "lerobot>=0.3.3",
-#     "torch",
-#     "tqdm",
-#     "configuronic",
-#     "numpy",
-#     "scipy",
-# ]
-# ///
 """
-PEP 723 standalone script
--------------------------
-
-This script is intentionally decoupled from the core library’s dependencies so
-that `lerobot` does not become a hard requirement of `positronic`.
-
-How to run (recommended):
-- Use uv to run the script in an isolated env that also installs the local
-  project and its dependencies, while adding only the script-specific deps
-  (like `lerobot`) as declared above.
+This utility converts Positronic datasets into LeRobot format. Now that
+`lerobot` ships with the Positronic training dependencies, the easiest way to
+run the tool is from the project environment (virtualenv or `uv run`).
 
 Examples:
 - Convert to a new LeRobot dataset
-  uv run --with-editable . -s positronic/training/to_lerobot.py \
-    convert --input-dir /path/to/local_dataset --output-dir /path/to/lerobot_ds
+  python -m positronic.training.to_lerobot convert \
+    --dataset.path=/path/to/local_dataset \
+    --output_dir=/path/to/lerobot_ds
 
 - Append to an existing LeRobot dataset
-  uv run --with-editable . -s positronic/training/to_lerobot.py \
-    append --dataset-dir /path/to/lerobot_ds --input-dir /path/to/local_dataset
-
-Notes:
-- The `--with-editable .` flag ensures your local `positronic` package and its
-  dependencies are available inside the ephemeral uv environment without
-  making `lerobot` a core dependency of the project.
+  python -m positronic.training.to_lerobot append \
+    --dataset_dir=/path/to/lerobot_ds \
+    --dataset.path=/path/to/local_dataset
 """
 
 import resource  # This will fail on Windows, as this library is Unix only, but we don't support Windows anyway
@@ -158,7 +137,7 @@ def convert_to_lerobot_dataset(output_dir: str, fps: int, video: bool, dataset: 
     lr_dataset = LeRobotDataset.create(
         repo_id='local',
         fps=fps,
-        root=Path(output_dir),
+        root=Path(output_dir).expanduser().absolute(),
         use_videos=video,
         features=_extract_features(dataset),
         image_writer_threads=32,
@@ -172,7 +151,7 @@ def convert_to_lerobot_dataset(output_dir: str, fps: int, video: bool, dataset: 
     dataset=positronic.cfg.dataset.transformed, task='pick plate from the table and place it into the dishwasher'
 )
 def append_data_to_lerobot_dataset(lerobot_dataset_dir: str, dataset: Dataset, task: str):
-    lr_dataset = LeRobotDataset(repo_id='local', root=lerobot_dataset_dir)
+    lr_dataset = LeRobotDataset(repo_id='local', root=Path(lerobot_dataset_dir).expanduser().absolute())
     append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task)
     print(f'Dataset extended and saved to {lerobot_dataset_dir}')
 

--- a/utilities/convert_ds.py
+++ b/utilities/convert_ds.py
@@ -1,0 +1,79 @@
+"""Utility for exporting a transformed dataset to disk.
+
+The CLI defined here reads a configured source dataset—most often a
+``TransformedDataset`` that reshapes signals lazily—and streams it into a new
+``LocalDataset`` directory. The default configuration targets
+``update_v0_1_0`` transformation around specified local dataset,
+but you are welcome to use your own transformations with ``original_ds`` config entry.
+
+Most signals are copied sample-by-sample; however, video signals require
+special handling. Instead of materialising individual frames, the underlying
+``VideoSignal`` files (the encoded video and its frame index) are copied
+verbatim so the resulting dataset preserves the original video assets without
+re-encoding.
+
+Example:
+
+    python -m utilities.convert_ds --original_ds.path /path/to/transformed_source \
+        --output_path /path/to/export_root
+"""
+
+import shutil
+from pathlib import Path
+
+import configuronic as cfn
+import tqdm
+
+from positronic.dataset import Dataset, transforms
+from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
+from positronic.dataset.signal import Kind
+from positronic.dataset.transforms import KeyFuncEpisodeTransform, TransformedDataset
+from positronic.dataset.video import VideoSignal
+
+
+@cfn.config()
+def update_v0_1_0(path: str):
+    dataset = LocalDataset(Path(path))
+    image_features = [key for key, meta in dataset.signals_meta.items() if meta.kind == Kind.IMAGE]
+
+    funcs = {
+        'controller_positions.right': lambda ep: transforms.concat(
+            ep['right_controller_translation'], ep['right_controller_quaternion']
+        ),
+        'robot_commands.pose': lambda ep: transforms.concat(
+            ep['target_robot_position_translation'], ep['target_robot_position_quaternion']
+        ),
+        'robot_state.q': lambda ep: ep['robot_joints'],
+        'robot_state.dq': lambda ep: ep['robot_joints_velocity'],
+        'robot_state.ee_pose': lambda ep: transforms.concat(
+            ep['robot_position_translation'], ep['robot_position_quaternion']
+        ),
+    }
+
+    return TransformedDataset(
+        dataset, KeyFuncEpisodeTransform(**funcs), pass_through=['grip', 'target_grip'] + image_features
+    )
+
+
+@cfn.config(original_ds=update_v0_1_0)
+def main(output_path: str, original_ds: Dataset | None = None):
+    root = Path(output_path)
+    with LocalDatasetWriter(root) as writer:
+        for episode in tqdm.tqdm(original_ds):
+            with writer.new_episode() as ew:
+                for key, value in episode.static.items():
+                    ew.set_static(key, value)
+
+                for key, signal in episode.signals.items():
+                    if signal.kind == Kind.IMAGE:
+                        assert isinstance(signal, VideoSignal)
+                        shutil.copy(signal.video_path, ew.path / signal.video_path.name)
+                        shutil.copy(signal.frames_index_path, ew.path / signal.frames_index_path.name)
+                        continue
+
+                    for value, ts in signal:
+                        ew.append(key, value, ts)
+
+
+if __name__ == '__main__':
+    cfn.cli(main)

--- a/utilities/sync_policy_runner.py
+++ b/utilities/sync_policy_runner.py
@@ -111,7 +111,7 @@ run = cfn.Config(
     run_policy_in_simulator,
     env=positronic.cfg.simulator.simulator,
     state_encoder=positronic.cfg.policy.observation.end_effector_back_front,
-    action_decoder=positronic.cfg.policy.action.relative_robot_position,
+    action_decoder=positronic.cfg.policy.action.absolute_position,
     policy=positronic.cfg.policy.policy.act,
     rerun_path='rerun.rrd',
     inference_time_sec=10,


### PR DESCRIPTION
* Introduced a callable-based episode transform stack (`KeyFuncEpisodeTransform`, selective passthrough, `transforms.view`) and extended rotation recoding so derived signals can target pose sub-slices without materializing arrays; refreshed dataset docs and tests to exercise the new utilities plus disk-writer safety on exceptions.

* Reworked policy observation/action decoders to consume the new pose/grip keys, updated configs/tests, switched the sync runner to the absolute action path, and tuned server dataset blueprints for literal signal names.

* Added a CLI helper to stream transformed datasets into LocalDataset layouts while preserving video assets, and updated README/train scripts to prefer python -m … invocations with normalized paths.