### PR TITLE
Register `PUBLIC` pos3 profile for anonymous public-bucket access

### DIFF
--- a/positronic/cfg/ds/__init__.py
+++ b/positronic/cfg/ds/__init__.py
@@ -12,10 +12,7 @@ from positronic.dataset.dataset import ConcatDataset, Dataset, FilterDataset
 from positronic.dataset.local_dataset import LocalDataset, load_all_datasets
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.transforms.episode import EpisodeTransform, Group
-
-PUBLIC = Profile(
-    local_name='positronic-public', endpoint='https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1'
-)
+from positronic.utils import PUBLIC
 
 
 @cfn.config()

--- a/positronic/cfg/ds/__init__.py
+++ b/positronic/cfg/ds/__init__.py
@@ -8,11 +8,11 @@ import configuronic as cfn
 import pos3
 from pos3 import Profile
 
+import positronic.utils  # noqa: F401  -- registers the 'PUBLIC' S3 profile that these loaders' s3://PUBLIC@ URLs use
 from positronic.dataset.dataset import ConcatDataset, Dataset, FilterDataset
 from positronic.dataset.local_dataset import LocalDataset, load_all_datasets
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.transforms.episode import EpisodeTransform, Group
-from positronic.utils import PUBLIC
 
 
 @cfn.config()

--- a/positronic/cfg/ds/sim.py
+++ b/positronic/cfg/ds/sim.py
@@ -1,13 +1,13 @@
 """Positronic datasets for tasks ran in simulation."""
 
-from . import PUBLIC, local, transform
+from . import local, transform
 from .internal import SIM_ROBOT_TRANSFORM
 
 # Simulated cube stacking dataset
 # Migrated from: @positronic.cfg.ds.internal.sim_stack
 # Size: 499MB, 317 episodes with transforms baked in (ee_pose, robot_joints, task)
 sim_stack_cubes = transform.override(
-    base=local.override(path='s3://positronic-public/datasets/sim-stack-cubes/', profile=PUBLIC),
+    base=local.override(path='s3://PUBLIC@positronic-public/datasets/sim-stack-cubes/'),
     transforms=[SIM_ROBOT_TRANSFORM],
 )
 
