### PR TITLE
Add Nebius serverless workflow for vendor training and dataset conversion and serving

### DIFF
--- a/positronic/cfg/eval.py
+++ b/positronic/cfg/eval.py
@@ -755,8 +755,28 @@ def _prod_predicate(ep):
     return ep.get('variant', '') == PROD_VARIANTS[model]
 
 
+# AUDIT-CORRECTED EPISODES — manual edits to static.json on both private and
+# public S3 (audit captured wrong eval.* fields; fixed in place rather than
+# adding a transform). Re-running release_phail.py inference will OVERWRITE
+# these corrections unless the same edit is re-applied. Keep this list:
+#   - public 000000000000/000000000338 (private 100326/000000000000/000000000021):
+#     eval.successful_items 0 → 2 (audit missed 2 successful placements; ACT/Scissors).
+#   - public 000000000000/000000000285 (private 050326/000000000000/000000000015):
+#     eval.object 'Towels' → 'Wooden spoons' (operator selected wrong task at record time;
+#     content is wooden spoons; task field intentionally left as recorded).
 phail_inference_prod = base_cfg.filter_ds.override(dataset=phail_inference_release, predicate=_prod_predicate)
 
+# TELEOP HEURISTIC OVER-COUNTS — calculate_units (line ~486) returns
+# FIXED_ITEM_COUNTS[BATTERIES_TASK]=8 for every Batteries teleop episode, but
+# manual review found episodes that actually contain only 7 batteries. The
+# heuristic does not look inside the video; it just trusts the task label.
+# eval.successful_items / eval.total_items end up at 8/8 ('Success') instead
+# of 7/7, so totals across the teleop split are inflated. Documented for now,
+# not yet patched — see EPISODE_ITEM_COUNT_OVERRIDES if/when added.
+#   - public training 000000000000/000000000380 (private raw/droid/batteries/310126/000000000000/000000000001):
+#     manual count = 7 batteries, heuristic = 8.
+#   - public training 000000000000/000000000408 (private raw/droid/batteries/310126/000000000000/000000000037):
+#     manual count = 7 batteries, heuristic = 8.
 phail_teleop_release = base_cfg.transform.override(
     base=_teleop_with_items,
     transforms=[

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -123,11 +123,19 @@ class PolicyClient:
 class Gr00tSubprocess:
     """Manages the gr00t ZMQ server subprocess."""
 
-    def __init__(self, checkpoint_dir: str, modality_config_path: str, groot_venv_path: str, zmq_port: int = 5555):
+    def __init__(
+        self,
+        checkpoint_dir: str,
+        modality_config_path: str,
+        groot_venv_path: str,
+        zmq_port: int = 5555,
+        ready_timeout: float = 120.0,
+    ):
         self.checkpoint_dir = checkpoint_dir
         self.modality_config_path = modality_config_path
         self.groot_venv_path = groot_venv_path
         self.zmq_port = zmq_port
+        self.ready_timeout = ready_timeout
         self.process: subprocess.Popen | None = None
         self._client: PolicyClient | None = None
 
@@ -155,7 +163,9 @@ class Gr00tSubprocess:
         exit_code = self.process.poll()
         return exit_code is not None, exit_code
 
-    def _wait_for_ready(self, timeout: float = 120.0, poll_interval: float = 1.0):
+    def _wait_for_ready(self, timeout: float | None = None, poll_interval: float = 1.0):
+        if timeout is None:
+            timeout = self.ready_timeout
         """Wait for the gr00t server to be ready by polling with ping."""
         client = PolicyClient(host='127.0.0.1', port=self.zmq_port, timeout_ms=2000)
         start_time = time.time()
@@ -202,7 +212,7 @@ class Gr00tSubprocess:
                 check_crashed=self._check_crashed,
                 description='GR00T subprocess',
                 on_progress=on_progress,
-                max_wait=120.0,
+                max_wait=self.ready_timeout,
             )
         finally:
             client.close()
@@ -267,6 +277,7 @@ class InferenceServer(VendorServer):
         port: int = 8000,
         zmq_port: int = 5555,
         recording_dir: str | None = None,
+        ready_timeout: float = 120.0,
     ):
         super().__init__(codec=codec, host=host, port=port, recording_dir=recording_dir)
         self.checkpoints_dir = checkpoints_dir.rstrip('/')
@@ -275,6 +286,7 @@ class InferenceServer(VendorServer):
         self.modality_config_path = MODALITY_CONFIGS.get(modality_config, modality_config)
         self.groot_venv_path = groot_venv_path
         self.zmq_port = zmq_port
+        self.ready_timeout = ready_timeout
 
         self.subprocess: Gr00tSubprocess | None = None
         self.current_checkpoint_id: str | None = None
@@ -332,6 +344,7 @@ class InferenceServer(VendorServer):
             modality_config_path=self.modality_config_path,
             groot_venv_path=self.groot_venv_path,
             zmq_port=self.zmq_port,
+            ready_timeout=self.ready_timeout,
         )
         await subprocess_obj.start_async(on_progress=send_progress)
 
@@ -362,6 +375,7 @@ class InferenceServer(VendorServer):
     groot_venv_path='/.venv/',
     modality_config='ee',
     recording_dir=None,
