### PR TITLE
Mount a shared Nebius filesystem for uv/HF/openpi caches across cold starts

### DIFF
--- a/positronic/vendors/openpi/__init__.py
+++ b/positronic/vendors/openpi/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import urllib.request
 from pathlib import Path
 
@@ -7,7 +8,10 @@ logger = logging.getLogger(__name__)
 # Google revoked anonymous access to gs://big_vision, breaking OpenPI's tokenizer download.
 # Track: https://github.com/Physical-Intelligence/openpi/issues/881
 _TOKENIZER_URL = 'https://storage.eu-north1.nebius.cloud/positronic-public/assets/paligemma_tokenizer.model'
-_TOKENIZER_CACHE = Path.home() / '.cache' / 'openpi' / 'big_vision' / 'paligemma_tokenizer.model'
+# Mirror upstream openpi's OPENPI_DATA_HOME convention so the tokenizer co-locates
+# with the gs://openpi-assets cache (default ~/.cache/openpi when unset).
+_OPENPI_DATA_HOME = Path(os.getenv('OPENPI_DATA_HOME', Path.home() / '.cache' / 'openpi')).expanduser()
+_TOKENIZER_CACHE = _OPENPI_DATA_HOME / 'big_vision' / 'paligemma_tokenizer.model'
 
 
 def ensure_paligemma_tokenizer():

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -91,6 +91,39 @@ The filesystem is RWX — many jobs/endpoints attach it concurrently. pos3's own
 (`~/.cache/positronic/s3/`) is deliberately *not* redirected here; it stays on each container's
 local disk and re-fetches from S3 by design.
 
+### Cleaning the shared cache
+
+There is no file browser for the filesystem — to inspect or wipe it you mount it in a
+throwaway job. Make sure no jobs/endpoints are using the cache first (a wipe while a
+warm job reads it will break that job).
+
+Inspect usage:
+
+```bash
+nebius ai job create --parent-id "$PARENT_ID" --subnet-id "$SUBNET_ID" \
+  --name cache-du --image busybox:latest \
+  --container-command du --args '-sh /cache /cache/uv /cache/hf /cache/openpi' \
+  --platform cpu-e2 --preset 4vcpu-16gb --timeout 1h \
+  --volume "$NEBIUS_CACHE_FS:/cache:rw"
+# then: nebius ai job logs <aijob-id>
+```
+
+Wipe everything (full reset — the next run repays the cold download):
+
+```bash
+nebius ai job create --parent-id "$PARENT_ID" --subnet-id "$SUBNET_ID" \
+  --name cache-wipe --image busybox:latest \
+  --container-command find --args '/cache -mindepth 1 -delete' \
+  --platform cpu-e2 --preset 4vcpu-16gb --timeout 1h \
+  --volume "$NEBIUS_CACHE_FS:/cache:rw"
+```
+
+To clear only one tool's cache, target its subdir, e.g. `--args '/cache/uv -mindepth 1
+-delete'`. Two gotchas: `--volume` needs the filesystem **ID** (not name), and Nebius
+space-splits `--args`, so use a no-shell command (`find`/`du`) — a quoted `sh -c "..."`
+gets torn apart. Deleting and recreating the filesystem also works but loses the warm
+cache for every workflow.
+
 ## Convert a Positronic dataset
 
 Each model family expects a specific dataset format. `convert.sh` runs the right converter
@@ -266,9 +299,6 @@ later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
 
 No VM to provision, SSH into, or remember to shut down. Credentials stay in MysteryBox instead
 of on operator laptops. Compute is released the moment a job finishes — idle cost goes to zero.
-The trade-off is a cold start per job (image pull + venv resolve) instead of a warm VM —
-mitigated by the shared `/cache` filesystem, so only the first run after a dependency change
-pays the full download.
 
 ## Configuration
 

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -70,6 +70,27 @@ nebius mysterybox secret create \
 The names matter — `convert.sh`, `train.sh`, and `serve.sh` reference the secrets by name. If a
 secret with one of these names already exists, the create call fails; skip it.
 
+Also create one shared filesystem for the dependency caches. Every job and endpoint mounts it
+read-write at `/cache`; `uv`, HuggingFace, and openpi asset downloads land there and persist
+across cold starts, so only the first run after a dependency change pays the download cost:
+
+```bash
+nebius compute filesystem create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-cache \
+  --type network_ssd \
+  --size-gibibytes 512
+
+# --volume needs the filesystem ID, not its name. Grab it and export it:
+nebius compute filesystem list --parent-id "$PARENT_ID" --format json \
+  | jq -r '.items[] | select(.metadata.name=="positronic-serverless-cache") | .metadata.id'
+# → computefilesystem-...   (pass via NEBIUS_CACHE_FS, or rely on the script default)
+```
+
+The filesystem is RWX — many jobs/endpoints attach it concurrently. pos3's own cache
+(`~/.cache/positronic/s3/`) is deliberately *not* redirected here; it stays on each container's
+local disk and re-fetches from S3 by design.
+
 ## Convert a Positronic dataset
 
 Each model family expects a specific dataset format. `convert.sh` runs the right converter
