### PR TITLE
Publish versioned docker tags only on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,5 +79,8 @@ jobs:
         env:
           PUBLISH_RELEASE: "1"
         run: |
+          # Unset CI so `ifdef CI` blocks (which push :latest) do not fire —
+          # a release may be cut from a non-main commit and must not move :latest.
+          unset CI
           VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' ../pyproject.toml | head -n 1)
           make push IMAGE_TAG=v${VERSION}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish Release
 
 on:
   release:
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  build-and-publish:
+  publish-pypi:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,3 +48,36 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-docker:
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}/CodeQL"
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}/node"
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}/go"
+          sudo rm -rf /usr/lib/jvm
+          sudo docker system prune -af || true
+          df -h
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push versioned images
+        working-directory: docker
+        env:
+          PUBLISH_RELEASE: "1"
+        run: |
+          VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' ../pyproject.toml | head -n 1)
+          make push IMAGE_TAG=v${VERSION}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -93,6 +93,8 @@ tag-training: build-training
 	docker tag $(LOCAL_TAG_TRAINING) $(IMAGE_NAME_TRAINING):$(GIT_SHA)
 ifdef CI
 	docker tag $(LOCAL_TAG_TRAINING) $(IMAGE_NAME_TRAINING):latest
+endif
+ifdef PUBLISH_RELEASE
 	docker tag $(LOCAL_TAG_TRAINING) $(IMAGE_NAME_TRAINING):v$(VERSION)
 endif
 	@echo "Tagged: $(IMAGE_TAG), $(GIT_SHA)"
@@ -104,6 +106,9 @@ tag-openpi: build-openpi
 ifdef CI
 	docker tag $(IMAGE_NAME_OPENPI):local $(IMAGE_NAME_OPENPI):latest
 endif
+ifdef PUBLISH_RELEASE
+	docker tag $(IMAGE_NAME_OPENPI):local $(IMAGE_NAME_OPENPI):v$(VERSION)
+endif
 	@echo "Tagged: $(IMAGE_TAG), $(GIT_SHA)"
 
 tag-groot: build-groot
@@ -113,6 +118,9 @@ tag-groot: build-groot
 ifdef CI
 	docker tag $(IMAGE_NAME_GROOT):local $(IMAGE_NAME_GROOT):latest
 endif
+ifdef PUBLISH_RELEASE
+	docker tag $(IMAGE_NAME_GROOT):local $(IMAGE_NAME_GROOT):v$(VERSION)
+endif
 	@echo "Tagged: $(IMAGE_TAG), $(GIT_SHA)"
 
 tag-dreamzero: build-dreamzero
@@ -121,6 +129,9 @@ tag-dreamzero: build-dreamzero
 	docker tag $(IMAGE_NAME_DREAMZERO):local $(IMAGE_NAME_DREAMZERO):$(GIT_SHA)
 ifdef CI
 	docker tag $(IMAGE_NAME_DREAMZERO):local $(IMAGE_NAME_DREAMZERO):latest
+endif
+ifdef PUBLISH_RELEASE
+	docker tag $(IMAGE_NAME_DREAMZERO):local $(IMAGE_NAME_DREAMZERO):v$(VERSION)
 endif
 	@echo "Tagged: $(IMAGE_TAG), $(GIT_SHA)"
 
@@ -132,6 +143,8 @@ push-training: tag-training
 	docker push $(IMAGE_NAME_TRAINING):$(GIT_SHA)
 ifdef CI
 	docker push $(IMAGE_NAME_TRAINING):latest
+endif
+ifdef PUBLISH_RELEASE
 	docker push $(IMAGE_NAME_TRAINING):v$(VERSION)
 endif
 	@echo "IMAGE_TAG=$(IMAGE_TAG)" > .env
@@ -145,6 +158,9 @@ push-openpi: tag-openpi
 ifdef CI
 	docker push $(IMAGE_NAME_OPENPI):latest
 endif
+ifdef PUBLISH_RELEASE
+	docker push $(IMAGE_NAME_OPENPI):v$(VERSION)
+endif
 	@echo "IMAGE_TAG=$(IMAGE_TAG)" > .env
 
 push-groot: tag-groot
@@ -154,6 +170,9 @@ push-groot: tag-groot
 ifdef CI
 	docker push $(IMAGE_NAME_GROOT):latest
 endif
+ifdef PUBLISH_RELEASE
+	docker push $(IMAGE_NAME_GROOT):v$(VERSION)
+endif
 	@echo "IMAGE_TAG=$(IMAGE_TAG)" > .env
 
 push-dreamzero: tag-dreamzero
@@ -162,6 +181,9 @@ push-dreamzero: tag-dreamzero
 	docker push $(IMAGE_NAME_DREAMZERO):$(GIT_SHA)
 ifdef CI
 	docker push $(IMAGE_NAME_DREAMZERO):latest
+endif
+ifdef PUBLISH_RELEASE
+	docker push $(IMAGE_NAME_DREAMZERO):v$(VERSION)
 endif
 	@echo "IMAGE_TAG=$(IMAGE_TAG)" > .env
 


### PR DESCRIPTION
## Summary
- Split `docker/Makefile`'s `ifdef CI` block: `latest` stays under `CI` (tracks main); `v\$(VERSION)` moves to a new `ifdef PUBLISH_RELEASE` block so main-merges no longer overwrite release tags
- Add `v\$(VERSION)` tagging/pushing for `openpi`, `gr00t`, and `dreamzero` (previously only `positronic` got versioned)
- Extend `.github/workflows/release.yaml` with a `publish-docker` job that runs after the existing PyPI publish, sets `PUBLISH_RELEASE=1`, and builds/pushes images from the release-tag commit

Closes the bug where `positro/positronic:v0.2.1` (and siblings) were re-pushed from main-HEAD on every merge — silently breaking the reproducibility anchor those tags are supposed to provide.

## Test plan
- Dry-run `make -n push-training CI=true` shows no `v\$(VERSION)` push (only IMAGE_TAG, SHA, latest)
- Dry-run `make -n push-training CI=true PUBLISH_RELEASE=1 IMAGE_TAG=v0.2.1` shows `v\$(VERSION)` push appears
- Verified analogous behavior across `push-openpi`, `push-groot`, `push-dreamzero`
- End-to-end release workflow will be exercised on the next published GitHub Release (cannot be tested before merge)