### PR TITLE
Add support for authenticating to remote servers

### DIFF
--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -59,7 +59,7 @@ def sample(origins: list[cfn.Config], weights: list[float] | None):
     return SampledPolicy(*origins, weights=weights)
 
 
-@cfn.config(host='localhost', port=8000, resize=640, model_id=None, horizon_sec=None, codec=None)
+@cfn.config(host='localhost', port=8000, resize=640, model_id=None, horizon_sec=None, codec=None, secure=False)
 def remote(
     host: str,
     port: int,
@@ -67,18 +67,21 @@ def remote(
     model_id: str | None = None,
     horizon_sec: float | None = None,
     codec: Codec | None = None,
+    headers: dict[str, str] | None = None,
+    secure: bool = False,
 ):
     from positronic.policy.codec import ActionHorizon
     from positronic.policy.remote import RemotePolicy
 
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
-    policy = RemotePolicy(host, port, effective_resize, model_id=model_id)
+    policy = RemotePolicy(
+        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure)
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)
     return codec.wrap(policy) if codec else policy
 
 
-@cfn.config(host=None, port=8000, weight=1.0, model_id=None, resize=640, horizon_sec=None, codec=None)
+@cfn.config(host=None, port=8000, weight=1.0, model_id=None, resize=640, horizon_sec=None, codec=None, secure=False)
 def weighted_remote(
     host: str | None,
     port: int,
@@ -87,6 +90,8 @@ def weighted_remote(
     resize: int | None,
     horizon_sec: float | None,
     codec: Codec | None = None,
+    headers: dict[str, str] | None = None,
+    secure: bool = False,
 ):
     if not host:
         return None
@@ -95,7 +100,9 @@ def weighted_remote(
     from positronic.policy.remote import RemotePolicy
 
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
-    policy = RemotePolicy(host, port, effective_resize, model_id=model_id)
+    policy = RemotePolicy(
+        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure
+    )
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)
     return (codec.wrap(policy) if codec else policy), weight

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -74,8 +74,7 @@ def remote(
     from positronic.policy.remote import RemotePolicy
 
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
-    policy = RemotePolicy(
-        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure)
+    policy = RemotePolicy(host, port, effective_resize, model_id=model_id, headers=headers, secure=secure)
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)
     return codec.wrap(policy) if codec else policy
@@ -100,9 +99,7 @@ def weighted_remote(
     from positronic.policy.remote import RemotePolicy
 
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
-    policy = RemotePolicy(
-        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure
-    )
+    policy = RemotePolicy(host, port, effective_resize, model_id=model_id, headers=headers, secure=secure)
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)
     return (codec.wrap(policy) if codec else policy), weight

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -80,8 +80,7 @@ class InferenceClient:
     def __init__(self, host: str, port: int, *, headers: dict[str, str] | None = None, secure: bool = False):
         self.host = host
         self.port = port
-        self.secure = secure
-        self.headers = dict(headers) if headers else {}
+        self.headers = dict(headers) if headers else None
         ws_scheme = 'wss' if secure else 'ws'
         http_scheme = 'https' if secure else 'http'
         default_port = 443 if secure else 80
@@ -111,6 +110,6 @@ class InferenceClient:
 
     def list_models(self) -> list[str]:
         """List available models from the server."""
-        response = httpx.get(f'{self.api_url}/models', headers=self.headers or None)
+        response = httpx.get(f'{self.api_url}/models', headers=self.headers)
         response.raise_for_status()
         return response.json()['models']

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -77,11 +77,17 @@ class InferenceSession:
 
 
 class InferenceClient:
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int, *, headers: dict[str, str] | None = None, secure: bool = False):
         self.host = host
         self.port = port
