### PR TITLE
Add `positronic-probe` debugging tool

### DIFF
--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -284,13 +284,17 @@ class Recorder:
 
     ``timelines`` maps rerun timeline names to observation keys. The values are read
     once per inference at the outermost tap and reused by inner taps so every tap
-    stamps the inference identically.
+    stamps the inference identically. ``blueprint``, if given, is sent as the recording's
+    layout instead of the auto-built one.
     """
 
-    def __init__(self, recording_dir: str | Path, timelines: dict[str, str] | None = None):
+    def __init__(
+        self, recording_dir: str | Path, timelines: dict[str, str] | None = None, blueprint: rrb.Blueprint | None = None
+    ):
         self._dir = Path(recording_dir)
         self._dir.mkdir(parents=True, exist_ok=True)
         self._timelines = dict(timelines) if timelines is not None else dict(DEFAULT_TIMELINES)
+        self._blueprint = blueprint
         self._stream: rr.RecordingStream | None = None
         self._live = 0
         self._depth = 0
@@ -302,6 +306,11 @@ class Recorder:
 
     def tap(self, name: str) -> '_RecordingTap':
         return _RecordingTap(self, name)
+
+    @property
+    def stream(self) -> rr.RecordingStream | None:
+        """The active recording stream, for logging supplementary panels into the current ``.rrd``."""
+        return self._stream
 
     def _open_stream(self) -> rr.RecordingStream:
         if self._live == 0:
@@ -394,7 +403,9 @@ class _RecordingTapSession(DelegatingSession):
 
     def _send_blueprint(self) -> None:
         rec = self._rec
-        bp = _build_blueprint(rec._image_paths, rec._numeric_paths, rec._path3d_paths, rec._series_paths)
+        bp = rec._blueprint or _build_blueprint(
+            rec._image_paths, rec._numeric_paths, rec._path3d_paths, rec._series_paths
+        )
         if bp is not None:
             rr.send_blueprint(bp)
 

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -106,15 +106,7 @@ def _blueprint(image_keys: list[str]) -> rrb.Blueprint:
     return rrb.Blueprint(rrb.Vertical(top, bottom))
 
 
-@cfn.config(
-    dataset=positronic.cfg.ds.local,
-    policy=policy_cfg.remote,
-    episode=0,
-    at=0.0,
-    task=None,
-    label=None,
-    output_dir='./probe_recordings',
-)
+@cfn.config(dataset=positronic.cfg.ds.local, policy=policy_cfg.remote, episode=0, at=0.0, task=None, label=None)
 def main(
     dataset: Dataset, policy: Policy, episode: int, at: float, task: str | None, label: str | None, output_dir: str
 ):

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -1,0 +1,156 @@
+"""Replay one recorded observation through a live inference endpoint and save an ``.rrd``.
+
+Point this at a recorded episode and a moment in it; the observation at that moment is
+sent to a remote policy endpoint and the returned action chunk is written to a rerun
+recording, with the predicted end-effector trajectory overlaid on the robot's actual
+pose at that moment. Open the ``.rrd`` to see whether the predicted chunk descends
+toward the object or rises away.
+
+The recording is named after the served model (from the server's handshake metadata, or
+``--label``) and that metadata is logged as a ``meta`` panel, so several probes load into
+one rerun viewer as distinguishable, self-describing recordings.
+
+Usage::
+
+    uv run --locked positronic-probe \\
+        --dataset.path=<episode-or-dataset> --episode=0 --at=3.0 \\
+        --policy=.remote --policy.host=<host> --policy.port=<port> \\
+        --task='Pick ...' --output_dir=./probe_recordings
+"""
+
+import re
+import time
+
+import configuronic as cfn
+import numpy as np
+import pos3
+import rerun as rr
+import rerun.blueprint as rrb
+
+import positronic.cfg.ds
+import positronic.cfg.policy as policy_cfg
+from positronic.dataset.dataset import Dataset
+from positronic.drivers.roboarm.command import CartesianPosition
+from positronic.policy import Policy, Recorder
+from positronic.utils.logging import init_logging
+
+# Tap name; the recorder logs each obs/action entity under ``{_TAP}/{key}`` (see recording.py).
+_TAP = 'raw'
+# Observation keys the endpoint expects, mirroring the inference harness, plus every image.*.
+_STATE_KEYS = ('robot_state.q', 'robot_state.dq', 'robot_state.ee_pose', 'robot_state.status', 'grip')
+
+
+def _build_wire_obs(sample: dict, task: str | None, now_ns: int, recorded_ts: int) -> dict:
+    obs = {k: sample[k] for k in _STATE_KEYS if k in sample}
+    obs.update({k: v for k, v in sample.items() if k.startswith('image.')})
+    if task:
+        obs['task'] = task
+    obs['wall_time_ns'] = now_ns  # rerun wall_time timeline
+    obs['inference_time_ns'] = recorded_ts  # rerun inference_time + action_time anchor
+    return obs
+
+
+def _recording_name(meta: dict) -> str:
+    """A short recording name from server metadata, e.g. ``groot@110000`` / ``gyros@18500``."""
+    server_type = meta.get('server.type', 'model')
+    ckpt = meta.get('server.checkpoint_id')
+    if not ckpt:
+        path = str(meta.get('server.checkpoint_path', ''))
+        match = re.search(r'step_count=0*(\d+)', path)
+        ckpt = match.group(1) if match else (path.rstrip('/').rsplit('/', 1)[-1] or None)
+    return f'{server_type}@{ckpt}' if ckpt else str(server_type)
+
+
+def _meta_doc(name: str, meta: dict) -> str:
+    rows = '\n'.join(f'- **{k.removeprefix("server.")}**: {v}' for k, v in meta.items() if k.startswith('server.'))
+    return f'## {name}\n\n{rows}'
+
+
+def _log_commands(actions: list[dict], wall_ns: int, inf_ns: int) -> None:
+    """Log the Cartesian chunk's fields as one named time-series on the obs's live timelines.
+
+    The tap already logs this on ``action_time``, but a rerun time-series view plots only the
+    active timeline, and the images live on ``wall_time`` — so to read the chunk on the same
+    timeline as the scene we re-stamp each waypoint on ``wall_time`` / ``inference_time``
+    (offset by its horizon), with a relative ``chunk_time`` axis alongside.
+    """
+    commands = [a['robot_command'] for a in actions]
+    if not all(isinstance(c, CartesianPosition) for c in commands):
+        return
+    horizon = np.array([float(a.get('timestamp', i)) for i, a in enumerate(actions)])
+    horizon -= horizon[0]
+    labels = ['tx', 'ty', 'tz', 'qw', 'qx', 'qy', 'qz']
+    rows = [[*c.pose.translation, *c.pose.rotation.as_quat] for c in commands]
+    if all('target_grip' in a for a in actions):
+        labels.append('target_grip')
+        rows = [row + [a['target_grip']] for row, a in zip(rows, actions, strict=True)]
+    data = np.array(rows, float)
+
+    rr.log('commands', rr.SeriesLines(names=labels), static=True)
+    for i, h in enumerate(horizon):
+        h_ns = int(round(h * 1e9))
+        rr.set_time('wall_time', timestamp=np.datetime64(wall_ns + h_ns, 'ns'))
+        rr.set_time('inference_time', timestamp=np.datetime64(inf_ns + h_ns, 'ns'))
+        rr.set_time('chunk_time', duration=float(h))
+        rr.log('commands', rr.Scalars(data[i]))
+
+
+def _blueprint(image_keys: list[str]) -> rrb.Blueprint:
+    """Images + server meta on top; 3D trajectory + commands time-series below."""
+    images = [rrb.Spatial2DView(origin=f'{_TAP}/{key}', name=key) for key in image_keys]
+    top = rrb.Horizontal(*images, rrb.TextDocumentView(origin='meta', name='server'))
+    bottom = rrb.Horizontal(
+        rrb.Spatial3DView(origin=f'{_TAP}/robot_command/trajectory', name='trajectory'),
+        rrb.TimeSeriesView(origin='commands', name='commands'),
+    )
+    return rrb.Blueprint(rrb.Vertical(top, bottom))
+
+
+@cfn.config(
+    dataset=positronic.cfg.ds.local,
+    policy=policy_cfg.remote,
+    episode=0,
+    at=0.0,
+    task=None,
+    label=None,
+    output_dir='./probe_recordings',
+)
+def main(
+    dataset: Dataset, policy: Policy, episode: int, at: float, task: str | None, label: str | None, output_dir: str
+):
+    ep = dataset[episode]
+    ts = int(np.clip(ep.start_ts + int(at * 1e9), ep.start_ts, ep.last_ts))
+    sample = ep.time[ts]
+    if 'robot_state.ee_pose' not in sample:
+        raise ValueError('episode has no robot_state.ee_pose; cannot overlay actual pose')
+    task = task or ep.static.get('task')
+
+    now_ns = time.time_ns()
+    obs = _build_wire_obs(sample, task, now_ns, ts)
+    image_keys = [k for k in obs if k.startswith('image.')]
+
+    rec = Recorder(pos3.sync(output_dir), blueprint=_blueprint(image_keys))
+    session = rec.tap(_TAP).wrap(policy).new_session({'task': task} if task else None)
+    meta = dict(session.meta)
+    name = label or _recording_name(meta)
+    try:
+        actions = session(obs)
+        n = 0 if actions is None else len(actions)
+        print(f'episode {episode} @ {at:.3f}s (ts={ts}) [{name}]: {n} action(s); rrd -> {output_dir}')
+        with rec.stream:
+            rec.stream.send_recording_name(name)
+            rr.log('meta', rr.TextDocument(_meta_doc(name, meta), media_type=rr.MediaType.MARKDOWN), static=True)
+            if actions:
+                _log_commands(actions, now_ns, ts)
+    finally:
+        session.close()
+
+
+@pos3.with_mirror()
+def _internal_main():
+    init_logging()
+    cfn.cli(main)
+
+
+if __name__ == '__main__':
+    _internal_main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
 [project.scripts]
 positronic-server="positronic.server.positronic_server:_internal_main"
 positronic-inference="positronic.inference:_internal_main"
+positronic-probe="positronic.probe:_internal_main"
 positronic-data-collection="positronic.data_collection:_internal_main"
 
 


### PR DESCRIPTION
## Summary
- New `positronic-probe` CLI: replays a single recorded observation from a Positronic episode through a live inference endpoint and saves the returned action chunk as an `.rrd`.
- The recording shows the predicted end-effector trajectory overlaid on the robot's **actual** pose at that moment (so you can see at a glance whether the chunk descends toward the object or rises away), the chunk's commands as a time series, the server's camera images, and a server-metadata panel. Recordings are named after the served model, so several probes load into one rerun viewer as distinguishable, self-describing recordings.
- Addressed by `--dataset`/`--episode`/`--at` (seconds from the first frame; `0` = first), reusing the existing `cfg.ds` and `cfg.policy.remote` configs — so `--policy.host/.port/.secure/.headers` work the same as `positronic-inference`.
- `positronic/policy/recording.py` gains two small, additive members to support the tool: `Recorder.stream` (log supplementary panels into the active recording) and a `Recorder(blueprint=...)` override (send an explicit layout instead of the auto-built one). Both default to the previous behavior, so live-recording output is unchanged.

## Test plan
- `uv run --locked pytest positronic/policy/tests --no-cov` → 108 passed (covers the `Recorder` additions; default `blueprint=None` keeps the live path identical).
- `uv run --locked ruff check` / `ruff format` / `py_compile` clean.
- Manual: `positronic-probe --dataset.path=<episode> --episode=0 --at=0 --policy=.remote --policy.host=<host> --policy.port=<port> --task='...'`, then `rerun ./probe_recordings/*.rrd` and confirm the trajectory / commands / images / meta views populate. Used this way against live gr00t and gyros endpoints during the debugging work that motivated the tool.