+    ready_timeout=120.0,
 )
 def server(
     codec: Codec,
@@ -371,6 +385,7 @@ def server(
     groot_venv_path: str,
     modality_config: str,
     recording_dir: str | None,
+    ready_timeout: float,
 ):
     """Starts the GR00T inference server with encoding/decoding."""
 
@@ -383,6 +398,7 @@ def server(
             groot_venv_path=groot_venv_path,
             port=port,
             recording_dir=recording_dir,
+            ready_timeout=ready_timeout,
         ).serve()
 
 

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -16,8 +16,11 @@ follow in an upcoming change.
 
 ## One-time setup
 
-Create three MysteryBox secrets that the training job will reference by name. AWS keys are read
-from your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`.
+Create four MysteryBox secrets that the jobs will reference by name. AWS keys are read from
+your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`. The first three are
+single-key payloads consumed via `--env-secret`. The fourth is a two-key payload consumed by
+`--volume` for Mountpoint-S3 authentication (Nebius requires the keys to be named
+`S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`).
 
 ```bash
 PARENT_ID=project-e00f38wexevrr52b8j  # adjust to your own project
@@ -46,6 +49,15 @@ nebius mysterybox secret create \
   --secret-version-payload "$(jq -nc \
     --arg v "$(grep -E '^WANDB_API_KEY=' docker/.env.wandb | cut -d= -f2-)" \
     '[{key:"WANDB_API_KEY",string_value:$v}]')"
+
+nebius mysterybox secret create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-s3-creds \
+  --description "S3 credentials for serverless --volume Mountpoint-S3 mounts" \
+  --secret-version-payload "$(jq -nc \
+    --arg k "$(aws configure get aws_access_key_id --profile "$AWS_PROFILE_FOR_S3")" \
+    --arg s "$(aws configure get aws_secret_access_key --profile "$AWS_PROFILE_FOR_S3")" \
+    '[{key:"S3_ACCESS_KEY_ID",string_value:$k},{key:"S3_SECRET_ACCESS_KEY",string_value:$s}]')"
 ```
 
 The names matter — `train.sh` references the secrets by name. If a secret with one of these
@@ -82,7 +94,11 @@ The output path is what you pass to `train.sh --input_path=...` next.
 ## Train ACT
 
 `train.sh` runs `python -m positronic.vendors.lerobot_0_3_3.train` inside a Nebius Job on H100
-(`gpu-h100-sxm`, `1gpu-16vcpu-200gb`).
+(`gpu-h100-sxm`, `1gpu-16vcpu-200gb`). The bucket from `--input_path=s3://...` is mounted with
+[Mountpoint-S3](https://docs.nebius.com/object-storage/interfaces/mountpoint-s3) at `/mnt/input`
+(read-only) so the dataset is streamed on demand instead of being downloaded into local cache.
+`--output_dir` stays an `s3://` URL handled by `pos3` — LeRobot's checkpoint saver uses
+symlinks, which Mountpoint-S3 does not support.
 
 Example: train ACT on the converted `sim_stack_cubes` dataset from the previous step:
 

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -68,16 +68,18 @@ secret with one of these names already exists, the create call fails; skip it.
 ## Convert a Positronic dataset to LeRobot 0.3.3 format
 
 ACT (and SmolVLA, GR00T, OpenPI) trains on the LeRobot 0.3.3 dataset format. `convert.sh` runs
-`python -m positronic.vendors.lerobot_0_3_3.to_lerobot convert` inside a Nebius Job on CPU
+`python -m positronic.vendors.<vendor>.to_lerobot convert` inside a Nebius Job on CPU
 (`cpu-e2`, `8vcpu-32gb`). Conversion is video-encoding heavy — CPU is the right resource; a GPU
-would be wasted.
+would be wasted. Supported vendors: `lerobot_0_3_3` (used by ACT) and `lerobot` (used by SmolVLA
+and other lerobot 0.4.x policies). OpenPI and GR00T have no converter of their own — they read
+the `lerobot_0_3_3` output directly.
 
 Example: convert the public [`sim_stack_cubes`](../../positronic/cfg/ds/phail.py) dataset (317
 cube-stacking episodes, hosted on Positronic's public S3 bucket) into a LeRobot dataset on your
 own bucket:
 
 ```bash
-bash workflows/nebius/convert.sh \
+bash workflows/nebius/convert.sh lerobot_0_3_3 \
   --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
   --dataset.codec=@positronic.vendors.lerobot_0_3_3.codecs.ee \
   --output_dir=s3://<your-bucket>/sim_stack_cubes_lerobot/
@@ -93,25 +95,32 @@ The output is a standard LeRobot 0.3.3 layout — `data/`, `videos/`, `meta/{inf
 episodes_stats,tasks}.jsonl`, plus a `run_metadata_*.yaml` capturing the conversion code state.
 The output path is what you pass to `train.sh --input_path=...` next.
 
-## Train ACT
+## Train
 
-`train.sh` runs `python -m positronic.vendors.lerobot_0_3_3.train` inside a Nebius Job on H100
-(`gpu-h100-sxm`, `1gpu-16vcpu-200gb`). The bucket from `--input_path=s3://...` is mounted with
+`train.sh` runs `python -m positronic.vendors.<vendor>.train` inside a Nebius Job on H100
+(`gpu-h100-sxm`, `1gpu-16vcpu-200gb`). Supported vendors: `lerobot_0_3_3` (ACT), `lerobot`
+(SmolVLA), `openpi`, `gr00t`. The vendor selects the container image and `uv` extras — the rest
+of the job spec (preset, secrets, S3 endpoint, mount) is identical.
+
+The bucket from `--input_path=s3://...` is mounted with
 [Mountpoint-S3](https://docs.nebius.com/object-storage/interfaces/mountpoint-s3) at `/mnt/input`
 (read-only) so the dataset is streamed on demand instead of being downloaded into local cache.
-`--output_dir` stays an `s3://` URL handled by `pos3` — LeRobot's checkpoint saver uses
+`--output_dir` stays an `s3://` URL handled by `pos3` — vendor checkpoint savers tend to use
 symlinks, which Mountpoint-S3 does not support.
 
 Example: train ACT on the converted `sim_stack_cubes` dataset from the previous step:
 
 ```bash
-bash workflows/nebius/train.sh \
+bash workflows/nebius/train.sh lerobot_0_3_3 \
   --input_path=s3://<your-bucket>/sim_stack_cubes_lerobot/ \
   --exp_name=act_sim_stack_v1 \
   --output_dir=s3://<your-bucket>/checkpoints/lerobot/ \
   --num_train_steps=50000 \
   --save_freq=10000
 ```
+
+Swap `lerobot_0_3_3` for `lerobot`, `openpi`, or `gr00t` to train other policies on the same
+dataset; remaining flags forward to that vendor's `train` CLI.
 
 The CLI prints the new job ID and useful follow-up commands:
 
@@ -137,30 +146,48 @@ When the job state reaches `COMPLETED`, the checkpoint structure mirrors a local
 aws s3 ls s3://<your-bucket>/checkpoints/lerobot/<exp_name>/ --recursive
 ```
 
-Expected layout: `checkpoints/<step>/pretrained_model/{config.json,model.safetensors,...}`,
+Expected ACT layout: `checkpoints/<step>/pretrained_model/{config.json,model.safetensors,...}`,
 `checkpoints/<step>/training_state/...`, a `run_metadata_*.yaml` capturing the code state, and
-an empty `wandb/` placeholder. Live WandB metrics flow to your account directly via the API
-key — they aren't synced to S3.
+an empty `wandb/` placeholder. SmolVLA matches the same layout; OpenPI and GR00T use their own
+checkpoint shapes (see each vendor's README under `positronic/vendors/`). Live WandB metrics
+flow to your account directly via the API key — they aren't synced to S3.
 
 ## Serve a checkpoint as an HTTP endpoint
 
 `serve.sh` creates a [Nebius Serverless Endpoint](https://docs.nebius.com/serverless/endpoints/manage)
-running `python -m positronic.vendors.lerobot_0_3_3.server` on H100, with a public static IP on
+running `python -m positronic.vendors.<vendor>.server` on H100, with a public static IP on
 port 8000. Endpoints don't have managed DNS yet, so the IP is the contact address — it's stable
-across endpoint stop/start, but new endpoints get new IPs.
+across endpoint stop/start, but new endpoints get new IPs. Supported vendors:
+`lerobot_0_3_3`, `lerobot`, `openpi`, `gr00t`.
 
-Take a unique endpoint name as the first argument; remaining arguments forward to the server CLI.
-Example using the public ACT demo checkpoint at `s3://positronic-public/checkpoints/sim_stack_cubes/act/`:
+Take a vendor and a unique endpoint name as the first two arguments; remaining arguments forward
+to the server CLI. Example using the public ACT demo checkpoint at
+`s3://positronic-public/checkpoints/sim_stack_cubes/act/` (no S3 credentials needed inside the
+container — the `demo` subcommand is `lerobot_0_3_3`-only and reads anonymously):
 
 ```bash
-bash workflows/nebius/serve.sh my-act-demo demo
+bash workflows/nebius/serve.sh lerobot_0_3_3 my-act-demo demo
 ```
 
 Or against your own trained checkpoint:
 
 ```bash
-bash workflows/nebius/serve.sh act-server serve \
+bash workflows/nebius/serve.sh lerobot_0_3_3 act-server serve \
   --checkpoints_dir=s3://<your-bucket>/checkpoints/lerobot/<exp_name>/
+```
+
+Same shape for the other vendors — replace the vendor token and point `--checkpoints_dir` at the
+matching checkpoint:
+
+```bash
+bash workflows/nebius/serve.sh lerobot smolvla-server serve \
+  --checkpoints_dir=s3://<your-bucket>/checkpoints/smolvla/<exp_name>/
+
+bash workflows/nebius/serve.sh openpi pi-server serve \
+  --checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/
+
+bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \
+  --checkpoints_dir=s3://<your-bucket>/checkpoints/groot/<exp_name>/
 ```
 
 `serve.sh` blocks until the public IP is allocated (typically <1 min), then prints a banner with
@@ -215,5 +242,13 @@ project:
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
 
-Other operational settings (image, platform/preset, MysteryBox secret names, S3 endpoint URL,
-region) are hardcoded — change them by editing the script directly.
+Other operational settings (platform/preset, MysteryBox secret names, S3 endpoint URL, region)
+are hardcoded — change them by editing the script directly. The vendor positional arg selects
+the container image and `uv` extras:
+
+| Vendor | Image | `uv` extra |
+|---|---|---|
+| `lerobot_0_3_3` (ACT) | `positro/positronic` | `--extra lerobot_0_3_3` |
+| `lerobot` (SmolVLA) | `positro/positronic` | `--extra lerobot` |
+| `openpi` | `positro/openpi` | _(none — `/openpi` is co-installed)_ |
+| `gr00t` | `positro/gr00t` | _(none — `/gr00t` is co-installed)_ |

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -1,0 +1,155 @@
+# Nebius Serverless Workflow
+
+Run Positronic training on [Nebius Serverless Jobs](https://docs.nebius.com/serverless/jobs/manage)
+instead of provisioning a GPU VM. Same containers, same training scripts, no VM lifecycle to
+manage and no idle compute cost.
+
+This page mirrors **Steps 1 (Convert) and 2 (Train)** of
+[docs/training-workflow.md](../../docs/training-workflow.md). Step 3 (inference serving) will
+follow in an upcoming change.
+
+## Prerequisites
+
+- Nebius CLI v0.12.209 or newer, authenticated to your project
+- Read access to your input dataset bucket and write access to your checkpoint output bucket
+- AWS access key, AWS secret key, and a Weights & Biases API key
+
+## One-time setup
+
+Create three MysteryBox secrets that the training job will reference by name. AWS keys are read
+from your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`.
+
+```bash
+PARENT_ID=project-e00f38wexevrr52b8j  # adjust to your own project
+AWS_PROFILE_FOR_S3=default            # adjust if your S3 profile isn't `default`
+
+nebius mysterybox secret create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-aws-access-key-id \
+  --description "AWS access key for serverless training jobs" \
+  --secret-version-payload "$(jq -nc \
+    --arg v "$(aws configure get aws_access_key_id --profile "$AWS_PROFILE_FOR_S3")" \
+    '[{key:"AWS_ACCESS_KEY_ID",string_value:$v}]')"
+
+nebius mysterybox secret create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-aws-secret-access-key \
+  --description "AWS secret key for serverless training jobs" \
+  --secret-version-payload "$(jq -nc \
+    --arg v "$(aws configure get aws_secret_access_key --profile "$AWS_PROFILE_FOR_S3")" \
+    '[{key:"AWS_SECRET_ACCESS_KEY",string_value:$v}]')"
+
+nebius mysterybox secret create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-wandb-api-key \
+  --description "WandB API key for serverless training jobs" \
+  --secret-version-payload "$(jq -nc \
+    --arg v "$(grep -E '^WANDB_API_KEY=' docker/.env.wandb | cut -d= -f2-)" \
+    '[{key:"WANDB_API_KEY",string_value:$v}]')"
+```
+
+The names matter — `train.sh` references the secrets by name. If a secret with one of these
+names already exists, the create call fails; skip it.
+
+## Convert a Positronic dataset to LeRobot 0.3.3 format
+
+ACT (and SmolVLA, GR00T, OpenPI) trains on the LeRobot 0.3.3 dataset format. `convert.sh` runs
+`python -m positronic.vendors.lerobot_0_3_3.to_lerobot convert` inside a Nebius Job on CPU
+(`cpu-e2`, `8vcpu-32gb`). Conversion is video-encoding heavy — CPU is the right resource; a GPU
+would be wasted.
+
+Example: convert the public [`sim_stack_cubes`](../../positronic/cfg/ds/phail.py) dataset (317
+cube-stacking episodes, hosted on Positronic's public S3 bucket) into a LeRobot dataset on your
+own bucket:
+
+```bash
+bash workflows/nebius/convert.sh \
+  --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
+  --dataset.codec=@positronic.vendors.lerobot_0_3_3.codecs.ee \
+  --output_dir=s3://<your-bucket>/sim_stack_cubes_lerobot/
+```
+
+The job reads from `s3://positronic-public/...` anonymously — the dataset's `PUBLIC` profile in
+[`positronic/cfg/ds/__init__.py`](../../positronic/cfg/ds/__init__.py) opts into unauthenticated
+S3 access, so no extra credentials are needed for the read side. The write side uses the AWS
+keys you stored in MysteryBox. Wall-clock for `sim_stack_cubes` is ~25 min (~7 min cold start,
+~13 min processing + video encoding, seconds for upload).
+
+The output is a standard LeRobot 0.3.3 layout — `data/`, `videos/`, `meta/{info,episodes,
+episodes_stats,tasks}.jsonl`, plus a `run_metadata_*.yaml` capturing the conversion code state.
+The output path is what you pass to `train.sh --input_path=...` next.
+
+## Train ACT
+
+`train.sh` runs `python -m positronic.vendors.lerobot_0_3_3.train` inside a Nebius Job on H100
+(`gpu-h100-sxm`, `1gpu-16vcpu-200gb`).
+
+Example: train ACT on the converted `sim_stack_cubes` dataset from the previous step:
+
+```bash
+bash workflows/nebius/train.sh \
+  --input_path=s3://<your-bucket>/sim_stack_cubes_lerobot/ \
+  --exp_name=act_sim_stack_v1 \
+  --output_dir=s3://<your-bucket>/checkpoints/lerobot/ \
+  --num_train_steps=50000 \
+  --save_freq=10000
+```
+
+The CLI prints the new job ID and useful follow-up commands:
+
+```
+resource_id: aijob-e00...
+status: {}
+
+Useful Commands
+  • To stream job logs:  nebius ai job logs aijob-e00... --follow
+  • To view job details: nebius ai job get aijob-e00...
+  ...
+```
+
+The job stays in `PROVISIONING`/`STARTING` for ~10 min while the image pulls and the Python
+environment resolves inside the container, then runs the actual training. Cost scales with
+total wall clock — the cold-start fraction shrinks for longer runs.
+
+## Verifying the run
+
+When the job state reaches `COMPLETED`, the checkpoint structure mirrors a local run:
+
+```bash
+aws s3 ls s3://<your-bucket>/checkpoints/lerobot/<exp_name>/ --recursive
+```
+
+Expected layout: `checkpoints/<step>/pretrained_model/{config.json,model.safetensors,...}`,
+`checkpoints/<step>/training_state/...`, a `run_metadata_*.yaml` capturing the code state, and
+an empty `wandb/` placeholder. Live WandB metrics flow to your account directly via the API
+key — they aren't synced to S3.
+
+## What changed vs. running on a VM
+
+| Concern | VM flow | Serverless Job |
+|---|---|---|
+| First-run setup | provision VM, install drivers, configure SSH/network, mount AWS credentials | three `nebius mysterybox secret create` calls |
+| Per-run lifecycle | boot VM → SSH → `docker compose run` → stop VM | `bash train.sh ...` |
+| Idle cost | accrues until the VM is stopped | none — job releases compute on completion |
+| Credentials | live on operator's laptop, mounted into the container | stay in MysteryBox; never leave the cloud |
+| Cold-start | seconds (VM kept warm) | ~10 min per job (image pull + venv resolve) |
+
+Trade fast cold-starts for zero idle cost and zero VM administration.
+
+## Configuration
+
+`train.sh` reads two environment variables, both with defaults pointing at the Positronic
+project:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job in |
+| `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the job's compute instance |
+
+Other operational settings (image, GPU platform/preset, MysteryBox secret names, S3 endpoint
+URL, region) are hardcoded — change them by editing `train.sh` directly.
+
+## Coming next
+
+- **Inference serving** — currently a long-running `lerobot-0_3_3-server` container on a GPU VM.
+  Next phase explores serving via a Nebius Serverless Endpoint.

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -65,24 +65,45 @@ nebius mysterybox secret create \
 The names matter — `convert.sh`, `train.sh`, and `serve.sh` reference the secrets by name. If a
 secret with one of these names already exists, the create call fails; skip it.
 
-## Convert a Positronic dataset to LeRobot 0.3.3 format
+## Convert a Positronic dataset to a LeRobot dataset
 
-ACT (and SmolVLA, GR00T, OpenPI) trains on the LeRobot 0.3.3 dataset format. `convert.sh` runs
-`python -m positronic.vendors.<vendor>.to_lerobot convert` inside a Nebius Job on CPU
-(`cpu-e2`, `8vcpu-32gb`). Conversion is video-encoding heavy — CPU is the right resource; a GPU
-would be wasted. Supported vendors: `lerobot_0_3_3` (used by ACT) and `lerobot` (used by SmolVLA
-and other lerobot 0.4.x policies). OpenPI and GR00T have no converter of their own — they read
-the `lerobot_0_3_3` output directly.
+ACT, SmolVLA, OpenPI, and GR00T all train on a LeRobot dataset, but each vendor recommends a
+specific converter + codec pair (see the vendor's `positronic/vendors/<vendor>/README.md`).
+`convert.sh` accepts the vendor as a positional and dispatches to the recommended converter:
+
+| Vendor | Converter | Codec namespace |
+|---|---|---|
+| `lerobot_0_3_3` (ACT) | `positronic.vendors.lerobot_0_3_3.to_lerobot` | `@positronic.vendors.lerobot_0_3_3.codecs.*` |
+| `lerobot` (SmolVLA) | `positronic.vendors.lerobot.to_lerobot` | `@positronic.vendors.lerobot.codecs.*` |
+| `openpi` | `positronic.vendors.lerobot_0_3_3.to_lerobot` (re-used) | `@positronic.vendors.openpi.codecs.*` |
+| `gr00t` | `positronic.vendors.lerobot_0_3_3.to_lerobot` (re-used) | `@positronic.vendors.gr00t.codecs.*` |
+
+The job runs on CPU (`cpu-e2`, `8vcpu-32gb`) — conversion is video-encoding heavy; a GPU would
+be wasted.
 
 Example: convert the public [`sim_stack_cubes`](../../positronic/cfg/ds/phail.py) dataset (317
-cube-stacking episodes, hosted on Positronic's public S3 bucket) into a LeRobot dataset on your
-own bucket:
+cube-stacking episodes, hosted on Positronic's public S3 bucket) into an ACT-ready LeRobot
+dataset on your own bucket:
 
 ```bash
 bash workflows/nebius/convert.sh lerobot_0_3_3 \
   --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
   --dataset.codec=@positronic.vendors.lerobot_0_3_3.codecs.ee \
   --output_dir=s3://<your-bucket>/sim_stack_cubes_lerobot/
+```
+
+Same shape for the other vendors — swap the vendor token and the codec:
+
+```bash
+bash workflows/nebius/convert.sh openpi \
+  --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
+  --dataset.codec=@positronic.vendors.openpi.codecs.ee \
+  --output_dir=s3://<your-bucket>/sim_stack_cubes_openpi/
+
+bash workflows/nebius/convert.sh gr00t \
+  --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
+  --dataset.codec=@positronic.vendors.gr00t.codecs.ee_rot6d_joints \
+  --output_dir=s3://<your-bucket>/sim_stack_cubes_gr00t/
 ```
 
 The job reads from `s3://positronic-public/...` anonymously — the dataset's `PUBLIC` profile in

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -264,5 +264,5 @@ the container image and `uv` extras:
 |---|---|---|
 | `lerobot_0_3_3` (ACT) | `positro/positronic` | `--extra lerobot_0_3_3` |
 | `lerobot` (SmolVLA) | `positro/positronic` | `--extra lerobot` |
-| `openpi` | `positro/openpi` | _(none — `/openpi` is co-installed)_ |
+| `openpi` | `positro/openpi` | `--extra openpi` (serve); none for train/stats |
 | `gr00t` | `positro/gr00t` | _(none — `/gr00t` is co-installed)_ |

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -1,12 +1,14 @@
 # Nebius Serverless Workflow
 
-Run Positronic training on [Nebius Serverless Jobs](https://docs.nebius.com/serverless/jobs/manage)
-instead of provisioning a GPU VM. Same containers, same training scripts, no VM lifecycle to
-manage and no idle compute cost.
+Run the full Positronic training and inference workflow on
+[Nebius Serverless](https://docs.nebius.com/serverless) — Jobs for batch work (data conversion,
+training) and Endpoints for HTTP inference servers. Same containers, same scripts, no VM
+lifecycle to manage and no idle compute cost.
 
-This page mirrors **Steps 1 (Convert) and 2 (Train)** of
-[docs/training-workflow.md](../../docs/training-workflow.md). Step 3 (inference serving) will
-follow in an upcoming change.
+This page mirrors all three cloud-side steps of
+[docs/training-workflow.md](../../docs/training-workflow.md): Convert, Train, Serve. Step 4
+(running inference from your robot or simulator against the served policy) is unchanged — see
+[docs/inference.md](../../docs/inference.md).
 
 ## Prerequisites
 
@@ -60,8 +62,8 @@ nebius mysterybox secret create \
     '[{key:"S3_ACCESS_KEY_ID",string_value:$k},{key:"S3_SECRET_ACCESS_KEY",string_value:$s}]')"
 ```
 
-The names matter — `train.sh` references the secrets by name. If a secret with one of these
-names already exists, the create call fails; skip it.
+The names matter — `convert.sh`, `train.sh`, and `serve.sh` reference the secrets by name. If a
+secret with one of these names already exists, the create call fails; skip it.
 
 ## Convert a Positronic dataset to LeRobot 0.3.3 format
 
@@ -140,6 +142,57 @@ Expected layout: `checkpoints/<step>/pretrained_model/{config.json,model.safeten
 an empty `wandb/` placeholder. Live WandB metrics flow to your account directly via the API
 key — they aren't synced to S3.
 
+## Serve a checkpoint as an HTTP endpoint
+
+`serve.sh` creates a [Nebius Serverless Endpoint](https://docs.nebius.com/serverless/endpoints/manage)
+running `python -m positronic.vendors.lerobot_0_3_3.server` on H100, with a public static IP on
+port 8000. Endpoints don't have managed DNS yet, so the IP is the contact address — it's stable
+across endpoint stop/start, but new endpoints get new IPs.
+
+Take a unique endpoint name as the first argument; remaining arguments forward to the server CLI.
+Example using the public ACT demo checkpoint at `s3://positronic-public/checkpoints/sim_stack_cubes/act/`:
+
+```bash
+bash workflows/nebius/serve.sh my-act-demo demo
+```
+
+Or against your own trained checkpoint:
+
+```bash
+bash workflows/nebius/serve.sh act-server serve \
+  --checkpoints_dir=s3://<your-bucket>/checkpoints/lerobot/<exp_name>/
+```
+
+`serve.sh` blocks until the public IP is allocated (typically <1 min), then prints a banner with
+the URL, endpoint ID, and the commands to follow logs and tear down. The container takes another
+~10–15 min to finish `uv sync` and load the model into GPU memory; once `INFO Started server
+process` appears in `nebius ai endpoint logs`, sanity-check with:
+
+```bash
+curl http://<endpoint-ip>:8000/api/v1/models
+# → {"models": ["050000"]}
+```
+
+Run inference from your laptop or robot host using the existing `positronic-inference` CLI
+([docs/inference.md](../../docs/inference.md)):
+
+```bash
+uv run positronic-inference sim \
+  --policy=.remote \
+  --policy.host=<endpoint-ip> \
+  --policy.port=8000 \
+  --output_dir=.data/inference/<run-name>/
+```
+
+When you're done, `stop.sh` deletes the endpoint and releases the public IP:
+
+```bash
+bash workflows/nebius/stop.sh my-act-demo
+```
+
+To pause an endpoint without releasing its static IP (useful if you want to reuse the same IP
+later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
+
 ## What changed vs. running on a VM
 
 | Concern | VM flow | Serverless Job |
@@ -154,18 +207,13 @@ Trade fast cold-starts for zero idle cost and zero VM administration.
 
 ## Configuration
 
-`train.sh` reads two environment variables, both with defaults pointing at the Positronic
+All scripts read two environment variables, both with defaults pointing at the Positronic
 project:
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job in |
-| `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the job's compute instance |
+| `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
+| `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
 
-Other operational settings (image, GPU platform/preset, MysteryBox secret names, S3 endpoint
-URL, region) are hardcoded — change them by editing `train.sh` directly.
-
-## Coming next
-
-- **Inference serving** — currently a long-running `lerobot-0_3_3-server` container on a GPU VM.
-  Next phase explores serving via a Nebius Serverless Endpoint.
+Other operational settings (image, platform/preset, MysteryBox secret names, S3 endpoint URL,
+region) are hardcoded — change them by editing the script directly.

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -13,16 +13,21 @@ This page mirrors all three cloud-side steps of
 ## Prerequisites
 
 - Nebius CLI v0.12.209 or newer, authenticated to your project
-- Read access to your input dataset bucket and write access to your checkpoint output bucket
-- AWS access key, AWS secret key, and a Weights & Biases API key
+- Write access to an S3 bucket where converted datasets and checkpoints will land
+  (Public datasets like `sim_stack_cubes` are read anonymously — no credentials needed for
+  the read side)
+- AWS access key + secret for that bucket
+- _Optional:_ a Weights & Biases API key for live training metrics. To skip wandb, omit the
+  wandb secret below and run training jobs with `WANDB_SECRET= bash workflows/nebius/train.sh ...`.
 
 ## One-time setup
 
-Create four MysteryBox secrets that the jobs will reference by name. AWS keys are read from
-your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`. The first three are
-single-key payloads consumed via `--env-secret`. The fourth is a two-key payload consumed by
-`--volume` for Mountpoint-S3 authentication (Nebius requires the keys to be named
-`S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`).
+Create up to four MysteryBox secrets that the jobs will reference by name. AWS keys are read
+from your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`. The first three
+are single-key payloads consumed via `--env-secret`. The fourth is a two-key payload consumed
+by `--volume` for Mountpoint-S3 authentication (Nebius requires the keys to be named
+`S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`). The wandb secret is optional — skip it if you
+don't use Weights & Biases.
 
 ```bash
 PARENT_ID=project-e00f38wexevrr52b8j  # adjust to your own project
@@ -65,18 +70,18 @@ nebius mysterybox secret create \
 The names matter — `convert.sh`, `train.sh`, and `serve.sh` reference the secrets by name. If a
 secret with one of these names already exists, the create call fails; skip it.
 
-## Convert a Positronic dataset to a LeRobot dataset
+## Convert a Positronic dataset
 
-ACT, SmolVLA, OpenPI, and GR00T all train on a LeRobot dataset, but each vendor recommends a
-specific converter + codec pair (see the vendor's `positronic/vendors/<vendor>/README.md`).
-`convert.sh` accepts the vendor as a positional and dispatches to the recommended converter:
+Each model family expects a specific dataset format. `convert.sh` runs the right converter
+with the right [codec](../../docs/codecs.md) for the model you choose, dispatched by the
+vendor positional:
 
-| Vendor | Converter | Codec namespace |
-|---|---|---|
-| `lerobot_0_3_3` (ACT) | `positronic.vendors.lerobot_0_3_3.to_lerobot` | `@positronic.vendors.lerobot_0_3_3.codecs.*` |
-| `lerobot` (SmolVLA) | `positronic.vendors.lerobot.to_lerobot` | `@positronic.vendors.lerobot.codecs.*` |
-| `openpi` | `positronic.vendors.lerobot_0_3_3.to_lerobot` (re-used) | `@positronic.vendors.openpi.codecs.*` |
-| `gr00t` | `positronic.vendors.lerobot_0_3_3.to_lerobot` (re-used) | `@positronic.vendors.gr00t.codecs.*` |
+| Model | `<vendor>` arg | Converter | Codec namespace |
+|---|---|---|---|
+| ACT | `lerobot_0_3_3` | `positronic.vendors.lerobot_0_3_3.to_lerobot` | `@positronic.vendors.lerobot_0_3_3.codecs.*` |
+| SmolVLA | `lerobot` | `positronic.vendors.lerobot.to_lerobot` | `@positronic.vendors.lerobot.codecs.*` |
+| OpenPI | `openpi` | `positronic.vendors.lerobot_0_3_3.to_lerobot` (re-used) | `@positronic.vendors.openpi.codecs.*` |
+| GR00T | `gr00t` | `positronic.vendors.lerobot_0_3_3.to_lerobot` (re-used) | `@positronic.vendors.gr00t.codecs.*` |
 
 The job runs on CPU (`cpu-e2`, `8vcpu-32gb`) — conversion is video-encoding heavy; a GPU would
 be wasted.
@@ -106,15 +111,8 @@ bash workflows/nebius/convert.sh gr00t \
   --output_dir=s3://<your-bucket>/sim_stack_cubes_gr00t/
 ```
 
-The job reads from `s3://positronic-public/...` anonymously — the dataset's `PUBLIC` profile in
-[`positronic/cfg/ds/__init__.py`](../../positronic/cfg/ds/__init__.py) opts into unauthenticated
-S3 access, so no extra credentials are needed for the read side. The write side uses the AWS
-keys you stored in MysteryBox. Wall-clock for `sim_stack_cubes` is ~25 min (~7 min cold start,
-~13 min processing + video encoding, seconds for upload).
-
-The output is a standard LeRobot 0.3.3 layout — `data/`, `videos/`, `meta/{info,episodes,
-episodes_stats,tasks}.jsonl`, plus a `run_metadata_*.yaml` capturing the conversion code state.
-The output path is what you pass to `train.sh --input_path=...` next.
+`sim_stack_cubes` is publicly hosted on Nebius and read anonymously. The output path is what
+you pass to `train.sh --input_path=...` next.
 
 ## Train
 
@@ -126,8 +124,8 @@ of the job spec (preset, secrets, S3 endpoint, mount) is identical.
 The bucket from `--input_path=s3://...` is mounted with
 [Mountpoint-S3](https://docs.nebius.com/object-storage/interfaces/mountpoint-s3) at `/mnt/input`
 (read-only) so the dataset is streamed on demand instead of being downloaded into local cache.
-`--output_dir` stays an `s3://` URL handled by `pos3` — vendor checkpoint savers tend to use
-symlinks, which Mountpoint-S3 does not support.
+`--output_dir` stays an `s3://` URL handled by [`pos3`](https://github.com/Positronic-Robotics/pos3)
+— vendor checkpoint savers tend to use symlinks, which Mountpoint-S3 does not support.
 
 Example: train ACT on the converted `sim_stack_cubes` dataset from the previous step:
 
@@ -204,7 +202,7 @@ matching checkpoint:
 bash workflows/nebius/serve.sh lerobot smolvla-server serve \
   --checkpoints_dir=s3://<your-bucket>/checkpoints/smolvla/<exp_name>/
 
-bash workflows/nebius/serve.sh openpi pi-server serve \
+bash workflows/nebius/serve.sh openpi my-openpi serve \
   --checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/
 
 bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \
@@ -243,25 +241,20 @@ later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
 
 ## What changed vs. running on a VM
 
-| Concern | VM flow | Serverless Job |
-|---|---|---|
-| First-run setup | provision VM, install drivers, configure SSH/network, mount AWS credentials | three `nebius mysterybox secret create` calls |
-| Per-run lifecycle | boot VM → SSH → `docker compose run` → stop VM | `bash train.sh ...` |
-| Idle cost | accrues until the VM is stopped | none — job releases compute on completion |
-| Credentials | live on operator's laptop, mounted into the container | stay in MysteryBox; never leave the cloud |
-| Cold-start | seconds (VM kept warm) | ~10 min per job (image pull + venv resolve) |
-
-Trade fast cold-starts for zero idle cost and zero VM administration.
+No VM to provision, SSH into, or remember to shut down. Credentials stay in MysteryBox instead
+of on operator laptops. Compute is released the moment a job finishes — idle cost goes to zero.
+The trade-off is a ~10-min cold start per job (image pull + venv resolve) instead of a warm VM.
 
 ## Configuration
 
-All scripts read two environment variables, both with defaults pointing at the Positronic
-project:
+The script defaults point at Positronic Robotics' own Nebius project — **external users must
+override them** with their own project + subnet IDs:
 
-| Variable | Default | Purpose |
+| Variable | Default (Positronic-internal) | Purpose |
 |---|---|---|
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
+| `WANDB_SECRET` | `positronic-serverless-wandb-api-key` | MysteryBox secret name for the WandB key. Set empty (`WANDB_SECRET=`) to skip wandb entirely. |
 
 Other operational settings (platform/preset, MysteryBox secret names, S3 endpoint URL, region)
 are hardcoded — change them by editing the script directly. The vendor positional arg selects

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Convert a Positronic dataset into LeRobot 0.3.3 format as a Nebius Serverless Job.
+#
+# Hardcoded: image, CPU platform/preset, MysteryBox secret names, S3 endpoint URL.
+# Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
+#
+# All flags after the script name are forwarded to:
+#     python -m positronic.vendors.lerobot_0_3_3.to_lerobot convert
+
+set -euo pipefail
+
+PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
+SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
+
+if [ $# -eq 0 ]; then
+  cat >&2 <<'EOF'
+Usage: bash workflows/nebius/convert.sh [convert args...]
+
+Forwards all arguments to positronic.vendors.lerobot_0_3_3.to_lerobot convert. Example:
+
+  bash workflows/nebius/convert.sh \
+    --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
+    --dataset.codec=@positronic.vendors.lerobot_0_3_3.codecs.ee \
+    --output_dir=s3://<your-bucket>/sim_stack_cubes_lerobot/
+EOF
+  exit 1
+fi
+
+JOB_NAME="convert-$(date +%Y%m%d-%H%M%S)"
+CONVERT_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.to_lerobot convert $*"
+
+nebius ai job create \
+  --parent-id "$PARENT_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --name "$JOB_NAME" \
+  --image positro/positronic:latest \
+  --container-command uv \
+  --args "$CONVERT_ARGS" \
+  --platform cpu-e2 \
+  --preset 8vcpu-32gb \
+  --timeout 4h \
+  --working-dir /positronic \
+  --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
+  --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
+  --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
+  --env AWS_DEFAULT_REGION=eu-north1

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -15,18 +15,28 @@ if [ $# -lt 1 ]; then
   cat >&2 <<'EOF'
 Usage: bash workflows/nebius/convert.sh <vendor> [convert args...]
 
-Vendors: lerobot_0_3_3 | lerobot
+Vendors: lerobot_0_3_3 | lerobot | openpi | gr00t
 
-Forwards remaining arguments to positronic.vendors.<vendor>.to_lerobot convert.
-Example:
+Forwards remaining arguments to the converter recommended by each vendor's
+README (lerobot 0.3.3 for ACT/OpenPI/GR00T; lerobot 0.4.x for SmolVLA). The
+caller picks a vendor-specific codec via `--dataset.codec=...`.
+
+Examples:
 
   bash workflows/nebius/convert.sh lerobot_0_3_3 \
     --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
     --dataset.codec=@positronic.vendors.lerobot_0_3_3.codecs.ee \
     --output_dir=s3://<your-bucket>/sim_stack_cubes_lerobot/
 
-OpenPI and GR00T do not have a converter — they consume LeRobot 0.3.3 datasets
-produced by `lerobot_0_3_3`.
+  bash workflows/nebius/convert.sh openpi \
+    --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
+    --dataset.codec=@positronic.vendors.openpi.codecs.ee \
+    --output_dir=s3://<your-bucket>/sim_stack_cubes_openpi/
+
+  bash workflows/nebius/convert.sh gr00t \
+    --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
+    --dataset.codec=@positronic.vendors.gr00t.codecs.ee_rot6d_joints \
+    --output_dir=s3://<your-bucket>/sim_stack_cubes_gr00t/
 EOF
   exit 1
 fi
@@ -34,17 +44,19 @@ fi
 VENDOR="$1"
 shift
 
+# OpenPI and GR00T don't ship their own converter — they re-use the lerobot_0_3_3
+# converter with their own codec namespaces (per each vendor's README).
 case "$VENDOR" in
-  lerobot_0_3_3) EXTRA="--extra lerobot_0_3_3 " ;;
-  lerobot)       EXTRA="--extra lerobot " ;;
+  lerobot_0_3_3|openpi|gr00t) CONVERTER_MODULE="positronic.vendors.lerobot_0_3_3.to_lerobot"; EXTRA="--extra lerobot_0_3_3 " ;;
+  lerobot)                    CONVERTER_MODULE="positronic.vendors.lerobot.to_lerobot";       EXTRA="--extra lerobot " ;;
   *)
-    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot" >&2
+    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t" >&2
     exit 1
     ;;
 esac
 
 JOB_NAME="${VENDOR//_/-}-convert-$(date +%Y%m%d-%H%M%S)"
-CONVERT_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.to_lerobot convert $*"
+CONVERT_ARGS="run --python 3.11 ${EXTRA}python -m ${CONVERTER_MODULE} convert $*"
 
 nebius ai job create \
   --parent-id "$PARENT_ID" \

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -156,7 +156,7 @@ nebius ai job create \
 
 cat <<EOM
 
-Stats output will land at: ${STATS_PATH}
+Stats output will land at: ${STATS_PATH} (with assets in ${STATS_PATH}assets/)
 When training, pass:
-  --input_path=${OUTPUT_DIR} --stats_path=${STATS_PATH}
+  --input_path=${OUTPUT_DIR} --stats_path=${STATS_PATH}assets/
 EOM

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -5,6 +5,11 @@
 # Hardcoded: CPU platform/preset, MysteryBox secret names, S3 endpoint URL.
 # Vendor selects image + uv extra. Override-able via env: NEBIUS_PARENT_ID,
 # NEBIUS_SUBNET_ID.
+#
+# OpenPI also requires normalization stats. When vendor=openpi, this script
+# blocks until the convert job completes, then submits a second job (in the
+# `positro/openpi` image) that runs `compute_norm_stats.py` and writes assets
+# to <output_dir>/stats/. Use `--stats_path=<output_dir>/stats/` when training.
 
 set -euo pipefail
 
@@ -55,10 +60,23 @@ case "$VENDOR" in
     ;;
 esac
 
+# OpenPI needs the dataset path so we can chain a stats job after convert finishes.
+OUTPUT_DIR=""
+for arg in "$@"; do
+  case "$arg" in
+    --output_dir=*) OUTPUT_DIR="${arg#--output_dir=}" ;;
+  esac
+done
+
+if [ "$VENDOR" = "openpi" ] && [ -z "$OUTPUT_DIR" ]; then
+  echo "openpi convert requires --output_dir=s3://... so a stats job can be chained." >&2
+  exit 1
+fi
+
 JOB_NAME="${VENDOR//_/-}-convert-$(date +%Y%m%d-%H%M%S)"
 CONVERT_ARGS="run --python 3.11 ${EXTRA}python -m ${CONVERTER_MODULE} convert $*"
 
-nebius ai job create \
+CREATE_OUT=$(nebius ai job create \
   --parent-id "$PARENT_ID" \
   --subnet-id "$SUBNET_ID" \
   --name "$JOB_NAME" \
@@ -72,4 +90,70 @@ nebius ai job create \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
+  --env AWS_DEFAULT_REGION=eu-north1)
+
+echo "$CREATE_OUT"
+
+# For non-openpi vendors we're done — the create call already streamed the job ID
+# and follow-up commands.
+if [ "$VENDOR" != "openpi" ]; then
+  exit 0
+fi
+
+CONVERT_ID=$(echo "$CREATE_OUT" | grep -oE 'aijob-[a-z0-9]+' | head -1)
+if [ -z "$CONVERT_ID" ]; then
+  echo "Could not parse convert job id from create output." >&2
+  exit 1
+fi
+
+echo
+echo "Waiting for convert job $CONVERT_ID to complete before submitting openpi stats..."
+while true; do
+  STATE=$(nebius ai job get "$CONVERT_ID" --format json 2>/dev/null | jq -r '.status.state // ""')
+  case "$STATE" in
+    COMPLETED)
+      echo "Convert COMPLETED."
+      break
+      ;;
+    FAILED|CANCELLED)
+      echo "Convert finished with state $STATE — not submitting stats job." >&2
+      exit 1
+      ;;
+    "")
+      echo "Could not read job state; retrying..."
+      ;;
+    *)
+      printf '\rConvert state: %-20s' "$STATE"
+      ;;
+  esac
+  sleep 30
+done
+
+STATS_PATH="${OUTPUT_DIR%/}/stats/"
+STATS_JOB_NAME="openpi-stats-$(date +%Y%m%d-%H%M%S)"
+STATS_ARGS="run --python 3.11 python -m positronic.vendors.openpi.stats --input_path=${OUTPUT_DIR} --output_path=${STATS_PATH}"
+
+echo
+echo "Submitting openpi stats job (image positro/openpi)..."
+nebius ai job create \
+  --parent-id "$PARENT_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --name "$STATS_JOB_NAME" \
+  --image positro/openpi:latest \
+  --container-command uv \
+  --args "$STATS_ARGS" \
+  --platform cpu-e2 \
+  --preset 8vcpu-32gb \
+  --timeout 4h \
+  --working-dir /positronic \
+  --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
+  --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
+  --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
   --env AWS_DEFAULT_REGION=eu-north1
+
+cat <<EOM
+
+Stats output will land at: ${STATS_PATH}
+When training, pass:
+  --input_path=${OUTPUT_DIR} --stats_path=${STATS_PATH}
+EOM

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -129,7 +129,10 @@ while true; do
   sleep 30
 done
 
-STATS_PATH="${OUTPUT_DIR%/}/stats/"
+# Stats must be a SIBLING of the dataset, not a child — pos3 refuses when an
+# upload destination is inside the dataset it's also downloading.
+DATASET_TRIM="${OUTPUT_DIR%/}"
+STATS_PATH="${DATASET_TRIM%/*}/stats/"
 STATS_JOB_NAME="openpi-stats-$(date +%Y%m%d-%H%M%S)"
 STATS_ARGS="run --python 3.11 python -m positronic.vendors.openpi.stats --input_path=${OUTPUT_DIR} --output_path=${STATS_PATH}"
 

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -1,33 +1,50 @@
 #!/usr/bin/env bash
-# Convert a Positronic dataset into LeRobot 0.3.3 format as a Nebius Serverless Job.
+# Convert a Positronic dataset into a vendor's LeRobot dataset format
+# as a Nebius Serverless Job.
 #
-# Hardcoded: image, CPU platform/preset, MysteryBox secret names, S3 endpoint URL.
-# Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
-#
-# All flags after the script name are forwarded to:
-#     python -m positronic.vendors.lerobot_0_3_3.to_lerobot convert
+# Hardcoded: CPU platform/preset, MysteryBox secret names, S3 endpoint URL.
+# Vendor selects image + uv extra. Override-able via env: NEBIUS_PARENT_ID,
+# NEBIUS_SUBNET_ID.
 
 set -euo pipefail
 
 PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
 SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
 
-if [ $# -eq 0 ]; then
+if [ $# -lt 1 ]; then
   cat >&2 <<'EOF'
-Usage: bash workflows/nebius/convert.sh [convert args...]
+Usage: bash workflows/nebius/convert.sh <vendor> [convert args...]
 
-Forwards all arguments to positronic.vendors.lerobot_0_3_3.to_lerobot convert. Example:
+Vendors: lerobot_0_3_3 | lerobot
 
-  bash workflows/nebius/convert.sh \
+Forwards remaining arguments to positronic.vendors.<vendor>.to_lerobot convert.
+Example:
+
+  bash workflows/nebius/convert.sh lerobot_0_3_3 \
     --dataset.dataset=@positronic.cfg.ds.phail.sim_stack_cubes \
     --dataset.codec=@positronic.vendors.lerobot_0_3_3.codecs.ee \
     --output_dir=s3://<your-bucket>/sim_stack_cubes_lerobot/
+
+OpenPI and GR00T do not have a converter — they consume LeRobot 0.3.3 datasets
+produced by `lerobot_0_3_3`.
 EOF
   exit 1
 fi
 
-JOB_NAME="convert-$(date +%Y%m%d-%H%M%S)"
-CONVERT_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.to_lerobot convert $*"
+VENDOR="$1"
+shift
+
+case "$VENDOR" in
+  lerobot_0_3_3) EXTRA="--extra lerobot_0_3_3 " ;;
+  lerobot)       EXTRA="--extra lerobot " ;;
+  *)
+    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot" >&2
+    exit 1
+    ;;
+esac
+
+JOB_NAME="${VENDOR//_/-}-convert-$(date +%Y%m%d-%H%M%S)"
+CONVERT_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.to_lerobot convert $*"
 
 nebius ai job create \
   --parent-id "$PARENT_ID" \

--- a/workflows/nebius/e2e.sh
+++ b/workflows/nebius/e2e.sh
@@ -95,6 +95,8 @@ if [ "$VENDOR" = "openpi" ]; then
   # Sibling of the dataset (see convert.sh — pos3 forbids upload-inside-download).
   STATS_PATH="${DATASET_DIR%/}"
   STATS_PATH="${STATS_PATH%/*}/stats/"
+  # train consumes the assets subdirectory that openpi.stats writes inside STATS_PATH.
+  STATS_TRAIN_INPUT="${STATS_PATH}assets/"
 fi
 
 # ---- 2. Train (200 short steps; goal is wiring, not loss) ----
@@ -119,7 +121,7 @@ case "$VENDOR" in
   openpi)
     TRAIN_OUT=$(bash "$SCRIPT_DIR/train.sh" openpi \
       "--input_path=$DATASET_DIR" \
-      "--stats_path=$STATS_PATH" \
+      "--stats_path=$STATS_TRAIN_INPUT" \
       "--output_path=$CKPT_DIR" \
       "--exp_name=$EXP_NAME" \
       --num_train_steps=500 2>&1)

--- a/workflows/nebius/e2e.sh
+++ b/workflows/nebius/e2e.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Full-pipeline validation harness for one vendor:
+#   convert (+ openpi stats) → train (200 steps) → serve → /api/v1/models smoke → teardown
+#
+# Submits jobs via the user-facing primitives (convert.sh / train.sh / serve.sh / stop.sh),
+# polls Nebius for completion, and reports a status line per stage. Intended for CI or for
+# verifying a vendor's pipeline still works after an image / dependency / script change.
+#
+# Cost: ~$2-5 per run (cold-start dominated; the actual compute is short).
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
+S3_BASE="${E2E_S3_BASE:-s3://tmp/e2e_validation}"
+EXP_NAME="${E2E_EXP_NAME:-e2e_$(date +%Y%m%d_%H%M%S)}"
+LOG_ROOT="${E2E_LOG_ROOT:-/tmp/e2e_logs}"
+DATASET="${E2E_DATASET:-@positronic.cfg.ds.phail.sim_stack_cubes}"
+
+VENDOR="${1:-}"
+if [ -z "$VENDOR" ]; then
+  cat >&2 <<'EOF'
+Usage: bash workflows/nebius/e2e.sh <vendor>
+
+Vendors: lerobot_0_3_3 | lerobot | openpi | gr00t
+
+Optional env:
+  E2E_S3_BASE     S3 base for outputs (default: s3://tmp/e2e_validation)
+  E2E_EXP_NAME    Experiment name (default: e2e_<timestamp>)
+  E2E_LOG_ROOT    Local log dir (default: /tmp/e2e_logs)
+  E2E_DATASET     Dataset config target (default: @positronic.cfg.ds.phail.sim_stack_cubes)
+
+To run all four in parallel:
+  for v in lerobot_0_3_3 lerobot openpi gr00t; do bash workflows/nebius/e2e.sh "$v" & done; wait
+EOF
+  exit 1
+fi
+
+case "$VENDOR" in
+  lerobot_0_3_3) CODEC=positronic.vendors.lerobot_0_3_3.codecs.ee ;;
+  lerobot)       CODEC=positronic.vendors.lerobot.codecs.ee ;;
+  openpi)        CODEC=positronic.vendors.openpi.codecs.ee ;;
+  gr00t)         CODEC=positronic.vendors.gr00t.codecs.ee_rot6d ;;
+  *) echo "Unknown vendor '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t" >&2; exit 1 ;;
+esac
+
+mkdir -p "$LOG_ROOT"
+DATASET_DIR="$S3_BASE/$VENDOR/dataset/"
+CKPT_DIR="$S3_BASE/$VENDOR/checkpoints/"
+ENDPOINT_NAME="e2e-${VENDOR//_/-}-$(date +%H%M%S)"
+LOG="$LOG_ROOT/$VENDOR.log"
+
+note() {
+  local ts; ts=$(date +%H:%M:%S)
+  echo "[$ts][$VENDOR] $*" | tee -a "$LOG"
+}
+
+extract_job_id() { echo "$1" | grep -oE 'aijob-[a-z0-9]+' | head -1; }
+
+wait_job() {
+  local job_id="$1"; local stage="$2"
+  while true; do
+    local state
+    state=$(nebius ai job get "$job_id" --format json 2>/dev/null | jq -r '.status.state // ""')
+    case "$state" in
+      COMPLETED)        note "$stage $job_id COMPLETED"; return 0 ;;
+      FAILED|CANCELLED) note "$stage $job_id $state";    return 1 ;;
+    esac
+    sleep 30
+  done
+}
+
+# ---- 1. Convert (convert.sh openpi additionally chains a stats job) ----
+note "convert -> $DATASET_DIR"
+CONVERT_OUT=$(bash "$SCRIPT_DIR/convert.sh" "$VENDOR" \
+  "--dataset.dataset=${DATASET}" \
+  "--dataset.codec=@${CODEC}" \
+  "--output_dir=${DATASET_DIR}" 2>&1)
+echo "$CONVERT_OUT" >> "$LOG"
+CONVERT_ID=$(extract_job_id "$CONVERT_OUT")
+[ -z "$CONVERT_ID" ] && { note "FAIL: no convert job id"; exit 1; }
+note "convert job: $CONVERT_ID"
+wait_job "$CONVERT_ID" "convert" || exit 1
+
+# OpenPI: convert.sh has already submitted a stats job by this point. Find it by name.
+STATS_PATH=""
+if [ "$VENDOR" = "openpi" ]; then
+  sleep 15
+  STATS_ID=$(nebius ai job list --parent-id "$PARENT_ID" --format json | \
+    jq -r '.items[]? | select(.metadata.name | startswith("openpi-stats-")) | "\(.metadata.created_at)|\(.metadata.id)"' | \
+    sort | tail -1 | cut -d'|' -f2)
+  [ -z "$STATS_ID" ] && { note "FAIL: stats job not found"; exit 1; }
+  note "stats job: $STATS_ID"
+  wait_job "$STATS_ID" "stats" || exit 1
+  STATS_PATH="${DATASET_DIR%/}/stats/"
+fi
+
+# ---- 2. Train (200 short steps; goal is wiring, not loss) ----
+note "train -> $CKPT_DIR"
+case "$VENDOR" in
+  lerobot_0_3_3)
+    TRAIN_OUT=$(bash "$SCRIPT_DIR/train.sh" lerobot_0_3_3 \
+      "--input_path=$DATASET_DIR" \
+      "--exp_name=$EXP_NAME" \
+      "--output_dir=$CKPT_DIR" \
+      --num_train_steps=200 --save_freq=100 2>&1)
+    SERVE_SUBCMD=(serve --checkpoints_dir="$CKPT_DIR$EXP_NAME/")
+    ;;
+  lerobot)
+    TRAIN_OUT=$(bash "$SCRIPT_DIR/train.sh" lerobot expert_only \
+      "--input_path=$DATASET_DIR" \
+      "--exp_name=$EXP_NAME" \
+      "--output_dir=$CKPT_DIR" \
+      --num_train_steps=200 --save_freq=100 2>&1)
+    SERVE_SUBCMD=(serve --checkpoints_dir="$CKPT_DIR$EXP_NAME/")
+    ;;
+  openpi)
+    TRAIN_OUT=$(bash "$SCRIPT_DIR/train.sh" openpi \
+      "--input_path=$DATASET_DIR" \
+      "--stats_path=$STATS_PATH" \
+      "--output_path=$CKPT_DIR" \
+      "--exp_name=$EXP_NAME" \
+      --num_train_steps=500 2>&1)
+    # openpi.train writes to <output_path>/<config_name>/<exp_name>/
+    SERVE_SUBCMD=(serve --checkpoints_dir="${CKPT_DIR%/}/pi05_positronic_lowmem/$EXP_NAME/")
+    ;;
+  gr00t)
+    TRAIN_OUT=$(bash "$SCRIPT_DIR/train.sh" gr00t \
+      "--input_path=$DATASET_DIR" \
+      "--output_path=$CKPT_DIR" \
+      "--exp_name=$EXP_NAME" \
+      --num_train_steps=200 --save_steps=100 \
+      --modality_config=ee_rot6d 2>&1)
+    SERVE_SUBCMD=(ee_rot6d --checkpoints_dir="$CKPT_DIR$EXP_NAME/")
+    ;;
+esac
+echo "$TRAIN_OUT" >> "$LOG"
+TRAIN_ID=$(extract_job_id "$TRAIN_OUT")
+[ -z "$TRAIN_ID" ] && { note "FAIL: no train job id"; exit 1; }
+note "train job: $TRAIN_ID"
+wait_job "$TRAIN_ID" "train" || exit 1
+
+# ---- 3. Serve ----
+note "serve -> $ENDPOINT_NAME"
+SERVE_OUT=$(bash "$SCRIPT_DIR/serve.sh" "$VENDOR" "$ENDPOINT_NAME" "${SERVE_SUBCMD[@]}" 2>&1)
+echo "$SERVE_OUT" >> "$LOG"
+SERVE_URL=$(echo "$SERVE_OUT" | awk '/Endpoint URL:/ {print $3; exit}')
+[ -z "$SERVE_URL" ] && { note "FAIL: no serve URL"; exit 1; }
+note "serve URL: $SERVE_URL"
+
+# ---- 4. Smoke /api/v1/models (up to 25 min for warm-up) ----
+RESP=""
+for i in $(seq 1 50); do
+  RESP=$(curl --max-time 5 -s "$SERVE_URL/api/v1/models" 2>/dev/null || true)
+  [ -n "$RESP" ] && break
+  sleep 30
+done
+if [ -n "$RESP" ]; then
+  note "infer: $RESP"
+else
+  note "infer: TIMEOUT"
+fi
+
+# ---- 5. Teardown ----
+note "teardown -> $ENDPOINT_NAME"
+bash "$SCRIPT_DIR/stop.sh" "$ENDPOINT_NAME" >> "$LOG" 2>&1 || true
+note "DONE"

