### PR TITLE
Make keyboard `p` finish and write the episode

### DIFF
--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -42,7 +42,7 @@ class KeyboardHandler:
             case 's':
                 return Directive.RUN(task=self.task)
             case 'p':
-                return Directive.STOP()
+                return Directive.FINISH()
             case 'r':
                 return Directive.HOME()
         return None


### PR DESCRIPTION
## Summary
- The keyboard inference driver mapped `p` to `Directive.STOP()`, which only emits `DsWriterCommand.SUSPEND()` — recording is suspended but never finalized, so episodes were never written from the keyboard driver.
- Remap `p` to `Directive.FINISH()` so it finalizes and writes the episode (then homes the robot), matching what the `timed` driver does.

## Test plan
Not run on hardware — the keyboard driver requires the real droid setup (Franka arm + ZED cameras). Correctness verified by reading the harness directive handling in `positronic/policy/harness.py`: `STOP` emits `DsWriterCommand.SUSPEND()` (never finalizes), whereas `FINISH` emits `DsWriterCommand.STOP(...)` which writes the episode and then homes the devices.