@@ -15,6 +15,5 @@ sim_stack_cubes = transform.override(
 # Migrated from: @positronic.cfg.ds.internal.sim_pnp
 # Size: 1.3GB, 214 episodes with transforms baked in
 sim_pick_place = transform.override(
-    base=local.override(path='s3://positronic-public/datasets/sim-pick-place/', profile=PUBLIC),
-    transforms=[SIM_ROBOT_TRANSFORM],
+    base=local.override(path='s3://PUBLIC@positronic-public/datasets/sim-pick-place/'), transforms=[SIM_ROBOT_TRANSFORM]
 )

--- a/positronic/cfg/phail/v1_0.py
+++ b/positronic/cfg/phail/v1_0.py
@@ -22,6 +22,10 @@ from positronic.server.positronic_server import main as server_main
 from positronic.utils.logging import init_logging
 
 _ROOT = 's3://positronic-public/phail/v1.0'
+# Model URLs carry the `PUBLIC@` profile selector so they resolve to anonymous access on
+# their own — a no-creds reader can pass them straight to an inference server's
+# `--checkpoints_dir`, which never sees the PUBLIC object the dataset configs pass explicitly.
+_MODELS_ROOT = f'{_ROOT.replace("s3://", "s3://PUBLIC@")}/models'
 
 ds = types.SimpleNamespace(
     teleop=local_all.override(path=f'{_ROOT}/dataset/teleoperation/', profile=PUBLIC),
@@ -30,10 +34,10 @@ ds = types.SimpleNamespace(
 )
 
 models = types.SimpleNamespace(
-    openpi=f'{_ROOT}/models/openpi/',
-    gr00t=f'{_ROOT}/models/gr00t/',
-    smolvla=f'{_ROOT}/models/smolvla/',
-    act=f'{_ROOT}/models/act/',
+    openpi=f'{_MODELS_ROOT}/openpi/',
+    gr00t=f'{_MODELS_ROOT}/gr00t/',
+    smolvla=f'{_MODELS_ROOT}/smolvla/',
+    act=f'{_MODELS_ROOT}/act/',
 )
 
 UNIFIED_TASK = 'Pick all the items one by one from transparent tote and place them into the large grey tote.'

--- a/positronic/cfg/phail/v1_0.py
+++ b/positronic/cfg/phail/v1_0.py
@@ -13,7 +13,7 @@ from datetime import datetime
 import configuronic as cfn
 import pos3
 
-from positronic.cfg.ds import PUBLIC, group, local_all, transform
+from positronic.cfg.ds import group, local_all, transform
 from positronic.dataset import Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Identity
 from positronic.server.positronic_server import ColumnConfig as C
@@ -21,23 +21,22 @@ from positronic.server.positronic_server import GroupTableConfig
 from positronic.server.positronic_server import main as server_main
 from positronic.utils.logging import init_logging
 
-_ROOT = 's3://positronic-public/phail/v1.0'
-# Model URLs carry the `PUBLIC@` profile selector so they resolve to anonymous access on
-# their own — a no-creds reader can pass them straight to an inference server's
-# `--checkpoints_dir`, which never sees the PUBLIC object the dataset configs pass explicitly.
-_MODELS_ROOT = f'{_ROOT.replace("s3://", "s3://PUBLIC@")}/models'
+# The PUBLIC@ profile selector resolves to anonymous (unsigned) access, so these URLs work
+# with no AWS credentials — a reader can pass a model URL straight to an inference server's
+# `--checkpoints_dir`.
+_ROOT = 's3://PUBLIC@positronic-public/phail/v1.0'
 
 ds = types.SimpleNamespace(
-    teleop=local_all.override(path=f'{_ROOT}/dataset/teleoperation/', profile=PUBLIC),
-    rollouts=local_all.override(path=f'{_ROOT}/dataset/rollouts/', profile=PUBLIC),
-    human=local_all.override(path=f'{_ROOT}/dataset/human/', profile=PUBLIC),
+    teleop=local_all.override(path=f'{_ROOT}/dataset/teleoperation/'),
+    rollouts=local_all.override(path=f'{_ROOT}/dataset/rollouts/'),
+    human=local_all.override(path=f'{_ROOT}/dataset/human/'),
 )
 
 models = types.SimpleNamespace(
-    openpi=f'{_MODELS_ROOT}/openpi/',
-    gr00t=f'{_MODELS_ROOT}/gr00t/',
-    smolvla=f'{_MODELS_ROOT}/smolvla/',
-    act=f'{_MODELS_ROOT}/act/',
+    openpi=f'{_ROOT}/models/openpi/',
+    gr00t=f'{_ROOT}/models/gr00t/',
+    smolvla=f'{_ROOT}/models/smolvla/',
+    act=f'{_ROOT}/models/act/',
 )
 
 UNIFIED_TASK = 'Pick all the items one by one from transparent tote and place them into the large grey tote.'

--- a/positronic/utils/__init__.py
+++ b/positronic/utils/__init__.py
@@ -17,12 +17,16 @@ from positronic.utils.checkpoints import get_latest_checkpoint, list_checkpoints
 from positronic.utils.frozen_dict import frozen_keys_dict, frozen_view
 from positronic.utils.git import get_git_diff, get_git_state
 
-# Register Positronic's public S3 bucket as the 'PUBLIC' profile, here in a low-level module
+# Positronic's public S3 bucket, registered under the name 'PUBLIC' here in a low-level module
 # every S3 entrypoint imports, so the `s3://PUBLIC@positronic-public/...` URL form resolves to
 # anonymous (unsigned) access everywhere — including inference servers that take a bare
-# `--checkpoints_dir` string and never import cfg.
+# `--checkpoints_dir` string and never import cfg. The Profile object is kept for the few callers
+# that need it as a value rather than a URL (e.g. deriving a write-credentialed variant).
+PUBLIC = pos3.Profile(
+    local_name='positronic-public', endpoint='https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1'
+)
 pos3.register_profile(
-    'PUBLIC', 'https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1', local_name='positronic-public'
+    'PUBLIC', PUBLIC.endpoint, public=PUBLIC.public, region=PUBLIC.region, local_name=PUBLIC.local_name
 )
 
 

--- a/positronic/utils/__init__.py
+++ b/positronic/utils/__init__.py
@@ -17,15 +17,12 @@ from positronic.utils.checkpoints import get_latest_checkpoint, list_checkpoints
 from positronic.utils.frozen_dict import frozen_keys_dict, frozen_view
 from positronic.utils.git import get_git_diff, get_git_state
 
-# Positronic's public S3 bucket. Defined here (a low-level module every S3 entrypoint
-# imports) and registered under the name 'PUBLIC' so the `s3://PUBLIC@positronic-public/...`
-# URL form resolves to anonymous access everywhere — including inference servers that take a
-# bare `--checkpoints_dir` string and never see the PUBLIC object.
-PUBLIC = pos3.Profile(
-    local_name='positronic-public', endpoint='https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1'
-)
+# Register Positronic's public S3 bucket as the 'PUBLIC' profile, here in a low-level module
+# every S3 entrypoint imports, so the `s3://PUBLIC@positronic-public/...` URL form resolves to
+# anonymous (unsigned) access everywhere — including inference servers that take a bare
+# `--checkpoints_dir` string and never import cfg.
 pos3.register_profile(
-    'PUBLIC', PUBLIC.endpoint, public=PUBLIC.public, region=PUBLIC.region, local_name=PUBLIC.local_name
+    'PUBLIC', 'https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1', local_name='positronic-public'
 )
 
 

--- a/positronic/utils/__init__.py
+++ b/positronic/utils/__init__.py
@@ -9,12 +9,24 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pos3
 import yaml
 
 from positronic import __file__ as pkg_init_file
 from positronic.utils.checkpoints import get_latest_checkpoint, list_checkpoints
 from positronic.utils.frozen_dict import frozen_keys_dict, frozen_view
 from positronic.utils.git import get_git_diff, get_git_state
+
+# Positronic's public S3 bucket. Defined here (a low-level module every S3 entrypoint
+# imports) and registered under the name 'PUBLIC' so the `s3://PUBLIC@positronic-public/...`
+# URL form resolves to anonymous access everywhere — including inference servers that take a
+# bare `--checkpoints_dir` string and never see the PUBLIC object.
+PUBLIC = pos3.Profile(
+    local_name='positronic-public', endpoint='https://storage.eu-north1.nebius.cloud', public=True, region='eu-north1'
+)
+pos3.register_profile(
+    'PUBLIC', PUBLIC.endpoint, public=PUBLIC.public, region=PUBLIC.region, local_name=PUBLIC.local_name
+)
 
 
 def resolve_host_ip() -> str:

--- a/positronic/utils/tests/test_profiles.py
+++ b/positronic/utils/tests/test_profiles.py
@@ -1,0 +1,49 @@
+import subprocess
+import sys
+
+from botocore import UNSIGNED
+from pos3.profiles import _create_s3_client, _resolve_profile
+
+import positronic.cfg.phail.v1_0 as phail_v1_0
+from positronic.cfg.ds import PUBLIC as cfg_ds_public
+from positronic.utils import PUBLIC
+
+
+def test_public_profile_registered():
+    assert _resolve_profile('PUBLIC') == PUBLIC
+    assert PUBLIC.public
+    assert PUBLIC.local_name == 'positronic-public'
+    assert PUBLIC.endpoint == 'https://storage.eu-north1.nebius.cloud'
+
+
+def test_public_profile_uses_anonymous_access():
+    # public=True must yield an UNSIGNED client so a reader with no AWS credentials never
+    # tries to sign requests to the public bucket (which would raise NoCredentialsError
+    # before reaching S3).
+    client = _create_s3_client(_resolve_profile('PUBLIC'))
+    assert client.meta.config.signature_version is UNSIGNED
+
+
+def test_cfg_ds_reexports_public():
+    assert cfg_ds_public is PUBLIC
+
+
+def test_phail_models_use_public_profile_url():
+    urls = list(vars(phail_v1_0.models).values())
+    assert urls
+    for url in urls:
+        assert url.startswith('s3://PUBLIC@positronic-public/phail/v1.0/models/')
+
+
+def test_registration_reaches_servers_without_cfg_import():
+    # Inference servers register the profile only transitively: they import
+    # positronic.utils.checkpoints to enumerate checkpoints and never import
+    # positronic.cfg.ds. A fresh interpreter importing just that utility must already
+    # resolve PUBLIC, or a no-creds serve from s3://PUBLIC@... silently breaks.
+    code = (
+        'import positronic.utils.checkpoints\n'
+        'from pos3.profiles import _resolve_profile\n'
+        "assert _resolve_profile('PUBLIC').public\n"
+    )
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr

--- a/positronic/utils/tests/test_profiles.py
+++ b/positronic/utils/tests/test_profiles.py
@@ -5,15 +5,13 @@ from botocore import UNSIGNED
 from pos3.profiles import _create_s3_client, _resolve_profile
 
 import positronic.cfg.phail.v1_0 as phail_v1_0
-from positronic.cfg.ds import PUBLIC as cfg_ds_public
-from positronic.utils import PUBLIC
 
 
 def test_public_profile_registered():
-    assert _resolve_profile('PUBLIC') == PUBLIC
-    assert PUBLIC.public
-    assert PUBLIC.local_name == 'positronic-public'
-    assert PUBLIC.endpoint == 'https://storage.eu-north1.nebius.cloud'
+    profile = _resolve_profile('PUBLIC')
+    assert profile.public
+    assert profile.local_name == 'positronic-public'
+    assert profile.endpoint == 'https://storage.eu-north1.nebius.cloud'
 
 
 def test_public_profile_uses_anonymous_access():
@@ -22,10 +20,6 @@ def test_public_profile_uses_anonymous_access():
     # before reaching S3).
     client = _create_s3_client(_resolve_profile('PUBLIC'))
     assert client.meta.config.signature_version is UNSIGNED
-
-
-def test_cfg_ds_reexports_public():
-    assert cfg_ds_public is PUBLIC
 
 
 def test_phail_models_use_public_profile_url():
@@ -40,10 +34,17 @@ def test_registration_reaches_servers_without_cfg_import():
     # positronic.utils.checkpoints to enumerate checkpoints and never import
     # positronic.cfg.ds. A fresh interpreter importing just that utility must already
     # resolve PUBLIC, or a no-creds serve from s3://PUBLIC@... silently breaks.
-    code = (
-        'import positronic.utils.checkpoints\n'
-        'from pos3.profiles import _resolve_profile\n'
-        "assert _resolve_profile('PUBLIC').public\n"
-    )
+    _assert_registers_public('import positronic.utils.checkpoints')
+
+
+def test_registration_reaches_cfg_ds_consumers():
+    # Dataset configs (e.g. cfg.ds.sim) reach the profile only via cfg.ds, which imports
+    # positronic.utils for the registration side effect. A fresh interpreter importing just
+    # cfg.ds must resolve PUBLIC, or those s3://PUBLIC@... dataset paths silently break.
+    _assert_registers_public('import positronic.cfg.ds')
+
+
+def _assert_registers_public(import_stmt: str) -> None:
+    code = f'{import_stmt}\nfrom pos3.profiles import _resolve_profile\nassert _resolve_profile("PUBLIC").public\n'
     result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr

--- a/positronic/utils/tests/test_profiles.py
+++ b/positronic/utils/tests/test_profiles.py
@@ -2,23 +2,15 @@ import subprocess
 import sys
 
 
-def test_registration_reaches_servers_without_cfg_import():
-    # Inference servers register the profile only transitively: they import
-    # positronic.utils.checkpoints to enumerate checkpoints and never import
-    # positronic.cfg.ds. A fresh interpreter importing just that utility must already
-    # resolve PUBLIC, or a no-creds serve from s3://PUBLIC@... silently breaks.
-    _assert_registers_public('import positronic.utils.checkpoints')
-
-
-def test_registration_reaches_cfg_ds_consumers():
-    # Dataset configs (e.g. cfg.ds.sim) reach the profile only via cfg.ds, which imports
-    # positronic.utils purely for the registration side effect. That import looks unused and
-    # a fresh interpreter importing just cfg.ds must still resolve PUBLIC, or those
-    # s3://PUBLIC@... dataset paths silently break.
-    _assert_registers_public('import positronic.cfg.ds')
-
-
-def _assert_registers_public(import_stmt: str) -> None:
-    code = f'{import_stmt}\nfrom pos3.profiles import _resolve_profile\nassert _resolve_profile("PUBLIC").public\n'
-    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
-    assert result.returncode == 0, result.stderr
+def test_registration_reaches_every_import_path():
+    # The PUBLIC profile is registered as a side effect of importing positronic.utils. Both
+    # entry points that resolve s3://PUBLIC@... must reach that registration on their own, in
+    # a fresh interpreter:
+    #   - inference servers import positronic.utils.checkpoints and never import cfg.ds;
+    #   - dataset configs (e.g. cfg.ds.sim) import positronic.cfg.ds, which imports
+    #     positronic.utils purely for the side effect — an import that looks unused and a
+    #     future dev would happily delete.
+    for import_stmt in ('import positronic.utils.checkpoints', 'import positronic.cfg.ds'):
+        code = f'{import_stmt}\nfrom pos3.profiles import _resolve_profile\nassert _resolve_profile("PUBLIC").public\n'
+        result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
+        assert result.returncode == 0, f'{import_stmt!r} did not register PUBLIC:\n{result.stderr}'

--- a/positronic/utils/tests/test_profiles.py
+++ b/positronic/utils/tests/test_profiles.py
@@ -1,15 +1,6 @@
 import subprocess
 import sys
 
-import positronic.cfg.phail.v1_0 as phail_v1_0
-
-
-def test_phail_models_use_public_profile_url():
-    urls = list(vars(phail_v1_0.models).values())
-    assert urls
-    for url in urls:
-        assert url.startswith('s3://PUBLIC@positronic-public/phail/v1.0/models/')
-
 
 def test_registration_reaches_servers_without_cfg_import():
     # Inference servers register the profile only transitively: they import
@@ -21,8 +12,9 @@ def test_registration_reaches_servers_without_cfg_import():
 
 def test_registration_reaches_cfg_ds_consumers():
     # Dataset configs (e.g. cfg.ds.sim) reach the profile only via cfg.ds, which imports
-    # positronic.utils for the registration side effect. A fresh interpreter importing just
-    # cfg.ds must resolve PUBLIC, or those s3://PUBLIC@... dataset paths silently break.
+    # positronic.utils purely for the registration side effect. That import looks unused and
+    # a fresh interpreter importing just cfg.ds must still resolve PUBLIC, or those
+    # s3://PUBLIC@... dataset paths silently break.
     _assert_registers_public('import positronic.cfg.ds')
 
 

--- a/positronic/utils/tests/test_profiles.py
+++ b/positronic/utils/tests/test_profiles.py
@@ -1,25 +1,7 @@
 import subprocess
 import sys
 
-from botocore import UNSIGNED
-from pos3.profiles import _create_s3_client, _resolve_profile
-
 import positronic.cfg.phail.v1_0 as phail_v1_0
-
-
-def test_public_profile_registered():
-    profile = _resolve_profile('PUBLIC')
-    assert profile.public
-    assert profile.local_name == 'positronic-public'
-    assert profile.endpoint == 'https://storage.eu-north1.nebius.cloud'
-
-
-def test_public_profile_uses_anonymous_access():
-    # public=True must yield an UNSIGNED client so a reader with no AWS credentials never
-    # tries to sign requests to the public bucket (which would raise NoCredentialsError
-    # before reaching S3).
-    client = _create_s3_client(_resolve_profile('PUBLIC'))
-    assert client.meta.config.signature_version is UNSIGNED
 
 
 def test_phail_models_use_public_profile_url():

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -139,16 +139,14 @@ sim_stack = main.override(
     checkpoints_dir='s3://checkpoints/sim_stack/lerobot/230226-ee/',
     recording_dir='s3://inference/sim_stack/server_recordings/lerobot/230226-ee/',
 )
-_DEMO_CHECKPOINT = 's3://positronic-public/checkpoints/sim_stack_cubes/act/'
+_DEMO_CHECKPOINT = 's3://PUBLIC@positronic-public/checkpoints/sim_stack_cubes/act/'
 
 
 @cfn.config(
     policy_factory=act, codec=lerobot_codecs.ee, checkpoint=None, port=8000, host='0.0.0.0', idle_timeout_min=None
 )
 def demo(policy_factory, checkpoint, codec, port, host, idle_timeout_min):
-    from positronic.cfg.ds import PUBLIC
-
-    checkpoints_dir = str(pos3.download(_DEMO_CHECKPOINT, profile=PUBLIC))
+    checkpoints_dir = str(pos3.download(_DEMO_CHECKPOINT))
     InferenceServer(
         policy_factory, codec, checkpoints_dir, checkpoint, host=host, port=port, idle_timeout_min=idle_timeout_min
     ).serve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "opencv-python-headless",
     # openpi-client: optional, see [project.optional-dependencies] openpi
     "plotly>=6.5.0",
-    "pos3>=0.3.1",  # s3://<profile>@bucket URL selectors (anonymous public access) need 0.3.x
+    "pos3>=0.3.1",
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "opencv-python-headless",
     # openpi-client: optional, see [project.optional-dependencies] openpi
     "plotly>=6.5.0",
-    "pos3>=0.2.0",
+    "pos3>=0.3.1",  # s3://<profile>@bucket URL selectors (anonymous public access) need 0.3.x
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",

--- a/utilities/release_phail.py
+++ b/utilities/release_phail.py
@@ -29,9 +29,9 @@ import numpy as np
 import pos3
 
 from positronic.cfg import eval as eval_cfg
-from positronic.cfg.ds import PUBLIC
 from positronic.dataset.dataset import Dataset
 from positronic.dataset.utilities.migrate_remote import migrate_dataset
+from positronic.utils import PUBLIC
 from positronic.utils.checkpoints import get_latest_checkpoint
 from positronic.utils.logging import init_logging
 

--- a/uv.lock
+++ b/uv.lock
@@ -3249,7 +3249,7 @@ requires-dist = [
     { name = "openpi-client", marker = "extra == 'openpi'", git = "https://github.com/Positronic-Robotics/openpi.git?subdirectory=packages%2Fopenpi-client&rev=main-positronic" },
     { name = "placo", marker = "extra == 'hardware'" },
     { name = "plotly", specifier = ">=6.5.0" },
-    { name = "pos3", specifier = ">=0.2.0" },
+    { name = "pos3", specifier = ">=0.3.1" },
     { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyarrow" },


### PR DESCRIPTION
## Summary

Lets a reader with **no AWS credentials** serve the public phail models directly, by making the `s3://PUBLIC@positronic-public/...` URL form resolve to anonymous (unsigned) access everywhere.

- **`positronic/utils/__init__.py`** — define the public S3 `Profile` here (a low-level module every S3 entrypoint already imports, at zero added import cost) and `register_profile('PUBLIC', …)` from it. This is the one place reachable by inference servers, which take a bare `--checkpoints_dir` string and never import `cfg.ds`. `positronic/__init__.py` stays minimal, so pure-compute imports don't pull in boto3.
- **`positronic/cfg/ds/__init__.py`** — re-export `PUBLIC` from `utils` instead of holding a duplicate `Profile` (single source of truth; utils never imports cfg, so no cycle). `cfg.phail`, `cfg.ds.sim`, and the lerobot server keep importing it from `cfg.ds` unchanged.
- **`positronic/cfg/phail/v1_0.py`** — point the v1.0 **model** URLs at the `s3://PUBLIC@…` form so they resolve anonymously on their own (datasets keep `profile=PUBLIC`, which they pass explicitly).

Every pos3 op (`download`/`ls`/checkpoint listing) routes through `_effective_profile(profile, remote)`, where the URL's `@PUBLIC` wins — so the servers' existing bare `pos3.download` / `pos3.ls` need no change.

## Test plan

New offline regression suite `positronic/utils/tests/test_profiles.py` (5 tests):
- registration + fields, re-export identity, phail model URLs use the `PUBLIC@` form;
- `public=True` yields an **UNSIGNED** client (the no-creds property, asserted without network);
- a fresh interpreter importing only `utils.checkpoints` (what servers use, never `cfg.ds`) must already resolve `PUBLIC` — guards the design against the registration drifting to a module servers don't import.

Manually verified anonymous access with **all** AWS credential sources scrubbed in a fresh interpreter:
- bare `s3://positronic-public/...` (signed) → `NoCredentialsError` (negative control);
- `s3://PUBLIC@positronic-public/phail/v1.0/models/gr00t/` → lists `checkpoint-150000`.

`pytest positronic/cfg/tests positronic/utils/tests --no-cov` → 24 passed.