--- a/workflows/nebius/e2e.sh
+++ b/workflows/nebius/e2e.sh
@@ -92,7 +92,9 @@ if [ "$VENDOR" = "openpi" ]; then
   [ -z "$STATS_ID" ] && { note "FAIL: stats job not found"; exit 1; }
   note "stats job: $STATS_ID"
   wait_job "$STATS_ID" "stats" || exit 1
-  STATS_PATH="${DATASET_DIR%/}/stats/"
+  # Sibling of the dataset (see convert.sh — pos3 forbids upload-inside-download).
+  STATS_PATH="${DATASET_DIR%/}"
+  STATS_PATH="${STATS_PATH%/*}/stats/"
 fi
 
 # ---- 2. Train (200 short steps; goal is wiring, not loss) ----

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# Submit a Nebius Serverless Endpoint running positronic.vendors.lerobot_0_3_3.server.
+# Submit a Nebius Serverless Endpoint running a vendor inference server.
 #
 # After creation, polls until a public IP is allocated and prints connection
 # details. The container itself takes ~10-15 min more to finish uv sync and
 # load the model into GPU memory after the IP appears.
 #
-# Hardcoded: image, GPU platform/preset, MysteryBox secret names, S3 endpoint URL,
-# container port. Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
+# Hardcoded: GPU platform/preset, MysteryBox secret names, S3 endpoint URL,
+# container port. Vendor selects image + uv extra. Override-able via env:
+# NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
 
 set -euo pipefail
 
