### PR TITLE
Seed sim trials: `--eval.seed` rides the RUN context, `Task` owns the scene reset

### DIFF
--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -1,3 +1,5 @@
+import random
+
 import configuronic as cfn
 
 import positronic.cfg.policy as policy_cfg
@@ -15,9 +17,17 @@ def placeholder():
 @cfn.config(eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=default_wrappers)
 def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, wrap=default_wrappers):
     """Run a selected eval (embodiment + task) through the shared inference harness."""
-    # The trial plan: one RUN context per trial, consumed by the self-driving Harness.
+    # The trial plan: one RUN context per trial, consumed by the self-driving Harness. Per-trial seeds
+    # are known upfront — ``--eval.seed`` + trial index, or an independent random draw per trial when
+    # unset — and ride the RUN context, so the seed used always lands in episode meta.
+    base = eval.task.seed
     trials = [
-        {'inference_latency': inference_latency, 'eval.trial_index': i, 'eval.trial_count': trial_count}
+        {
+            'inference_latency': inference_latency,
+            'eval.seed': base + i if base is not None else random.randrange(2**31),
+            'eval.trial_index': i,
+            'eval.trial_count': trial_count,
+        }
         for i in range(trial_count)
     ]
     inference.main(

--- a/positronic/cfg/eval/sim/positronic.py
+++ b/positronic/cfg/eval/sim/positronic.py
@@ -15,18 +15,22 @@ from positronic.utils import package_assets_path
     # Full sim state is the privileged ground truth; scoring is computed downstream.
     observers={'sim_state': FullSimState()},
     timeout=15,
+    seed=None,
 )
-def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, observers, instruction, timeout):
+def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, observers, instruction, timeout, seed):
     """A Mujoco Franka sim eval: the eval holds the sim, the embodiment is pure robot.
 
-    The task carries the instruction, the per-trial ``timeout``, and the privileged sim-state
-    ground truth (built from the eval's sim, recorded but never fed to the policy). The scene
-    (``loaders``) is embodiment-specific and wired here, not a generic Task field.
+    The task carries the instruction, the per-trial ``timeout``, the privileged sim-state
+    ground truth (built from the eval's sim, recorded but never fed to the policy), and the
+    sim's seeded scene reset. The scene (``loaders``) is embodiment-specific and wired here,
+    not a generic Task field; the loaders carry no seeds of their own — the per-trial seed
+    handed to ``sim.reset`` drives the whole scene draw.
     """
     sim = MujocoSim(mujoco_model_path, loaders, observers=observers)
     embodiment = mujoco_franka(sim, camera_fps, camera_dict)
     privileged = {name: Observation(sim.observations[name], None) for name in observers}
