### PR TITLE
Add wan2.2 backbone support and update DreamZero to upstream HEAD

### DIFF
--- a/positronic/vendors/dreamzero/Dockerfile
+++ b/positronic/vendors/dreamzero/Dockerfile
@@ -1,4 +1,4 @@
-# Base image for DreamZero inference.
+# Base image for DreamZero inference and training.
 # Produces: positro/dreamzero-base:latest
 #
 # Build (from repo root):
@@ -24,11 +24,7 @@ RUN uv python install 3.11 && uv venv /.venv --python 3.11
 ENV VIRTUAL_ENV=/.venv
 ENV PATH="/.venv/bin:$PATH"
 
-# Clone DreamZero at pinned commit
-ARG DREAMZERO_SHA=a0490c701f4e4424dd198fa8df71ba63e6ae383d
-RUN git clone https://github.com/dreamzero0/dreamzero.git /dreamzero && \
-    cd /dreamzero && git checkout ${DREAMZERO_SHA}
-
+# Heavy compilation layers — placed before git clone so they stay cached across SHA updates.
 # Install PyTorch 2.8 with CUDA 12.9 first (dreamzero depends on it)
 RUN uv pip install \
     torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 \
@@ -38,6 +34,11 @@ RUN uv pip install \
 RUN uv pip install packaging wheel
 RUN uv pip install flash-attn --no-build-isolation
 RUN uv pip install "transformer-engine[pytorch]" --no-build-isolation
+
+# Clone DreamZero at pinned commit
+ARG DREAMZERO_SHA=d70a8025ac77f7486f38032c718a1ca814a4d8c7
+RUN git clone https://github.com/dreamzero0/dreamzero.git /dreamzero && \
+    cd /dreamzero && git checkout ${DREAMZERO_SHA}
 
 # Install DreamZero and all its dependencies
 RUN cd /dreamzero && uv pip install -e .
@@ -53,26 +54,6 @@ RUN cd /dreamzero && uv pip install -e .
 # fused_attn_bwd. It controls causal mask alignment and sits between the `window_size` and
 # `cu_seqlens_q` args (fwd) / between `window_size` and `deterministic` (bwd). Without this
 # arg the C++ binding raises TypeError because tensors land in a bool slot.
-#
-# The error looked like:
-#   TypeError: fused_attn_fwd(): incompatible function arguments.
-#   Expected arg11: bool, got tensor([0, 880]).
-#
-# We confirmed the fix by:
-#   1. Printing `tex.fused_attn_fwd.__doc__` inside the container to see the 30-arg signature
-#   2. Comparing with DreamZero's 29-arg tuple (missing the new bool at position 11)
-#   3. Checking TE's Python wrapper (`fused_attn.py`) which names it `bottom_right_diagonal`
-#      and defaults it to False for non-causal masks (DreamZero uses `no_mask`)
-#
-# Other options considered:
-#   - Pinning TE to 2.10: would work but means missing future fixes/performance improvements,
-#     and TE compilation from source is slow (~10 min). The version guard approach is what
-#     DreamZero already uses for TE 2.8/2.9/2.10, so adding 2.12 follows the existing pattern.
-#   - Forking DreamZero: unnecessary — this is the only patch, and it's a 2-line version guard
-#     addition that follows the existing pattern in the file. Applied via string replace at
-#     Docker build time, no fork to maintain.
-#   - Disabling fused attention: DreamZero's code calls tex.fused_attn_fwd directly with no
-#     fallback path, so there's no env var or config to bypass it.
 #
 # The patch inserts `if _TE_VER >= (2, 12): args += (False,)` in both the fwd and bwd
 # functions, matching the existing version guard style (see _TE_VER >= (2, 9) etc.).

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -99,16 +99,22 @@ class RoboarenaClient:
 
 
 class DreamZeroSubprocess:
+    # wan2.1 (14B): socket_test_optimized_AR.py — uses --enable-dit-cache
+    # wan2.2 (5B):  eval_utils/serve_dreamzero_wan22.py — causal chunked inference
+    _BACKBONE_SCRIPTS = {'wan2.1': 'socket_test_optimized_AR.py', 'wan2.2': 'eval_utils/serve_dreamzero_wan22.py'}
+
     def __init__(
         self,
         model_path: str,
         dreamzero_venv: Path,
+        backbone: str = 'wan2.1',
         num_gpus: int = 1,
         roboarena_port: int = 9000,
         enable_dit_cache: bool = True,
     ):
         self.model_path = model_path
         self.dreamzero_venv = dreamzero_venv
+        self.backbone = backbone
         self.num_gpus = num_gpus
         self.roboarena_port = roboarena_port
         self.enable_dit_cache = enable_dit_cache
@@ -117,16 +123,17 @@ class DreamZeroSubprocess:
     def _build_command(self) -> list[str]:
         root = _dreamzero_root()
         torchrun = str(self.dreamzero_venv / 'bin' / 'torchrun')
+        script = self._BACKBONE_SCRIPTS.get(self.backbone, self._BACKBONE_SCRIPTS['wan2.1'])
         command = [
             torchrun,
             f'--nproc_per_node={self.num_gpus}',
-            str(root / 'socket_test_optimized_AR.py'),
+            str(root / script),
             '--port',
             str(self.roboarena_port),
             '--model-path',
             self.model_path,
         ]
-        if self.enable_dit_cache:
+        if self.backbone == 'wan2.1' and self.enable_dit_cache:
             command.append('--enable-dit-cache')
         return command
 
@@ -191,6 +198,7 @@ class InferenceServer(VendorServer):
         codec: Codec | None,
         model_path: str,
         dreamzero_venv: str = '/.venv/',
+        backbone: str = 'wan2.1',
         num_gpus: int = 1,
         host: str = '0.0.0.0',
         port: int = 8000,
@@ -201,6 +209,7 @@ class InferenceServer(VendorServer):
         super().__init__(codec=codec, host=host, port=port, recording_dir=recording_dir)
         self.model_path = model_path
         self.dreamzero_venv = Path(dreamzero_venv)
+        self.backbone = backbone
         self.num_gpus = num_gpus
         self.roboarena_port = roboarena_port
         self.enable_dit_cache = enable_dit_cache
@@ -211,6 +220,7 @@ class InferenceServer(VendorServer):
             'host': host,
             'port': port,
             'type': 'dreamzero',
+            'backbone': backbone,
             'model_path': model_path,
             'num_gpus': num_gpus,
         }
