### PR TITLE
Deliver `timeout` + `inference_latency` on the RUN directive; Harness self-terminates trials

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -67,9 +67,9 @@ Use local when latency is critical (<50ms), robot has built-in GPU, or offline o
 
 ## Inference Drivers
 
-Positronic provides three drivers for managing inference episodes (see [`positronic/inference.py`](../positronic/inference.py)):
+Positronic provides two interactive drivers for managing inference episodes (see [`positronic/inference.py`](../positronic/inference.py)), plus an unattended mode:
 
-**Timed driver (automatic):** Runs inference automatically for a fixed duration per episode — the task's `timeout` (override with `--eval.timeout=60`, seconds per episode); also set `--trial_count=10` (number of episodes), and optionally `--show_gui=True` for DearPyGui visualization. The default for `sim`. Useful for batch evaluation without manual intervention.
+**Unattended (automatic):** The default for `sim` — runs `--trial_count=10` episodes back-to-back, each ending when the task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode); optionally `--show_gui=True` for DearPyGui visualization. Useful for batch evaluation without manual intervention.
 
 **Keyboard driver (manual):** Control inference with keyboard. Press `s` to start episode, `p` to stop and save, `r` to home the robot, `q` to quit. The default for `real`; optionally pass `--driver.show_gui=True` for DearPyGui visualization. Useful for manual evaluation and debugging.
 

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -13,15 +13,11 @@ def placeholder():
 
 
 @cfn.config(eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=default_wrappers)
-def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, simulate_inference=False, wrap=default_wrappers):
+def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, wrap=default_wrappers):
     """Run a selected eval (embodiment + task) through the shared inference harness."""
-    driver = inference.timed(num_iterations=trial_count, simulation_time=eval.task.timeout, show_gui=show_gui)
+    driver = inference.sequencer(
+        trial_count=trial_count, timeout=eval.task.timeout, inference_latency=inference_latency, show_gui=show_gui
+    )
     inference.main(
-        embodiment=eval.embodiment,
-        task=eval.task,
-        policy=policy,
-        driver=driver,
-        output_dir=output_dir,
-        simulate_inference=simulate_inference,
-        wrap=wrap,
+        embodiment=eval.embodiment, task=eval.task, policy=policy, driver=driver, output_dir=output_dir, wrap=wrap
     )

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -15,9 +15,23 @@ def placeholder():
 @cfn.config(eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=default_wrappers)
 def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, wrap=default_wrappers):
     """Run a selected eval (embodiment + task) through the shared inference harness."""
-    driver = inference.sequencer(
-        trial_count=trial_count, timeout=eval.task.timeout, inference_latency=inference_latency, show_gui=show_gui
-    )
+    # The trial plan: one RUN context per trial, consumed by the self-driving Harness.
+    # (Step 5 adds the per-trial seed `base + i` here.)
+    trials = [
+        {
+            'timeout': eval.task.timeout,
+            'inference_latency': inference_latency,
+            'eval.trial_index': i,
+            'eval.trial_count': trial_count,
+        }
+        for i in range(trial_count)
+    ]
     inference.main(
-        embodiment=eval.embodiment, task=eval.task, policy=policy, driver=driver, output_dir=output_dir, wrap=wrap
+        embodiment=eval.embodiment,
+        task=eval.task,
+        policy=policy,
+        trials=trials,
+        show_gui=show_gui,
+        output_dir=output_dir,
+        wrap=wrap,
     )

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -16,14 +16,8 @@ def placeholder():
 def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, wrap=default_wrappers):
     """Run a selected eval (embodiment + task) through the shared inference harness."""
     # The trial plan: one RUN context per trial, consumed by the self-driving Harness.
