### PR TITLE
Make Harness observations name-free; record full sim state as privileged signal

### DIFF
--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -16,8 +16,9 @@ import positronic.cfg.simulator
 import positronic.cfg.sound
 import positronic.cfg.webxr
 from positronic import geom, wire
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, Serializers, TimeMode
+from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
+from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import State as RoboarmState
 from positronic.drivers.webxr import WebXR

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -333,7 +333,7 @@ Key ideas
   - `None`: the sample is dropped (not recorded).
 - Omitting the serializer (or passing `None`) records the value unchanged.
 
-Built‑in serializers (`positronic.dataset.ds_writer_agent.Serializers`)
+Built‑in serializers (`positronic.dataset.serializers.Serializers`)
 - `transform_3d(pose: Transform3D) -> np.ndarray`
   - Returns `[tx, ty, tz, qw, qx, qy, qz]` (shape `(7,)`).
 - `robot_state(state: roboarm.State) -> dict | None`

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -1,19 +1,14 @@
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from typing import Any
 
-import numpy as np
-
 import pimm
-from positronic import geom
-from positronic.drivers.roboarm import RobotStatus, State
-from positronic.drivers.roboarm.command import CartesianPosition, CommandType, JointDelta, JointPosition, Reset
 from positronic.utils import frozen_keys_dict
 
 from .dataset import DatasetWriter
 from .episode import EpisodeWriter
+from .serializers import Serializer, StatefulSerializer, Timestamped, _PureSerializer, expand_suffixed
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -62,132 +57,6 @@ class DsWriterCommand:
     @staticmethod
     def SUSPEND():
         return DsWriterCommand(DsWriterCommandType.SUSPEND_EPISODE)
-
-
-# Serializer contract for inputs:
-# - Register signals with `DsWriterAgent.add_signal(name, serializer=None)`.
-# - If `serializer` is omitted or None, the value is passed through unchanged.
-# - If a callable is provided, it is invoked as serializer(value) and can return:
-#     * a transformed value -> recorded under the same signal name
-#     * a dict mapping suffix -> value -> expands into multiple signals recorded as name+suffix
-#         - use "" (empty string) to keep the base name as-is
-#         - any dict entry with value None is skipped (not recorded)
-#     * None -> the sample is dropped (not recorded)
-#     * a list[Timestamped] -> a self-timestamped stream: each item is recorded at
-#       its own ``ts_ns`` (not the agent loop/message timestamp). An empty list
-#       defers (records nothing now); a StatefulSerializer may emit the remainder
-#       later from ``flush()``. The per-item ``value`` follows the same
-#       value/dict/None rules above.
-Serializer = Callable[[Any], Any | dict[str, Any]]
-
-
-@dataclass
-class Timestamped:
-    """A sample paired with its own absolute timestamp (ns)."""
-
-    ts: int
-    value: Any
-
-
-class StatefulSerializer:
-    """Base for serializers registered with ``DsWriterAgent``.
-
-    ``reset`` is called automatically at the start of each episode.
-    The default implementation is a no-op, suitable for pure serializers.
-    Subclasses that maintain per-episode state should override ``reset``.
-    """
-
-    def reset(self) -> None:
-        pass
-
-    def __call__(self, value: Any) -> Any | dict[str, Any] | list['Timestamped']:
-        raise NotImplementedError
-
-    def flush(self, now_ns: int | None = None) -> list['Timestamped']:
-        """Drain any buffered samples at episode end (mirror of ``reset``).
-
-        Called once on ``STOP_EPISODE`` before the episode is finalized. ``now_ns``
-        is the episode-end time; serializers that buffer future-scheduled samples
-        use it to drop the un-executed tail. The default keeps stateless
-        serializers a no-op.
-        """
-        return []
-
-
-class _PureSerializer(StatefulSerializer):
-    """Wraps a plain callable so every serializer has a uniform interface."""
-
-    def __init__(self, fn: Callable[[Any], Any | dict[str, Any]]):
-        self._fn = fn
-
-    def __call__(self, value: Any) -> Any | dict[str, Any]:
-        return self._fn(value)
-
-
-class Serializers:
-    """Namespace of built-in serializers for convenience.
-
-    Usage:
-        from positronic.dataset.ds_writer_agent import Serializers
-        agent = DsWriterAgent(writer)
-        agent.add_signal("ee_pose", Serializers.transform_3d)
-
-    Notes:
-        - Also exported as `Serializers` (US spelling) for convenience.
-    """
-
-    @staticmethod
-    def transform_3d(x: geom.Transform3D) -> np.ndarray:
-        """Serialize a Transform3D into a 7D vector [tx, ty, tz, qw, qx, qy, qz]."""
-        return x.as_vector(geom.Rotation.Representation.QUAT)
-
-    class ContinuousTransform3D(StatefulSerializer):
-        """Stateful serializer that canonicalises quaternion signs for temporal continuity.
-
-        Each quaternion is flipped to the sign closest to the previous frame,
-        avoiding arbitrary sign jumps from the double-cover ambiguity.
-        """
-
-        def __init__(self):
-            self._prev: geom.Rotation | None = None
-
-        def reset(self):
-            self._prev = None
-
-        def __call__(self, x: geom.Transform3D) -> np.ndarray:
-            rotation = x.rotation
-            if self._prev is not None:
-                rotation = geom.quat_closest(rotation, self._prev)
-            self._prev = rotation
-            return geom.Transform3D(x.translation, rotation).as_vector(geom.Rotation.Representation.QUAT)
-
-    @staticmethod
-    def robot_state(state: State) -> dict[str, np.ndarray | int] | None:
-        if state.status == RobotStatus.RESETTING:
-            return None
-        return {
-            '.q': state.q,
-            '.dq': state.dq,
-            '.ee_pose': Serializers.transform_3d(state.ee_pose),
-            '.error': int(state.status == RobotStatus.ERROR),
-        }
-
-    @staticmethod
-    def robot_command(command: CommandType) -> dict[str, np.ndarray | int] | None:
-        match command:
-            case CartesianPosition(pose):
-                return {'.pose': Serializers.transform_3d(pose)}
-            case JointPosition(positions):
-                return {'.joints': positions}
-            case JointDelta(delta):
-                return {'.joint_deltas': delta}
-            case Reset():
-                return {'.reset': 1}
-
-    @staticmethod
-    def camera_images(data: pimm.shared_memory.NumpySMAdapter) -> np.ndarray:
-        """Extract array from NumpySMAdapter for storage."""
-        return data.array
 
 
 class TrajectoryOverrideSerializer(StatefulSerializer):