@@ -234,6 +244,7 @@ class InferenceServer(VendorServer):
             sp = DreamZeroSubprocess(
                 model_path=str(download_task.result()),
                 dreamzero_venv=self.dreamzero_venv,
+                backbone=self.backbone,
                 num_gpus=self.num_gpus,
                 roboarena_port=self.roboarena_port,
                 enable_dit_cache=self.enable_dit_cache,
@@ -259,6 +270,7 @@ class InferenceServer(VendorServer):
     codec=codecs.joints,
     model_path=DEFAULT_HF_REPO,
     dreamzero_venv='/.venv/',
+    backbone='wan2.1',
     num_gpus=1,
     port=8000,
     enable_dit_cache=True,
@@ -268,6 +280,7 @@ def server(
     codec: Codec | None,
     model_path: str,
     dreamzero_venv: str,
+    backbone: str,
     num_gpus: int,
     port: int,
     enable_dit_cache: bool,
@@ -279,6 +292,7 @@ def server(
             codec=codec,
             model_path=model_path,
             dreamzero_venv=dreamzero_venv,
+            backbone=backbone,
             num_gpus=num_gpus,
             port=port,
             enable_dit_cache=enable_dit_cache,

--- a/positronic/vendors/dreamzero/train.py
+++ b/positronic/vendors/dreamzero/train.py
@@ -237,19 +237,7 @@ _ALL_PRESETS = {
     # Legacy
     'h100x1': h100x1,
     'h100x8': h100x8,
-    'h200x1': h200x1,
 }
-
-# h200x1: Same constraints as h100x1 (ZeRO-2 on 1 GPU can't shard optimizer state), but
-# 141GB HBM3e allows batch_size=2. We halve gradient_accumulation_steps to keep the same
-# effective batch size of 8.
-h200x1 = main.override(
-    num_gpus=1,
-    batch_size=2,
-    gradient_accumulation_steps=4,
-    deepspeed='groot/vla/configs/deepspeed/zero2.json',
-    extra_args=['+training_args.save_only_model=true'],
-)
 
 
 if __name__ == '__main__':

--- a/positronic/vendors/dreamzero/train.py
+++ b/positronic/vendors/dreamzero/train.py
@@ -1,4 +1,4 @@
-"""DreamZero LoRA fine-tuning: wraps upstream Hydra training pipeline."""
+"""DreamZero fine-tuning: wraps upstream Hydra training pipeline."""
 
 import os
 import subprocess
@@ -9,6 +9,38 @@ import pos3
 
 from positronic import utils
 
+# Backbone-specific constants.
+# wan2.1: 14B params, 176px height, frame_seqlen=880
+# wan2.2: 5B params, 160px height, frame_seqlen from config (not CLI)
+_BACKBONE_PARAMS = {
+    'wan2.1': {
+        'data_config': 'dreamzero/droid_relative',
+        'action_head': 'wan_flow_matching_action_tf',
+        'image_resolution_height': 176,
+        'frame_seqlen': 880,
+    },
+    'wan2.2': {
+        'data_config': 'dreamzero/droid_relative_wan22',
+        'action_head': 'wan_flow_matching_action_tf_wan22',
+        'image_resolution_height': 160,
+        'frame_seqlen': None,  # set in config, not CLI
+    },
+}
+
+# Architecture-specific constants.
+_ARCH_PARAMS = {
+    'lora': {
+        'deepspeed_config': 'groot/vla/configs/deepspeed/zero2.json',
+        'save_lora_only': 'true',
+        'learning_rate': 1e-4,
+    },
+    'full': {
+        'deepspeed_config': 'groot/vla/configs/deepspeed/zero2_offload.json',
+        'save_lora_only': 'false',
+        'learning_rate': 1e-5,
+    },
+}
+
 
 def _dreamzero_root():
     return Path(__file__).parents[4] / 'dreamzero'
@@ -16,9 +48,11 @@ def _dreamzero_root():
 
 @cfn.config(
     dreamzero_venv='/.venv/',
+    backbone='wan2.1',
+    train_architecture='lora',
     num_gpus=1,
     max_steps=100,
-    learning_rate=1e-5,
+    learning_rate=None,
     weight_decay=1e-5,
     save_steps=1000,
     batch_size=1,
@@ -34,9 +68,11 @@ def main(
     output_path: str,
     exp_name: str,
     dreamzero_venv: str,
+    backbone: str,
+    train_architecture: str,
     num_gpus: int,
     max_steps: int,
-    learning_rate: float,
+    learning_rate: float | None,
     weight_decay: float,
     save_steps: int,
     batch_size: int,
@@ -47,6 +83,19 @@ def main(
     resume: bool,
     extra_args: list[str],
 ):
+    if backbone not in _BACKBONE_PARAMS:
+        raise ValueError(f'Unknown backbone: {backbone!r}. Choose from {list(_BACKBONE_PARAMS)}')
+    if train_architecture not in _ARCH_PARAMS:
+        raise ValueError(f'Unknown train_architecture: {train_architecture!r}. Choose from {list(_ARCH_PARAMS)}')
+
+    bb = _BACKBONE_PARAMS[backbone]
+    arch = _ARCH_PARAMS[train_architecture]
+
+    if learning_rate is None:
+        learning_rate = arch['learning_rate']
+    if deepspeed is None:
+        deepspeed = arch['deepspeed_config']
+
     root = _dreamzero_root()
     venv = Path(dreamzero_venv)
     torchrun = str(venv / 'bin' / 'torchrun')
@@ -57,18 +106,18 @@ def main(
     output_dir = pos3.sync(output_path + '/' + exp_name, delete_remote=not resume)
     utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])
 
-    # Architecture constants from upstream droid_training.sh.
-    # These define the DreamZero DROID model geometry and must match the pretrained weights.
+    deepspeed_path = str(root / deepspeed) if not Path(deepspeed).is_absolute() else deepspeed
+
     command = [
         torchrun,
         f'--nproc_per_node={num_gpus}',
         'groot/vla/experiment/experiment.py',
-        'data=dreamzero/droid_relative',
+        f'data={bb["data_config"]}',
         f'droid_data_root={dataset_local_path}',
         'model=dreamzero/vla',
-        'model/dreamzero/action_head=wan_flow_matching_action_tf',
+        f'model/dreamzero/action_head={bb["action_head"]}',
         'model/dreamzero/transform=dreamzero_cotrain',
-        'train_architecture=lora',
+        f'train_architecture={train_architecture}',
         f'report_to={"wandb" if os.environ.get("WANDB_API_KEY") else "none"}',
         'wandb_project=dreamzero',
         'num_frames=33',
@@ -78,8 +127,7 @@ def main(
         'num_action_per_block=24',
         'num_state_per_block=1',
         'image_resolution_width=320',
-        'image_resolution_height=176',
-        'frame_seqlen=880',
+        f'image_resolution_height={bb["image_resolution_height"]}',
         'max_chunk_size=4',
         f'per_device_train_batch_size={batch_size}',
         f'gradient_accumulation_steps={gradient_accumulation_steps}',
@@ -89,16 +137,16 @@ def main(
         'tf32=true',
         f'training_args.learning_rate={learning_rate}',
         f'training_args.warmup_ratio={warmup_ratio}',
+        f'training_args.deepspeed={deepspeed_path}',
         f'weight_decay={weight_decay}',
         f'max_steps={max_steps}',
         f'save_steps={save_steps}',
         f'output_dir={output_dir}',
-        'save_lora_only=true',
+        f'save_lora_only={arch["save_lora_only"]}',
         'save_total_limit=10',
     ]
-    if deepspeed is not None:
-        deepspeed_path = str(root / deepspeed) if not Path(deepspeed).is_absolute() else deepspeed
-        command.append(f'training_args.deepspeed={deepspeed_path}')
+    if bb['frame_seqlen'] is not None:
+        command.append(f'frame_seqlen={bb["frame_seqlen"]}')
     command.extend(extra_args)
 
     env = os.environ.copy()
@@ -124,16 +172,73 @@ def main(
 #
 # h100x8: ZeRO-2 shards across 8 GPUs (~12GB per shard), no ZIP64 issue. Full DeepSpeed
 # checkpoints are saved, so resume restores optimizer state exactly.
-h100x1 = main.override(
+
+# --- wan2.1 (14B) presets ---
+wan21_lora_h100x1 = main.override(
+    backbone='wan2.1',
+    train_architecture='lora',
     num_gpus=1,
     batch_size=1,
     gradient_accumulation_steps=8,
-    deepspeed='groot/vla/configs/deepspeed/zero2.json',
     extra_args=['+training_args.save_only_model=true'],
 )
-h100x8 = main.override(
-    num_gpus=8, batch_size=1, gradient_accumulation_steps=1, deepspeed='groot/vla/configs/deepspeed/zero2.json'
+wan21_lora_h100x8 = main.override(
+    backbone='wan2.1', train_architecture='lora', num_gpus=8, batch_size=1, gradient_accumulation_steps=1
 )
+wan21_full_h100x1 = main.override(
+    backbone='wan2.1',
+    train_architecture='full',
+    num_gpus=1,
+    batch_size=1,
+    gradient_accumulation_steps=8,
+    extra_args=['+training_args.save_only_model=true'],
+)
+wan21_full_h100x8 = main.override(
+    backbone='wan2.1', train_architecture='full', num_gpus=8, batch_size=1, gradient_accumulation_steps=1
+)
+
+# --- wan2.2 (5B) presets ---
+wan22_lora_h100x1 = main.override(
+    backbone='wan2.2',
+    train_architecture='lora',
+    num_gpus=1,
+    batch_size=1,
+    gradient_accumulation_steps=8,
+    extra_args=['+training_args.save_only_model=true'],
+)
+wan22_lora_h100x8 = main.override(
+    backbone='wan2.2', train_architecture='lora', num_gpus=8, batch_size=1, gradient_accumulation_steps=1
+)
+wan22_full_h100x1 = main.override(
+    backbone='wan2.2',
+    train_architecture='full',
+    num_gpus=1,
+    batch_size=1,
+    gradient_accumulation_steps=8,
+    extra_args=['+training_args.save_only_model=true'],
+)
+wan22_full_h100x8 = main.override(
+    backbone='wan2.2', train_architecture='full', num_gpus=8, batch_size=1, gradient_accumulation_steps=1
+)
+
+# Legacy aliases
+h100x1 = wan21_lora_h100x1
+h100x8 = wan21_lora_h100x8
+
+_ALL_PRESETS = {
+    'wan21_lora_h100x1': wan21_lora_h100x1,
+    'wan21_lora_h100x8': wan21_lora_h100x8,
+    'wan21_full_h100x1': wan21_full_h100x1,
+    'wan21_full_h100x8': wan21_full_h100x8,
+    'wan22_lora_h100x1': wan22_lora_h100x1,
+    'wan22_lora_h100x8': wan22_lora_h100x8,
+    'wan22_full_h100x1': wan22_full_h100x1,
+    'wan22_full_h100x8': wan22_full_h100x8,
+    # Legacy
+    'h100x1': h100x1,
+    'h100x8': h100x8,
+    'h200x1': h200x1,
+}
 
 # h200x1: Same constraints as h100x1 (ZeRO-2 on 1 GPU can't shard optimizer state), but
 # 141GB HBM3e allows batch_size=2. We halve gradient_accumulation_steps to keep the same
@@ -149,4 +254,4 @@ h200x1 = main.override(
 
 if __name__ == '__main__':
     with pos3.mirror():
-        cfn.cli({'h100x1': h100x1, 'h100x8': h100x8, 'h200x1': h200x1})
+        cfn.cli(_ALL_PRESETS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ hardware = [
     "positronic-franka>=0.3.0; sys_platform == 'linux'",
     # "kortex_api; sys_platform == 'linux'",  # Kinova: disabled, artifactory.kinovaapps.com is unreliable
     "linuxpy",  # For Linux video capture
-    "pinocchio",  # For Kinova
     "placo",
     "pyaudio; sys_platform == 'linux'",  # For SoundSystem
     "pymodbus",  # For grippers
@@ -97,9 +96,6 @@ conflicts = [
         {extra = "lerobot-0-3-3"},
     ],
 ]
-
-[tool.uv.sources.kortex_api]
-url = "https://artifactory.kinovaapps.com/artifactory/generic-local-public/kortex/API/2.7.0/kortex_api-2.7.0.post5-py3-none-any.whl"
 
 [tool.uv.sources.pyzed]
 url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl"


### PR DESCRIPTION
## Summary
- Update pinned DreamZero SHA to `d70a8025` (upstream HEAD)
- Restructure base Dockerfile: heavy pip installs (torch, flash-attn, transformer-engine) before git clone for better layer caching
- Add `backbone` (wan2.1/wan2.2) and `train_architecture` (lora/full) params to `train.py` with 8 presets for all combinations
- Add wan2.2 inference support in `server.py` via backbone-specific DreamZero scripts
- Remove `kortex_api` from dependencies (Kinova driver disabled)

## Test plan
Tested all viable h100x1 configs on Nebius VMs:

**Training** (15 optimizer steps each):
- wan2.1 LoRA: loss=0.504, 18min
- wan2.2 LoRA: loss=1.817, 4.5min
- wan2.2 Full: loss=1.387, 5.6min
- wan2.1 Full: OOM on 196GB RAM (needs 8 GPUs — upstream default)

**Inference** (2 sim_stack episodes each, saved to `s3://inference/dreamzero_update/`):
- wan2.1 LoRA, wan2.2 LoRA, wan2.2 Full — all passed