-    # (Step 5 adds the per-trial seed `base + i` here.)
     trials = [
-        {
-            'timeout': eval.task.timeout,
-            'inference_latency': inference_latency,
-            'eval.trial_index': i,
-            'eval.trial_count': trial_count,
-        }
+        {'inference_latency': inference_latency, 'eval.trial_index': i, 'eval.trial_count': trial_count}
         for i in range(trial_count)
     ]
     inference.main(

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -1,7 +1,10 @@
 import logging
 from collections import Counter
+from collections.abc import Callable
 from contextlib import nullcontext
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import configuronic as cfn
 import pos3
@@ -38,27 +41,43 @@ class KeyboardHandler:
         return None
 
 
-class TimedDriver(pimm.ControlSystem):
-    """Control system that orchestrates inference episodes by sending directives."""
+@dataclass
+class Driver:
+    """What a driver config supplies: the directive source ``main`` wires into the Harness."""
 
-    def __init__(self, num_iterations: int, simulation_time: float):
-        self.num_iterations = num_iterations
-        self.simulation_time = simulation_time
+    gui: DearpyguiUi | None
+    directives: pimm.SignalEmitter
+    directive_wrapper: Callable
+    control_systems: list[pimm.ControlSystem]
+    episode_ended: pimm.ControlSystemReceiver | None = None
+
+
+class TrialSequencer(pimm.ControlSystem):
+    """Pure trial sequencer: emits RUN per trial, then waits for the harness to end the episode.
+
+    The harness owns trial termination (timeout, later the task's stop-signal); the
+    sequencer just paces the trials and carries the per-trial RUN context.
+    """
+
+    def __init__(self, trial_count: int, run_context: dict[str, Any]):
+        self.trial_count = trial_count
+        self.run_context = run_context
         self.directives = pimm.ControlSystemEmitter(self)
+        self.episode_ended = pimm.ControlSystemReceiver(self, default=None)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        for i in range(self.num_iterations):
-            meta = {'simulation.iteration': str(i), 'simulation.total_iterations': str(self.num_iterations)}
-            self.directives.emit(Directive.RUN(**meta))
-            yield pimm.Sleep(self.simulation_time)
-            self.directives.emit(Directive.FINISH())
-            yield pimm.Sleep(0.5)
+        for i in range(self.trial_count):
+            context = {**self.run_context, 'eval.trial_index': i, 'eval.trial_count': self.trial_count}
+            self.directives.emit(Directive.RUN(**context))
+            while not should_stop.value and not self.episode_ended.read().updated:
+                yield pimm.Sleep(0.01)
+        yield pimm.Sleep(0.5)  # let the DsWriterAgent commit the last episode before world exit
 
 
 @cfn.config(ui_scale=1)
 def eval_ui(ui_scale):
     gui = EvalUI(ui_scale=ui_scale)
-    return gui, (gui.directive, pimm.utils.identity), []
+    return Driver(gui, gui.directive, pimm.utils.identity, [])
 
 
 @cfn.config(show_gui=False)
@@ -66,18 +85,19 @@ def keyboard(show_gui, task):
     keyboard = KeyboardControl(quit_key='q')
     keyboard_handler = KeyboardHandler(task=task)
     print('Keyboard controls: [s]tart, sto[p], [r] home, [q]uit')
-    return (
+    return Driver(
         None if not show_gui else DearpyguiUi(),
-        (keyboard.keyboard_inputs, pimm.map(keyboard_handler.harness_directive)),
+        keyboard.keyboard_inputs,
+        pimm.map(keyboard_handler.harness_directive),
         [keyboard],
     )
 
 
-@cfn.config(num_iterations=1, simulation_time=15, show_gui=False)
-def timed(num_iterations, simulation_time, show_gui):
+@cfn.config(trial_count=1, timeout=15, inference_latency=False, show_gui=False)
+def sequencer(trial_count, timeout, inference_latency, show_gui):
     gui = None if not show_gui else DearpyguiUi()
-    driver = TimedDriver(num_iterations, simulation_time)
-    return gui, (driver.directives, pimm.utils.identity), [driver]
+    driver = TrialSequencer(trial_count, {'timeout': timeout, 'inference_latency': inference_latency})
+    return Driver(gui, driver.directives, pimm.utils.identity, [driver], driver.episode_ended)
 
 
 def _seed_counter(policy, output_dir: Path):
@@ -114,9 +134,8 @@ def _connect_ds_command(world, harness, ds_agent, policy):
 def main(
     embodiment: Embodiment,
     policy,
-    driver: tuple,
+    driver: Driver,
     output_dir: str | Path | None = None,
-    simulate_inference: bool | float = False,
     task: Task | None = None,
     wrap=default_wrappers,
 ):
@@ -130,10 +149,9 @@ def main(
         embodiment,
         instruction=task.instruction if task is not None else None,
         wrap=wrap,
-        simulate_inference=simulate_inference,
         on_episode_complete=_completion_sink(policy),
     )
-    gui, harness_emitter, foreground_cs = driver
+    gui = driver.gui
 
     if output_dir is not None:
         output_dir = pos3.sync(output_dir, sync_on_error=True)
@@ -152,16 +170,18 @@ def main(
             for name, obs in embodiment.observations.items():
                 if name.startswith('image.'):
                     world.connect(obs.source, gui.cameras[name])
-        world.connect(harness_emitter[0], harness.directive, emitter_wrapper=harness_emitter[1])
+        world.connect(driver.directives, harness.directive, emitter_wrapper=driver.directive_wrapper)
+        if driver.episode_ended is not None:
+            world.connect(harness.episode_ended, driver.episode_ended)
         _connect_ds_command(world, harness, ds_agent, policy)
 
         # Sim runs devices + recorder in-process under the virtual clock; real runs them as
         # background subprocesses. The harness, driver, and GUI placement is identical.
         devices = [cs for cs in [*embodiment.control_systems, ds_agent] if cs is not None]
         if embodiment.simulated:
-            world.run([harness, *foreground_cs, *devices], gui)
+            world.run([harness, *driver.control_systems, *devices], gui)
         else:
-            world.run([harness, *foreground_cs], [*devices, gui])
+            world.run([harness, *driver.control_systems], [*devices, gui])
 
 
 run_cfg = cfn.Config(main, embodiment=positronic.cfg.embodiment.droid, policy=policy_cfg.placeholder, driver=keyboard)

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -112,20 +112,16 @@ def main(
 ):
     """Run inference for an embodiment, real or simulated.
 
-    ``task`` (when given) supplies the policy-facing instruction and the privileged
-    ground-truth signals to record; without it the instruction rides the driver.
-    Exactly one of ``driver`` (attended: an operator surface emits the directives)
-    or ``trials`` (unattended: the harness runs the plan itself) must be given;
-    ``show_gui`` applies to the unattended path (attended surfaces bring their own).
+    ``task`` (when given) supplies the policy-facing instruction, the per-trial
+    ``timeout`` bounding self-driven trials, and the privileged ground-truth signals
+    to record; without it the instruction rides the driver. Exactly one of ``driver``
+    (attended: an operator surface emits the directives) or ``trials`` (unattended:
+    the harness runs the plan itself) must be given; ``show_gui`` applies to the
+    unattended path (attended surfaces bring their own).
     """
     assert (driver is None) != (trials is None), 'Provide exactly one of driver or trials'
     harness = Harness(
-        policy,
-        embodiment,
-        instruction=task.instruction if task is not None else None,
-        trials=trials,
-        wrap=wrap,
-        on_episode_complete=_completion_sink(policy),
+        policy, embodiment, task=task, trials=trials, wrap=wrap, on_episode_complete=_completion_sink(policy)
     )
     gui = driver.gui if driver is not None else (DearpyguiUi() if show_gui else None)
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import configuronic as cfn
 import pos3
@@ -43,35 +42,12 @@ class KeyboardHandler:
 
 @dataclass
 class Driver:
-    """What a driver config supplies: the directive source ``main`` wires into the Harness."""
+    """An attended operator surface: the directive source ``main`` wires into the Harness."""
 
     gui: DearpyguiUi | None
     directives: pimm.SignalEmitter
     directive_wrapper: Callable
     control_systems: list[pimm.ControlSystem]
-    episode_ended: pimm.ControlSystemReceiver | None = None
-
-
-class TrialSequencer(pimm.ControlSystem):
-    """Pure trial sequencer: emits RUN per trial, then waits for the harness to end the episode.
-
-    The harness owns trial termination (timeout, later the task's stop-signal); the
-    sequencer just paces the trials and carries the per-trial RUN context.
-    """
-
-    def __init__(self, trial_count: int, run_context: dict[str, Any]):
-        self.trial_count = trial_count
-        self.run_context = run_context
-        self.directives = pimm.ControlSystemEmitter(self)
-        self.episode_ended = pimm.ControlSystemReceiver(self, default=None)
-
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        for i in range(self.trial_count):
-            context = {**self.run_context, 'eval.trial_index': i, 'eval.trial_count': self.trial_count}
-            self.directives.emit(Directive.RUN(**context))
-            while not should_stop.value and not self.episode_ended.read().updated:
-                yield pimm.Sleep(0.01)
-        yield pimm.Sleep(0.5)  # let the DsWriterAgent commit the last episode before world exit
 
 
 @cfn.config(ui_scale=1)
@@ -91,13 +67,6 @@ def keyboard(show_gui, task):
         pimm.map(keyboard_handler.harness_directive),
         [keyboard],
     )
-
-
-@cfn.config(trial_count=1, timeout=15, inference_latency=False, show_gui=False)
-def sequencer(trial_count, timeout, inference_latency, show_gui):
-    gui = None if not show_gui else DearpyguiUi()
-    driver = TrialSequencer(trial_count, {'timeout': timeout, 'inference_latency': inference_latency})
-    return Driver(gui, driver.directives, pimm.utils.identity, [driver], driver.episode_ended)
 
 
 def _seed_counter(policy, output_dir: Path):
@@ -134,24 +103,31 @@ def _connect_ds_command(world, harness, ds_agent, policy):
 def main(
     embodiment: Embodiment,
     policy,
-    driver: Driver,
+    driver: Driver | None = None,
     output_dir: str | Path | None = None,
     task: Task | None = None,
+    trials: list[dict] | None = None,
+    show_gui: bool = False,
     wrap=default_wrappers,
 ):
     """Run inference for an embodiment, real or simulated.
 
     ``task`` (when given) supplies the policy-facing instruction and the privileged
     ground-truth signals to record; without it the instruction rides the driver.
+    Exactly one of ``driver`` (attended: an operator surface emits the directives)
+    or ``trials`` (unattended: the harness runs the plan itself) must be given;
+    ``show_gui`` applies to the unattended path (attended surfaces bring their own).
     """
+    assert (driver is None) != (trials is None), 'Provide exactly one of driver or trials'
     harness = Harness(
         policy,
         embodiment,
         instruction=task.instruction if task is not None else None,
+        trials=trials,
         wrap=wrap,
         on_episode_complete=_completion_sink(policy),
     )
-    gui = driver.gui
+    gui = driver.gui if driver is not None else (DearpyguiUi() if show_gui else None)
 
     if output_dir is not None:
         output_dir = pos3.sync(output_dir, sync_on_error=True)
@@ -170,18 +146,18 @@ def main(
             for name, obs in embodiment.observations.items():
                 if name.startswith('image.'):
                     world.connect(obs.source, gui.cameras[name])
-        world.connect(driver.directives, harness.directive, emitter_wrapper=driver.directive_wrapper)
-        if driver.episode_ended is not None:
-            world.connect(harness.episode_ended, driver.episode_ended)
+        if driver is not None:
+            world.connect(driver.directives, harness.directive, emitter_wrapper=driver.directive_wrapper)
         _connect_ds_command(world, harness, ds_agent, policy)
 
         # Sim runs devices + recorder in-process under the virtual clock; real runs them as
         # background subprocesses. The harness, driver, and GUI placement is identical.
+        foreground = driver.control_systems if driver is not None else []
         devices = [cs for cs in [*embodiment.control_systems, ds_agent] if cs is not None]
         if embodiment.simulated:
-            world.run([harness, *driver.control_systems, *devices], gui)
+            world.run([harness, *foreground, *devices], gui)
         else:
-            world.run([harness, *driver.control_systems], [*devices, gui])
+            world.run([harness, *foreground], [*devices, gui])
 
 
 run_cfg = cfn.Config(main, embodiment=positronic.cfg.embodiment.droid, policy=policy_cfg.placeholder, driver=keyboard)

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -112,12 +112,11 @@ def main(
 ):
     """Run inference for an embodiment, real or simulated.
 
-    ``task`` (when given) supplies the policy-facing instruction, the per-trial
-    ``timeout`` bounding self-driven trials, and the privileged ground-truth signals
-    to record; without it the instruction rides the driver. Exactly one of ``driver``
-    (attended: an operator surface emits the directives) or ``trials`` (unattended:
-    the harness runs the plan itself) must be given; ``show_gui`` applies to the
-    unattended path (attended surfaces bring their own).
+    ``task`` (when given) supplies the policy-facing instruction, the per-trial ``timeout``
+    bounding self-driven trials, and the privileged ground-truth signals to record; without it
+    the instruction rides the driver. Exactly one of ``driver`` (attended: an operator surface
+    emits the directives) or ``trials`` (unattended: the harness runs the plan itself) must be
+    given; ``show_gui`` applies to the unattended path (attended surfaces bring their own).
     """
     assert (driver is None) != (trials is None), 'Provide exactly one of driver or trials'
     harness = Harness(

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -163,29 +163,26 @@ def default_wrappers(clock: pimm.Clock) -> PolicyWrapper:
 class Harness(pimm.ControlSystem):
     """Control system that manages episode lifecycle and forwards trajectories to drivers.
 
-    The harness handles directives (RUN/STOP/FINISH/HOME) and dataset recording.
-    All inference intelligence (scheduling, error recovery, blending, absolute
-    time stamping) lives in the policy/session layer — the harness just calls
-    the session, demuxes the action dicts into per-channel trajectories, and
-    emits.
+    The harness handles directives (RUN/STOP/FINISH/HOME) and dataset recording. All inference
+    intelligence (scheduling, error recovery, blending, absolute time stamping) lives in the
+    policy/session layer — the harness just calls the session, demuxes the action dicts into
+    per-channel trajectories, and emits.
 
-    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation)
-    in its context. A ``trials`` plan (a sequence of RUN contexts) makes the
-    harness self-driving: whenever it is idle it starts the next trial itself —
-    bounded by the task's ``timeout`` — and exits once the plan is exhausted, so
-    the unattended path needs no driver at all. Attended drivers own episode
+    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation) in its context.
+    A ``trials`` plan (a sequence of RUN contexts) makes the harness self-driving: whenever it is
+    idle it starts the next trial itself — bounded by the task's ``timeout`` — and exits once the
+    plan is exhausted, so the unattended path needs no driver at all. Attended drivers own episode
     termination themselves; directive-driven trials get no deadline.
 
-    The ``Embodiment`` provides the observation serializers (which own the
-    canonical key names), the command channels, and the home action; the harness
-    reads them to assemble inputs and demux actions, treating every channel alike.
+    The ``Embodiment`` provides the observation serializers (which own the canonical key names),
+    the command channels, and the home action; the harness reads them to assemble inputs and demux
+    actions, treating every channel alike.
 
-    The outermost wrapper (typically ``ChunkedSchedule`` or a swap-in alternative
-    like RTC) is responsible for producing absolute timestamps.
+    The outermost wrapper (typically ``ChunkedSchedule`` or a swap-in alternative like RTC) is
+    responsible for producing absolute timestamps.
 
-    By default, wraps the given policy with ``ErrorRecovery | ChunkedSchedule``.
-    Pass ``wrap=None`` to skip auto-wrapping (if you've already composed your
-    own pipeline).
+    By default, wraps the given policy with ``ErrorRecovery | ChunkedSchedule``. Pass ``wrap=None``
+    to skip auto-wrapping (if you've already composed your own pipeline).
     """
 
     def __init__(
@@ -203,9 +200,9 @@ class Harness(pimm.ControlSystem):
         self._raw_policy = policy
         self._embodiment = embodiment
         self._task = task
-        # The unattended trial plan: each entry is a RUN context. When set, the run
-        # loop starts the next trial whenever it is idle and returns once the plan
-        # is exhausted; when None, directives are the only lifecycle source.
+        # The unattended trial plan: each entry is a RUN context. When set, the run loop starts the
+        # next trial whenever it is idle and returns once the plan is exhausted; when None,
+        # directives are the only lifecycle source.
         self._trials = iter(trials) if trials is not None else None
         self._wrap = wrap
         # Called with (session, context) when an episode completes successfully (clean
@@ -218,14 +215,17 @@ class Harness(pimm.ControlSystem):
         self.context: dict[str, Any] = {}
         self._static_meta = static_meta or {}
         self._session: Session | None = None
-        # ``inference_latency`` is delivered on the RUN context (sim-only): ``True``
-        # advances the (sim) clock by the wall-clock cost of the inference call; a
-        # float is a fixed deterministic delay (used by the reproducible golden).
-        # Sleep is yielded BEFORE ``ChunkedSchedule`` reads ``clock.now()`` so the
-        # trajectory is anchored to inference-finish, not inference-start.
+        # Directive-driven lifecycle flags: ``_running`` gates stepping; ``_recording`` survives STOP
+        # (the suspended episode is in review until FINISH/HOME).
+        self._running = False
+        self._recording = False
+        # ``inference_latency`` is delivered on the RUN context (sim-only): ``True`` advances the
+        # (sim) clock by the wall-clock cost of the inference call; a float is a fixed deterministic
+        # delay (used by the reproducible golden). Sleep is yielded BEFORE ``ChunkedSchedule`` reads
+        # ``clock.now()`` so the trajectory is anchored to inference-finish, not inference-start.
         self._inference_latency: bool | float = False
-        # Self-driven trials are bounded by ``task.timeout``; attended drivers own
-        # termination themselves, so directive-driven trials get no deadline.
+        # Self-driven trials are bounded by ``task.timeout``; attended drivers own termination
+        # themselves, so directive-driven trials get no deadline.
         self._deadline: float | None = None
 
         self._descriptor = embodiment.descriptor
@@ -261,10 +261,10 @@ class Harness(pimm.ControlSystem):
     def _bump_schedule_end(self, delta_sec: float) -> None:
         """Shift the active ``ChunkedSchedule._Session`` ``_trajectory_end`` by ``delta_sec``.
 
-        Used by ``inference_latency``: the session anchored the chunk pre-sleep,
-        then we slept and post-shifted the emitted timestamps. The scheduling
-        wrapper's internal end-of-chunk gate must move forward too, or it will
-        re-infer before the driver has actually played the (shifted) trajectory.
+        Used by ``inference_latency``: the session anchored the chunk pre-sleep, then we slept and
+        post-shifted the emitted timestamps. The scheduling wrapper's internal end-of-chunk gate
+        must move forward too, or it will re-infer before the driver has actually played the (shifted)
+        trajectory.
         """
         s = self._session
         while s is not None:
@@ -288,13 +288,11 @@ class Harness(pimm.ControlSystem):
         if self._session is not None:
             self._session.cancel()
 
-    def _handle_directive(
-        self, directive: Directive, clock: pimm.Clock, recording: bool
-    ) -> Generator[pimm.Sleep, None, tuple[bool, bool]]:
-        """Handle a directive, yielding any necessary pauses. Returns (running, recording)."""
+    def _handle_directive(self, directive: Directive, clock: pimm.Clock) -> Generator[pimm.Sleep, None, None]:
+        """Handle a directive, yielding any necessary pauses; updates ``_running``/``_recording``."""
         match directive.type:
             case DirectiveType.RUN:
-                if recording:
+                if self._recording:
                     if self._session:
                         self._on_complete(self._session, self.context)
                     self._cancel_trajectories()
@@ -311,22 +309,23 @@ class Harness(pimm.ControlSystem):
                     self._session.close()
                 self._session = self.policy.new_session(self.context)
                 self.ds_command.emit(DsWriterCommand.START(self._build_episode_meta(self.context)))
-                return True, True
+                self._running = True
+                self._recording = True
             case DirectiveType.STOP:
                 # SUSPEND before the cancel: the writer flushes the due trajectory
                 # prefix (dropping the future tail) when it handles SUSPEND, then skips
                 # inputs — so the `[]` cancel that follows is only acted on by the robot.
-                if recording:
+                if self._recording:
                     self.ds_command.emit(DsWriterCommand.SUSPEND())
                 self._cancel_trajectories()
-                return False, recording
+                self._running = False
             case DirectiveType.FINISH:
-                if recording:
+                if self._recording:
                     if self._session:
                         self._on_complete(self._session, self.context)
                     self._cancel_trajectories()
                     self.ds_command.emit(DsWriterCommand.STOP(directive.payload or {}))
-                    recording = False
+                    self._recording = False
                 # End the per-episode session here (not just at RUN/shutdown) so a
                 # ``RemoteSession``'s websocket closes promptly and the offboard server's
                 # per-session cleanup (active-session decrement, idle watchdog) runs now.
@@ -335,17 +334,17 @@ class Harness(pimm.ControlSystem):
                     self._session = None
                 self._home(clock)
                 yield pimm.Yield()
-                return False, recording
+                self._running = False
             case DirectiveType.HOME:
-                if recording:
+                if self._recording:
                     self.ds_command.emit(DsWriterCommand.ABORT())
-                    recording = False
+                    self._recording = False
                 if self._session:  # HOME aborts the episode; release the session like FINISH
                     self._session.close()
                     self._session = None
                 self._home(clock)
                 yield pimm.Yield()
-                return False, recording
+                self._running = False
             case _:
                 raise ValueError(f'Unknown directive type: {directive.type}')
 
@@ -404,12 +403,11 @@ class Harness(pimm.ControlSystem):
         if obs is None:
             return
 
-        # Advance the (sim) clock by the inference cost so rollouts feel the
-        # model's latency. We only sleep on cycles where inference actually ran
-        # (session returned a chunk) — otherwise blocked cycles would slow the
-        # harness's directive-handling loop. The trajectory was anchored
-        # pre-sleep, so we post-shift it and also bump the scheduling
-        # wrapper's internal ``_trajectory_end`` to stay consistent.
+        # Advance the (sim) clock by the inference cost so rollouts feel the model's latency. We only
+        # sleep on cycles where inference actually ran (session returned a chunk) — otherwise blocked
+        # cycles would slow the harness's directive-handling loop. The trajectory was anchored
+        # pre-sleep, so we post-shift it and also bump the scheduling wrapper's internal
+        # ``_trajectory_end`` to stay consistent.
         wall_start = time.monotonic()
         actions = self._session(frozen_view(obs))
         if actions is None:
@@ -420,10 +418,9 @@ class Harness(pimm.ControlSystem):
             actions = [{**a, 'timestamp': a['timestamp'] + delay} for a in actions]
             self._bump_schedule_end(delay)
 
-        # Recheck the deadline: the latency sleep (or a slow inference call on a
-        # real clock) may have crossed it. Drop the chunk rather than emit past
-        # the advertised self-termination point — the run loop fires the timeout
-        # FINISH on its next cycle.
+        # Recheck the deadline: the latency sleep (or a slow inference call on a real clock) may have
+        # crossed it. Drop the chunk rather than emit past the advertised self-termination point —
+        # the run loop fires the timeout FINISH on its next cycle.
         if self._deadline is not None and clock.now() >= self._deadline:
             return
 
@@ -438,36 +435,31 @@ class Harness(pimm.ControlSystem):
         else:  # factory: Callable[[Clock], PolicyWrapper]
             self.policy = self._wrap(clock).wrap(self._raw_policy)
 
-        running = False
-        recording = False
-
         while not should_stop.value:
             directive_msg = self.directive.read()
             if directive_msg.updated:
-                running, recording = yield from self._handle_directive(directive_msg.data, clock, recording)
-            elif not running and self._trials is not None:
+                yield from self._handle_directive(directive_msg.data, clock)
+            elif not self._running and self._trials is not None:
                 trial = next(self._trials, None)
-                if trial is None:  # plan exhausted — wind the run down
-                    yield pimm.Sleep(0.5)  # let the recorder commit the final episode before the world exits
+                if trial is None:  # plan exhausted — let the recorder commit the final episode, then exit
+                    yield pimm.Sleep(0.5)
                     break
-                running, recording = yield from self._handle_directive(Directive.RUN(**trial), clock, recording)
+                yield from self._handle_directive(Directive.RUN(**trial), clock)
                 self._deadline = clock.now() + self._task.timeout
 
-            if running and self._deadline is not None and clock.now() >= self._deadline:
-                # Trial time budget exhausted: self-terminate. ``eval.terminated`` is False —
-                # the trial ran out of time rather than being terminated by a stop-signal.
-                finish = Directive.FINISH(**{'eval.terminated': False})
-                running, recording = yield from self._handle_directive(finish, clock, recording)
+            if self._running and self._deadline is not None and clock.now() >= self._deadline:
+                # Time budget exhausted: ``eval.terminated`` is False — timed out rather than stop-signal terminated.
+                yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': False}), clock)
 
             try:
-                if running:
+                if self._running:
                     yield from self._step(clock)
             except pimm.NoValueException:
                 pass
             finally:
                 yield pimm.Sleep(0.01)
 
-        if recording:
+        if self._recording:
             if self._session:
                 self._on_complete(self._session, self.context)
             # Stop the live drivers before finalizing (matches FINISH/RUN). The

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -169,6 +169,11 @@ class Harness(pimm.ControlSystem):
     the session, demuxes the action dicts into per-channel trajectories, and
     emits.
 
+    ``RUN`` may carry per-trial lifecycle knobs in its context: ``timeout``
+    (seconds; the harness self-terminates the trial when it expires) and
+    ``inference_latency`` (sim-only inference-cost simulation). ``episode_ended``
+    fires whenever an episode is finalized, so a trial sequencer can pace on it.
+
     The ``Embodiment`` provides the observation serializers (which own the
     canonical key names), the command channels, and the home action; the harness
     reads them to assemble inputs and demux actions, treating every channel alike.
@@ -189,7 +194,6 @@ class Harness(pimm.ControlSystem):
         instruction: str | None = None,
         static_meta: dict[str, Any] | None = None,
         wrap: PolicyWrapper | Callable[[pimm.Clock], PolicyWrapper] | None = default_wrappers,
-        simulate_inference: bool | float = False,
         on_episode_complete: Callable[[Session, dict[str, Any]], None] | None = None,
     ):
         self._raw_policy = policy
@@ -206,11 +210,14 @@ class Harness(pimm.ControlSystem):
         self.context: dict[str, Any] = {}
         self._static_meta = static_meta or {}
         self._session: Session | None = None
-        # ``True`` advances the (sim) clock by the wall-clock cost of the inference
-        # call; a float is a fixed deterministic delay (used by the reproducible
-        # golden). Sleep is yielded BEFORE ``ChunkedSchedule`` reads ``clock.now()``
-        # so the trajectory is anchored to inference-finish, not inference-start.
-        self.simulate_inference = simulate_inference
+        # Per-trial lifecycle knobs, delivered on the RUN context. ``inference_latency``
+        # (sim-only): ``True`` advances the (sim) clock by the wall-clock cost of the
+        # inference call; a float is a fixed deterministic delay (used by the
+        # reproducible golden). Sleep is yielded BEFORE ``ChunkedSchedule`` reads
+        # ``clock.now()`` so the trajectory is anchored to inference-finish, not
+        # inference-start. ``timeout`` sets the deadline for self-termination.
+        self._inference_latency: bool | float = False
+        self._deadline: float | None = None
 
         self._descriptor = embodiment.descriptor
         self.observations = pimm.ReceiverDict(self)
@@ -222,13 +229,14 @@ class Harness(pimm.ControlSystem):
 
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
+        # Fired when an episode is finalized (FINISH, including timeout self-termination).
+        self.episode_ended = pimm.ControlSystemEmitter(self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
         meta = dict(self._embodiment.static_meta)
         meta.update(self._static_meta)
         meta.update(self.robot_meta_in.value)
-        meta['inference.simulate_inference'] = self.simulate_inference
         # ``policy.meta`` is the static baseline (the wrapped policy aggregates model +
         # codec meta); the session overlays per-episode specifics (e.g. the sampled
         # sub-policy) and wins on conflict.
@@ -246,7 +254,7 @@ class Harness(pimm.ControlSystem):
     def _bump_schedule_end(self, delta_sec: float) -> None:
         """Shift the active ``ChunkedSchedule._Session`` ``_trajectory_end`` by ``delta_sec``.
 
-        Used by ``simulate_inference``: the session anchored the chunk pre-sleep,
+        Used by ``inference_latency``: the session anchored the chunk pre-sleep,
         then we slept and post-shifted the emitted timestamps. The scheduling
         wrapper's internal end-of-chunk gate must move forward too, or it will
         re-infer before the driver has actually played the (shifted) trajectory.
@@ -289,6 +297,10 @@ class Harness(pimm.ControlSystem):
                 self.context = directive.payload or {}
                 if self._instruction is not None:
                     self.context = {**self.context, 'task': self._instruction}
+                # Lifecycle knobs ride the RUN context (and land in episode meta with it).
+                self._inference_latency = self.context.get('inference_latency', False)
+                timeout = self.context.get('timeout')
+                self._deadline = clock.now() + timeout if timeout is not None else None
                 if self._session:
                     self._session.close()
                 self._session = self.policy.new_session(self.context)
@@ -317,6 +329,7 @@ class Harness(pimm.ControlSystem):
                     self._session = None
                 self._home(clock)
                 yield pimm.Yield()
+                self.episode_ended.emit(True)
                 return False, recording
             case DirectiveType.HOME:
                 if recording:
@@ -392,10 +405,10 @@ class Harness(pimm.ControlSystem):
         actions = self._session(frozen_view(obs))
         if actions is None:
             return
-        if self.simulate_inference is True:  # bool is an int subclass — check identity first
+        if self._inference_latency is True:  # bool is an int subclass — check identity first
             delay = time.monotonic() - wall_start
-        elif self.simulate_inference:
-            delay = float(self.simulate_inference)
+        elif self._inference_latency:
+            delay = float(self._inference_latency)
         else:
             delay = 0.0
         if delay > 0.0:
@@ -421,6 +434,12 @@ class Harness(pimm.ControlSystem):
             directive_msg = self.directive.read()
             if directive_msg.updated:
                 running, recording = yield from self._handle_directive(directive_msg.data, clock, recording)
+
+            if running and self._deadline is not None and clock.now() >= self._deadline:
+                # Trial time budget exhausted: self-terminate. ``eval.terminated`` is False —
+                # the trial ran out of time rather than being terminated by a stop-signal.
+                finish = Directive.FINISH(**{'eval.terminated': False})
+                running, recording = yield from self._handle_directive(finish, clock, recording)
 
             try:
                 if running:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -416,6 +416,13 @@ class Harness(pimm.ControlSystem):
             actions = [{**a, 'timestamp': a['timestamp'] + delay} for a in actions]
             self._bump_schedule_end(delay)
 
+        # Recheck the deadline: the latency sleep (or a slow inference call on a
+        # real clock) may have crossed it. Drop the chunk rather than emit past
+        # the advertised self-termination point — the run loop fires the timeout
+        # FINISH on its next cycle.
+        if self._deadline is not None and clock.now() >= self._deadline:
+            return
+
         self._emit_commands(actions)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -8,7 +8,7 @@ import pimm
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.drivers import roboarm
-from positronic.eval import Embodiment
+from positronic.eval import Embodiment, Task
 from positronic.policy.base import DelegatingSession, Policy, PolicyWrapper, Session
 from positronic.utils import flatten_dict, frozen_view
 
@@ -169,12 +169,12 @@ class Harness(pimm.ControlSystem):
     the session, demuxes the action dicts into per-channel trajectories, and
     emits.
 
-    ``RUN`` may carry per-trial lifecycle knobs in its context: ``timeout``
-    (seconds; the harness self-terminates the trial when it expires) and
-    ``inference_latency`` (sim-only inference-cost simulation). A ``trials`` plan
-    (a sequence of RUN contexts) makes the harness self-driving: whenever it is
-    idle it starts the next trial itself and exits once the plan is exhausted —
-    the unattended path needs no driver at all.
+    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation)
+    in its context. A ``trials`` plan (a sequence of RUN contexts) makes the
+    harness self-driving: whenever it is idle it starts the next trial itself —
+    bounded by the task's ``timeout`` — and exits once the plan is exhausted, so
+    the unattended path needs no driver at all. Attended drivers own episode
+    termination themselves; directive-driven trials get no deadline.
 
     The ``Embodiment`` provides the observation serializers (which own the
     canonical key names), the command channels, and the home action; the harness
@@ -193,15 +193,16 @@ class Harness(pimm.ControlSystem):
         policy: Policy,
         embodiment: Embodiment,
         *,
-        instruction: str | None = None,
+        task: Task | None = None,
         trials: Iterable[dict[str, Any]] | None = None,
         static_meta: dict[str, Any] | None = None,
         wrap: PolicyWrapper | Callable[[pimm.Clock], PolicyWrapper] | None = default_wrappers,
         on_episode_complete: Callable[[Session, dict[str, Any]], None] | None = None,
     ):
+        assert trials is None or task is not None, 'A trial plan needs a task: its timeout bounds each trial'
         self._raw_policy = policy
         self._embodiment = embodiment
-        self._instruction = instruction
+        self._task = task
         # The unattended trial plan: each entry is a RUN context. When set, the run
         # loop starts the next trial whenever it is idle and returns once the plan
         # is exhausted; when None, directives are the only lifecycle source.
@@ -217,13 +218,14 @@ class Harness(pimm.ControlSystem):
         self.context: dict[str, Any] = {}
         self._static_meta = static_meta or {}
         self._session: Session | None = None
-        # Per-trial lifecycle knobs, delivered on the RUN context. ``inference_latency``
-        # (sim-only): ``True`` advances the (sim) clock by the wall-clock cost of the
-        # inference call; a float is a fixed deterministic delay (used by the
-        # reproducible golden). Sleep is yielded BEFORE ``ChunkedSchedule`` reads
-        # ``clock.now()`` so the trajectory is anchored to inference-finish, not
-        # inference-start. ``timeout`` sets the deadline for self-termination.
+        # ``inference_latency`` is delivered on the RUN context (sim-only): ``True``
+        # advances the (sim) clock by the wall-clock cost of the inference call; a
+        # float is a fixed deterministic delay (used by the reproducible golden).
+        # Sleep is yielded BEFORE ``ChunkedSchedule`` reads ``clock.now()`` so the
+        # trajectory is anchored to inference-finish, not inference-start.
         self._inference_latency: bool | float = False
+        # Self-driven trials are bounded by ``task.timeout``; attended drivers own
+        # termination themselves, so directive-driven trials get no deadline.
         self._deadline: float | None = None
 
         self._descriptor = embodiment.descriptor
@@ -300,12 +302,11 @@ class Harness(pimm.ControlSystem):
                     self._home(clock)
                     yield pimm.Yield()
                 self.context = directive.payload or {}
-                if self._instruction is not None:
-                    self.context = {**self.context, 'task': self._instruction}
-                # Lifecycle knobs ride the RUN context (and land in episode meta with it).
+                if self._task is not None:
+                    self.context = {**self.context, 'task': self._task.instruction}
+                # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
                 self._inference_latency = self.context.get('inference_latency', False)
-                timeout = self.context.get('timeout')
-                self._deadline = clock.now() + timeout if timeout is not None else None
+                self._deadline = None  # set by the run loop for self-driven trials only
                 if self._session:
                     self._session.close()
                 self._session = self.policy.new_session(self.context)
@@ -387,6 +388,12 @@ class Harness(pimm.ControlSystem):
             traj = [(int(a['timestamp'] * 1e9), a[name]) for a in actions if name in a]
             emitter.emit(traj)
 
+    def _inference_delay(self, wall_start: float) -> float:
+        """The inference cost to simulate: measured wall time (``True``), a fixed float, or 0 (``False``)."""
+        if self._inference_latency is True:  # bool is an int subclass — check identity first
+            return time.monotonic() - wall_start
+        return float(self._inference_latency)
+
     def _step(self, clock: pimm.Clock) -> Generator[pimm.Sleep, None, None]:
         """Build obs, call session, demux trajectories into per-channel emissions.
 
@@ -398,10 +405,8 @@ class Harness(pimm.ControlSystem):
             return
 
         # Advance the (sim) clock by the inference cost so rollouts feel the
-        # model's latency. ``True`` measures real wall time around the session
-        # call; a float is a fixed deterministic delay (used by the golden).
-        # We only sleep on cycles where inference actually ran (session
-        # returned a chunk) — otherwise blocked cycles would slow the
+        # model's latency. We only sleep on cycles where inference actually ran
+        # (session returned a chunk) — otherwise blocked cycles would slow the
         # harness's directive-handling loop. The trajectory was anchored
         # pre-sleep, so we post-shift it and also bump the scheduling
         # wrapper's internal ``_trajectory_end`` to stay consistent.
@@ -409,12 +414,7 @@ class Harness(pimm.ControlSystem):
         actions = self._session(frozen_view(obs))
         if actions is None:
             return
-        if self._inference_latency is True:  # bool is an int subclass — check identity first
-            delay = time.monotonic() - wall_start
-        elif self._inference_latency:
-            delay = float(self._inference_latency)
-        else:
-            delay = 0.0
+        delay = self._inference_delay(wall_start)
         if delay > 0.0:
             yield pimm.Sleep(delay)
             actions = [{**a, 'timestamp': a['timestamp'] + delay} for a in actions]
@@ -451,6 +451,7 @@ class Harness(pimm.ControlSystem):
                     yield pimm.Sleep(0.5)  # let the recorder commit the final episode before the world exits
                     break
                 running, recording = yield from self._handle_directive(Directive.RUN(**trial), clock, recording)
+                self._deadline = clock.now() + self._task.timeout
 
             if running and self._deadline is not None and clock.now() >= self._deadline:
                 # Trial time budget exhausted: self-terminate. ``eval.terminated`` is False —

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,5 +1,5 @@
 import time
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -171,8 +171,10 @@ class Harness(pimm.ControlSystem):
 
     ``RUN`` may carry per-trial lifecycle knobs in its context: ``timeout``
     (seconds; the harness self-terminates the trial when it expires) and
-    ``inference_latency`` (sim-only inference-cost simulation). ``episode_ended``
-    fires whenever an episode is finalized, so a trial sequencer can pace on it.
+    ``inference_latency`` (sim-only inference-cost simulation). A ``trials`` plan
+    (a sequence of RUN contexts) makes the harness self-driving: whenever it is
+    idle it starts the next trial itself and exits once the plan is exhausted —
+    the unattended path needs no driver at all.
 
     The ``Embodiment`` provides the observation serializers (which own the
     canonical key names), the command channels, and the home action; the harness
@@ -192,6 +194,7 @@ class Harness(pimm.ControlSystem):
         embodiment: Embodiment,
         *,
         instruction: str | None = None,
+        trials: Iterable[dict[str, Any]] | None = None,
         static_meta: dict[str, Any] | None = None,
         wrap: PolicyWrapper | Callable[[pimm.Clock], PolicyWrapper] | None = default_wrappers,
         on_episode_complete: Callable[[Session, dict[str, Any]], None] | None = None,
@@ -199,6 +202,10 @@ class Harness(pimm.ControlSystem):
         self._raw_policy = policy
         self._embodiment = embodiment
         self._instruction = instruction
+        # The unattended trial plan: each entry is a RUN context. When set, the run
+        # loop starts the next trial whenever it is idle and returns once the plan
+        # is exhausted; when None, directives are the only lifecycle source.
+        self._trials = iter(trials) if trials is not None else None
         self._wrap = wrap
         # Called with (session, context) when an episode completes successfully (clean
         # STOP/FINISH), never on abort. Used to feed completion bookkeeping like a
@@ -229,8 +236,6 @@ class Harness(pimm.ControlSystem):
 
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
-        # Fired when an episode is finalized (FINISH, including timeout self-termination).
-        self.episode_ended = pimm.ControlSystemEmitter(self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -329,7 +334,6 @@ class Harness(pimm.ControlSystem):
                     self._session = None
                 self._home(clock)
                 yield pimm.Yield()
-                self.episode_ended.emit(True)
                 return False, recording
             case DirectiveType.HOME:
                 if recording:
@@ -441,6 +445,12 @@ class Harness(pimm.ControlSystem):
             directive_msg = self.directive.read()
             if directive_msg.updated:
                 running, recording = yield from self._handle_directive(directive_msg.data, clock, recording)
+            elif not running and self._trials is not None:
+                trial = next(self._trials, None)
+                if trial is None:  # plan exhausted — wind the run down
+                    yield pimm.Sleep(0.5)  # let the recorder commit the final episode before the world exits
+                    break
+                running, recording = yield from self._handle_directive(Directive.RUN(**trial), clock, recording)
 
             if running and self._deadline is not None and clock.now() >= self._deadline:
                 # Trial time budget exhausted: self-terminate. ``eval.terminated`` is False —

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -13,7 +13,7 @@ robot changes state only when a command is *applied*, so
   * horizon/gating regression   -> the state trajectory diverges
 
 Everything runs on CPU in a virtual-time world only: no GL/GPU/MuJoCo, no wall
-clock in the asserted path (a fixed-float ``simulate_inference`` is used so
+clock in the asserted path (a fixed-float ``inference_latency`` is used so
 inference latency is deterministic).
 
 Regenerate the golden after an intentional behavior change:
@@ -53,7 +53,7 @@ TARGET_POS = np.array([0.50, 0.00, 0.45], dtype=np.float32)
 
 # Fixed deterministic inference latency. Spans >1 control tick (harness loop is
 # 0.01 s) so the post-inference anchoring effect is observable in recorded ts.
-SIMULATE_INFERENCE_S = 0.05
+INFERENCE_LATENCY_S = 0.05
 ACTION_FPS = 15.0
 ACTION_HORIZON_S = 0.5  # 8 of every 10-action chunk survives truncation
 CONTROL_PERIOD_S = 0.005  # fake robot/gripper sampling cadence (200 Hz)
@@ -197,7 +197,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
             static_meta=dict(ROBOT_STATIC_META),
             meta_source=robot.robot_meta,
         )
-        harness = Harness(policy, embodiment, simulate_inference=SIMULATE_INFERENCE_S)
+        harness = Harness(policy, embodiment)
         ds_agent = wire.wire_embodiment(world, harness, embodiment, ds_writer, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
         directive_em = world.pair(harness.directive)
@@ -205,7 +205,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
         # Robot/gripper emit state every tick, so the script only drives the
         # episode lifecycle and the one-shot error injection.
         script = [
-            (partial(directive_em.emit, Directive.RUN(task='golden')), 0.0),
+            (partial(directive_em.emit, Directive.RUN(task='golden', inference_latency=INFERENCE_LATENCY_S)), 0.0),
             (None, 1.5),  # several reactive inference + chunk/horizon cycles
             (robot.inject_error, 0.0),  # -> ERROR -> harness Recover -> resume
             (None, 0.5),

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -477,6 +477,29 @@ def test_finish_emits_ds_stop_with_data_and_homes(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_run_timeout_self_terminates(world):
+    policy = StubPolicy()
+    harness = Harness(policy, make_embodiment())
+    p = _pair_all(world, harness)
+    ended = RecordingEmitter()
+    harness.episode_ended._bind(ended)
+
+    driver = ManualDriver([
+        (partial(p['directive_em'].emit, Directive.RUN(task='test', timeout=0.05)), 0.0),
+        (None, 0.2),
+    ])
+
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=200)
+
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.terminated'] is False
+    assert isinstance(_last_command(p), Reset)
+    assert ended.emitted, 'episode_ended not fired on self-termination'
+
+
+@pytest.mark.timeout(3.0)
 def test_home_aborts_recording_and_homes(world):
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment())

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -500,6 +500,44 @@ def test_run_timeout_self_terminates(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
+    """A chunk whose latency sleep crosses the deadline is dropped, never emitted."""
+    policy = StubPolicy()
+    harness = Harness(policy, make_embodiment())
+    cmd_recorder = RecordingEmitter()
+    grip_recorder = RecordingEmitter()
+    ds_recorder = RecordingEmitter()
+    harness.commands['robot_command']._bind(cmd_recorder)
+    harness.commands['target_grip']._bind(grip_recorder)
+    harness.ds_command._bind(ds_recorder)
+
+    frame_em = world.pair(harness.observations['image.cam'])
+    robot_em = world.pair(harness.observations['robot_state'])
+    grip_em = world.pair(harness.observations['grip'])
+    directive_em = world.pair(harness.directive)
+
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+
+    driver = ManualDriver([
+        # The 0.2s latency sleep crosses the 0.05s deadline before the chunk is emitted.
+        (partial(directive_em.emit, Directive.RUN(task='test', timeout=0.05, inference_latency=0.2)), 0.0),
+        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
+        (None, 0.3),
+    ])
+
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=200)
+
+    stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.terminated'] is False
+    # The post-deadline chunk must not reach the drivers: the only non-empty
+    # emissions are the homing Reset / home grip from the timeout FINISH.
+    assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))
+    assert _emitted_grips(grip_recorder) == [0.0]
+
+
+@pytest.mark.timeout(3.0)
 def test_home_aborts_recording_and_homes(world):
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment())

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -481,8 +481,6 @@ def test_run_timeout_self_terminates(world):
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment())
     p = _pair_all(world, harness)
-    ended = RecordingEmitter()
-    harness.episode_ended._bind(ended)
 
     driver = ManualDriver([
         (partial(p['directive_em'].emit, Directive.RUN(task='test', timeout=0.05)), 0.0),
@@ -496,7 +494,25 @@ def test_run_timeout_self_terminates(world):
     assert len(stops) == 1
     assert stops[0].static_data['eval.terminated'] is False
     assert isinstance(_last_command(p), Reset)
-    assert ended.emitted, 'episode_ended not fired on self-termination'
+
+
+@pytest.mark.timeout(3.0)
+def test_trial_plan_self_drives(world):
+    """With a trial plan the harness runs unattended: no driver, one episode per entry."""
+    policy = StubPolicy()
+    trials = [{'task': f'trial-{i}', 'timeout': 0.05, 'eval.trial_index': i} for i in range(2)]
+    harness = Harness(policy, make_embodiment(), trials=trials)
+    p = _pair_all(world, harness)
+
+    scheduler = world.start([harness])
+    drive_scheduler(scheduler, steps=400)
+
+    starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert [s.static_data['eval.trial_index'] for s in starts] == [0, 1]
+    assert len(stops) == 2
+    assert all(s.static_data['eval.terminated'] is False for s in stops)
+    assert policy.reset_calls == 2
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -541,8 +541,8 @@ def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
     stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
     assert stops[0].static_data['eval.terminated'] is False
-    # The post-deadline chunk must not reach the drivers: the only non-empty
-    # emissions are the homing Reset / home grip from the timeout FINISH.
+    # The post-deadline chunk must not reach the drivers: the only non-empty emissions are the homing
+    # Reset / home grip from the timeout FINISH.
     assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))
     assert _emitted_grips(grip_recorder) == [0.0]
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -9,7 +9,7 @@ from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import CartesianPosition, Recover, Reset, from_wire, to_wire
-from positronic.eval import Command, Embodiment, Observation
+from positronic.eval import Command, Embodiment, Observation, Task
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
 from positronic.policy.codec import ActionTimestamp
@@ -477,17 +477,13 @@ def test_finish_emits_ds_stop_with_data_and_homes(world):
 
 
 @pytest.mark.timeout(3.0)
-def test_run_timeout_self_terminates(world):
+def test_trial_timeout_self_terminates(world):
+    """A self-driven trial ends at ``task.timeout``: terminated=False, robot homed."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
+    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=0.05), trials=[{}])
     p = _pair_all(world, harness)
 
-    driver = ManualDriver([
-        (partial(p['directive_em'].emit, Directive.RUN(task='test', timeout=0.05)), 0.0),
-        (None, 0.2),
-    ])
-
-    scheduler = world.start([harness, driver])
+    scheduler = world.start([harness])
     drive_scheduler(scheduler, steps=200)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
@@ -500,8 +496,8 @@ def test_run_timeout_self_terminates(world):
 def test_trial_plan_self_drives(world):
     """With a trial plan the harness runs unattended: no driver, one episode per entry."""
     policy = StubPolicy()
-    trials = [{'task': f'trial-{i}', 'timeout': 0.05, 'eval.trial_index': i} for i in range(2)]
-    harness = Harness(policy, make_embodiment(), trials=trials)
+    trials = [{'eval.trial_index': i} for i in range(2)]
+    harness = Harness(policy, make_embodiment(), task=Task(instruction='stack', timeout=0.05), trials=trials)
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -510,6 +506,7 @@ def test_trial_plan_self_drives(world):
     starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert [s.static_data['eval.trial_index'] for s in starts] == [0, 1]
+    assert all(s.static_data['task'] == 'stack' for s in starts)
     assert len(stops) == 2
     assert all(s.static_data['eval.terminated'] is False for s in stops)
     assert policy.reset_calls == 2
@@ -519,7 +516,10 @@ def test_trial_plan_self_drives(world):
 def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
     """A chunk whose latency sleep crosses the deadline is dropped, never emitted."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
+    # The 0.2s latency sleep crosses the 0.05s deadline before the chunk is emitted.
+    harness = Harness(
+        policy, make_embodiment(), task=Task(instruction='test', timeout=0.05), trials=[{'inference_latency': 0.2}]
+    )
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     ds_recorder = RecordingEmitter()
@@ -530,16 +530,10 @@ def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
     frame_em = world.pair(harness.observations['image.cam'])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations['grip'])
-    directive_em = world.pair(harness.directive)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
-    driver = ManualDriver([
-        # The 0.2s latency sleep crosses the 0.05s deadline before the chunk is emitted.
-        (partial(directive_em.emit, Directive.RUN(task='test', timeout=0.05, inference_latency=0.2)), 0.0),
-        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
-        (None, 0.3),
-    ])
+    driver = ManualDriver([(partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01), (None, 0.3)])
 
     scheduler = world.start([harness, driver])
     drive_scheduler(scheduler, steps=200)

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -64,18 +64,19 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             camera_fps=10,
             camera_dict=camera_dict,
             instruction='integration-test',
+            timeout=0.4,
         )
         main(
             embodiment=ev.embodiment,
             task=ev.task,
             policy=policy,
-            trials=[{'timeout': 0.4, 'eval.trial_index': i} for i in range(2)],
+            trials=[{'eval.trial_index': i} for i in range(2)],
             output_dir=str(tmp_path),
         )
 
     ds = LocalDataset(tmp_path)
     # Two trials: the harness runs the plan itself, self-terminating each trial
-    # at the RUN-borne timeout.
+    # at the task's timeout.
     assert len(ds) == 2
 
     episode = ds[0]

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -75,8 +75,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
         )
 
     ds = LocalDataset(tmp_path)