-        self.base_uri = f'ws://{host}:{port}/api/v1/session'
-        self.api_url = f'http://{host}:{port}/api/v1'
+        self.secure = secure
+        self.headers = dict(headers) if headers else {}
+        ws_scheme = 'wss' if secure else 'ws'
+        http_scheme = 'https' if secure else 'http'
+        default_port = 443 if secure else 80
+        netloc = host if port == default_port else f'{host}:{port}'
+        self.base_uri = f'{ws_scheme}://{netloc}/api/v1/session'
+        self.api_url = f'{http_scheme}://{netloc}/api/v1'
 
     def new_session(self, model_id: str | None = None, open_timeout: float = 10.0) -> InferenceSession:
         """
@@ -94,14 +100,17 @@ class InferenceClient:
                         Model loading timeout is controlled by per-message timeout in handshake.
         """
         uri = self.base_uri if model_id is None else f'{self.base_uri}/{model_id}'
+        connect_kwargs: dict[str, object] = {'open_timeout': open_timeout}
+        if self.headers:
+            connect_kwargs['additional_headers'] = self.headers
         try:
-            ws = connect(uri, open_timeout=open_timeout)
+            ws = connect(uri, **connect_kwargs)
         except OSError as e:
             raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
         return InferenceSession(ws)
 
     def list_models(self) -> list[str]:
         """List available models from the server."""
-        response = httpx.get(f'{self.api_url}/models')
+        response = httpx.get(f'{self.api_url}/models', headers=self.headers or None)
         response.raise_for_status()
         return response.json()['models']

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any
 
 import httpx
@@ -88,7 +89,9 @@ class InferenceClient:
         self.base_uri = f'{ws_scheme}://{netloc}/api/v1/session'
         self.api_url = f'{http_scheme}://{netloc}/api/v1'
 