@@ -15,34 +16,60 @@ SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
 
 if [ $# -lt 2 ]; then
   cat >&2 <<'EOF'
-Usage: bash workflows/nebius/serve.sh <endpoint-name> [server args...]
+Usage: bash workflows/nebius/serve.sh <vendor> <endpoint-name> [server args...]
 
-The first argument is a unique endpoint name (lowercase alphanumeric + dashes).
-Remaining arguments forward to positronic.vendors.lerobot_0_3_3.server.
+Vendors: lerobot_0_3_3 | lerobot | openpi | gr00t
+
+The endpoint name must be unique in the project (lowercase alphanumeric + dashes).
+Remaining arguments forward to positronic.vendors.<vendor>.server.
 
 Examples:
 
-  # Public ACT demo checkpoint (no S3 credentials needed inside the container)
-  bash workflows/nebius/serve.sh my-act-demo demo
+  # ACT public demo checkpoint (no S3 credentials needed inside the container)
+  bash workflows/nebius/serve.sh lerobot_0_3_3 my-act-demo demo
 
-  # Your own checkpoint
-  bash workflows/nebius/serve.sh act-server serve \
+  # Your own ACT checkpoint
+  bash workflows/nebius/serve.sh lerobot_0_3_3 act-server serve \
     --checkpoints_dir=s3://<your-bucket>/checkpoints/lerobot/<exp_name>/
+
+  # SmolVLA / lerobot 0.4.x checkpoint
+  bash workflows/nebius/serve.sh lerobot smolvla-server serve \
+    --checkpoints_dir=s3://<your-bucket>/checkpoints/smolvla/<exp_name>/
+
+  # OpenPI
+  bash workflows/nebius/serve.sh openpi pi-server serve \
+    --checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/
+
+  # GR00T
+  bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \
+    --checkpoints_dir=s3://<your-bucket>/checkpoints/groot/<exp_name>/
 EOF
   exit 1
 fi
 
-NAME="$1"
-shift
+VENDOR="$1"
+NAME="$2"
+shift 2
 
-SERVER_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.server $*"
+case "$VENDOR" in
+  lerobot_0_3_3) IMAGE="positro/positronic:latest"; EXTRA="--extra lerobot_0_3_3 " ;;
+  lerobot)       IMAGE="positro/positronic:latest"; EXTRA="--extra lerobot " ;;
+  openpi)        IMAGE="positro/openpi:latest";     EXTRA="" ;;
+  gr00t)         IMAGE="positro/gr00t:latest";      EXTRA="" ;;
+  *)
+    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t" >&2
+    exit 1
+    ;;
+esac
 
