### PR TITLE
Add connect-your-model inference guide

### DIFF
--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -16,31 +16,31 @@ This guide covers:
 
 ## Run a Reference Model
 
-Start an ACT inference server using a public checkpoint trained on the simulated cube stacking task. No GPU or cloud credentials required:
+Start an ACT inference server using a public checkpoint trained on the simulated cube stacking task:
 
 ```bash
 cd docker && docker compose run --rm --service-ports lerobot-0_3_3-server demo
 ```
 
-The server downloads the checkpoint (~505MB) from public storage and starts a WebSocket API on port 8000. Verify it's ready:
+The server downloads the checkpoint (~505MB) and starts a WebSocket API on port 8000. The server requires Docker on Linux. Verify it's ready:
 
 ```bash
 curl http://localhost:8000/api/v1/models
 # {"models": ["050000"]}
 ```
 
-In a separate terminal, run inference in MuJoCo simulation:
+In a separate terminal, run inference in MuJoCo simulation. The inference client runs on Mac or Linux:
 
 ```bash
 uv run positronic-inference sim \
-  --policy=.remote --policy.host=localhost --policy.port=8000
+  --policy=.remote --policy.host=<server-host> --policy.port=8000
 ```
 
-The inference client connects to the server, streams observations from the simulator, and executes the returned actions. You should see the Franka arm attempting to stack cubes.
+The client connects to the server, streams observations from the simulator, and executes the returned action chunks. You should see the Franka arm attempting to stack cubes.
 
 ## Observations and Actions
 
