### PR TITLE
Add dataset sampling for LeRobot conversion and `droid_spoons` ablation setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-        exclude: docker-compose\.phail\..*yml  # Uses Docker Compose !override tags
+        exclude: docker-compose\..+\.yml  # Uses Docker Compose !override tags
       - id: check-toml
       - id: check-added-large-files
         args: ['--maxkb=1000']

--- a/docker/docker-compose.spoons-ablation.yml
+++ b/docker/docker-compose.spoons-ablation.yml
@@ -1,0 +1,42 @@
+# GR00T spoons data ablation servers (~4.6GB each, 2 fit on desktop, 1 on notebook)
+#
+# Desktop (2 servers):
+#   IMAGE_TAG=latest CACHE_ROOT=/home/vertix docker --context desktop compose -f docker-compose.spoons-ablation.yml up spoons-100 spoons-50
+# Notebook (1 server):
+#   IMAGE_TAG=latest docker --context notebook compose -f docker-compose.spoons-ablation.yml up spoons-25
+services:
+  spoons-100:
+    extends:
+      file: docker-compose.yml
+      service: groot-server
+    container_name: spoons-100
+    pull_policy: always
+    command:
+      - "ee_rot6d_rel"
+      - "--checkpoints_dir=s3://checkpoints/droid_spoons/groot/ee_rot6d_rel_100/"
+    ports: !override
+      - "8000:8000"
+
+  spoons-50:
+    extends:
+      file: docker-compose.yml
+      service: groot-server
+    container_name: spoons-50
+    pull_policy: always
+    command:
+      - "ee_rot6d_rel"
+      - "--checkpoints_dir=s3://checkpoints/droid_spoons/groot/ee_rot6d_rel_50_v2/"
+    ports: !override
+      - "8001:8000"
+
+  spoons-25:
+    extends:
+      file: docker-compose.yml
+      service: groot-server
+    container_name: spoons-25
+    pull_policy: always
+    command:
+      - "ee_rot6d_rel"
+      - "--checkpoints_dir=s3://checkpoints/droid_spoons/groot/ee_rot6d_rel_25/"
+    ports: !override
+      - "8002:8000"

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -177,6 +177,12 @@ def droid_clean(dataset):
 
 droid_clean = droid_clean.override(dataset=droid)
 
+
+@cfn.config(dataset=droid_clean)
+def droid_spoons(dataset):
+    return FilterDataset(dataset, lambda ep: ep.static.get('task') == SPOONS_TASK)
+
+
 droid_recovery = droid_clean.override(
     dataset=droid.override(recovery_all=True, recovery_towels=True, duplicate_recovery=False)
 )

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -178,6 +178,8 @@ def droid_clean(dataset):
 droid_clean = droid_clean.override(dataset=droid)
 
 
+# Spoons-only subset of droid_clean. Used as the base for data-size ablation experiments
+# (combined with --share/--seed in the LeRobot conversion to produce 100% / 50% / 25% variants).
 @cfn.config(dataset=droid_clean)
 def droid_spoons(dataset):
     return FilterDataset(dataset, lambda ep: ep.static.get('task') == SPOONS_TASK)

--- a/positronic/vendors/lerobot/to_lerobot.py
+++ b/positronic/vendors/lerobot/to_lerobot.py
@@ -69,12 +69,20 @@ def _collate_fn(x):
     return x[0]
 
 
-def append_data_to_dataset(lr_dataset: LeRobotDataset, p_dataset: Dataset, fps, task=None, num_workers=16):
+def append_data_to_dataset(
+    lr_dataset: LeRobotDataset, p_dataset: Dataset, fps, task=None, num_workers=16, share=1.0, seed=42
+):
     _raise_fd_limit()
     lr_dataset.start_image_writer()
     total_length_sec = 0
 
     episode_dataset = EpisodeDictDataset(p_dataset, fps=fps)
+    if share < 1.0:
+        n = len(episode_dataset)
+        k = max(1, round(n * share))
+        indices = sorted(np.random.default_rng(seed).choice(n, size=k, replace=False))
+        episode_dataset = torch.utils.data.Subset(episode_dataset, indices)
+        logging.info(f'Sampling {k}/{n} episodes (share={share}, seed={seed})')
     dataloader = torch.utils.data.DataLoader(
         episode_dataset, batch_size=1, shuffle=False, num_workers=num_workers, collate_fn=_collate_fn
     )
@@ -99,8 +107,10 @@ def append_data_to_dataset(lr_dataset: LeRobotDataset, p_dataset: Dataset, fps, 
     logging.info(f'Total length of the dataset: {seconds_to_str(total_length_sec)}')
 
 
-@cfn.config(video=True, dataset=apply_codec, fps=None)
-def convert_to_lerobot_dataset(output_dir: str, fps: int | None, video: bool, dataset: Dataset, task=None):
+@cfn.config(video=True, dataset=apply_codec, fps=None, share=1.0, seed=42)
+def convert_to_lerobot_dataset(
+    output_dir: str, fps: int | None, video: bool, dataset: Dataset, task=None, share=1.0, seed=42
+):
     if fps is None:
         assert 'action_fps' in dataset.meta, "--fps not provided and dataset has no 'action_fps' metadata"
         fps = int(dataset.meta['action_fps'])
@@ -117,12 +127,12 @@ def convert_to_lerobot_dataset(output_dir: str, fps: int | None, video: bool, da
     )
     utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])
 
-    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps)
+    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps, share=share, seed=seed)
     logging.info(f'Dataset converted and saved to {output_dir}')
 
 