-echo "Creating endpoint '$NAME'..."
+SERVER_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
+
+echo "Creating $VENDOR endpoint '$NAME'..."
 nebius ai endpoint create \
   --parent-id "$PARENT_ID" \
   --subnet-id "$SUBNET_ID" \
   --name "$NAME" \
-  --image positro/positronic:latest \
+  --image "$IMAGE" \
   --container-command uv \
   --args "$SERVER_ARGS" \
   --container-port 8000 \
@@ -85,6 +112,7 @@ cat <<BANNER
   Endpoint URL:  http://$IP
   Endpoint ID:   $ID
   Endpoint name: $NAME
+  Vendor:        $VENDOR
 ==============================================================
 
 The container is still warming up (image pull + uv sync + checkpoint load,

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Submit a Nebius Serverless Endpoint running positronic.vendors.lerobot_0_3_3.server.
+#
+# After creation, polls until a public IP is allocated and prints connection
+# details. The container itself takes ~10-15 min more to finish uv sync and
+# load the model into GPU memory after the IP appears.
+#
+# Hardcoded: image, GPU platform/preset, MysteryBox secret names, S3 endpoint URL,
+# container port. Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
+
+set -euo pipefail
+
+PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
+SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
+
+if [ $# -lt 2 ]; then
+  cat >&2 <<'EOF'
+Usage: bash workflows/nebius/serve.sh <endpoint-name> [server args...]
+
+The first argument is a unique endpoint name (lowercase alphanumeric + dashes).
+Remaining arguments forward to positronic.vendors.lerobot_0_3_3.server.
+
+Examples:
+
+  # Public ACT demo checkpoint (no S3 credentials needed inside the container)
+  bash workflows/nebius/serve.sh my-act-demo demo
+
+  # Your own checkpoint
+  bash workflows/nebius/serve.sh act-server serve \
+    --checkpoints_dir=s3://<your-bucket>/checkpoints/lerobot/<exp_name>/
+EOF
+  exit 1
+fi
+
+NAME="$1"
+shift
+
+SERVER_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.server $*"
+
+echo "Creating endpoint '$NAME'..."
+nebius ai endpoint create \
+  --parent-id "$PARENT_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --name "$NAME" \
+  --image positro/positronic:latest \
+  --container-command uv \
+  --args "$SERVER_ARGS" \
+  --container-port 8000 \
+  --platform gpu-h100-sxm \
+  --preset 1gpu-16vcpu-200gb \
+  --working-dir /positronic \
+  --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
+  --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
+  --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
+  --env AWS_DEFAULT_REGION=eu-north1 \
+  --public >/dev/null
+
+ID=$(nebius ai endpoint list --parent-id "$PARENT_ID" --format json \
+  | jq -r --arg n "$NAME" '.items[]? | select(.metadata.name==$n) | .metadata.id')
+
+if [ -z "$ID" ]; then
+  echo "Endpoint create did not return a known resource for name '$NAME'." >&2
+  exit 1
+fi
+
+echo "Endpoint ID: $ID"
+echo "Waiting for public IP (typically <1 min)..."
+
+IP=""
+for i in $(seq 1 30); do
+  IP=$(nebius ai endpoint get "$ID" --format json 2>/dev/null \
+    | jq -r '.status.public_endpoints[0]? // empty')
+  if [ -n "$IP" ]; then break; fi
+  sleep 10
+done
+
+if [ -z "$IP" ]; then
+  echo "Public IP not allocated within 5 min. Check: nebius ai endpoint get $ID" >&2
+  exit 1
+fi
+
+cat <<BANNER
+
+==============================================================
+  Endpoint URL:  http://$IP
+  Endpoint ID:   $ID
+  Endpoint name: $NAME
+==============================================================
+
+The container is still warming up (image pull + uv sync + checkpoint load,
+~10-15 min total). Follow startup logs:
+
+  nebius ai endpoint logs $ID --follow
+
+Once the model is loaded, sanity-check with:
+
+  curl http://$IP/api/v1/models
+
+To release the endpoint and its public IP:
+
+  bash workflows/nebius/stop.sh $NAME
+
+BANNER

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -54,7 +54,8 @@ shift 2
 case "$VENDOR" in
   lerobot_0_3_3) IMAGE="positro/positronic:latest"; EXTRA="--extra lerobot_0_3_3 " ;;
   lerobot)       IMAGE="positro/positronic:latest"; EXTRA="--extra lerobot " ;;
