### PR TITLE
Add `--extra openpi` to openpi-server entrypoint

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -136,7 +136,7 @@ services:
   openpi-server: &openpi-server-common
     <<: *openpi-common
     container_name: openpi-server
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.openpi.server"]
+    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "openpi", "python", "-m", "positronic.vendors.openpi.server"]
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
## Summary
- The openpi-client package was moved to optional dependencies in e406176, but the docker-compose `openpi-server` entrypoint wasn't updated to pass `--extra openpi` to `uv run`, breaking the server with `ModuleNotFoundError: No module named 'openpi_client'`

## Test plan
- Re-run `CACHE_ROOT=/home/vertix docker --context vm-openpi compose -f docker-compose.phail.openpi.yml up` — server should start without import errors