### PR TITLE
Fix `CLAUDE.md` symlink broken by repo root declutter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+docs/AGENTS.md


### PR DESCRIPTION
## Summary
- Top-level `CLAUDE.md` was a symlink to `AGENTS.md`. PR #379 moved `AGENTS.md` into `docs/`, leaving `CLAUDE.md` as a broken symlink.
- Repoint `CLAUDE.md` → `docs/AGENTS.md` so Claude Code's repo-root discovery keeps working.

## Test plan
- `readlink CLAUDE.md` → `docs/AGENTS.md`
- `cat CLAUDE.md` resolves and shows the contributor guide.