-Every timestep, the inference client sends the current robot state to the server and receives an action back. All messages use [msgpack](https://msgpack.org/) with numpy array support (see [Serialization](#serialization) below).
+Every timestep, the inference client sends the current robot state to the server and receives a chunk of actions back. All messages use [msgpack](https://msgpack.org/) with numpy array support (see [Serialization](#serialization) below).
 
 ### Observations (client to server)
 
@@ -58,18 +58,21 @@ Your server receives all fields. Use what your model needs, ignore the rest.
 
 ### Actions (server to client)
 
-The server returns an action dict (or a list of dicts for action chunks):
+The server returns a list of action dicts (an action chunk). The client executes them sequentially at the configured action frequency:
 
 ```python
-{"result": [{"target_pose": array([...]), "target_grip": array([...])}]}
+{"result": [{"robot_command": {...}, "target_grip": 0.04}, ...]}
 ```
 
-| Field | Type | Shape | Description |
-|-------|------|-------|-------------|
-| `target_pose` | float32 | (7,) | Target EE pose: x, y, z, qx, qy, qz, qw |
-| `target_grip` | float32 | (1,) | Target gripper opening |
+The `robot_command` field specifies the control mode:
 
-Return a single action dict for one-step policies, or a list for multi-step action chunks (the client executes them sequentially at the configured action frequency).
+| Command type | Fields | Description |
+|--------------|--------|-------------|
+| `cartesian_pos` | `pose`: float32 (12,) | Target EE pose (position + rotation matrix) |
+| `joint_pos` | `positions`: float32 (7,) | Target joint angles (radians) |
+| `joint_delta` | `velocities`: float32 (7,) | Joint velocity command |
+
+The codec determines which command type the model produces (see below).
 
 ## Codecs: State and Action Representations
 
@@ -159,11 +162,14 @@ class MyPolicy(Policy):
         images = obs['exterior_image']
         ee = obs['ee_pose']
 
-        # Run your model
-        predicted_pose = self._model.predict(images, ee)
+        # Run your model, get a list of predicted poses
+        predicted_poses = self._model.predict(images, ee)
 
-        # Return raw action format
-        return {'target_pose': predicted_pose, 'target_grip': obs['grip']}
+        # Return action chunk: list of commands
+        return [
+            {'robot_command': {'type': 'cartesian_pos', 'pose': pose}, 'target_grip': 0.04}
+            for pose in predicted_poses
+        ]
 
     def reset(self, context=None):
         pass

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -16,15 +16,13 @@ This guide covers:
 
 ## Run a Reference Model
 
-Start an ACT inference server using a public checkpoint trained on the simulated cube stacking task:
+Start an ACT inference server using a public checkpoint trained on the simulated cube stacking task. No GPU or cloud credentials required:
 
 ```bash
-cd docker && docker compose run --rm --service-ports lerobot-0_3_3-server \
-  serve \
-  --checkpoints_dir=s3://positronic-public/checkpoints/sim_stack_cubes/act/
+cd docker && docker compose run --rm --service-ports lerobot-0_3_3-server demo
 ```
 
-The server downloads the checkpoint (~505MB) and starts a WebSocket API on port 8000. Verify it's ready:
+The server downloads the checkpoint (~505MB) from public storage and starts a WebSocket API on port 8000. Verify it's ready:
 
 ```bash
 curl http://localhost:8000/api/v1/models

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -1,0 +1,228 @@
+# Connect Your Model
+
+Run your policy against Positronic's simulation environment, or connect it for real-robot evaluation on [PhAIL](https://phail.ai).
+
+This guide covers:
+
+1. Running a reference model to see the system end-to-end
+2. Understanding observations, actions, and codecs
+3. Implementing your own inference server
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- [Docker](https://www.docker.com/)
+- Clone the repo: `git clone git@github.com:Positronic-Robotics/positronic.git && cd positronic`
+
+## Run a Reference Model
+
+Start an ACT inference server using a public checkpoint trained on the simulated cube stacking task:
+
+```bash
+cd docker && docker compose run --rm --service-ports lerobot-0_3_3-server \
+  serve \
+  --checkpoints_dir=s3://positronic-public/checkpoints/sim_stack_cubes/act/
+```
+
+The server downloads the checkpoint (~505MB) and starts a WebSocket API on port 8000. Verify it's ready:
+
+```bash
+curl http://localhost:8000/api/v1/models
+# {"models": ["050000"]}
+```
+
+In a separate terminal, run inference in MuJoCo simulation:
+
+```bash
+uv run positronic-inference sim \
+  --policy=.remote --policy.host=localhost --policy.port=8000
+```
+
+The inference client connects to the server, streams observations from the simulator, and executes the returned actions. You should see the Franka arm attempting to stack cubes.
+
+## Observations and Actions
+
+Every timestep, the inference client sends the current robot state to the server and receives an action back. All messages use [msgpack](https://msgpack.org/) with numpy array support (see [Serialization](#serialization) below).
+
+### Observations (client to server)
+
+The client sends the full raw robot state as a dict:
+
+| Field | Type | Shape | Description |
+|-------|------|-------|-------------|
+| `ee_pose` | float32 | (7,) | End-effector pose: x, y, z, qx, qy, qz, qw |
+| `joints` | float32 | (7,) | Joint positions (radians) |
+| `grip` | float32 | (1,) | Gripper opening |
+| `wrist_image` | uint8 | (H, W, 3) | Wrist camera RGB |
+| `exterior_image` | uint8 | (H, W, 3) | External camera RGB |
+
+Your server receives all fields. Use what your model needs, ignore the rest.
+
+### Actions (server to client)
+
+The server returns an action dict (or a list of dicts for action chunks):
+
+```python
+{"result": [{"target_pose": array([...]), "target_grip": array([...])}]}
+```
+
+| Field | Type | Shape | Description |
+|-------|------|-------|-------------|
+| `target_pose` | float32 | (7,) | Target EE pose: x, y, z, qx, qy, qz, qw |
+| `target_grip` | float32 | (1,) | Target gripper opening |
+
+Return a single action dict for one-step policies, or a list for multi-step action chunks (the client executes them sequentially at the configured action frequency).
+
+## Codecs: State and Action Representations
+
+Different models expect different input/output formats. Some use end-effector pose, others use joint positions. Some output absolute targets, others output deltas. Positronic uses **codecs** to handle this translation.
+
+A codec sits between the wire protocol and the model:
+
+```
+Raw observation (wire) --> codec.encode() --> model input
+Model output           --> codec.decode() --> raw action (wire)
+```
+
+The wire format (what your server receives and returns) is always the raw robot state described above. If you use Positronic's built-in servers, the codec is configured at server startup:
+
+```bash
+# EE pose observation, absolute position actions
+docker compose run --rm --service-ports lerobot-0_3_3-server serve \
+  --checkpoints_dir=... \
+  --codec=@positronic.vendors.lerobot_0_3_3.codecs.ee
+
+# Joint position observation
+docker compose run --rm --service-ports lerobot-0_3_3-server serve \
+  --checkpoints_dir=... \
+  --codec=@positronic.vendors.lerobot_0_3_3.codecs.joints
+```
+
+If you implement your own server, you handle this transformation yourself: pick the fields you need from the raw observation, and return actions in the raw format.
+
+### Common representations
+
+| Observation space | What the model sees | When to use |
+|-------------------|--------------------|----|
+| EE pose (7D) + grip + images | Position and orientation of the end-effector | Most common; sufficient for most manipulation tasks |
+| EE pose + joint positions (7D) + grip + images | Both EE and joint state | When joint configuration matters (redundancy resolution, singularity avoidance) |
+| Joint positions (7D) + grip + images | Joint angles only | Joint-space policies; no EE computation needed |
+
+| Action space | What the model outputs | When to use |
+|--------------|----------------------|-----|
+| Absolute EE position (7D) + grip | Target pose the robot should move to | Default; works with position controllers |
+| EE delta + grip | Displacement from current pose | Relative policies; smaller action space |
+| Joint positions (7D) + grip | Target joint angles | Direct joint control; bypasses IK |
+
+All built-in codecs are documented in the [Codecs Guide](codecs.md) with vendor-specific variants.
+
+## Implement Your Own Server
+
+To connect a custom model, implement a WebSocket server that speaks Positronic's Protocol v1.
+
+### Endpoints
+
+Your server must expose:
+
+| Endpoint | Type | Description |
+|----------|------|-------------|
+| `GET /api/v1/models` | HTTP | Returns `{"models": ["model_a", "model_b"]}` |
+| `WS /api/v1/session` | WebSocket | Inference session with default model |
+| `WS /api/v1/session/{model_id}` | WebSocket | Inference session with specific model |
+
+### Session Flow
+
+1. Client connects via WebSocket
+2. Server sends status messages while loading (optional but recommended for slow loads):
+   ```python
+   {"status": "loading", "message": "Loading model..."}
+   ```
+3. Server sends ready with metadata:
+   ```python
+   {"status": "ready", "meta": {"type": "my_model", "checkpoint_id": "v1"}}
+   ```
+4. Inference loop: client sends observation, server returns action, repeat until disconnect
+
+### Using Positronic's Server Base Class
+
+The simplest way is to subclass `InferenceServer` and provide a policy:
+
+```python
+from positronic.offboard.basic_server import InferenceServer
+from positronic.policy import Policy
+
+class MyPolicy(Policy):
+    def __init__(self, model):
+        self._model = model
+
+    def select_action(self, obs):
+        # obs contains: ee_pose, joints, grip, wrist_image, exterior_image
+        # Pick what your model needs:
+        images = obs['exterior_image']
+        ee = obs['ee_pose']
+
+        # Run your model
+        predicted_pose = self._model.predict(images, ee)
+
+        # Return raw action format
+        return {'target_pose': predicted_pose, 'target_grip': obs['grip']}
+
+    def reset(self, context=None):
+        pass
+
+    @property
+    def meta(self):
+        return {'type': 'my_model'}
+
+# Create server with policy registry
+server = InferenceServer(
+    policy_registry={'default': lambda: MyPolicy(load_my_model())},
+    host='0.0.0.0',
+    port=8000,
+)
+server.serve()
+```
+
+Test it:
+
+```bash
+uv run positronic-inference sim \
+  --policy=.remote --policy.host=localhost --policy.port=8000
+```
+
+### Standalone Implementation
+
+If you prefer not to depend on Positronic for the server, implement the WebSocket protocol directly. The key requirement is msgpack serialization with numpy support (see below).
+
+### Serialization
+
+All messages use msgpack. Numpy arrays are encoded with a custom extension:
+
+```python
+# numpy array -> msgpack
+{
+    b"__ndarray__": True,
+    b"data": array.tobytes(),   # raw bytes
+    b"dtype": str(array.dtype), # e.g. "<f4"
+    b"shape": array.shape       # tuple
+}
+```
+
+Positronic provides `serialise()` and `deserialise()` in `positronic.utils.serialization` that handle this automatically:
+
+```python
+from positronic.utils.serialization import serialise, deserialise
+
+# Server-side WebSocket handler
+async for message in websocket.iter_bytes():
+    obs = deserialise(message)           # dict with numpy arrays
+    action = policy.select_action(obs)
+    await websocket.send_bytes(serialise({"result": action}))
+```
+
+## See Also
+
+- [Inference Guide](inference.md) – local and remote inference patterns
+- [Codecs Guide](codecs.md) – all available codecs by vendor
+- [Offboard Protocol](../positronic/offboard/README.md) – full Protocol v1 specification
+- [Training Workflow](training-workflow.md) – training with public datasets

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -120,13 +120,18 @@ sim_stack = main.override(
     checkpoints_dir='s3://checkpoints/sim_stack/lerobot/230226-ee/',
     recording_dir='s3://inference/sim_stack/server_recordings/lerobot/230226-ee/',
 )
-demo = main.override(checkpoints_dir='s3://positronic-public/checkpoints/sim_stack_cubes/act/')
+_DEMO_CHECKPOINT = 's3://positronic-public/checkpoints/sim_stack_cubes/act/'
+
+
+@cfn.config(policy_factory=act, codec=lerobot_codecs.ee, checkpoint=None, port=8000, host='0.0.0.0')
+def demo(policy_factory, checkpoint, codec, port, host):
+    from positronic.cfg.ds import PUBLIC
+
+    checkpoints_dir = str(pos3.download(_DEMO_CHECKPOINT, profile=PUBLIC))
+    InferenceServer(policy_factory, codec, checkpoints_dir, checkpoint, host=host, port=port).serve()
 
 
 if __name__ == '__main__':
     init_logging()
-    pos3.register_profile(
-        'positronic-public', endpoint='https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1'
-    )
     with pos3.mirror():
         cfn.cli({'serve': main, 'phail': phail, 'sim_stack': sim_stack, 'demo': demo})

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -120,9 +120,13 @@ sim_stack = main.override(
     checkpoints_dir='s3://checkpoints/sim_stack/lerobot/230226-ee/',
     recording_dir='s3://inference/sim_stack/server_recordings/lerobot/230226-ee/',
 )
+demo = main.override(checkpoints_dir='s3://positronic-public/checkpoints/sim_stack_cubes/act/')
 
 
 if __name__ == '__main__':
     init_logging()
+    pos3.register_profile(
+        'positronic-public', endpoint='https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1'
+    )
     with pos3.mirror():
-        cfn.cli({'serve': main, 'phail': phail, 'sim_stack': sim_stack})
+        cfn.cli({'serve': main, 'phail': phail, 'sim_stack': sim_stack, 'demo': demo})


### PR DESCRIPTION
## Summary
- New `docs/connect-your-model.md` guide for model developers to connect their policies to Positronic's inference stack
- Published ACT checkpoint to `s3://positronic-public/checkpoints/sim_stack_cubes/act/` (~505MB)
- Covers: running a reference model via server, observations/actions/codecs, implementing a custom Protocol v1 server

## Test plan
- [x] Public checkpoint uploaded and verified on S3
- [x] Server starts and loads checkpoint from public S3
- [x] End-to-end sim inference works against the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)