### PR TITLE
Add spoons ablation config and USB-C eval objects

### DIFF
--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -145,3 +145,15 @@ phail_multiple = production.override(**{
     'sampler': balanced,
     'sampler.group_fields': ['task', 'eval.object', 'eval.tote_placement', 'eval.external_camera'],
 })
+
+
+spoons_ablation = production.override(**{
+    'groot.host': 'vm-openpi',
+    'groot.port': 8000,
+    'smolvla.host': 'vm-openpi',
+    'smolvla.port': 8001,
+    'act.host': 'vm-openpi',
+    'act.port': 8002,
+    'sampler': balanced,
+    'sampler.group_fields': ['task', 'eval.object', 'eval.tote_placement', 'eval.external_camera'],
+})

--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -19,7 +19,7 @@ class State(Enum):
 
 UNIFIED_TASK = 'Pick all the items one by one from transparent tote and place them into the large grey tote.'
 
-OBJECTS = ['Towels', 'Wooden spoons', 'Scissors', 'Batteries']
+OBJECTS = ['Towels', 'Wooden spoons', 'Scissors', 'Batteries', 'USB-C Boxes', 'USB-C Cables']
 
 TASKS = [
     UNIFIED_TASK,


### PR DESCRIPTION
## Summary
- Add `spoons_ablation` policy config: routes groot/smolvla/act to `vm-openpi` on ports 8000/8001/8002 (openpi excluded), with the same balanced sampler/group_fields as `phail_multiple`. Enables running ablation experiments on different dataset sizes and on unseen objects.
- Extend eval GUI `OBJECTS` list with `USB-C Boxes` and `USB-C Cables` for unseen-object ablations.

## Test plan
- [x] Launch eval with `--policy=.spoons_ablation` and confirm the three remote policies connect and the balanced sampler runs.
- [x] Confirm the new objects appear in the eval GUI dropdown.