@@ -261,12 +130,7 @@ class TrajectoryOverrideSerializer(StatefulSerializer):
 
 
 def _append(ep_writer: EpisodeWriter, name: str, value: Any, ts_ns: int, extra_ts: dict[str, int] | None = None):
-    if isinstance(value, dict):
-        items = ((name + suffix, v) for suffix, v in value.items())
-    else:
-        items = ((name, value),)
-
-    for full_name, v in items:
+    for full_name, v in expand_suffixed(name, value):
         if v is None:
             continue
         ep_writer.append(full_name, v, ts_ns, extra_ts)

--- a/positronic/dataset/serializers.py
+++ b/positronic/dataset/serializers.py
@@ -1,0 +1,161 @@
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+import pimm
+from positronic import geom
+from positronic.drivers.roboarm import RobotStatus, State
+from positronic.drivers.roboarm.command import CartesianPosition, CommandType, JointDelta, JointPosition, Reset
+
+# Serializer contract for values:
+# - Used by `DsWriterAgent.add_signal(name, serializer=None)` (recording) and the
+#   Harness observation channels (policy input). In both cases `serializer=None`
+#   passes the value through unchanged; a callable is invoked as serializer(value)
+#   and can return:
+#     * a transformed value -> recorded/keyed under the same name
+#     * a dict mapping suffix -> value -> expands into multiple entries named name+suffix
+#         - use "" (empty string) to keep the base name as-is
+#         - any dict entry with value None is skipped
+#     * None -> the sample is dropped
+#     * a list[Timestamped] -> a self-timestamped stream (recording only): each item is
+#       recorded at its own ``ts_ns``. An empty list defers; a StatefulSerializer may emit
+#       the remainder later from ``flush()``. The per-item ``value`` follows the rules above.
+Serializer = Callable[[Any], Any | dict[str, Any]]
+
+
+@dataclass
+class Timestamped:
+    """A sample paired with its own absolute timestamp (ns)."""
+
+    ts: int
+    value: Any
+
+
+class StatefulSerializer:
+    """Base for serializers registered with ``DsWriterAgent``.
+
+    ``reset`` is called automatically at the start of each episode.
+    The default implementation is a no-op, suitable for pure serializers.
+    Subclasses that maintain per-episode state should override ``reset``.
+    """
+
+    def reset(self) -> None:
+        pass
+
+    def __call__(self, value: Any) -> Any | dict[str, Any] | list['Timestamped']:
+        raise NotImplementedError
+
+    def flush(self, now_ns: int | None = None) -> list['Timestamped']:
+        """Drain any buffered samples at episode end (mirror of ``reset``).
+
+        Called once on ``STOP_EPISODE`` before the episode is finalized. ``now_ns``
+        is the episode-end time; serializers that buffer future-scheduled samples
+        use it to drop the un-executed tail. The default keeps stateless
+        serializers a no-op.
+        """
+        return []
+
+
+class _PureSerializer(StatefulSerializer):
+    """Wraps a plain callable so every serializer has a uniform interface."""
+
+    def __init__(self, fn: Callable[[Any], Any | dict[str, Any]]):
+        self._fn = fn
+
+    def __call__(self, value: Any) -> Any | dict[str, Any]:
+        return self._fn(value)
+
+
+class Serializers:
+    """Namespace of built-in, type-keyed serializers.
+
+    Shared by the dataset writer (``agent.add_signal("ee_pose", Serializers.transform_3d)``)
+    and the Harness observation assembly. Each method owns a domain type's split into the
+    canonical ``name + suffix`` entries.
+    """
+
+    @staticmethod
+    def transform_3d(x: geom.Transform3D) -> np.ndarray:
+        """Serialize a Transform3D into a 7D vector [tx, ty, tz, qw, qx, qy, qz]."""
+        return x.as_vector(geom.Rotation.Representation.QUAT)
+
+    class ContinuousTransform3D(StatefulSerializer):
+        """Stateful serializer that canonicalises quaternion signs for temporal continuity.
+
+        Each quaternion is flipped to the sign closest to the previous frame,
+        avoiding arbitrary sign jumps from the double-cover ambiguity.
+        """
+
+        def __init__(self):
+            self._prev: geom.Rotation | None = None
+
+        def reset(self):
+            self._prev = None
+
+        def __call__(self, x: geom.Transform3D) -> np.ndarray:
+            rotation = x.rotation
+            if self._prev is not None:
+                rotation = geom.quat_closest(rotation, self._prev)
+            self._prev = rotation
+            return geom.Transform3D(x.translation, rotation).as_vector(geom.Rotation.Representation.QUAT)
+
+    @staticmethod
+    def robot_state(state: State) -> dict[str, np.ndarray | int] | None:
+        if state.status == RobotStatus.RESETTING:
+            return None
+        return {
+            '.q': state.q,
+            '.dq': state.dq,
+            '.ee_pose': Serializers.transform_3d(state.ee_pose),
+            '.error': int(state.status == RobotStatus.ERROR),
+        }
+
+    @staticmethod
+    def robot_state_obs(state: State) -> dict[str, Any]:
+        """Observation-side robot-state split, keyed for ``name + suffix`` expansion.
+
+        Mirrors :meth:`robot_state` but keeps ``.status`` as the raw ``RobotStatus``
+        enum (``ErrorRecovery`` matches on it) and never drops RESETTING — the policy
+        must always see the current state. Step 7 unifies the obs and recording
+        serializers onto one declared serializer.
+        """
+        return {
+            '.q': state.q,
+            '.dq': state.dq,
+            '.ee_pose': Serializers.transform_3d(state.ee_pose),
+            '.status': state.status,
+        }
+
+    @staticmethod
+    def robot_command(command: CommandType) -> dict[str, np.ndarray | int] | None:
+        match command:
+            case CartesianPosition(pose):
+                return {'.pose': Serializers.transform_3d(pose)}
+            case JointPosition(positions):
+                return {'.joints': positions}
+            case JointDelta(delta):
+                return {'.joint_deltas': delta}
+            case Reset():
+                return {'.reset': 1}
+
+    @staticmethod
+    def camera_images(data: pimm.shared_memory.NumpySMAdapter) -> np.ndarray:
+        """Extract array from NumpySMAdapter for storage."""
+        return data.array
+
+
+def expand_suffixed(name: str, value: Any) -> Iterator[tuple[str, Any]]:
+    """Unfold a serialized value into ``(full_name, value)`` pairs.
+
+    A dict result expands into ``name + suffix`` entries (use ``""`` to keep the base
+    name); any other value yields the single ``(name, value)`` pair. Shared by the
+    dataset writer (``DsWriterAgent._append``) and the Harness obs assembly so both
+    follow one naming convention. Callers decide whether to skip ``None`` values.
+    """
+    if isinstance(value, dict):
+        for suffix, v in value.items():
+            yield name + suffix, v
+    else:
+        yield name, value