-  openpi)        IMAGE="positro/openpi:latest";     EXTRA="" ;;
+  # openpi.server imports `openpi_client` at module top → needs --extra openpi
+  openpi)        IMAGE="positro/openpi:latest";     EXTRA="--extra openpi " ;;
   gr00t)         IMAGE="positro/gr00t:latest";      EXTRA="" ;;
   *)
     echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t" >&2

--- a/workflows/nebius/stop.sh
+++ b/workflows/nebius/stop.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Delete a Nebius Serverless Endpoint by name (releases compute + public IP).
+#
+# To pause an endpoint without releasing its static IP, use
+# `nebius ai endpoint stop <id>` directly instead — `start` resumes it later.
+
+set -euo pipefail
+
+PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
+
+if [ $# -ne 1 ]; then
+  echo "Usage: bash workflows/nebius/stop.sh <endpoint-name>" >&2
+  exit 1
+fi
+NAME="$1"
+
+ID=$(nebius ai endpoint list --parent-id "$PARENT_ID" --format json \
+  | jq -r --arg n "$NAME" '.items[]? | select(.metadata.name==$n) | .metadata.id')
+
+if [ -z "$ID" ]; then
+  echo "No endpoint named '$NAME' found in $PARENT_ID" >&2
+  exit 1
+fi
+
+echo "Deleting endpoint '$NAME' ($ID)..."
+nebius ai endpoint delete "$ID"
+echo "Released endpoint and public IP."

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Submit ACT (lerobot 0.3.3) training as a Nebius Serverless Job.
 #
+# The bucket referenced by --input_path=s3://... is mounted via Mountpoint-S3
+# (FUSE) at /mnt/input, and --input_path is rewritten to a path under that mount.
+# This skips the dataset download into local cache and streams reads on demand.
+#
+# --output_dir stays as an s3:// URL handled by pos3 — LeRobot's checkpoint save
+# uses symlinks, which Mountpoint-S3 does not support.
+#
 # Hardcoded: image, GPU platform/preset, MysteryBox secret names, S3 endpoint URL.
 # Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
 #
@@ -19,16 +26,40 @@ Usage: bash workflows/nebius/train.sh [train args...]
 Forwards all arguments to positronic.vendors.lerobot_0_3_3.train. Example:
 
   bash workflows/nebius/train.sh \
-    --input_path=s3://interim/sim_stack/lerobot/ee/ \
-    --exp_name=act_sim_stack_$(date +%Y%m%d_%H%M%S) \
-    --output_dir=s3://checkpoints/sim_stack/lerobot/serverless/ \
-    --num_train_steps=200 --save_freq=100
+    --input_path=s3://<your-bucket>/sim_stack_cubes_lerobot/ \
+    --exp_name=act_sim_stack_v1 \
+    --output_dir=s3://<your-bucket>/checkpoints/lerobot/ \
+    --num_train_steps=50000 --save_freq=10000
 EOF
   exit 1
 fi
 
+# Rewrite --input_path=s3://bucket/key/ → /mnt/input/key/, plan an S3 mount.
+INPUT_BUCKET=""
+NEW_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --input_path=s3://*)
+      val="${arg#--input_path=}"
+      INPUT_BUCKET="${val#s3://}"
+      INPUT_BUCKET="${INPUT_BUCKET%%/*}"
+      key="${val#s3://${INPUT_BUCKET}}"
+      key="${key#/}"
+      NEW_ARGS+=("--input_path=/mnt/input/${key}")
+      ;;
+    *)
+      NEW_ARGS+=("$arg")
+      ;;
+  esac
+done
+
+VOLUME_FLAGS=()
+if [ -n "$INPUT_BUCKET" ]; then
+  VOLUME_FLAGS+=(--volume "s3://${INPUT_BUCKET}:/mnt/input:ro:default@positronic-serverless-s3-creds")
+fi
+
 JOB_NAME="act-train-$(date +%Y%m%d-%H%M%S)"