@@ -153,9 +174,11 @@ Useful Commands
   ...
 ```
 
-The job stays in `PROVISIONING`/`STARTING` for ~10 min while the image pulls and the Python
-environment resolves inside the container, then runs the actual training. Cost scales with
-total wall clock — the cold-start fraction shrinks for longer runs.
+The job stays in `PROVISIONING`/`STARTING` while the image pulls and the Python environment
+resolves inside the container, then runs the actual training. The first job after a dependency
+change pays the full `uv`/HF download cost (~10 min); subsequent jobs reuse the shared `/cache`
+filesystem and start substantially faster. Cost scales with total wall clock — the cold-start
+fraction shrinks for longer runs.
 
 ## Verifying the run
 
@@ -243,7 +266,9 @@ later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
 
 No VM to provision, SSH into, or remember to shut down. Credentials stay in MysteryBox instead
 of on operator laptops. Compute is released the moment a job finishes — idle cost goes to zero.
-The trade-off is a ~10-min cold start per job (image pull + venv resolve) instead of a warm VM.
+The trade-off is a cold start per job (image pull + venv resolve) instead of a warm VM —
+mitigated by the shared `/cache` filesystem, so only the first run after a dependency change
+pays the full download.
 
 ## Configuration
 
@@ -255,6 +280,7 @@ override them** with their own project + subnet IDs:
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
 | `WANDB_SECRET` | `positronic-serverless-wandb-api-key` | MysteryBox secret name for the WandB key. Set empty (`WANDB_SECRET=`) to skip wandb entirely. |
+| `NEBIUS_CACHE_FS` | `computefilesystem-e00f6jyfr5wkawyrab` | Shared filesystem **ID** (not name — `--volume` rejects names) mounted RW at `/cache` for the `uv`/HF/openpi caches (`UV_CACHE_DIR`, `HF_HOME`, `OPENPI_DATA_HOME`). Not used by pos3. The default is Positronic-internal; external users must override with their own filesystem ID. |
 
 Other operational settings (platform/preset, MysteryBox secret names, S3 endpoint URL, region)
 are hardcoded — change them by editing the script directly. The vendor positional arg selects

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 
 PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
 SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
+# Shared filesystem (RWX) holding the uv / HF / openpi caches across cold starts.
+# pos3's cache stays on local disk (~/.cache/positronic/s3) — never redirected here.
+CACHE_FS="${NEBIUS_CACHE_FS:-computefilesystem-e00f6jyfr5wkawyrab}"
 
 if [ $# -lt 1 ]; then
   cat >&2 <<'EOF'
@@ -87,6 +90,10 @@ CREATE_OUT=$(nebius ai job create \
   --preset 8vcpu-32gb \
   --timeout 4h \
   --working-dir /positronic \
+  --volume "${CACHE_FS}:/cache:rw" \
+  --env UV_CACHE_DIR=/cache/uv \
+  --env HF_HOME=/cache/hf \
+  --env OPENPI_DATA_HOME=/cache/openpi \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
@@ -149,6 +156,10 @@ nebius ai job create \
   --preset 8vcpu-32gb \
   --timeout 4h \
   --working-dir /positronic \
+  --volume "${CACHE_FS}:/cache:rw" \
+  --env UV_CACHE_DIR=/cache/uv \
+  --env HF_HOME=/cache/hf \
+  --env OPENPI_DATA_HOME=/cache/openpi \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \

--- a/workflows/nebius/e2e.sh
+++ b/workflows/nebius/e2e.sh
@@ -32,6 +32,12 @@ Optional env:
 
 To run all four in parallel:
   for v in lerobot_0_3_3 lerobot openpi gr00t; do bash workflows/nebius/e2e.sh "$v" & done; wait
+
+The shared cache FS (NEBIUS_CACHE_FS) is RWX, but a cold (empty) cache plus a
+4-way parallel fan-out means several jobs racing to populate the same entries.
+On a fresh cache, seed it first with one vendor, then fan out the rest warm:
+  bash workflows/nebius/e2e.sh lerobot_0_3_3
+  for v in lerobot openpi gr00t; do bash workflows/nebius/e2e.sh "$v" & done; wait
 EOF
   exit 1
 fi

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 
 PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
 SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
+# Shared filesystem (RWX) holding the uv / HF / openpi caches across cold starts.
+# pos3's cache stays on local disk (~/.cache/positronic/s3) — never redirected here.
+CACHE_FS="${NEBIUS_CACHE_FS:-computefilesystem-e00f6jyfr5wkawyrab}"
 
 if [ $# -lt 2 ]; then
   cat >&2 <<'EOF'
@@ -77,6 +80,10 @@ nebius ai endpoint create \
   --platform gpu-h100-sxm \
   --preset 1gpu-16vcpu-200gb \
   --working-dir /positronic \
+  --volume "${CACHE_FS}:/cache:rw" \
+  --env UV_CACHE_DIR=/cache/uv \
+  --env HF_HOME=/cache/hf \
+  --env OPENPI_DATA_HOME=/cache/openpi \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -17,6 +17,9 @@ set -euo pipefail
 PARENT_ID="${NEBIUS_PARENT_ID:-project-e00f38wexevrr52b8j}"
 SUBNET_ID="${NEBIUS_SUBNET_ID:-vpcsubnet-e00pk1j1x6hjmr4m92}"
 WANDB_SECRET="${WANDB_SECRET-positronic-serverless-wandb-api-key}"
+# Shared filesystem (RWX) holding the uv / HF / openpi caches across cold starts.
+# pos3's cache stays on local disk (~/.cache/positronic/s3) — never redirected here.
+CACHE_FS="${NEBIUS_CACHE_FS:-computefilesystem-e00f6jyfr5wkawyrab}"
 
 if [ $# -lt 1 ]; then
   cat >&2 <<'EOF'
@@ -101,6 +104,10 @@ nebius ai job create \
   --timeout 24h \
   --working-dir /positronic \
   ${VOLUME_FLAGS[@]+"${VOLUME_FLAGS[@]}"} \
+  --volume "${CACHE_FS}:/cache:rw" \
+  --env UV_CACHE_DIR=/cache/uv \
+  --env HF_HOME=/cache/hf \
+  --env OPENPI_DATA_HOME=/cache/openpi \
   --env-secret AWS_ACCESS_KEY_ID=positronic-serverless-aws-access-key-id \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   ${WANDB_FLAGS[@]+"${WANDB_FLAGS[@]}"} \


### PR DESCRIPTION
## Summary
- Serverless Nebius jobs/endpoints re-downloaded the uv, HuggingFace and openpi asset caches on every cold start (~10 min). Mount one RWX `compute filesystem` at `/cache` and point `UV_CACHE_DIR`/`HF_HOME`/`OPENPI_DATA_HOME` at it so the caches persist across cold starts.
- `pos3`'s cache deliberately stays on local disk (it re-fetches from S3 by design); only per-tool cache env vars are redirected, never `HOME`/`XDG_CACHE_HOME`, so non-serverless paths are unaffected.
- `positronic/vendors/openpi/__init__.py`: `_TOKENIZER_CACHE` now honors `OPENPI_DATA_HOME` (default unchanged at `~/.cache/openpi`), matching upstream openpi's own convention.
- `NEBIUS_CACHE_FS` defaults to the filesystem **ID** (not name — `--volume` rejects names); overridable. README documents one-time `nebius compute filesystem create` + ID lookup.
- No Dockerfile changes; images stay small.

## Test plan
- Local: `OPENPI_DATA_HOME` unset → `~/.cache/openpi/...` (unchanged); set → redirected. **Verified.**
- Real Nebius `e2e.sh openpi`:
  - convert **COMPLETED** (warm uv cache reused)
  - openpi-stats **COMPLETED** — runtime env confirmed `UV_CACHE_DIR=/cache/uv`, `HF_HOME=/cache/hf`, `OPENPI_DATA_HOME=/cache/openpi`; `Installed 242 packages in 34.92s` on the openpi image's first run
  - train **COMPLETED** — loss 1.02→0.24 over 500 steps, checkpoint saved; pos3 cache correctly stayed on local disk
  - serve **FAILED → ROOT-CAUSED**: mounting the `compute filesystem` `:rw` on a serverless **endpoint** makes endpoint creation fail (~30 min → gRPC code 13 INTERNAL). Control run of pre-change `serve.sh` (no cache volume), same checkpoint, **succeeded** (RUNNING + public IP in ~8 min). The same `:rw` filesystem works on jobs; the regression is endpoint-specific. Nebius docs only ever show `compute filesystem` mounted `:ro` on endpoints.

## Status
Cache change is validated and safe for the **job** path (convert/stats/train). The **serve.sh** filesystem mount regresses endpoint creation and needs rework (`:ro` on endpoints, or excluded from this PR).