-    return Eval(embodiment, Task(instruction=instruction, timeout=timeout, privileged=privileged))
+    task = Task(instruction=instruction, timeout=timeout, privileged=privileged, seed=seed, reset=sim.reset)
+    return Eval(embodiment, task)
 
 
 stack_cubes = _mujoco_franka_eval.override(instruction='Pick up the green cube and place it on the red cube.')

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -75,11 +76,18 @@ class Task:
     wall-clock for real). ``privileged`` maps a record key to the ground-truth source
     to capture (the sim's full ``save_state``, a real scale) — recorded but never fed
     to the policy.
+
+    ``seed`` is the base seed for reproducible runs (``None`` → fully random); the
+    runner derives per-trial seeds from it into the trial plan. ``reset`` re-randomizes
+    the scene for a new trial from a per-trial seed; ``None`` on real embodiments,
+    where reset is physical/human.
     """
 
     instruction: str
     timeout: float
     privileged: dict[str, Observation] = field(default_factory=dict)
+    seed: int | None = None
+    reset: Callable[[int | None], None] | None = None
 
 
 @dataclass

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -113,10 +113,11 @@ def main(
     """Run inference for an embodiment, real or simulated.
 
     ``task`` (when given) supplies the policy-facing instruction, the per-trial ``timeout``
-    bounding self-driven trials, and the privileged ground-truth signals to record; without it
-    the instruction rides the driver. Exactly one of ``driver`` (attended: an operator surface
-    emits the directives) or ``trials`` (unattended: the harness runs the plan itself) must be
-    given; ``show_gui`` applies to the unattended path (attended surfaces bring their own).
+    bounding self-driven trials, the privileged ground-truth signals to record, and the seeded
+    scene reset run at each trial start; without it the instruction rides the driver. Exactly
+    one of ``driver`` (attended: an operator surface emits the directives) or ``trials``
+    (unattended: the harness runs the plan itself) must be given; ``show_gui`` applies to the
+    unattended path (attended surfaces bring their own).
     """
     assert (driver is None) != (trials is None), 'Provide exactly one of driver or trials'
     harness = Harness(

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -296,7 +296,7 @@ class Harness(pimm.ControlSystem):
         if self._session is not None:
             self._session.cancel()
 
-    def _handle_directive(self, directive: Directive, clock: pimm.Clock) -> Generator[pimm.Sleep, None, None]:
+    def _handle_directive(self, directive: Directive, clock: pimm.Clock) -> Generator[pimm.Command, None, None]:
         """Handle a directive, yielding any necessary pauses; updates ``_running``/``_recording``."""
         match directive.type:
             case DirectiveType.RUN:
@@ -439,7 +439,7 @@ class Harness(pimm.ControlSystem):
 
         self._emit_commands(actions)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         # Resolve wrap now that we have the clock — some wrappers (e.g. ChunkedSchedule) need it.
         if self._wrap is None:
             self.policy = self._raw_policy

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -168,7 +168,8 @@ class Harness(pimm.ControlSystem):
     policy/session layer — the harness just calls the session, demuxes the action dicts into
     per-channel trajectories, and emits.
 
-    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation) in its context.
+    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation) and ``eval.seed``
+    (handed to the task's scene reset) in its context.
     A ``trials`` plan (a sequence of RUN contexts) makes the harness self-driving: whenever it is
     idle it starts the next trial itself — bounded by the task's ``timeout`` — and exits once the
     plan is exhausted, so the unattended path needs no driver at all. Attended drivers own episode
@@ -244,6 +245,13 @@ class Harness(pimm.ControlSystem):
         meta = dict(self._embodiment.static_meta)
         meta.update(self._static_meta)
         meta.update(self.robot_meta_in.value)
+        if self._task is not None:
+            # The eval-identity block: which eval produced this episode.
+            # TODO: also stamp the eval's catalog name and its resolved config — both need
+            # configuronic introspection that does not exist yet.
+            meta['eval.universe'] = 'sim' if self._embodiment.simulated else 'real'
+            meta['eval.embodiment'] = self._embodiment.descriptor
+            meta['eval.timeout'] = self._task.timeout
         # ``policy.meta`` is the static baseline (the wrapped policy aggregates model +
         # codec meta); the session overlays per-episode specifics (e.g. the sampled
         # sub-policy) and wins on conflict.
@@ -302,6 +310,11 @@ class Harness(pimm.ControlSystem):
                 self.context = directive.payload or {}
                 if self._task is not None:
                     self.context = {**self.context, 'task': self._task.instruction}
+                    if self._task.reset is not None:
+                        # Re-randomize the scene from the trial's seed, then give the device control
+                        # systems a slice so the first inference sees post-reset state.
+                        self._task.reset(self.context.get('eval.seed'))
+                        yield pimm.Yield()
                 # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
                 self._inference_latency = self.context.get('inference_latency', False)
                 self._deadline = None  # set by the run loop for self-driven trials only

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -493,6 +493,28 @@ def test_trial_timeout_self_terminates(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_trial_seed_reaches_task_reset_and_meta(world):
+    """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
+    eval-identity block land in episode meta."""
+    policy = StubPolicy()
+    seeds = []
+    trials = [{'eval.seed': 7 + i} for i in range(2)]
+    task = Task(instruction='stack', timeout=0.05, reset=seeds.append)
+    harness = Harness(policy, make_embodiment(), task=task, trials=trials)
+    p = _pair_all(world, harness)
+
+    scheduler = world.start([harness])
+    drive_scheduler(scheduler, steps=400)
+
+    assert seeds == [7, 8]
+    starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
+    assert [s.static_data['eval.seed'] for s in starts] == [7, 8]
+    assert all(s.static_data['eval.universe'] == 'real' for s in starts)
+    assert all(s.static_data['eval.embodiment'] == '' for s in starts)
+    assert all(s.static_data['eval.timeout'] == 0.05 for s in starts)
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_plan_self_drives(world):
     """With a trial plan the harness runs unattended: no driver, one episode per entry."""
     policy = StubPolicy()

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -93,7 +93,13 @@ class MujocoSim(pimm.ControlSystem):
             yield pimm.Sleep(self.model.opt.timestep)
 
     def reset(self, seed: int | None = None, *, reinitialize_model: bool = True):
-        """Re-randomize the scene by re-applying the loaders; ``seed`` makes the draw deterministic."""
+        """Re-randomize the scene by re-applying the loaders; ``seed`` makes the draw deterministic.
+
+        The fresh scene carries over as MuJoCo *state*, so randomized bodies must be freejointed
+        (their pose rides ``qpos``). Model-level loader effects (fixed-body poses, colors, cameras)
+        are discarded. TODO: make model-level randomization survive reset — the renderer and the IK
+        ``Physics`` pin the live model object, so the reloaded model cannot be swapped in today.
+        """
         mj.mj_resetData(self.model, self.data)
 
         if reinitialize_model:

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -13,7 +13,7 @@ from positronic import geom
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.simulator.mujoco.observers import MujocoSimObserver
-from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_model_from_spec_file
+from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_model_from_spec_file, np_seed
 from positronic.utils import package_assets_path
 
 logger = logging.getLogger(__name__)
@@ -92,11 +92,13 @@ class MujocoSim(pimm.ControlSystem):
             # One physics step is one tick of simulated time; sleeping a timestep paces the world clock.
             yield pimm.Sleep(self.model.opt.timestep)
 
-    def reset(self, reinitialize_model: bool = True):
+    def reset(self, seed: int | None = None, *, reinitialize_model: bool = True):
+        """Re-randomize the scene by re-applying the loaders; ``seed`` makes the draw deterministic."""
         mj.mj_resetData(self.model, self.data)
 
         if reinitialize_model:
-            model, _ = load_from_xml_path(self.mujoco_model_path, self.loaders)
+            with np_seed(seed):
+                model, _ = load_from_xml_path(self.mujoco_model_path, self.loaders)
             data = mj.MjData(model)
             state = save_state(model, data)
             self.load_state(state, reset_time=False)

--- a/positronic/simulator/mujoco/transforms.py
+++ b/positronic/simulator/mujoco/transforms.py
@@ -108,10 +108,8 @@ class SetBodyPosition(MujocoSceneTransform):
         quaternion: tuple[float, float, float, float] | None = None,
         random_position: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None,
         random_euler: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None,
-        seed: int | None = None,
     ):
         self.body_name = body_name
-        self.seed = seed
         assert (position is None) ^ (random_position is None), 'One of position or random_position must be provided'
         assert (quaternion is None) or (random_euler is None), (
             'At most one of quaternion or random_euler must be provided'
@@ -135,14 +133,13 @@ class SetBodyPosition(MujocoSceneTransform):
             self.quaternion_fn = quaternion_fn
 
     def apply(self, spec: mujoco.MjSpec) -> mujoco.MjSpec:
-        with np_seed(self.seed):
-            bodies = [g for g in spec.bodies if g.name == self.body_name]
-            assert len(bodies) == 1, f'Expected 1 body with name {self.body_name}, found {len(bodies)}'
-            bodies[0].pos = self.position_fn()
-            quaternion = self.quaternion_fn()
-            if quaternion is not None:
-                bodies[0].quat = quaternion
-            return spec
+        bodies = [g for g in spec.bodies if g.name == self.body_name]
+        assert len(bodies) == 1, f'Expected 1 body with name {self.body_name}, found {len(bodies)}'
+        bodies[0].pos = self.position_fn()
+        quaternion = self.quaternion_fn()
+        if quaternion is not None:
+            bodies[0].quat = quaternion
+        return spec
 
 
 class AddTote(MujocoSceneTransform):
@@ -227,7 +224,6 @@ class AddObjectsInTote(MujocoSceneTransform):
         object_size: tuple[float, float, float],
         tote_size: tuple[float, float, float],
         rgba: tuple[float, float, float, float],
-        seed: int | None = None,
     ):
         self.tote_name = tote_name
         self.object_name_prefix = object_name_prefix
@@ -235,7 +231,6 @@ class AddObjectsInTote(MujocoSceneTransform):
         self.object_size = object_size
         self.tote_size = tote_size
         self.rgba = rgba
-        self.seed = seed
 
     def apply(self, spec: mujoco.MjSpec) -> mujoco.MjSpec:
         tote_body = next(b for b in spec.bodies if b.name == f'{self.tote_name}_body')
@@ -250,27 +245,24 @@ class AddObjectsInTote(MujocoSceneTransform):
         min_y = tote_pos[1] - length + margin
         max_y = tote_pos[1] + length - margin
 
-        with np_seed(self.seed):
-            for i in range(self.num_objects):
-                x = np.random.uniform(min_x, max_x)
-                y = np.random.uniform(min_y, max_y)
-                # tote_pos[2] is the bottom of the tote body.
-                # The bottom geom has thickness 0.005 (default) and is at pos=[0, 0, t].
-                # So the floor of the tote is at tote_pos[2] + 2*t.
-                # We add a small margin + stacking.
-                # Assuming default thickness of 0.005 for now as it is not passed in.
-                tote_thickness = 0.005
-                z = tote_pos[2] + 2 * tote_thickness + self.object_size[2] + i * 2 * self.object_size[2]
+        for i in range(self.num_objects):
+            x = np.random.uniform(min_x, max_x)
+            y = np.random.uniform(min_y, max_y)
+            # The tote floor is at tote_pos[2] + 2 * thickness (the bottom geom has half-height
+            # ``thickness`` and sits at pos=[0, 0, thickness]); objects are stacked above it.
+            # Thickness is assumed at the AddTote default of 0.005 — it is not passed in.
+            tote_thickness = 0.005
+            z = tote_pos[2] + 2 * tote_thickness + self.object_size[2] + i * 2 * self.object_size[2]
 
-                body = spec.worldbody.add_body(name=f'{self.object_name_prefix}_{i}_body', pos=[x, y, z])
-                body.add_geom(
-                    name=f'{self.object_name_prefix}_{i}_geom',
-                    type=mujoco.mjtGeom.mjGEOM_BOX,
-                    size=self.object_size,
-                    rgba=self.rgba,
-                    density=1000,
-                )
-                body.add_freejoint()
+            body = spec.worldbody.add_body(name=f'{self.object_name_prefix}_{i}_body', pos=[x, y, z])
+            body.add_geom(
+                name=f'{self.object_name_prefix}_{i}_geom',
+                type=mujoco.mjtGeom.mjGEOM_BOX,
+                size=self.object_size,
+                rgba=self.rgba,
+                density=1000,
+            )
+            body.add_freejoint()
 
         return spec
 
@@ -283,44 +275,38 @@ class SetTwoObjectsPositions(MujocoSceneTransform):
         table_bounds: tuple[tuple[float, float], tuple[float, float]],
         min_distance: float,
         object_sizes: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None,
-        seed: int | None = None,
     ):
         self.object1_name = object1_name
         self.object2_name = object2_name
         self.table_bounds = table_bounds  # ((min_x, max_x), (min_y, max_y))
         self.min_distance = min_distance
         self.object_sizes = object_sizes
-        self.seed = seed
 
     def apply(self, spec: mujoco.MjSpec) -> mujoco.MjSpec:
-        with np_seed(self.seed):
-            body1 = next(b for b in spec.bodies if b.name == f'{self.object1_name}_body')
-            body2 = next(b for b in spec.bodies if b.name == f'{self.object2_name}_body')
+        body1 = next(b for b in spec.bodies if b.name == f'{self.object1_name}_body')
+        body2 = next(b for b in spec.bodies if b.name == f'{self.object2_name}_body')
 
-            (min_x, max_x), (min_y, max_y) = self.table_bounds
+        (min_x, max_x), (min_y, max_y) = self.table_bounds
 
-            for _ in range(100):  # Max attempts
-                pos1 = [np.random.uniform(min_x, max_x), np.random.uniform(min_y, max_y), body1.pos[2]]
-                pos2 = [np.random.uniform(min_x, max_x), np.random.uniform(min_y, max_y), body2.pos[2]]
+        for _ in range(100):  # Max attempts
+            pos1 = [np.random.uniform(min_x, max_x), np.random.uniform(min_y, max_y), body1.pos[2]]
+            pos2 = [np.random.uniform(min_x, max_x), np.random.uniform(min_y, max_y), body2.pos[2]]
 
-                dist = np.linalg.norm(np.array(pos1[:2]) - np.array(pos2[:2]))
+            dist = np.linalg.norm(np.array(pos1[:2]) - np.array(pos2[:2]))
 
-                overlap = False
-                if self.object_sizes is not None:
-                    s1, s2 = self.object_sizes
-                    # Check AABB overlap
-                    # sizes are half-sizes (w, l, h)
-                    # Overlap if |x1 - x2| < w1 + w2 AND |y1 - y2| < l1 + l2
-                    # We add a small margin to min_distance effectively
-                    if abs(pos1[0] - pos2[0]) < (s1[0] + s2[0]) and abs(pos1[1] - pos2[1]) < (s1[1] + s2[1]):
-                        overlap = True
+            overlap = False
+            if self.object_sizes is not None:
+                s1, s2 = self.object_sizes
+                # AABB overlap on half-sizes (w, l, h): |x1 - x2| < w1 + w2 and |y1 - y2| < l1 + l2.
+                if abs(pos1[0] - pos2[0]) < (s1[0] + s2[0]) and abs(pos1[1] - pos2[1]) < (s1[1] + s2[1]):
+                    overlap = True
 
-                if dist >= self.min_distance and not overlap:
-                    body1.pos = pos1
-                    body2.pos = pos2
-                    return spec
+            if dist >= self.min_distance and not overlap:
+                body1.pos = pos1
+                body2.pos = pos2
+                return spec
 
-            raise RuntimeError('Could not place objects without overlap after 100 attempts')
+        raise RuntimeError('Could not place objects without overlap after 100 attempts')
 
 
 def load_model_from_spec_file(

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -8,7 +8,7 @@ from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
-from positronic.simulator.mujoco.sim import FullSimState
+from positronic.simulator.mujoco.sim import FullSimState, MujocoSim
 
 
 # This integration test exercises the unified `main` end-to-end on the sim embodiment.
@@ -52,15 +52,11 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
     policy = StubPolicy()
 
     camera_dict = {'image.wrist': 'handcam_left_ph'}
-    loaders = positronic.cfg.simulator.stack_cubes_loaders()
-    for idx, loader in enumerate(loaders):
-        if idx in (2, 4):
-            loader.seed = idx
 
     with pos3.mirror():
         ev = stack_cubes(
             mujoco_model_path='positronic/assets/mujoco/franka_table.xml',
-            loaders=loaders,
+            loaders=positronic.cfg.simulator.stack_cubes_loaders(),
             camera_fps=10,
             camera_dict=camera_dict,
             instruction='integration-test',
@@ -70,7 +66,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             embodiment=ev.embodiment,
             task=ev.task,
             policy=policy,
-            trials=[{'eval.trial_index': i} for i in range(2)],
+            trials=[{'eval.trial_index': i, 'eval.seed': 100 + i} for i in range(2)],
             output_dir=str(tmp_path),
         )
 
@@ -81,6 +77,10 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
     episode = ds[0]
     assert episode.static['eval.terminated'] is False
     assert episode.static['eval.trial_index'] == 0
+    assert episode.static['eval.seed'] == 100
+    assert episode.static['eval.universe'] == 'sim'
+    assert episode.static['eval.embodiment'] == 'mujoco.franka'
+    assert episode.static['eval.timeout'] == 0.4
     signals = episode.signals
     assert 'robot_command.pose' in signals
     assert 'target_grip' in signals
@@ -115,6 +115,22 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
     # The task's instruction is injected by the harness (no longer carried by the driver).
     assert last_obs['task'] == 'integration-test'
     assert last_obs['descriptor'] == 'mujoco.franka'
+
+
+@pytest.mark.timeout(30.0)
+def test_sim_reset_seed_reproduces_scene():
+    """Same seed → identical post-reset sim state; different seed → a different scene."""
+    sim = MujocoSim('positronic/assets/mujoco/franka_table.xml', positronic.cfg.simulator.stack_cubes_loaders())
+    sim.reset(seed=123)
+    first = sim.save_state()
+    sim.reset(seed=99)
+    second = sim.save_state()
+    sim.reset(seed=123)
+    third = sim.save_state()
+
+    for name, array in first.items():
+        np.testing.assert_array_equal(third[name], array)
+    assert any(not np.array_equal(second[name], array) for name, array in first.items())
 
 
 def test_sim_embodiment_records_full_sim_state():


### PR DESCRIPTION
## Summary
Step 5 of the eval chain: reproducible, self-describing sim rollouts.

- **`--eval.seed`** (`Task.seed`, default `None` → fully random): the runner computes per-trial seeds upfront — `base + i`, or an independent random draw per trial when unset — into the trial plan, so each seed rides its trial's `RUN` context as `eval.seed` and lands in episode meta for free. Even fully-random runs are reproducible after the fact.
- **The scene reset moves to `RUN`-time, through a Task-owned hook** (`Task.reset`, wired to `sim.reset` by the eval config; `None` on real embodiments, where reset is physical/human). It must be `RUN`-time because the old scene-creation point — the robot `Reset()` home command at FINISH — fires before the next trial's seed exists. The Harness invokes the hook with the context's `eval.seed`, then yields so device control systems re-emit post-reset state before the first inference.
- **`MujocoSim.reset(seed)`** wraps the loader re-application in `np_seed(seed)` — one outer seed makes the whole scene draw deterministic. The per-loader `seed` params on the scene transforms are removed: nothing used them anymore, and they were a parallel seeding pathway.
- The `Reset()` robot command keeps resetting the sim (teleop relies on it to re-randomize between recordings); in the eval path the FINISH-home reset now just produces a throwaway scene that the next `RUN`'s seeded reset replaces.
- **Eval-identity meta:** `_build_episode_meta` stamps `eval.universe`, `eval.embodiment`, and `eval.timeout` whenever a `Task` is present; instruction, seed, and trial index/count already ride the `RUN` context. The eval's catalog name and resolved config dump need configuronic introspection that does not exist yet (TODO in code); `run_metadata_*.yaml` already records full argv at run level.

## Test plan
- New: `test_trial_seed_reaches_task_reset_and_meta` (each RUN hands its seed to the task's reset; seed + identity block land in meta), `test_sim_reset_seed_reproduces_scene` (same seed → identical post-reset state, different seed → different scene).
- Integration test now runs seeded trials and asserts `eval.seed`/`eval.universe`/`eval.embodiment`/`eval.timeout` in episode static meta.
- Full suite: 553 passed, 7 skipped locally.