-@cfn.config(dataset=apply_codec, fps=None)
-def append_data_to_lerobot_dataset(output_dir: str, dataset: Dataset, fps: int | None, task=None):
+@cfn.config(dataset=apply_codec, fps=None, share=1.0, seed=42)
+def append_data_to_lerobot_dataset(output_dir: str, dataset: Dataset, fps: int | None, task=None, share=1.0, seed=42):
     if fps is None:
         assert 'action_fps' in dataset.meta, "--fps not provided and dataset has no 'action_fps' metadata"
         fps = int(dataset.meta['action_fps'])
@@ -131,7 +141,7 @@ def append_data_to_lerobot_dataset(output_dir: str, dataset: Dataset, fps: int |
 
     utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'], prefix='append_metadata')
 
-    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps)
+    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps, share=share, seed=seed)
     logging.info(f'Dataset extended and saved to {output_dir}')
 
 

--- a/positronic/vendors/lerobot_0_3_3/to_lerobot.py
+++ b/positronic/vendors/lerobot_0_3_3/to_lerobot.py
@@ -78,13 +78,21 @@ def _collate_fn(x):
     return x[0]
 
 
-def append_data_to_dataset(lr_dataset: LeRobotDataset, p_dataset: Dataset, fps, task=None, num_workers=16):
+def append_data_to_dataset(
+    lr_dataset: LeRobotDataset, p_dataset: Dataset, fps, task=None, num_workers=16, share=1.0, seed=42
+):
     _raise_fd_limit()
     lr_dataset.start_image_writer(num_processes=num_workers)
     # Process each episode file
     total_length_sec = 0
 
     episode_dataset = EpisodeDictDataset(p_dataset, fps=fps)
+    if share < 1.0:
+        n = len(episode_dataset)
+        k = max(1, round(n * share))
+        indices = sorted(np.random.default_rng(seed).choice(n, size=k, replace=False))
+        episode_dataset = torch.utils.data.Subset(episode_dataset, indices)
+        logging.info(f'Sampling {k}/{n} episodes (share={share}, seed={seed})')
     dataloader = torch.utils.data.DataLoader(
         episode_dataset, batch_size=1, shuffle=False, num_workers=num_workers, collate_fn=_collate_fn
     )
@@ -112,8 +120,10 @@ def append_data_to_dataset(lr_dataset: LeRobotDataset, p_dataset: Dataset, fps, 
     logging.info(f'Total length of the dataset: {seconds_to_str(total_length_sec)}')
 
 
-@cfn.config(video=True, dataset=apply_codec, fps=None)
-def convert_to_lerobot_dataset(output_dir: str, fps: int | None, video: bool, dataset: Dataset, task=None):
+@cfn.config(video=True, dataset=apply_codec, fps=None, share=1.0, seed=42)
+def convert_to_lerobot_dataset(
+    output_dir: str, fps: int | None, video: bool, dataset: Dataset, task=None, share=1.0, seed=42
+):
     if fps is None:
         assert 'action_fps' in dataset.meta, "--fps not provided and dataset has no 'action_fps' metadata"
         fps = int(dataset.meta['action_fps'])
@@ -139,12 +149,12 @@ def convert_to_lerobot_dataset(output_dir: str, fps: int | None, video: bool, da
             with modality_path.open('w', encoding='utf-8') as f:
                 json.dump(modality, f, indent=2)
 
-    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps)
+    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps, share=share, seed=seed)
     logging.info(f'Dataset converted and saved to {output_dir}')
 
 
-@cfn.config(dataset=apply_codec, fps=None)
-def append_data_to_lerobot_dataset(output_dir: str, dataset: Dataset, fps: int | None, task=None):
+@cfn.config(dataset=apply_codec, fps=None, share=1.0, seed=42)
+def append_data_to_lerobot_dataset(output_dir: str, dataset: Dataset, fps: int | None, task=None, share=1.0, seed=42):
     if fps is None:
         assert 'action_fps' in dataset.meta, "--fps not provided and dataset has no 'action_fps' metadata"
         fps = int(dataset.meta['action_fps'])
@@ -169,7 +179,7 @@ def append_data_to_lerobot_dataset(output_dir: str, dataset: Dataset, fps: int |
         # If dataset has modality but lerobot dataset doesn't, this is an error
         raise ValueError("'gr00t_modality' exists in dataset.meta but not in the destination LeRobot dataset.")
 
-    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps)
+    append_data_to_dataset(lr_dataset=lr_dataset, p_dataset=dataset, task=task, fps=fps, share=share, seed=seed)
     logging.info(f'Dataset extended and saved to {output_dir}')
 
 


### PR DESCRIPTION
## Summary
- Add `share` (default 1.0) and `seed` (default 42) parameters to both `to_lerobot.py` conversion scripts to deterministically subsample episodes when converting Positronic datasets to LeRobot format
- Add `droid_spoons` config in `positronic/cfg/ds/internal.py` — `droid_clean` filtered to only spoons-task episodes (167/449 episodes)
- Add `docker/docker-compose.spoons-ablation.yml` for serving the resulting GR00T checkpoints
- Broaden pre-commit `check-yaml` exclude pattern to cover all `docker-compose.<suffix>.yml` files (not just `phail`)

## Test plan
- Verified `droid_spoons` produces 167 episodes (vs 449 for `droid_clean`)
- Used the new `--share` to convert 100% / 50% / 25% subsets of `droid_spoons` to GR00T's `ee_rot6d` interim format, then trained three GR00T-N1.6 jobs to 150k steps on H100 VMs. All three completed and saved checkpoints to `s3://checkpoints/droid_spoons/groot/ee_rot6d_rel_{100,50_v2,25}/`
- Sampling determinism: same `seed` produces same indices on re-runs (50% subset is nested inside the 100% set)