-TRAIN_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.train $*"
+TRAIN_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.train ${NEW_ARGS[*]}"
 
 nebius ai job create \
   --parent-id "$PARENT_ID" \
@@ -41,6 +72,7 @@ nebius ai job create \
   --preset 1gpu-16vcpu-200gb \
   --timeout 24h \
   --working-dir /positronic \
+  ${VOLUME_FLAGS[@]+"${VOLUME_FLAGS[@]}"} \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env-secret WANDB_API_KEY=positronic-serverless-wandb-api-key \

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -50,23 +50,31 @@ case "$VENDOR" in
 esac
 
 # Rewrite --input_path=s3://bucket/key/ → /mnt/input/key/, plan an S3 mount.
+# Only lerobot_0_3_3 is validated to work with the read-only mount; other
+# vendors (notably gr00t) write back into the dataset dir during training,
+# which the RO mount blocks. For those, leave --input_path as s3:// and let
+# pos3.download fetch into the local writable cache.
 INPUT_BUCKET=""
 NEW_ARGS=()
-for arg in "$@"; do
-  case "$arg" in
-    --input_path=s3://*)
-      val="${arg#--input_path=}"
-      INPUT_BUCKET="${val#s3://}"
-      INPUT_BUCKET="${INPUT_BUCKET%%/*}"
-      key="${val#s3://${INPUT_BUCKET}}"
-      key="${key#/}"
-      NEW_ARGS+=("--input_path=/mnt/input/${key}")
-      ;;
-    *)
-      NEW_ARGS+=("$arg")
-      ;;
-  esac
-done
+if [ "$VENDOR" = "lerobot_0_3_3" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      --input_path=s3://*)
+        val="${arg#--input_path=}"
+        INPUT_BUCKET="${val#s3://}"
+        INPUT_BUCKET="${INPUT_BUCKET%%/*}"
+        key="${val#s3://${INPUT_BUCKET}}"
+        key="${key#/}"
+        NEW_ARGS+=("--input_path=/mnt/input/${key}")
+        ;;
+      *)
+        NEW_ARGS+=("$arg")
+        ;;
+    esac
+  done
+else
+  NEW_ARGS=("$@")
+fi
 
 VOLUME_FLAGS=()
 if [ -n "$INPUT_BUCKET" ]; then

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Submit ACT (lerobot 0.3.3) training as a Nebius Serverless Job.
+#
+# Hardcoded: image, GPU platform/preset, MysteryBox secret names, S3 endpoint URL.
+# Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
+#
+# All flags after the script name are forwarded to:
+#     python -m positronic.vendors.lerobot_0_3_3.train
+
+set -euo pipefail
+
+PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
+SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
+
+if [ $# -eq 0 ]; then
+  cat >&2 <<'EOF'
+Usage: bash workflows/nebius/train.sh [train args...]
+
+Forwards all arguments to positronic.vendors.lerobot_0_3_3.train. Example:
+
+  bash workflows/nebius/train.sh \
+    --input_path=s3://interim/sim_stack/lerobot/ee/ \
+    --exp_name=act_sim_stack_$(date +%Y%m%d_%H%M%S) \
+    --output_dir=s3://checkpoints/sim_stack/lerobot/serverless/ \
+    --num_train_steps=200 --save_freq=100
+EOF
+  exit 1
+fi
+
+JOB_NAME="act-train-$(date +%Y%m%d-%H%M%S)"
+TRAIN_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.train $*"
+
+nebius ai job create \
+  --parent-id "$PARENT_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --name "$JOB_NAME" \
+  --image positro/positronic:latest \
+  --container-command uv \
+  --args "$TRAIN_ARGS" \
+  --platform gpu-h100-sxm \
+  --preset 1gpu-16vcpu-200gb \
+  --timeout 24h \
+  --working-dir /positronic \
+  --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
+  --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
+  --env-secret WANDB_API_KEY=positronic-serverless-wandb-api-key \
+  --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
+  --env AWS_DEFAULT_REGION=eu-north1

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
 SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
+WANDB_SECRET="${WANDB_SECRET-positronic-serverless-wandb-api-key}"
 
 if [ $# -lt 1 ]; then
   cat >&2 <<'EOF'
@@ -75,6 +76,11 @@ fi
 JOB_NAME="${VENDOR//_/-}-train-$(date +%Y%m%d-%H%M%S)"
 TRAIN_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.train ${NEW_ARGS[*]}"
 
+WANDB_FLAGS=()
+if [ -n "$WANDB_SECRET" ]; then
+  WANDB_FLAGS+=(--env-secret "WANDB_API_KEY=$WANDB_SECRET")
+fi
+
 nebius ai job create \
   --parent-id "$PARENT_ID" \
   --subnet-id "$SUBNET_ID" \
@@ -89,6 +95,6 @@ nebius ai job create \
   ${VOLUME_FLAGS[@]+"${VOLUME_FLAGS[@]}"} \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
-  --env-secret WANDB_API_KEY=positronic-serverless-wandb-api-key \
+  ${WANDB_FLAGS[@]+"${WANDB_FLAGS[@]}"} \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
   --env AWS_DEFAULT_REGION=eu-north1

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env bash
-# Submit ACT (lerobot 0.3.3) training as a Nebius Serverless Job.
+# Submit a vendor training run as a Nebius Serverless Job.
 #
 # The bucket referenced by --input_path=s3://... is mounted via Mountpoint-S3
 # (FUSE) at /mnt/input, and --input_path is rewritten to a path under that mount.
 # This skips the dataset download into local cache and streams reads on demand.
 #
-# --output_dir stays as an s3:// URL handled by pos3 — LeRobot's checkpoint save
-# uses symlinks, which Mountpoint-S3 does not support.
+# --output_dir stays as an s3:// URL handled by pos3 — vendor checkpoint savers
+# tend to use symlinks, which Mountpoint-S3 does not support.
 #
-# Hardcoded: image, GPU platform/preset, MysteryBox secret names, S3 endpoint URL.
-# Override-able via env: NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
-#
-# All flags after the script name are forwarded to:
-#     python -m positronic.vendors.lerobot_0_3_3.train
+# Hardcoded: GPU platform/preset, MysteryBox secret names, S3 endpoint URL.
+# Vendor selects image + uv extra. Override-able via env: NEBIUS_PARENT_ID,
+# NEBIUS_SUBNET_ID.
 
 set -euo pipefail
 
 PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
 SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
 
-if [ $# -eq 0 ]; then
+if [ $# -lt 1 ]; then
   cat >&2 <<'EOF'
-Usage: bash workflows/nebius/train.sh [train args...]
+Usage: bash workflows/nebius/train.sh <vendor> [train args...]
 
-Forwards all arguments to positronic.vendors.lerobot_0_3_3.train. Example:
+Vendors: lerobot_0_3_3 | lerobot | openpi | gr00t
 
-  bash workflows/nebius/train.sh \
+Forwards remaining arguments to positronic.vendors.<vendor>.train. Example:
+
+  bash workflows/nebius/train.sh lerobot_0_3_3 \
     --input_path=s3://<your-bucket>/sim_stack_cubes_lerobot/ \
     --exp_name=act_sim_stack_v1 \
     --output_dir=s3://<your-bucket>/checkpoints/lerobot/ \
@@ -33,6 +33,20 @@ Forwards all arguments to positronic.vendors.lerobot_0_3_3.train. Example:
 EOF
   exit 1
 fi
+
+VENDOR="$1"
+shift
+
+case "$VENDOR" in
+  lerobot_0_3_3) IMAGE="positro/positronic:latest"; EXTRA="--extra lerobot_0_3_3 " ;;
+  lerobot)       IMAGE="positro/positronic:latest"; EXTRA="--extra lerobot " ;;
+  openpi)        IMAGE="positro/openpi:latest";     EXTRA="" ;;
+  gr00t)         IMAGE="positro/gr00t:latest";      EXTRA="" ;;
+  *)
+    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t" >&2
+    exit 1
+    ;;
+esac
 
 # Rewrite --input_path=s3://bucket/key/ → /mnt/input/key/, plan an S3 mount.
 INPUT_BUCKET=""