-    def new_session(self, model_id: str | None = None, open_timeout: float = 10.0) -> InferenceSession:
+    def new_session(
+        self, model_id: str | None = None, open_timeout: float = 10.0, connect_deadline: float = 180.0
+    ) -> InferenceSession:
         """
         Creates a new inference session.
 
@@ -102,10 +105,21 @@ class InferenceClient:
         connect_kwargs: dict[str, object] = {'open_timeout': open_timeout}
         if self.headers:
             connect_kwargs['additional_headers'] = self.headers
-        try:
-            ws = connect(uri, **connect_kwargs)
-        except OSError as e:
-            raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
+
+        deadline = time.monotonic() + connect_deadline
+        backoff = 1.0
+        while True:
+            try:
+                ws = connect(uri, **connect_kwargs)
+                break
+            except TimeoutError as e:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f'{e} (connecting to {self.host}:{self.port})') from e
+                logger.info('Server not ready (cold start?); retrying in %.0fs', backoff)
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+            except OSError as e:
+                raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
         return InferenceSession(ws)
 
     def list_models(self) -> list[str]:

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -114,98 +114,7 @@ class TestPrepareObs:
 class TestInferenceClientHeaders:
     def test_default_headers_empty_and_ws_scheme(self):
         client = InferenceClient('localhost', 8000)
-        assert client.headers == {}
-        assert client.secure is False
-        assert client.base_uri == 'ws://localhost:8000/api/v1/session'
-        assert client.api_url == 'http://localhost:8000/api/v1'
-
-    def test_headers_stored_and_copied(self):
-        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
-        client = InferenceClient('localhost', 8000, headers=headers)
-        assert client.headers == headers
-        # Defensive copy — mutating the caller's dict must not affect the client.
-        headers['Modal-Key'] = 'mutated'
-        assert client.headers['Modal-Key'] == 'k'
-
-    def test_secure_switches_scheme_and_omits_default_port(self):
-        client = InferenceClient('example.com', 443, secure=True)
-        assert client.base_uri == 'wss://example.com/api/v1/session'
-        assert client.api_url == 'https://example.com/api/v1'
-
-    def test_secure_keeps_non_default_port(self):
-        client = InferenceClient('example.com', 8443, secure=True)
-        assert client.base_uri == 'wss://example.com:8443/api/v1/session'
-        assert client.api_url == 'https://example.com:8443/api/v1'
-
-    def test_insecure_omits_default_port(self):
-        client = InferenceClient('example.com', 80, secure=False)
-        assert client.base_uri == 'ws://example.com/api/v1/session'
-        assert client.api_url == 'http://example.com/api/v1'
-
-    def test_new_session_passes_additional_headers(self):
-        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
-        with (
-            patch('positronic.offboard.client.connect') as mock_connect,
-            patch('positronic.offboard.client.InferenceSession') as mock_session_cls,
-        ):
-            client = InferenceClient('localhost', 8000, headers=headers)
-            client.new_session()
-
-            mock_connect.assert_called_once()
-            assert mock_connect.call_args.kwargs['additional_headers'] == headers
-            mock_session_cls.assert_called_once_with(mock_connect.return_value)
-
-    def test_new_session_without_headers_omits_additional_headers(self):
-        with (
-            patch('positronic.offboard.client.connect') as mock_connect,
-            patch('positronic.offboard.client.InferenceSession'),
-        ):
-            client = InferenceClient('localhost', 8000)
-            client.new_session()
-
-            mock_connect.assert_called_once()
-            assert 'additional_headers' not in mock_connect.call_args.kwargs
-
-    def test_list_models_passes_headers(self):
-        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
-        with patch('positronic.offboard.client.httpx.get') as mock_get:
-            mock_get.return_value.json.return_value = {'models': ['m1']}
-            client = InferenceClient('localhost', 8000, headers=headers)
-
-            models = client.list_models()
-
-            assert models == ['m1']
-            assert mock_get.call_args.kwargs['headers'] == headers
-
-    def test_list_models_without_headers_passes_none(self):
-        with patch('positronic.offboard.client.httpx.get') as mock_get:
-            mock_get.return_value.json.return_value = {'models': []}
-            client = InferenceClient('localhost', 8000)
-            client.list_models()
-
-            assert mock_get.call_args.kwargs['headers'] is None
-
-
-class TestRemotePolicyHeaderPropagation:
-    def test_headers_and_secure_forwarded_to_client(self):
-        headers = {'Modal-Key': 'k'}
-        policy = RemotePolicy('example.com', 443, headers=headers, secure=True)
-        assert policy._client.headers == headers
-        assert policy._client.secure is True
-        assert policy._client.base_uri == 'wss://example.com/api/v1/session'
-
-    def test_defaults_match_pre_existing_behaviour(self):
-        policy = RemotePolicy('localhost', 8000)
-        assert policy._client.headers == {}
-        assert policy._client.secure is False
-        assert policy._client.base_uri == 'ws://localhost:8000/api/v1/session'
-
-
-class TestInferenceClientHeaders:
-    def test_default_headers_empty_and_ws_scheme(self):
-        client = InferenceClient('localhost', 8000)
         assert client.headers is None
-        assert client.secure is False
         assert client.base_uri == 'ws://localhost:8000/api/v1/session'
         assert client.api_url == 'http://localhost:8000/api/v1'
 
@@ -281,13 +190,11 @@ class TestRemotePolicyHeaderPropagation:
         headers = {'Modal-Key': 'k'}
         policy = RemotePolicy('example.com', 443, headers=headers, secure=True)
         assert policy._client.headers == headers
-        assert policy._client.secure is True
         assert policy._client.base_uri == 'wss://example.com/api/v1/session'
 
     def test_defaults_match_pre_existing_behaviour(self):
         policy = RemotePolicy('localhost', 8000)
-        assert policy._client.headers == {}
-        assert policy._client.secure is False
+        assert policy._client.headers is None
         assert policy._client.base_uri == 'ws://localhost:8000/api/v1/session'
 
 

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -1,7 +1,8 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
+from positronic.offboard.client import InferenceClient
 from positronic.policy import RemotePolicy
 from positronic.policy.base import SampledPolicy
 from positronic.policy.codec import ActionHorizon
@@ -108,6 +109,186 @@ class TestPrepareObs:
         np.testing.assert_array_equal(result['state'], obs['state'])
         assert result['task'] == 'pick cube'
         assert result['flag'] is True
+
+
+class TestInferenceClientHeaders:
+    def test_default_headers_empty_and_ws_scheme(self):
+        client = InferenceClient('localhost', 8000)
+        assert client.headers == {}
+        assert client.secure is False
+        assert client.base_uri == 'ws://localhost:8000/api/v1/session'
+        assert client.api_url == 'http://localhost:8000/api/v1'
+
+    def test_headers_stored_and_copied(self):
+        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
+        client = InferenceClient('localhost', 8000, headers=headers)
+        assert client.headers == headers
+        # Defensive copy — mutating the caller's dict must not affect the client.
+        headers['Modal-Key'] = 'mutated'
+        assert client.headers['Modal-Key'] == 'k'
+
+    def test_secure_switches_scheme_and_omits_default_port(self):
+        client = InferenceClient('example.com', 443, secure=True)
+        assert client.base_uri == 'wss://example.com/api/v1/session'
+        assert client.api_url == 'https://example.com/api/v1'
+
+    def test_secure_keeps_non_default_port(self):
+        client = InferenceClient('example.com', 8443, secure=True)
+        assert client.base_uri == 'wss://example.com:8443/api/v1/session'
+        assert client.api_url == 'https://example.com:8443/api/v1'
+
+    def test_insecure_omits_default_port(self):
+        client = InferenceClient('example.com', 80, secure=False)
+        assert client.base_uri == 'ws://example.com/api/v1/session'
+        assert client.api_url == 'http://example.com/api/v1'
+
+    def test_new_session_passes_additional_headers(self):
+        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
+        with (
+            patch('positronic.offboard.client.connect') as mock_connect,
+            patch('positronic.offboard.client.InferenceSession') as mock_session_cls,
+        ):
+            client = InferenceClient('localhost', 8000, headers=headers)
+            client.new_session()
+
+            mock_connect.assert_called_once()
+            assert mock_connect.call_args.kwargs['additional_headers'] == headers
+            mock_session_cls.assert_called_once_with(mock_connect.return_value)
+
+    def test_new_session_without_headers_omits_additional_headers(self):
+        with (
+            patch('positronic.offboard.client.connect') as mock_connect,
+            patch('positronic.offboard.client.InferenceSession'),
+        ):
+            client = InferenceClient('localhost', 8000)
+            client.new_session()
+
+            mock_connect.assert_called_once()
+            assert 'additional_headers' not in mock_connect.call_args.kwargs
+
+    def test_list_models_passes_headers(self):
+        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
+        with patch('positronic.offboard.client.httpx.get') as mock_get:
+            mock_get.return_value.json.return_value = {'models': ['m1']}
+            client = InferenceClient('localhost', 8000, headers=headers)
+
+            models = client.list_models()
+
+            assert models == ['m1']
+            assert mock_get.call_args.kwargs['headers'] == headers
+
+    def test_list_models_without_headers_passes_none(self):
+        with patch('positronic.offboard.client.httpx.get') as mock_get:
+            mock_get.return_value.json.return_value = {'models': []}
+            client = InferenceClient('localhost', 8000)
+            client.list_models()
+
+            assert mock_get.call_args.kwargs['headers'] is None
+
+
+class TestRemotePolicyHeaderPropagation:
+    def test_headers_and_secure_forwarded_to_client(self):
+        headers = {'Modal-Key': 'k'}
+        policy = RemotePolicy('example.com', 443, headers=headers, secure=True)
+        assert policy._client.headers == headers
+        assert policy._client.secure is True
+        assert policy._client.base_uri == 'wss://example.com/api/v1/session'
+
+    def test_defaults_match_pre_existing_behaviour(self):
+        policy = RemotePolicy('localhost', 8000)
+        assert policy._client.headers == {}
+        assert policy._client.secure is False
+        assert policy._client.base_uri == 'ws://localhost:8000/api/v1/session'
+
+
+class TestInferenceClientHeaders:
+    def test_default_headers_empty_and_ws_scheme(self):
+        client = InferenceClient('localhost', 8000)
+        assert client.headers is None
+        assert client.secure is False
+        assert client.base_uri == 'ws://localhost:8000/api/v1/session'
+        assert client.api_url == 'http://localhost:8000/api/v1'
+
+    def test_headers_stored_and_copied(self):
+        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
+        client = InferenceClient('localhost', 8000, headers=headers)
+        assert client.headers == headers
+        # Defensive copy — mutating the caller's dict must not affect the client.
+        headers['Modal-Key'] = 'mutated'
+        assert client.headers['Modal-Key'] == 'k'
+
+    def test_secure_switches_scheme_and_omits_default_port(self):
+        client = InferenceClient('example.com', 443, secure=True)
+        assert client.base_uri == 'wss://example.com/api/v1/session'
+        assert client.api_url == 'https://example.com/api/v1'
+
+    def test_secure_keeps_non_default_port(self):
+        client = InferenceClient('example.com', 8443, secure=True)
+        assert client.base_uri == 'wss://example.com:8443/api/v1/session'
+        assert client.api_url == 'https://example.com:8443/api/v1'
+
+    def test_insecure_omits_default_port(self):
+        client = InferenceClient('example.com', 80, secure=False)
+        assert client.base_uri == 'ws://example.com/api/v1/session'
+        assert client.api_url == 'http://example.com/api/v1'
+
+    def test_new_session_passes_additional_headers(self):
+        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
+        with (
+            patch('positronic.offboard.client.connect') as mock_connect,
+            patch('positronic.offboard.client.InferenceSession') as mock_session_cls,
+        ):
+            client = InferenceClient('localhost', 8000, headers=headers)
+            client.new_session()
+
+            mock_connect.assert_called_once()
+            assert mock_connect.call_args.kwargs['additional_headers'] == headers
+            mock_session_cls.assert_called_once_with(mock_connect.return_value)
+
+    def test_new_session_without_headers_omits_additional_headers(self):
+        with (
+            patch('positronic.offboard.client.connect') as mock_connect,
+            patch('positronic.offboard.client.InferenceSession'),
+        ):
+            client = InferenceClient('localhost', 8000)
+            client.new_session()
+
+            mock_connect.assert_called_once()
+            assert 'additional_headers' not in mock_connect.call_args.kwargs
+
+    def test_list_models_passes_headers(self):
+        headers = {'Modal-Key': 'k', 'Modal-Secret': 's'}
+        with patch('positronic.offboard.client.httpx.get') as mock_get:
+            mock_get.return_value.json.return_value = {'models': ['m1']}
+            client = InferenceClient('localhost', 8000, headers=headers)
+
+            models = client.list_models()
+
+            assert models == ['m1']
+            assert mock_get.call_args.kwargs['headers'] == headers
+
+    def test_list_models_without_headers_passes_none(self):
+        with patch('positronic.offboard.client.httpx.get') as mock_get:
+            mock_get.return_value.json.return_value = {'models': []}
+            client = InferenceClient('localhost', 8000)
+            client.list_models()
+
+            assert mock_get.call_args.kwargs['headers'] is None
+
+
+class TestRemotePolicyHeaderPropagation:
+    def test_headers_and_secure_forwarded_to_client(self):
+        headers = {'Modal-Key': 'k'}
+        policy = RemotePolicy('example.com', 443, headers=headers, secure=True)
+        assert policy._client.headers == headers
+        assert policy._client.secure is True
+        assert policy._client.base_uri == 'wss://example.com/api/v1/session'
+
+    def test_defaults_match_pre_existing_behaviour(self):
+        policy = RemotePolicy('localhost', 8000)
+        assert policy._client.headers == {}
+        assert policy._client.secure is False
+        assert policy._client.base_uri == 'ws://localhost:8000/api/v1/session'
 
 
 class TestActionHorizonWrapping:

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -18,8 +18,17 @@ class RemotePolicy(Policy):
     sizes. Server-reported sizes always take precedence.
     """
 
-    def __init__(self, host: str, port: int, resize: int | None = None, model_id: str | None = None):
-        self._client = InferenceClient(host, port)
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        resize: int | None = None,
+        model_id: str | None = None,
+        *,
+        headers: dict[str, str] | None = None,
+        secure: bool = False,
+    ):
+        self._client = InferenceClient(host, port, headers=headers, secure=secure)
         self.__session: InferenceSession | None = None
         self._resize = resize
         self._model_id = model_id


### PR DESCRIPTION
## Summary

Add support for setting custom headers on requests to the server to enable requests to secured server endpoints.

Example usage:

```
uv run positronic-inference sim \
     --policy=.remote \
     --policy.host=<workspace> \
     --policy.port=443 --policy.secure=True \
     --policy.headers='{"Key": "<VALUE>"}'
```