### PR TITLE
Fix timed driver episode recording

### DIFF
--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -33,10 +33,19 @@ In a separate terminal, run inference in MuJoCo simulation. The inference client
 
 ```bash
 uv run positronic-inference sim \
-  --policy=.remote --policy.host=<server-host> --policy.port=8000
+  --policy=.remote --policy.host=<server-host> --policy.port=8000 \
+  --driver.show_gui=True \
+  --output_dir=~/datasets/demo_run
 ```
 
-The client connects to the server, streams observations from the simulator, and executes the returned action chunks. You should see the Franka arm attempting to stack cubes.
+The MuJoCo window shows the Franka arm executing the policy in real time. The `--output_dir` flag records all episodes (robot state, camera feeds, actions) for later review.
+
+Browse recorded episodes with:
+
+```bash
+uv run positronic-server --dataset.path=~/datasets/demo_run --port=5001
+# Open http://localhost:5001
+```
 
 ## Observations and Actions
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -64,7 +64,7 @@ class TimedDriver(pimm.ControlSystem):
                 meta['task'] = self.task
             self.directives.emit(Directive.RUN(**meta))
             yield pimm.Sleep(self.simulation_time)
-            self.directives.emit(Directive.STOP())
+            self.directives.emit(Directive.FINISH())
             yield pimm.Sleep(0.5)
 
 


### PR DESCRIPTION
## Summary
- Fix: TimedDriver emitted `Directive.STOP()` which mapped to `SUSPEND` (pause without flush). Changed to `Directive.FINISH()` which properly finalizes episodes and writes data to disk.
- Doc: add `--driver.show_gui` and `--output_dir` flags to connect-your-model guide, plus `positronic-server` review instructions.

## Test plan
- [x] Ran inference with `--output_dir`, verified episode data is written
- [x] Reviewed recorded episodes with `positronic-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)