-    # Two trials: the harness runs the plan itself, self-terminating each trial
-    # at the task's timeout.
+    # Two trials: the harness runs the plan itself, self-terminating each trial at the task's timeout.
     assert len(ds) == 2
 
     episode = ds[0]

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -6,7 +6,7 @@ import tqdm
 import positronic.cfg.simulator
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.dataset.local_dataset import LocalDataset
-from positronic.inference import main, sequencer
+from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
 from positronic.simulator.mujoco.sim import FullSimState
 
@@ -69,13 +69,13 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             embodiment=ev.embodiment,
             task=ev.task,
             policy=policy,
-            driver=sequencer(timeout=0.4, show_gui=False, trial_count=2),
+            trials=[{'timeout': 0.4, 'eval.trial_index': i} for i in range(2)],
             output_dir=str(tmp_path),
         )
 
     ds = LocalDataset(tmp_path)
-    # Two trials: the sequencer paces on the harness's episode_ended, the harness
-    # self-terminates each trial at the RUN-borne timeout.
+    # Two trials: the harness runs the plan itself, self-terminating each trial
+    # at the RUN-borne timeout.
     assert len(ds) == 2
 
     episode = ds[0]

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -6,7 +6,7 @@ import tqdm
 import positronic.cfg.simulator
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.dataset.local_dataset import LocalDataset
-from positronic.inference import main, timed
+from positronic.inference import main, sequencer
 from positronic.policy.tests.test_harness import StubPolicy
 from positronic.simulator.mujoco.sim import FullSimState
 