--- a/positronic/dataset/serializers.py
+++ b/positronic/dataset/serializers.py
@@ -114,13 +114,8 @@ class Serializers:
 
     @staticmethod
     def robot_state_obs(state: State) -> dict[str, Any]:
-        """Observation-side robot-state split, keyed for ``name + suffix`` expansion.
-
-        Mirrors :meth:`robot_state` but keeps ``.status`` as the raw ``RobotStatus``
-        enum (``ErrorRecovery`` matches on it) and never drops RESETTING — the policy
-        must always see the current state. Step 7 unifies the obs and recording
-        serializers onto one declared serializer.
-        """
+        """Observation-side ``State`` split; keeps the raw ``RobotStatus`` that
+        ``ErrorRecovery`` matches on, unlike :meth:`robot_state`. Step 7 unifies the two."""
         return {
             '.q': state.q,
             '.dq': state.dq,
@@ -147,13 +142,8 @@ class Serializers:
 
 
 def expand_suffixed(name: str, value: Any) -> Iterator[tuple[str, Any]]:
-    """Unfold a serialized value into ``(full_name, value)`` pairs.
-
-    A dict result expands into ``name + suffix`` entries (use ``""`` to keep the base
-    name); any other value yields the single ``(name, value)`` pair. Shared by the
-    dataset writer (``DsWriterAgent._append``) and the Harness obs assembly so both
-    follow one naming convention. Callers decide whether to skip ``None`` values.
-    """
+    """Unfold a value into ``(full_name, value)`` pairs: a dict expands into ``name + suffix``
+    entries (``""`` keeps the base name), anything else yields ``(name, value)``."""
     if isinstance(value, dict):
         for suffix, v in value.items():
             yield name + suffix, v

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -11,11 +11,11 @@ from positronic.dataset.ds_writer_agent import (
     DsWriterAgent,
     DsWriterCommand,
     DsWriterCommandType,
-    Serializers,
     TimeMode,
     TrajectoryOverrideSerializer,
 )
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
+from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as rcmd
 from positronic.tests.testing_coutils import run_scripted_agent

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -22,8 +22,7 @@ from positronic.gui.eval import EvalUI
 from positronic.gui.keyboard import KeyboardControl
 from positronic.policy.base import SampledPolicy
 from positronic.policy.harness import Directive, Harness
-from positronic.simulator.mujoco.observers import BodyDistance, StackingSuccess
-from positronic.simulator.mujoco.sim import MujocoCameras, MujocoFranka, MujocoGripper, MujocoSim
+from positronic.simulator.mujoco.sim import FullSimState, MujocoCameras, MujocoFranka, MujocoGripper, MujocoSim
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform
 from positronic.utils import package_assets_path
 from positronic.utils.logging import init_logging
@@ -175,6 +174,7 @@ def main_sim(
     harness = Harness(
         policy,
         static_meta=static_meta,
+        descriptor='mujoco.franka',
         simulate_inference=simulate_inference,
         on_episode_complete=_completion_sink(policy),
     )
@@ -210,10 +210,9 @@ main_sim_cfg = cfn.Config(
     # We use 3 cameras not because we need it, but because Mujoco does not render
     # the second image when using only 2 cameras
     camera_dict={'image.wrist': 'handcam_left_ph', 'image.exterior': 'back_view_ph', 'image.agent_view': 'agentview'},
-    observers={
-        'box_distance': BodyDistance('box_0_body', 'box_1_body'),
-        'stacking_success': StackingSuccess('box_0_body', 'box_1_body', 'hand_ph', full_report=True),
-    },
+    # Record the full sim state as the privileged ground truth; success/distance
+    # criteria are computed downstream in analysis, not live.
+    observers={'sim_state': FullSimState()},
 )
 
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -210,8 +210,7 @@ main_sim_cfg = cfn.Config(
     # We use 3 cameras not because we need it, but because Mujoco does not render
     # the second image when using only 2 cameras
     camera_dict={'image.wrist': 'handcam_left_ph', 'image.exterior': 'back_view_ph', 'image.agent_view': 'agentview'},
-    # Record the full sim state as the privileged ground truth; success/distance
-    # criteria are computed downstream in analysis, not live.
+    # Full sim state is the privileged ground truth; scoring is computed downstream.
     observers={'sim_state': FullSimState()},
 )
 

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -5,7 +5,8 @@ from enum import Enum
 from typing import Any
 
 import pimm
-from positronic.dataset.ds_writer_agent import DsWriterCommand, Serializers
+from positronic.dataset.ds_writer_agent import DsWriterCommand
+from positronic.dataset.serializers import Serializers, expand_suffixed
 from positronic.drivers import roboarm
 from positronic.policy.base import DelegatingSession, Policy, PolicyWrapper, Session
 from positronic.utils import flatten_dict, frozen_view
@@ -153,25 +154,6 @@ def default_wrappers(clock: pimm.Clock) -> PolicyWrapper:
     return ErrorRecovery(clock) | ChunkedSchedule(clock)
 
 
-def _robot_state_obs(state: Any) -> dict[str, Any]:
-    """Canonical observation entries for a robot-state bundle.
-
-    Keeps ``robot_state.status`` as the raw ``RobotStatus`` enum — ``ErrorRecovery``
-    matches on it — so this is deliberately distinct from the recording serializer
-    ``Serializers.robot_state`` (which emits ``.error`` and drops RESETTING).
-    """
-    return {
-        'robot_state.q': state.q,
-        'robot_state.dq': state.dq,
-        'robot_state.ee_pose': Serializers.transform_3d(state.ee_pose),
-        'robot_state.status': state.status,
-    }
-
-
-def _grip_obs(grip: Any) -> dict[str, Any]:
-    return {'grip': grip}
-
-
 class Harness(pimm.ControlSystem):
     """Control system that manages episode lifecycle and forwards trajectories to drivers.
 
@@ -231,14 +213,14 @@ class Harness(pimm.ControlSystem):
         # every call so a multi-embodiment policy can condition on which robot it drives.
         # Empty until an embodiment declares one.
         self._descriptor = descriptor
-        # Observation channels: canonical name -> (receiver, serializer producing the
-        # canonical obs-dict entries). Camera frames are handled separately in
-        # ``_build_obs`` (the all-frames-present guard). Adding an arm/gripper channel is a
-        # new entry here, not new code in the assembly loop; the embodiment factory owns
-        # this mapping once it lands (PR 2b).
-        self._observations: dict[str, tuple[pimm.SignalReceiver, Callable[[Any], dict[str, Any]]]] = {
-            'robot_state': (self.robot_state, _robot_state_obs),
-            'grip': (self.gripper_state, _grip_obs),
+        # Observation channels: name -> (receiver, serializer-or-None), the same contract as
+        # ``DsWriterAgent.add_signal``. The serializer splits a device value into canonical
+        # ``name + suffix`` entries (or ``None`` passes a scalar through). The harness treats
+        # every channel identically — no robot-vs-grip knowledge. The embodiment factory owns
+        # this mapping once it lands (PR 2b); camera frames keep their own all-present guard.
+        self._observations: dict[str, tuple[pimm.SignalReceiver, Callable[[Any], Any] | None]] = {
+            'robot_state': (self.robot_state, Serializers.robot_state_obs),
+            'grip': (self.gripper_state, None),
         }
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -349,8 +331,13 @@ class Harness(pimm.ControlSystem):
     def _build_obs(self, clock: pimm.Clock) -> dict[str, Any] | None:
         """Read sensors and build observation dict. Returns None if not ready."""
         inputs: dict[str, Any] = {}
-        for receiver, serializer in self._observations.values():
-            inputs.update(serializer(receiver.value))
+        for name, (receiver, serializer) in self._observations.items():
+            value = receiver.value
+            if serializer is not None:
+                value = serializer(value)
+            for full_name, v in expand_suffixed(name, value):
+                if v is not None:
+                    inputs[full_name] = v
         frame_messages = {k: v.value for k, v in self.frames.items()}
         images = {k: v.array for k, v in frame_messages.items()}
         if len(images) != len(self.frames):

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -153,6 +153,25 @@ def default_wrappers(clock: pimm.Clock) -> PolicyWrapper:
     return ErrorRecovery(clock) | ChunkedSchedule(clock)
 
 
+def _robot_state_obs(state: Any) -> dict[str, Any]:
+    """Canonical observation entries for a robot-state bundle.
+
+    Keeps ``robot_state.status`` as the raw ``RobotStatus`` enum — ``ErrorRecovery``
+    matches on it — so this is deliberately distinct from the recording serializer
+    ``Serializers.robot_state`` (which emits ``.error`` and drops RESETTING).
+    """
+    return {
+        'robot_state.q': state.q,
+        'robot_state.dq': state.dq,
+        'robot_state.ee_pose': Serializers.transform_3d(state.ee_pose),
+        'robot_state.status': state.status,
+    }
+
+
+def _grip_obs(grip: Any) -> dict[str, Any]:
+    return {'grip': grip}
+
+
 class Harness(pimm.ControlSystem):
     """Control system that manages episode lifecycle and forwards trajectories to drivers.
 
@@ -175,6 +194,7 @@ class Harness(pimm.ControlSystem):
         policy: Policy,
         *,
         static_meta: dict[str, Any] | None = None,
+        descriptor: str = '',
         wrap: PolicyWrapper | Callable[[pimm.Clock], PolicyWrapper] | None = default_wrappers,
         simulate_inference: bool | float = False,
         on_episode_complete: Callable[[Session, dict[str, Any]], None] | None = None,
@@ -206,6 +226,20 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
+
+        # Embodiment descriptor — a bare string (``mujoco.franka``) handed to the policy on
+        # every call so a multi-embodiment policy can condition on which robot it drives.
+        # Empty until an embodiment declares one.
+        self._descriptor = descriptor
+        # Observation channels: canonical name -> (receiver, serializer producing the
+        # canonical obs-dict entries). Camera frames are handled separately in
+        # ``_build_obs`` (the all-frames-present guard). Adding an arm/gripper channel is a
+        # new entry here, not new code in the assembly loop; the embodiment factory owns
+        # this mapping once it lands (PR 2b).
+        self._observations: dict[str, tuple[pimm.SignalReceiver, Callable[[Any], dict[str, Any]]]] = {
+            'robot_state': (self.robot_state, _robot_state_obs),
+            'grip': (self.gripper_state, _grip_obs),
+        }
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
         meta = dict(self._static_meta)
@@ -314,14 +348,9 @@ class Harness(pimm.ControlSystem):
 
     def _build_obs(self, clock: pimm.Clock) -> dict[str, Any] | None:
         """Read sensors and build observation dict. Returns None if not ready."""
-        robot_state = self.robot_state.value
-        inputs = {
-            'robot_state.q': robot_state.q,
-            'robot_state.dq': robot_state.dq,
-            'robot_state.ee_pose': Serializers.transform_3d(robot_state.ee_pose),
-            'robot_state.status': robot_state.status,
-            'grip': self.gripper_state.value,
-        }
+        inputs: dict[str, Any] = {}
+        for receiver, serializer in self._observations.values():
+            inputs.update(serializer(receiver.value))
         frame_messages = {k: v.value for k, v in self.frames.items()}
         images = {k: v.array for k, v in frame_messages.items()}
         if len(images) != len(self.frames):
@@ -330,6 +359,9 @@ class Harness(pimm.ControlSystem):
         inputs['wall_time_ns'] = time.time_ns()
         inputs['inference_time_ns'] = clock.now_ns()
         inputs.update(self.context)
+        # The embodiment descriptor is harness-owned identity — set it last so a stray
+        # RUN-context key can't shadow it.
+        inputs['descriptor'] = self._descriptor
         return inputs
 
     def _step(self, clock: pimm.Clock) -> Generator[pimm.Sleep, None, None]:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -209,16 +209,11 @@ class Harness(pimm.ControlSystem):
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
 
-        # Embodiment descriptor — a bare string (``mujoco.franka``) handed to the policy on
-        # every call so a multi-embodiment policy can condition on which robot it drives.
-        # Empty until an embodiment declares one.
+        # Embodiment descriptor (e.g. ``mujoco.franka``) passed to the policy every call.
         self._descriptor = descriptor
-        # Observation channels: name -> (receiver, serializer-or-None), the same contract as
-        # ``DsWriterAgent.add_signal``. The serializer splits a device value into canonical
-        # ``name + suffix`` entries (or ``None`` passes a scalar through). The harness treats
-        # every channel identically — no robot-vs-grip knowledge. The embodiment factory owns
-        # this mapping once it lands (PR 2b); camera frames keep their own all-present guard.
-        self._observations: dict[str, tuple[pimm.SignalReceiver, Callable[[Any], Any] | None]] = {
+        # Observation channels: name -> (receiver, serializer-or-None), like ``add_signal``.
+        # The serializer owns the device value's split into ``name + suffix`` entries.
+        self._observations = {
             'robot_state': (self.robot_state, Serializers.robot_state_obs),
             'grip': (self.gripper_state, None),
         }
@@ -346,9 +341,7 @@ class Harness(pimm.ControlSystem):
         inputs['wall_time_ns'] = time.time_ns()
         inputs['inference_time_ns'] = clock.now_ns()
         inputs.update(self.context)
-        # The embodiment descriptor is harness-owned identity — set it last so a stray
-        # RUN-context key can't shadow it.
-        inputs['descriptor'] = self._descriptor
+        inputs['descriptor'] = self._descriptor  # last, so a context key can't shadow it
         return inputs
 
     def _step(self, clock: pimm.Clock) -> Generator[pimm.Sleep, None, None]:

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -240,6 +240,19 @@ def test_harness_emits_cartesian_move(world):
     np.testing.assert_allclose(obs['robot_state.dq'], np.zeros_like(robot_state.q))
     assert obs['grip'] == pytest.approx(0.25)
     assert obs['task'] == 'stack-blocks'
+    assert obs['descriptor'] == ''  # no descriptor passed -> empty string reaches the policy
+    # Parity: the channel-dict refactor preserves exactly the prior obs keys (plus descriptor);
+    # wall/inference timestamps carry volatile values, so lock the stable key set.
+    assert set(obs) - {'wall_time_ns', 'inference_time_ns'} == {
+        'image.cam',
+        'robot_state.q',
+        'robot_state.dq',
+        'robot_state.ee_pose',
+        'robot_state.status',
+        'grip',
+        'task',
+        'descriptor',
+    }
 
     # Last non-empty command (a trailing ``[]`` cancel is emitted on shutdown).
     cmds = _emitted_commands(cmd_recorder)
@@ -251,6 +264,34 @@ def test_harness_emits_cartesian_move(world):
 
     grips = _emitted_grips(grip_recorder)
     assert grips and grips[-1] == pytest.approx(0.33)
+
+
+@pytest.mark.timeout(3.0)
+def test_harness_passes_descriptor_to_policy(world):
+    """The embodiment descriptor reaches the policy on every call (stateless policy)."""
+    policy = SpyPolicy()
+    harness = Harness(policy, descriptor='mujoco.franka')
+    harness.robot_commands._bind(RecordingEmitter())
+    harness.target_grip._bind(RecordingEmitter())
+    harness.ds_command._bind(RecordingEmitter())
+
+    frame_em = world.pair(harness.frames['image.cam'])
+    robot_em = world.pair(harness.robot_state)
+    grip_em = world.pair(harness.gripper_state)
+    directive_em = world.pair(harness.directive)
+
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    driver = ManualDriver([
+        (partial(directive_em.emit, Directive.RUN(task='t')), 0.0),
+        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
+        (None, 0.05),
+    ])
+
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=20)
+
+    assert policy.last_obs is not None
+    assert policy.last_obs['descriptor'] == 'mujoco.franka'
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 import pimm
-from positronic.dataset.ds_writer_agent import DsWriterCommand, DsWriterCommandType, Serializers
+from positronic.dataset.ds_writer_agent import DsWriterCommand, DsWriterCommandType
+from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import CartesianPosition, Recover, Reset, from_wire, to_wire

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -50,6 +50,21 @@ def save_state(model, data) -> dict[str, np.ndarray]:
     return state_data
 
 
+class FullSimState(MujocoSimObserver):
+    """Privileged observer recording the full simulator state each step.
+
+    Returns ``save_state``'s raw arrays keyed for nested recording
+    (``sim_state.mjSTATE_FULLPHYSICS`` etc.), so success/distance criteria are computed
+    downstream from the recording instead of live. The leading ``.`` makes the writer
+    expand each spec into its own ``sim_state.<spec>`` signal; empty specs are skipped.
+    Lives here, not in observers.py, so it can reuse ``save_state`` without a circular
+    import (sim.py already imports ``MujocoSimObserver`` from observers.py).
+    """
+
+    def __call__(self, model: mj.MjModel, data: mj.MjData) -> dict[str, np.ndarray]:
+        return {f'.{name}': array for name, array in save_state(model, data).items() if array.size}
+
+
 class MujocoSim(pimm.ControlSystem):
     def __init__(
         self,

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -51,14 +51,10 @@ def save_state(model, data) -> dict[str, np.ndarray]:
 
 
 class FullSimState(MujocoSimObserver):
-    """Privileged observer recording the full simulator state each step.
+    """Privileged observer recording the full ``save_state`` each step.
 
-    Returns ``save_state``'s raw arrays keyed for nested recording
-    (``sim_state.mjSTATE_FULLPHYSICS`` etc.), so success/distance criteria are computed
-    downstream from the recording instead of live. The leading ``.`` makes the writer
-    expand each spec into its own ``sim_state.<spec>`` signal; empty specs are skipped.
-    Lives here, not in observers.py, so it can reuse ``save_state`` without a circular
-    import (sim.py already imports ``MujocoSimObserver`` from observers.py).
+    Keys each spec with a leading ``.`` so the writer expands it into a
+    ``sim_state.<spec>`` signal; scoring is computed downstream, not live.
     """
 
     def __call__(self, model: mj.MjModel, data: mj.MjData) -> dict[str, np.ndarray]:

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -7,8 +7,9 @@ import pytest
 import pimm
 from positronic import wire
 from positronic.data_collection import DataCollectionController, controller_positions_serializer
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType, Serializers
+from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
+from positronic.dataset.serializers import Serializers
 from positronic.geom import Rotation, Transform3D
 from positronic.tests.testing_coutils import ManualDriver, drive_scheduler
 

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -5,8 +5,9 @@ import tqdm
 
 import positronic.cfg.simulator
 from positronic.dataset.local_dataset import LocalDataset
-from positronic.inference import main_sim, timed
+from positronic.inference import main_sim, main_sim_cfg, timed
 from positronic.policy.tests.test_harness import StubPolicy
+from positronic.simulator.mujoco.sim import FullSimState
 
 
 # This integration test intentionally exercises the current `main_sim` wiring end-to-end.
@@ -63,6 +64,7 @@ def test_main_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             camera_fps=10,
             driver=timed.override(simulation_time=0.4, task='integration-test', show_gui=False, num_iterations=1)(),
             camera_dict=camera_dict,
+            observers={'sim_state': FullSimState()},
             output_dir=str(tmp_path),
         )
 
@@ -74,6 +76,8 @@ def test_main_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
     assert 'robot_commands.pose' in signals
     assert 'target_grip' in signals
     assert 'image.wrist' in signals
+    # Privileged ground truth: the full sim state is recorded as a time-series signal.
+    assert 'sim_state.mjSTATE_FULLPHYSICS' in signals
 
     camera_samples = list(signals['image.wrist'])
     assert camera_samples, 'Camera signal for handcam_left is empty'
@@ -100,3 +104,15 @@ def test_main_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
     assert isinstance(last_obs['image.wrist'], np.ndarray)
     assert 'robot_state.ee_pose' in last_obs
     assert 'task' in last_obs
+    assert last_obs['descriptor'] == 'mujoco.franka'
+
+
+def test_main_sim_cfg_records_full_sim_state():
+    """The stack_cubes eval records the privileged full sim state, not live success observers.
+
+    Guards the production observer swap directly (the heavyweight e2e test above wires its own
+    observers, so it cannot catch a regression of ``main_sim_cfg``).
+    """
+    observers = main_sim_cfg.kwargs['observers']
+    assert set(observers) == {'sim_state'}
+    assert isinstance(observers['sim_state'], FullSimState)

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -1,6 +1,7 @@
 import pimm
 from positronic.dataset import DatasetWriter
-from positronic.dataset.ds_writer_agent import DsWriterAgent, Serializers, TimeMode, TrajectoryOverrideSerializer
+from positronic.dataset.ds_writer_agent import DsWriterAgent, TimeMode, TrajectoryOverrideSerializer
+from positronic.dataset.serializers import Serializers
 
 ROBOT_STATIC_META = {'joint_signal': 'robot_state.q', 'pose_signals': ['robot_state.ee_pose', 'robot_commands.pose']}
 

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -6,8 +6,9 @@ import pos3
 
 import pimm
 from positronic import geom
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, Serializers, TimeMode
+from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
+from positronic.dataset.serializers import Serializers
 
 # --- Metadata Templates ---
 


### PR DESCRIPTION
## Summary
Groundwork for the embodiment / eval API (step **2a** of the PhAIL eval chain): reshape the Harness's observation assembly and move sim success-scoring downstream, without yet introducing the embodiment factory (that lands in 2b). Behavior-preserving for policy I/O.

- **Name-free obs assembly** — `Harness._build_obs` now iterates an internal `_observations` channel dict (`name -> (receiver, serializer)`); per-type serializers (`_robot_state_obs` / `_grip_obs`) own the canonical key names. The obs dict is identical to before — the obs side deliberately keeps the raw `RobotStatus` enum that `ErrorRecovery` matches on — plus one new key.
- **Embodiment descriptor** — a bare `descriptor` string (`mujoco.franka`) is handed to the policy on **every** call so a future multi-embodiment policy can condition on which robot it drives. Defaults to `''`.
- **Privileged full-state recording** — a new `FullSimState` observer records the entire MuJoCo state (`save_state`) as the `sim_state.*` privileged signal on `stack_cubes`; the live `StackingSuccess` / `BodyDistance` observers are dropped. Success / distance criteria move to analysis over the recording (a later step).

**Intended out-of-scope consequence:** `positronic/cfg/eval.py`'s live sim scoring keys off `stacking_success` / `box_distance`, so it stops scoring *new* sim episodes (degrades gracefully — `None`/blank, no crash) until the analysis step lands. Older episodes are unaffected.

## Test plan
- `uv run --locked pytest positronic/policy/tests/ positronic/tests/test_inference_integration.py positronic/dataset/tests/test_ds_writer_agent.py positronic/tests/test_data_collection.py` → **138 passed**.
- Golden pipeline **unchanged** — the descriptor never reaches a recorded signal (it flows only to the policy obs dict, not through `ds_command`), so no regeneration was needed.
- New/strengthened tests: descriptor reaches the policy (default `''` and `mujoco.franka`); an exact obs key-set parity lock; `FullSimState` records `sim_state.mjSTATE_FULLPHYSICS` end-to-end; and `main_sim_cfg` carries the swapped `{'sim_state'}` observers.