### PR TITLE
Resolve default checkpoint once at server startup

### DIFF
--- a/positronic/offboard/tests/test_vendor_server.py
+++ b/positronic/offboard/tests/test_vendor_server.py
@@ -121,9 +121,13 @@ class _LatestTrackingServer(VendorServer):
     def __init__(self, **kwargs):
         super().__init__(codec=None, **kwargs)
         self.latest = '100'
-        self.mock_policy = MagicMock(spec=Policy)
+        self.mock_session = MagicMock()
+        self.mock_session.return_value = [{'action': [1, 2, 3]}]
+        self.mock_session.meta = {}
+        self.mock_session.close = MagicMock()
+        self.mock_policy = MagicMock()
+        self.mock_policy.new_session.return_value = self.mock_session
         self.mock_policy.meta = {}
-        self.mock_policy.reset.return_value = None
 
     async def resolve_model(self, model_id, websocket):
         resolved = model_id if model_id is not None else self.latest

--- a/positronic/offboard/tests/test_vendor_server.py
+++ b/positronic/offboard/tests/test_vendor_server.py
@@ -114,6 +114,48 @@ def test_checkpoint_id_in_route(stub_server):
         session.close()
 
 
+class _LatestTrackingServer(VendorServer):
+    """Stub whose 'latest' checkpoint can change after startup; resolve_model(None)
+    returns the current latest, mirroring real vendor servers."""
+
+    def __init__(self, **kwargs):
+        super().__init__(codec=None, **kwargs)
+        self.latest = '100'
+        self.mock_policy = MagicMock(spec=Policy)
+        self.mock_policy.meta = {}
+        self.mock_policy.reset.return_value = None
+
+    async def resolve_model(self, model_id, websocket):
+        resolved = model_id if model_id is not None else self.latest
+        return 'handle', {'checkpoint_id': resolved}
+
+    def create_policy(self, model_handle):
+        return self.mock_policy
+
+    async def get_models(self):
+        return {'models': [self.latest]}
+
+
+def test_latest_checkpoint_pinned_once_at_startup():
+    server = _LatestTrackingServer(host='localhost', port=find_free_port())
+    host, port, _ = _start_server(server)
+    # A newer checkpoint lands after startup (e.g. a training job writes it)...
+    server.latest = '200'
+    client = InferenceClient(host, port)
+    # ...but a default session still serves the checkpoint pinned at startup.
+    session = client.new_session()
+    try:
+        assert session.metadata['checkpoint_id'] == '100'
+    finally:
+        session.close()
+    # Explicit requests still load the named checkpoint.
+    session = client.new_session('200')
+    try:
+        assert session.metadata['checkpoint_id'] == '200'
+    finally:
+        session.close()
+
+
 class _IdentityCodec(Codec):
     def encode(self, data):
         return data

--- a/positronic/offboard/vendor_server.py
+++ b/positronic/offboard/vendor_server.py
@@ -112,6 +112,13 @@ class VendorServer(ABC):
 
     On startup (before accepting connections):
         resolve_model(None) → create_policy → reset → warmup
+
+    The default checkpoint is resolved exactly once, at startup: whatever
+    resolve_model(None) picks (the latest checkpoint, or the configured one) is
+    pinned and reused for every request that does not name an explicit checkpoint.
+    A running server therefore never auto-switches to a newer checkpoint that lands
+    in checkpoints_dir after startup. Clients can still load a specific checkpoint on
+    demand via /api/v1/session/{model_id}.
     """
 
     def __init__(
@@ -132,6 +139,10 @@ class VendorServer(ABC):
         self.idle_timeout_min = idle_timeout_min
         self._active_sessions = 0
         self._last_activity = time.monotonic()
+
+        # The default checkpoint, resolved once at startup (see class docstring). Pinned
+        # here so a request without an explicit checkpoint never re-resolves the latest.
+        self._pinned_default_model: str | None = None
 
         self.metadata: dict[str, Any] = {}
 
@@ -191,7 +202,10 @@ class VendorServer(ABC):
         model_handle = None
         session = None
         try:
-            model_handle, extra_meta = await self.resolve_model(model_id, websocket)
+            # No explicit checkpoint requested -> serve the one pinned at startup
+            # (resolved once) rather than re-resolving the latest on every request.
+            requested_model = model_id if model_id is not None else self._pinned_default_model
+            model_handle, extra_meta = await self.resolve_model(requested_model, websocket)
             base_policy = self.create_policy(model_handle)
             if self._recording_dir is not None:
                 # Tap both sides of the codec so one recording holds the obs/action at the
@@ -239,7 +253,12 @@ class VendorServer(ABC):
                 await self.release_policy(model_handle)
 
     async def _startup(self):
-        model_handle, _meta = await self.resolve_model(None, websocket=None)
+        model_handle, meta = await self.resolve_model(None, websocket=None)
+        # Pin whatever was resolved now (latest, or the configured checkpoint) as the
+        # default for subsequent requests, so the latest is resolved exactly once.
+        self._pinned_default_model = meta.get('checkpoint_id')
+        if self._pinned_default_model is not None:
+            logger.info(f'Pinned default checkpoint at startup: {self._pinned_default_model}')
         policy = self.create_policy(model_handle)
         await self.warmup(policy)
 


### PR DESCRIPTION
## Summary
- Inference servers re-resolved the *latest* checkpoint on **every request**, so a running server would hot-swap to — and could crash on — a checkpoint a training job was still writing into `checkpoints_dir` (caught it loading a half-uploaded `checkpoint-100000`).
- `VendorServer` now resolves the default checkpoint **once, at startup**, and pins it (`_pinned_default_model`). Requests without an explicit checkpoint reuse the pinned one instead of re-resolving the latest.
- Fixed in the base class only, so it covers all vendors that return `checkpoint_id` in their `resolve_model` metadata (gr00t, openpi, lerobot, lerobot_0_3_3). DreamZero (fixed path, no `checkpoint_id`) is unaffected.
- Explicit `/api/v1/session/{model_id}` requests still load any checkpoint on demand (can be newer than the startup default).

## Test plan
- `uv run --locked pytest positronic/offboard/tests/test_vendor_server.py --no-cov` — passes, including the added `test_latest_checkpoint_pinned_once_at_startup` (a newer "latest" appears after startup; the default session still serves the pinned one, while an explicit request still loads the named one).