@@ -69,14 +69,18 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             embodiment=ev.embodiment,
             task=ev.task,
             policy=policy,
-            driver=timed(simulation_time=0.4, show_gui=False, num_iterations=1),
+            driver=sequencer(timeout=0.4, show_gui=False, trial_count=2),
             output_dir=str(tmp_path),
         )
 
     ds = LocalDataset(tmp_path)
-    assert len(ds) == 1
+    # Two trials: the sequencer paces on the harness's episode_ended, the harness
+    # self-terminates each trial at the RUN-borne timeout.
+    assert len(ds) == 2
 
     episode = ds[0]
+    assert episode.static['eval.terminated'] is False
+    assert episode.static['eval.trial_index'] == 0
     signals = episode.signals
     assert 'robot_command.pose' in signals
     assert 'target_grip' in signals

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -143,7 +143,7 @@ class FakeGenerator(pimm.ControlSystem):
                 'eval.tote_placement': random.choice(['left', 'right']),
                 'eval.external_camera': random.choices(['left', 'right', 'NA'], [5, 5, 1])[0],
                 'inference.policy_fps': self.fps,
-                'inference.simulate_inference': False,
+                'inference_latency': False,
                 **self.policy_meta,
             }
 


### PR DESCRIPTION
## Summary

Step 4 of the eval chain (follow-up to #420): lifecycle knobs and termination become explicit and recorded — and the unattended path loses its driver entirely.

- **The `Harness` holds the `Task`** (replacing its `instruction` arg) and reads the instruction and the per-trial `timeout` straight from it. The timeout never rides `RUN`: the harness sets the `start + task.timeout` deadline **only for trials it starts itself from the plan**, so a directive-driven `RUN` cannot acquire a deadline — the attended surface (keyboard/EvalUI) being its path's termination authority is structural, not a convention.
- **`inference_latency` rides the `RUN` context** and lands in episode meta with the rest of it. `simulate_inference` is renamed to `inference_latency` (`False` = ignore / `True` = measured wall time / `float` = fixed delay, sim-only) and leaves the `Harness` constructor and `inference.main()`; the CLI knob is now `positronic eval run --inference_latency=...`.
- **The Harness self-terminates a self-driven trial** at `start + task.timeout`, stamping `eval.terminated: False` in the episode static meta (time budget exhausted — a future privileged stop-signal will stamp `True`). The deadline is re-checked after the `inference_latency` sleep, so a chunk whose sleep crosses the deadline is dropped, never emitted. Termination is a binary flag; characterizing the end (success/safety/system/...) stays annotation territory — `FINISH(**annotations)` remains free-form, EvalUI/keyboard unchanged.
- **The unattended path has no driver.** A for-loop is not an operator surface: `cfg/eval/run` computes a **trial plan** — one RUN context per trial (`inference_latency`, `eval.trial_index`/`eval.trial_count`; step 5 adds the per-trial seed `base + i` here) — and `Harness(trials=...)` self-drives: whenever idle it starts the next trial and exits once the plan is exhausted. `TimedDriver` is gone (and with it the `simulation.iteration` meta keys).
- **Attended drivers keep their shape**: the anonymous driver tuple becomes a small `Driver` dataclass (`gui`, `directives`, `directive_wrapper`, `control_systems`) for the keyboard/EvalUI surfaces; `main()` takes exactly one of `driver` or `trials`.

## Test plan

- `uv run --locked pytest --no-cov` — full suite passes (551 passed, 7 skipped), including the golden pipeline (RUN-borne `inference_latency` reproduces the exact recorded timings) and the sim integration test, now running **two** planned trials end-to-end with no driver and asserting `eval.terminated`/`eval.trial_index` in episode meta.
- New unit tests: `test_trial_timeout_self_terminates` (self-driven trial ends at `task.timeout` → ds STOP carries `eval.terminated: False`, devices homed), `test_trial_plan_self_drives` (driverless harness runs the plan: one episode per entry, indices and the task instruction recorded), `test_timeout_crossed_during_latency_sleep_drops_chunk` (post-deadline chunk never reaches the drivers).
- Smoke: `positronic eval run --help`, `positronic-inference sim --help`, `utilities/check_packaging.py` (60 modules OK).