@@ -58,14 +72,14 @@ if [ -n "$INPUT_BUCKET" ]; then
   VOLUME_FLAGS+=(--volume "s3://${INPUT_BUCKET}:/mnt/input:ro:default@positronic-serverless-s3-creds")
 fi
 
-JOB_NAME="act-train-$(date +%Y%m%d-%H%M%S)"
-TRAIN_ARGS="run --python 3.11 --extra lerobot_0_3_3 python -m positronic.vendors.lerobot_0_3_3.train ${NEW_ARGS[*]}"
+JOB_NAME="${VENDOR//_/-}-train-$(date +%Y%m%d-%H%M%S)"
+TRAIN_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.train ${NEW_ARGS[*]}"
 
 nebius ai job create \
   --parent-id "$PARENT_ID" \
   --subnet-id "$SUBNET_ID" \
   --name "$JOB_NAME" \
-  --image positro/positronic:latest \
+  --image "$IMAGE" \
   --container-command uv \
   --args "$TRAIN_ARGS" \
   --platform gpu-h100-sxm \


### PR DESCRIPTION
## Summary
- New `workflows/` top-level directory holding workflow/runtime integrations
- `workflows/nebius/` with `README.md` and four scripts:
  - `convert.sh <vendor> ...` — Positronic dataset → LeRobot dataset conversion (CPU Job, `cpu-e2 / 8vcpu-32gb`). Vendor in `lerobot_0_3_3 | lerobot | openpi | gr00t`. OpenPI/GR00T re-use the `lerobot_0_3_3` converter with their own codec namespaces (matches each vendor's README).
  - `train.sh <vendor> ...` — vendor training (GPU Job, `gpu-h100-sxm / 1gpu-16vcpu-200gb`); rewrites `--input_path=s3://...` to a Mountpoint-S3 mount under `/mnt/input`. Vendor in `lerobot_0_3_3 | lerobot | openpi | gr00t`.
  - `serve.sh <vendor> <name> ...` — vendor inference Endpoint on H100 with public IP. Vendor in `lerobot_0_3_3 | lerobot | openpi | gr00t`.
  - `stop.sh <name>` — delete the endpoint and release its IP.
- Vendor positional selects container image (`positro/positronic` for lerobot/lerobot_0_3_3, `positro/openpi`, `positro/gr00t`) and `uv` extras; rest of the submission spec is identical across vendors.
- Credentials stay in MysteryBox; the operator's machine never holds AWS or WandB keys.
- README mirrors `docs/training-workflow.md` (Convert / Train / Serve) from the perspective of someone running in their own Nebius project; Step 4 (inference from a robot/sim) is unchanged.

## Test plan
- [x] `convert.sh lerobot_0_3_3` validated end-to-end on public `sim_stack_cubes` dataset → 967 objects, 148 MiB written to S3 in LeRobot 0.3.3 layout
- [x] `train.sh lerobot_0_3_3` validated end-to-end on the converted dataset (50k steps ACT, final loss 0.066, 5 checkpoints uploaded)
- [x] `serve.sh lerobot_0_3_3 ... demo` end-to-end: endpoint reaches `RUNNING`, `/api/v1/models` returns the expected checkpoint, 5×20s inference episodes captured locally
- [x] `train.sh {openpi, gr00t, lerobot} --help` smoke run inside each vendor's image — uv resolves, module imports, cfn prints config, exits 0
- [x] MysteryBox `--env-secret` resolution confirmed via name reference
- [x] Reviewer to skim the README for narrative coherence (this is the artifact for the upcoming Nebius webinar)

## Out of scope
- Full per-vendor end-to-end (train → serve → infer) for openpi/gr00t/SmolVLA. Tier-2 `--help` smoke confirms the wiring; full e2e is webinar-prep work, not refactor validation.
- OpenPI's `compute_norm_stats` step (between convert and train) — separate vendor stage, not yet a workflow script.
- DreamZero — supported by the same template but not exposed in the dispatch table since it isn't part of the demo flow.