### PR TITLE
Add the edit layer: uid-keyed `edits.jsonl` applied as a view over immutable recordings

### DIFF
--- a/positronic/cfg/ds/__init__.py
+++ b/positronic/cfg/ds/__init__.py
@@ -10,14 +10,14 @@ from pos3 import Profile
 
 import positronic.utils  # noqa: F401  -- registers the 'PUBLIC' S3 profile that these loaders' s3://PUBLIC@ URLs use
 from positronic.dataset.dataset import ConcatDataset, Dataset, FilterDataset
-from positronic.dataset.local_dataset import LocalDataset, load_all_datasets
+from positronic.dataset.local_dataset import load_all_datasets, load_dataset
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.transforms.episode import EpisodeTransform, Group
 
 
 @cfn.config()
 def local(path: str, profile: Profile | None = None):
-    return LocalDataset(pos3.download(path, profile=profile))
+    return load_dataset(pos3.download(path, profile=profile))
 
 
 @cfn.config()

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -25,7 +25,7 @@ An Episode has three kinds of data with distinct roles:
 
 ## Identity
 
-Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — the identity contract. Position in a `Dataset` is *access*, not identity: `FilterDataset`/`ConcatDataset` renumber episodes freely. The uid is *reference* — stable across views, processes, copies, and exports. Because transforms pass meta through unchanged, a transformed episode keeps its recording's uid: it is a view of the same recording event.
+Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — the identity contract. Episodes lacking a stamped uid derive a stable `ts-<created_ts_ns>` one from their recording timestamp, which is equally immutable and travels with the episode. Position in a `Dataset` is *access*, not identity: `FilterDataset`/`ConcatDataset` renumber episodes freely. The uid is *reference* — stable across views, processes, copies, and exports. Because transforms pass meta through unchanged, a transformed episode keeps its recording's uid: it is a view of the same recording event.
 
 ## Edits
 

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -8,6 +8,18 @@ An Episode has three kinds of data with distinct roles:
 
 - **Meta** (`episode.meta`) is *about* the episode — recording facts like `created_ts_ns`, `schema_version`, `writer`. Meta is not part of episode content, not in `keys()`, and transforms pass it through unchanged. Meta keys are optional and may vary by implementation (e.g. `size_mb` exists for disk episodes, may not for others).
 
+## Identity
+
+Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — the identity contract. Position in a `Dataset` is *access*, not identity: `FilterDataset`/`ConcatDataset` renumber episodes freely. The uid is *reference* — stable across views, processes, copies, and exports. Because transforms pass meta through unchanged, a transformed episode keeps its recording's uid: it is a view of the same recording event.
+
+## Edits
+
+Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. `LocalDataset` applies a discovered log automatically, so every consumer sees the edited view.
+
+- One JSON record per line: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records apply in log order; the last write per key wins. Each record carries its op and version, so a log stays replayable forever.
+- The layering order is **backend → edits → transforms → consumer**: edits bind to recorded keys and persist; transforms compute on the edited episode and never persist.
+- The format stays dumb plain data — smarts live in the library — so external editors can write it. The dataset directory assumes a single writer; readers fail loudly on corrupt or unrecognized records.
+
 ## Episode properties
 
 `duration_ns`, `start_ts`, `last_ts` are **first-class properties on Episode**, always derived from signals. They are never stored in meta. If a transform changes signals, these properties reflect the change.

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -1,5 +1,20 @@
 # Dataset Library — Design Principles
 
+## One API, many backends
+
+The library covers the data path of the robot-learning loop — record → curate/annotate → convert → train → eval → re-score — through a single interface: `Signal`/`Episode`/`Dataset` and the layers composed over them. Storage formats are backends behind that interface (`LocalDataset` is the native one, `RemoteDataset` serves it over HTTP, and foreign formats plug in as read adapters). Never push a capability into a storage format when it can live in a layer above it.
+
+## Layering: backend → edits → transforms → consumer
+
+Every dataset read composes in this order:
+
+- **Backend** reads immutable recordings (`LocalDataset`, `RemoteDataset`).
+- **Edits** (`edits.py`) persist post-hoc facts as a declarative log applied as a view. Edits bind to recorded keys and never compute.
+- **Transforms** compute lazy views over the curated episode. Transforms never persist.
+- **Consumers** (codecs, viewers, converters) see one `Dataset` interface and don't know which layers are present.
+
+The shape mirrors the systems that got this right — Lightroom catalogs over raw photos, video EDLs, git, Delta Lake logs over parquet: identity-keyed (uid, never path or position), time-addressed (absolute ns timestamps, never indices), append-only, dumb plain data with versioned records so a log replays forever.
+
 ## Episode data model
 
 An Episode has three kinds of data with distinct roles:
@@ -14,10 +29,9 @@ Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — 
 
 ## Edits
 
-Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. `LocalDataset` applies a discovered log automatically, so every consumer sees the edited view.
+Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. The edit layer (`edits.py`) is generic — `EditedDataset(base, edits)` composes over any backend (local, remote); the `load_dataset`/`load_all_datasets` one-liners discover and apply a dataset's log, while `LocalDataset` itself reads raw recordings.
 
 - One JSON record per line: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records apply in log order; the last write per key wins. Each record carries its op and version, so a log stays replayable forever.
-- The layering order is **backend → edits → transforms → consumer**: edits bind to recorded keys and persist; transforms compute on the edited episode and never persist.
 - The format stays dumb plain data — smarts live in the library — so external editors can write it. The dataset directory assumes a single writer; readers fail loudly on corrupt or unrecognized records.
 
 ## Episode properties

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -5,6 +5,7 @@ This is a library for recording, storing, sharing and using robotic datasets. We
 ## Table of Contents
 - [Core concepts](#core-concepts)
   - [We optimize for](#we-optimize-for)
+  - [Layers](#layers)
 - [Public API](#public-api)
   - [Signal metadata](#signal-metadata)
   - [Signal implementations](#signal-implementations)
@@ -48,6 +49,17 @@ __Dataset__ – ordered collection of Episodes with sequence-style access (index
 * Fast append during recording (low latency).
 * Random access at query time by the timestamp.
 * Window slices like "5 seconds before time X".
+
+### Layers
+
+A dataset read composes up to four layers, all behind the same `Dataset`/`Episode` interface:
+
+1. **Storage backends** read immutable recordings — `LocalDataset` (the native on-disk format), `RemoteDataset` (HTTP). The API is deliberately format-agnostic so further formats can plug in as read adapters.
+2. **Edits** persist post-hoc facts (operator verdicts, analysis scores) as a declarative log applied as a view — see [Editing datasets](#editing-datasets).
+3. **Transforms** are lazy compute views (derived signals, renames, model codecs) — see [Transforms](#transforms).
+4. **Consumers** — training pipelines, viewers, converters — work against the interface and don't know which layers sit underneath.
+
+Recordings are never modified: edits persist but never compute, transforms compute but never persist.
 
 ## Public API
 Signal implements `Sequence[(T, int)]` (iterable, indexable). We support three kinds of `Signal`s: scalar, vector, and image (video). Timestamps are int nanoseconds. The headline feature is the shared `time` accessor: all helpers such as `_search_ts` exist to make sure that asking for a value at, before, or across specific timestamps is fast, predictable, and consistent across storage backends.
@@ -319,18 +331,20 @@ with dataset_writer.new_episode() as ew:
 
 ### Editing datasets
 
-Recorded episodes are immutable. Post-hoc facts — an operator's verdict, analysis scores — are *edits*: declarative records appended to `edits.jsonl` in the dataset directory and applied as a view when the dataset is opened.
+Recorded episodes are immutable. Post-hoc facts — an operator's verdict, analysis scores — are *edits*: declarative records appended to `edits.jsonl` in the dataset directory and applied as a view on load. The edit layer lives in `positronic.dataset.edits`.
 
 ```python
-writer = LocalDatasetWriter(root)
-writer.set_static(episode.meta['uid'], {'eval.outcome': 'success', 'notes': 'clean run'})
+from positronic.dataset import edits
+from positronic.dataset.local_dataset import load_dataset
 
-ds = LocalDataset(root)  # every consumer sees the edited statics
+edits.set_static(root, episode.meta['uid'], {'eval.outcome': 'success', 'notes': 'clean run'})
+
+ds = load_dataset(root)  # LocalDataset(root) with the edit log applied as an EditedDataset view
 ```
 
-Each line of `edits.jsonl` is one JSON record: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records target episodes by `meta['uid']` and apply in log order with last-write-wins per key. Values follow the same restrictions as `EpisodeWriter.set_static`. A key colliding with a signal name raises when the episode is loaded; corrupt or unrecognized records fail loudly when the dataset is opened.
+Each line of `edits.jsonl` is one JSON record: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records target episodes by `meta['uid']` and apply in log order with last-write-wins per key. Values follow the same restrictions as `EpisodeWriter.set_static`. A key colliding with a signal name raises when the episode is loaded; corrupt or unrecognized records fail loudly when the log is loaded.
 
-The log is plain appendable JSON so external tools can write it; the dataset directory assumes a single writer.
+Application is composition: `EditedDataset(base, edits)` wraps any `Dataset` — local, remote, concatenated — merging each episode's edits over its recorded statics. The `load_dataset` and `load_all_datasets` loaders compose it automatically; `LocalDataset` itself always reads the raw recordings. The log is plain appendable JSON so external tools can write it; the dataset directory assumes a single writer.
 
 ## `DsWriterAgent` (streaming recorder)
 

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -328,7 +328,7 @@ writer.set_static(episode.meta['uid'], {'eval.outcome': 'success', 'notes': 'cle
 ds = LocalDataset(root)  # every consumer sees the edited statics
 ```
 
-Each line of `edits.jsonl` is one JSON record: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records target episodes by `meta['uid']` and apply in log order with last-write-wins per key. Values follow the same restrictions as `EpisodeWriter.set_static`. A key colliding with a signal name raises when the episode's items are accessed; corrupt or unrecognized records fail loudly when the dataset is opened.
+Each line of `edits.jsonl` is one JSON record: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records target episodes by `meta['uid']` and apply in log order with last-write-wins per key. Values follow the same restrictions as `EpisodeWriter.set_static`. A key colliding with a signal name raises when the episode is loaded; corrupt or unrecognized records fail loudly when the dataset is opened.
 
 The log is plain appendable JSON so external tools can write it; the dataset directory assumes a single writer.
 

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -279,7 +279,7 @@ Aborting: `abort()` stops recording, asks each underlying `Signal` writer to abo
 - Written: immediately on `EpisodeWriter` creation (side-effect of constructing the writer).
 - Contents (concise schema):
   - `schema_version: int` – manifest version (starts at 1).
-  - `uid: str` – episode identity (uuid4 hex), stamped at recording time. Stable across views, copies, and exports; position in a dataset is access, the uid is reference.
+  - `uid: str` – episode identity (uuid4 hex), stamped at recording time; episodes lacking one derive a stable `ts-<created_ts_ns>` uid from their recording timestamp. Stable across views, copies, and exports; position in a dataset is access, the uid is reference.
   - `created_ts_ns: int` – `Episode` creation time in nanoseconds.
   - `writer: object` – environment and provenance:
     - `name: str` – fully-qualified writer class (e.g., `positronic.dataset.local_dataset.DiskEpisodeWriter`).

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -21,6 +21,7 @@ This is a library for recording, storing, sharing and using robotic datasets. We
 - [Datasets](#datasets)
   - [Local dataset](#local-dataset)
   - [Writing datasets](#writing-datasets)
+  - [Editing datasets](#editing-datasets)
 - [`DsWriterAgent` (streaming recorder)](#dswriteragent-streaming-recorder)
 - [`DsPlayerAgent` (dataset player)](#dsplayeragent-dataset-player)
 - [Transforms](#transforms)
@@ -266,6 +267,7 @@ Aborting: `abort()` stops recording, asks each underlying `Signal` writer to abo
 - Written: immediately on `EpisodeWriter` creation (side-effect of constructing the writer).
 - Contents (concise schema):
   - `schema_version: int` – manifest version (starts at 1).
+  - `uid: str` – episode identity (uuid4 hex), stamped at recording time. Stable across views, copies, and exports; position in a dataset is access, the uid is reference.
   - `created_ts_ns: int` – `Episode` creation time in nanoseconds.
   - `writer: object` – environment and provenance:
     - `name: str` – fully-qualified writer class (e.g., `positronic.dataset.local_dataset.DiskEpisodeWriter`).
@@ -314,6 +316,21 @@ with dataset_writer.new_episode() as ew:
     ew.set_static("id", 123)
     ew.append("state", np.array([...]), ts_ns)
 ```
+
+### Editing datasets
+
+Recorded episodes are immutable. Post-hoc facts — an operator's verdict, analysis scores — are *edits*: declarative records appended to `edits.jsonl` in the dataset directory and applied as a view when the dataset is opened.
+
+```python
+writer = LocalDatasetWriter(root)
+writer.set_static(episode.meta['uid'], {'eval.outcome': 'success', 'notes': 'clean run'})
+
+ds = LocalDataset(root)  # every consumer sees the edited statics
+```
+
+Each line of `edits.jsonl` is one JSON record: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records target episodes by `meta['uid']` and apply in log order with last-write-wins per key. Values follow the same restrictions as `EpisodeWriter.set_static`. A key colliding with a signal name raises when the episode's items are accessed; corrupt or unrecognized records fail loudly when the dataset is opened.
+
+The log is plain appendable JSON so external tools can write it; the dataset directory assumes a single writer.
 
 ## `DsWriterAgent` (streaming recorder)
 

--- a/positronic/dataset/edits.py
+++ b/positronic/dataset/edits.py
@@ -1,0 +1,113 @@
+"""Edit log over immutable recordings.
+
+Episodes are never modified after recording. Post-hoc facts — operator verdicts, analysis scores — are *edits*:
+declarative records appended to an `edits.jsonl` file in the dataset directory and applied as a view on read.
+Each line is one JSON record: `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`. Records target
+episodes by `meta['uid']` and apply in log order, last write per key wins. The format is plain appendable JSON
+so external tools can write it; the dataset directory assumes a single writer.
+"""
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from .dataset import Dataset
+from .episode import Episode, _is_valid_static_value, _static_decode_hook, _StaticEncoder
+from .signal import Signal
+
+EDITS_FILE = 'edits.jsonl'
+
+
+def set_static(root: Path, uid: str, data: dict[str, Any]) -> None:
+    """Append a `set_static` edit for the episode with the given uid.
+
+    The edit applies when the dataset is loaded: the given items are merged over the episode's recorded
+    static items. The episode recording itself is never modified.
+
+    Args:
+        root: The dataset directory holding the edit log
+        uid: The target episode's `meta['uid']`
+        data: Static items to set; values follow the same restrictions as `EpisodeWriter.set_static`
+    """
+    if not (isinstance(uid, str) and uid):
+        raise ValueError(f'Episode uid must be a non-empty string, got {uid!r}')
+    if not (isinstance(data, dict) and _is_valid_static_value(data)):
+        raise ValueError(f'Edit data must be a mapping of static items to JSON-serializable values\n{data=!r}')
+    record = {'op': 'set_static', 'v': 1, 'ep': uid, 'data': data}
+    with (root / EDITS_FILE).open('a', encoding='utf-8') as f:
+        f.write(json.dumps(record, cls=_StaticEncoder) + '\n')
+
+
+def load_edits(root: Path) -> dict[str, dict[str, Any]]:
+    """Read the edit log and return merged static edits per episode uid.
+
+    Records apply in log order; the last write per key wins.
+    """
+    edits_path = root / EDITS_FILE
+    edits: dict[str, dict[str, Any]] = {}
+    if not edits_path.exists():
+        return edits
+    with edits_path.open('r', encoding='utf-8') as f:
+        for line_no, line in enumerate(f, start=1):
+            try:
+                record = json.loads(line, object_hook=_static_decode_hook)
+            except json.JSONDecodeError as e:
+                raise ValueError(f'Corrupt edit record at {edits_path}:{line_no}') from e
+            match record:
+                case {'op': 'set_static', 'v': 1, 'ep': str(ep_uid), 'data': dict(data)}:
+                    if not _is_valid_static_value(data):
+                        raise ValueError(
+                            f'Invalid static values in edit record at {edits_path}:{line_no}: {line.strip()}'
+                        )
+                    edits.setdefault(ep_uid, {}).update(data)
+                case _:
+                    raise ValueError(f'Unsupported edit record at {edits_path}:{line_no}: {line.strip()}')
+    return edits
+
+
+class EditedEpisode(Episode):
+    """View of an episode with edited static items merged over the recorded ones."""
+
+    def __init__(self, episode: Episode, edits: dict[str, Any]) -> None:
+        collisions = [k for k in edits if k in episode and isinstance(episode[k], Signal)]
+        if collisions:
+            raise ValueError(f'Edited static items {sorted(collisions)} collide with signals in {episode!r}')
+        self._episode = episode
+        self._edits = edits
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._episode
+        yield from (k for k in self._edits if k not in self._episode)
+
+    def __len__(self) -> int:
+        return len(self._episode) + sum(1 for k in self._edits if k not in self._episode)
+
+    def __getitem__(self, name: str) -> Signal[Any] | Any:
+        if name in self._edits:
+            return self._edits[name]
+        return self._episode[name]
+
+    @property
+    def meta(self) -> dict:
+        return self._episode.meta
+
+
+class EditedDataset(Dataset):
+    """View of a dataset with edits applied: per-episode static edits keyed by episode uid."""
+
+    def __init__(self, dataset: Dataset, edits: dict[str, dict[str, Any]]):
+        self._dataset = dataset
+        self._edits = edits
+
+    def __len__(self) -> int:
+        return len(self._dataset)
+
+    def _get_episode(self, index: int) -> Episode:
+        episode = self._dataset[index]
+        edits = self._edits.get(episode.meta.get('uid'))
+        return EditedEpisode(episode, edits) if edits else episode
+
+    @property
+    def meta(self) -> dict[str, Any]:
+        return self._dataset.meta

--- a/positronic/dataset/episode.py
+++ b/positronic/dataset/episode.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import AbstractContextManager
@@ -10,6 +12,33 @@ from .signal import Signal
 EPISODE_SCHEMA_VERSION = 1
 T = TypeVar('T')
 SIGNAL_FACTORY_T = Callable[[], Signal[Any]]
+
+_BYTES_TAG = '__bytes_b64__'
+
+
+class _StaticEncoder(json.JSONEncoder):
+    """JSON encoder that handles ``bytes`` values via base64."""
+
+    def default(self, o):
+        if isinstance(o, bytes):
+            return {_BYTES_TAG: base64.b64encode(o).decode('ascii')}
+        return super().default(o)
+
+
+def _static_decode_hook(obj: dict) -> Any:
+    if _BYTES_TAG in obj and len(obj) == 1:
+        return base64.b64decode(obj[_BYTES_TAG])
+    return obj
+
+
+def _is_valid_static_value(value: Any) -> bool:
+    if isinstance(value, str | int | float | bool | bytes):
+        return True
+    if isinstance(value, list | tuple):
+        return all(_is_valid_static_value(v) for v in value)
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _is_valid_static_value(v) for k, v in value.items())
+    return False
 
 
 class _EpisodeTimeIndexer:

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import platform
 import shutil
@@ -23,40 +22,22 @@ from positronic.utils.git import get_git_state
 from positronic.utils.lazy import LazyDict
 
 from .dataset import ConcatDataset, Dataset, DatasetWriter
-from .episode import EPISODE_SCHEMA_VERSION, SIGNAL_FACTORY_T, Episode, EpisodeWriter, T
+from .edits import EditedDataset, load_edits
+from .episode import (
+    EPISODE_SCHEMA_VERSION,
+    SIGNAL_FACTORY_T,
+    Episode,
+    EpisodeWriter,
+    T,
+    _is_valid_static_value,
+    _static_decode_hook,
+    _StaticEncoder,
+)
 from .signal import Signal
 from .vector import SimpleSignal, SimpleSignalWriter
 from .video import VideoSignal, VideoSignalWriter
 
 UNFINISHED_MARKER = '.unfinished'
-EDITS_FILE = 'edits.jsonl'
-
-_BYTES_TAG = '__bytes_b64__'
-
-
-class _StaticEncoder(json.JSONEncoder):
-    """JSON encoder that handles ``bytes`` values via base64."""
-
-    def default(self, o):
-        if isinstance(o, bytes):
-            return {_BYTES_TAG: base64.b64encode(o).decode('ascii')}
-        return super().default(o)
-
-
-def _static_decode_hook(obj: dict) -> Any:
-    if _BYTES_TAG in obj and len(obj) == 1:
-        return base64.b64decode(obj[_BYTES_TAG])
-    return obj
-
-
-def _is_valid_static_value(value: Any) -> bool:
-    if isinstance(value, str | int | float | bool | bytes):
-        return True
-    if isinstance(value, list | tuple):
-        return all(_is_valid_static_value(v) for v in value)
-    if isinstance(value, dict):
-        return all(isinstance(k, str) and _is_valid_static_value(v) for k, v in value.items())
-    return False
 
 
 def _is_numeric_dir(p: Path) -> bool:
@@ -300,20 +281,15 @@ class DiskEpisode(Episode):
     All signals in an episode share a common timeline.
     """
 
-    def __init__(self, directory: Path, *, static_overrides: dict[str, Any] | None = None) -> None:
+    def __init__(self, directory: Path) -> None:
         """Initialize episode reader from a directory (lazy).
 
         - Defers loading of signal data, static items, and meta until accessed.
         - Prepares lightweight factories for signals discovered on disk.
-
-        Args:
-            directory: Episode directory to read from
-            static_overrides: Edited static items merged over the recorded ones on access
         """
         if (directory / UNFINISHED_MARKER).exists():
             raise ValueError(f'Cannot read unfinished episode at {directory}')
         self._dir = directory
-        self._static_overrides = static_overrides or {}
         # WeakValueDictionary: signals are recreated from factories on demand, so caching
         # them strongly would leak resources (e.g. VideoSignal holds an open av.Container).
         # With weak refs, signals stay alive while callers hold them and get GC'd otherwise.
@@ -341,10 +317,6 @@ class DiskEpisode(Episode):
             if key in used_names:
                 continue
             self._signal_factories[key] = partial(SimpleSignal, file)
-
-        collisions = self._static_overrides.keys() & self._signal_factories.keys()
-        if collisions:
-            raise ValueError(f'Edited static items {sorted(collisions)} collide with signals in {self._dir}')
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(path={str(self._dir)!r})'
@@ -376,7 +348,6 @@ class DiskEpisode(Episode):
                     self._static.update(data)
                 else:
                     raise ValueError('static.json must contain a JSON object (mapping)')
-            self._static.update(self._static_overrides)
         return self._static
 
     def __iter__(self) -> Iterator[str]:
@@ -463,41 +434,6 @@ class DiskEpisode(Episode):
         return dict(self._static_data)
 
 
-def _episode_uid(ep_dir: Path) -> str | None:
-    meta_json = ep_dir / 'meta.json'
-    if not meta_json.exists():
-        return None
-    with meta_json.open('r', encoding='utf-8') as f:
-        return json.load(f).get('uid')
-
-
-def _load_edits(root: Path) -> dict[str, dict[str, Any]]:
-    """Read the edit log and return merged static overrides per episode uid.
-
-    Records apply in log order; the last write per key wins.
-    """
-    edits_path = root / EDITS_FILE
-    overrides: dict[str, dict[str, Any]] = {}
-    if not edits_path.exists():
-        return overrides
-    with edits_path.open('r', encoding='utf-8') as f:
-        for line_no, line in enumerate(f, start=1):
-            try:
-                record = json.loads(line, object_hook=_static_decode_hook)
-            except json.JSONDecodeError as e:
-                raise ValueError(f'Corrupt edit record at {edits_path}:{line_no}') from e
-            match record:
-                case {'op': 'set_static', 'v': 1, 'ep': str(ep_uid), 'data': dict(data)}:
-                    if not _is_valid_static_value(data):
-                        raise ValueError(
-                            f'Invalid static values in edit record at {edits_path}:{line_no}: {line.strip()}'
-                        )
-                    overrides.setdefault(ep_uid, {}).update(data)
-                case _:
-                    raise ValueError(f'Unsupported edit record at {edits_path}:{line_no}: {line.strip()}')
-    return overrides
-
-
 class LocalDataset(Dataset):
     """Filesystem-backed dataset of Episodes.
 
@@ -521,9 +457,6 @@ class LocalDataset(Dataset):
             )
         self._episodes: list[tuple[int, Path]] = []
         self._build_episode_list()
-        # An edit log binds to a dataset: a directory without episodes is not one, and discovery
-        # (load_all_datasets) probes arbitrary directories that may hold an unrelated edits.jsonl
-        self._static_overrides = _load_edits(self.root) if self._episodes else {}
 
     def _build_episode_list(self) -> None:
         self._episodes.clear()
@@ -545,10 +478,7 @@ class LocalDataset(Dataset):
     def _get_episode(self, index: int) -> DiskEpisode:
         if not (0 <= index < len(self)):
             raise IndexError(f'Index {index} out of range for {self.root} dataset with {len(self)} episodes')
-        ep_dir = self._episodes[index][1]
-        if not self._static_overrides:
-            return DiskEpisode(ep_dir)
-        return DiskEpisode(ep_dir, static_overrides=self._static_overrides.get(_episode_uid(ep_dir)))
+        return DiskEpisode(self._episodes[index][1])
 
 
 class LocalDatasetWriter(DatasetWriter):
@@ -598,26 +528,19 @@ class LocalDatasetWriter(DatasetWriter):
         writer = DiskEpisodeWriter(ep_dir, created_ts_ns=created_ts_ns, uid=uid)
         return writer
 
-    def set_static(self, uid: str, data: dict[str, Any]) -> None:
-        """Append a `set_static` edit for the episode with the given uid.
-
-        The edit is applied when the dataset is opened: the given items are merged over the episode's recorded
-        static items. The episode recording itself is never modified.
-
-        Args:
-            uid: The target episode's `meta['uid']`
-            data: Static items to set; values follow the same restrictions as `EpisodeWriter.set_static`
-        """
-        if not (isinstance(uid, str) and uid):
-            raise ValueError(f'Episode uid must be a non-empty string, got {uid!r}')
-        if not (isinstance(data, dict) and _is_valid_static_value(data)):
-            raise ValueError(f'Edit data must be a mapping of static items to JSON-serializable values\n{data=!r}')
-        record = {'op': 'set_static', 'v': 1, 'ep': uid, 'data': data}
-        with (self.root / EDITS_FILE).open('a', encoding='utf-8') as f:
-            f.write(json.dumps(record, cls=_StaticEncoder) + '\n')
-
     def __exit__(self, exc_type, exc, tb) -> None:
         pass
+
+
+def load_dataset(root: Path) -> Dataset:
+    """Open a local dataset with its edit log applied.
+
+    `LocalDataset` reads the raw recordings; a discovered `edits.jsonl` composes on top as an `EditedDataset`
+    view. The log is loaded only when the directory actually holds episodes — an edit log binds to a dataset.
+    """
+    ds = LocalDataset(root)
+    edits = load_edits(ds.root) if len(ds) else {}
+    return EditedDataset(ds, edits) if edits else ds
 
 
 def load_all_datasets(root: Path) -> Dataset:
@@ -656,7 +579,7 @@ def load_all_datasets(root: Path) -> Dataset:
 
         # Try to load this directory as a dataset; corrupt content (e.g. a bad edit log) propagates
         try:
-            dataset = LocalDataset(current_path)
+            dataset = load_dataset(current_path)
             if len(dataset) > 0:
                 datasets.append(dataset)
         except FileNotFoundError:

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -601,6 +601,8 @@ class LocalDatasetWriter(DatasetWriter):
             uid: The target episode's `meta['uid']`
             data: Static items to set; values follow the same restrictions as `EpisodeWriter.set_static`
         """
+        if not (isinstance(uid, str) and uid):
+            raise ValueError(f'Episode uid must be a non-empty string, got {uid!r}')
         if not _is_valid_static_value(data):
             raise ValueError(f'Static items must be JSON-serializable: dict/list over numbers and strings\n{data=!r}')
         record = {'op': 'set_static', 'v': 1, 'ep': uid, 'data': data}

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -342,6 +342,10 @@ class DiskEpisode(Episode):
                 continue
             self._signal_factories[key] = partial(SimpleSignal, file)
 
+        collisions = self._static_overrides.keys() & self._signal_factories.keys()
+        if collisions:
+            raise ValueError(f'Edited static items {sorted(collisions)} collide with signals in {self._dir}')
+
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(path={str(self._dir)!r})'
 
@@ -372,9 +376,6 @@ class DiskEpisode(Episode):
                     self._static.update(data)
                 else:
                     raise ValueError('static.json must contain a JSON object (mapping)')
-            collisions = self._static_overrides.keys() & self._signal_factories.keys()
-            if collisions:
-                raise ValueError(f'Edited static items {sorted(collisions)} collide with signals in {self._dir}')
             self._static.update(self._static_overrides)
         return self._static
 

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -603,8 +603,8 @@ class LocalDatasetWriter(DatasetWriter):
         """
         if not (isinstance(uid, str) and uid):
             raise ValueError(f'Episode uid must be a non-empty string, got {uid!r}')
-        if not _is_valid_static_value(data):
-            raise ValueError(f'Static items must be JSON-serializable: dict/list over numbers and strings\n{data=!r}')
+        if not (isinstance(data, dict) and _is_valid_static_value(data)):
+            raise ValueError(f'Edit data must be a mapping of static items to JSON-serializable values\n{data=!r}')
         record = {'op': 'set_static', 'v': 1, 'ep': uid, 'data': data}
         with (self.root / EDITS_FILE).open('a', encoding='utf-8') as f:
             f.write(json.dumps(record, cls=_StaticEncoder) + '\n')

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -105,6 +105,7 @@ class DiskEpisodeWriter(EpisodeWriter):
         *,
         on_close: Callable[[DiskEpisodeWriter], None] | None = None,
         created_ts_ns: int | None = None,
+        uid: str | None = None,
     ) -> None:
         """Initialize episode writer.
 
@@ -113,6 +114,8 @@ class DiskEpisodeWriter(EpisodeWriter):
             on_close: Optional callback invoked after successful episode close
             created_ts_ns: Optional creation timestamp (defaults to current time).
                 Use this to preserve original creation time during migration.
+            uid: Optional episode identity (defaults to a fresh uuid4 hex).
+                Use this to preserve identity when copying an existing recording.
         """
         self._path = directory
         assert not self._path.exists(), f'Writing to existing directory {self._path}'
@@ -131,7 +134,7 @@ class DiskEpisodeWriter(EpisodeWriter):
         # NB: falsy created_ts_ns (including 0) defaults to current time — epoch 0 is not a valid episode timestamp
         self._meta = {
             'schema_version': EPISODE_SCHEMA_VERSION,
-            'uid': uuid.uuid4().hex,
+            'uid': uid or uuid.uuid4().hex,
             'created_ts_ns': created_ts_ns or time.time_ns(),
         }
         self._meta['writer'] = _cached_env_writer_info()
@@ -568,12 +571,14 @@ class LocalDatasetWriter(DatasetWriter):
                     max_id = eid
         return max_id + 1
 
-    def new_episode(self, *, created_ts_ns: int | None = None) -> DiskEpisodeWriter:
+    def new_episode(self, *, created_ts_ns: int | None = None, uid: str | None = None) -> DiskEpisodeWriter:
         """Create a new episode writer.
 
         Args:
             created_ts_ns: Optional creation timestamp (defaults to current time).
                 Use this to preserve original creation time during migration.
+            uid: Optional episode identity (defaults to a fresh uuid4 hex).
+                Use this to preserve identity when copying an existing recording.
         """
         eid = self._next_episode_id
         self._next_episode_id += 1  # Reserve id immediately
@@ -583,7 +588,7 @@ class LocalDatasetWriter(DatasetWriter):
         # responsible for creating it and expects it to not exist yet.
         ep_dir = block_dir / f'{eid:012d}'
 
-        writer = DiskEpisodeWriter(ep_dir, created_ts_ns=created_ts_ns)
+        writer = DiskEpisodeWriter(ep_dir, created_ts_ns=created_ts_ns, uid=uid)
         return writer
 
     def set_static(self, uid: str, data: dict[str, Any]) -> None:
@@ -640,12 +645,12 @@ def load_all_datasets(root: Path) -> Dataset:
     while to_explore:
         current_path = to_explore.popleft()
 
-        # Try to load this directory as a dataset
+        # Try to load this directory as a dataset; corrupt content (e.g. a bad edit log) propagates
         try:
             dataset = LocalDataset(current_path)
             if len(dataset) > 0:
                 datasets.append(dataset)
-        except (FileNotFoundError, ValueError):
+        except FileNotFoundError:
             pass
 
         # Always explore non-numeric subdirs (numeric ones are dataset block internals)

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -487,6 +487,10 @@ def _load_edits(root: Path) -> dict[str, dict[str, Any]]:
                 raise ValueError(f'Corrupt edit record at {edits_path}:{line_no}') from e
             match record:
                 case {'op': 'set_static', 'v': 1, 'ep': str(ep_uid), 'data': dict(data)}:
+                    if not _is_valid_static_value(data):
+                        raise ValueError(
+                            f'Invalid static values in edit record at {edits_path}:{line_no}: {line.strip()}'
+                        )
                     overrides.setdefault(ep_uid, {}).update(data)
                 case _:
                     raise ValueError(f'Unsupported edit record at {edits_path}:{line_no}: {line.strip()}')

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -6,6 +6,7 @@ import platform
 import shutil
 import sys
 import time
+import uuid
 import weakref
 from collections import deque
 from collections.abc import Callable, Iterator
@@ -28,6 +29,7 @@ from .vector import SimpleSignal, SimpleSignalWriter
 from .video import VideoSignal, VideoSignalWriter
 
 UNFINISHED_MARKER = '.unfinished'
+EDITS_FILE = 'edits.jsonl'
 
 _BYTES_TAG = '__bytes_b64__'
 
@@ -127,7 +129,11 @@ class DiskEpisodeWriter(EpisodeWriter):
 
         # Write system metadata immediately
         # NB: falsy created_ts_ns (including 0) defaults to current time — epoch 0 is not a valid episode timestamp
-        self._meta = {'schema_version': EPISODE_SCHEMA_VERSION, 'created_ts_ns': created_ts_ns or time.time_ns()}
+        self._meta = {
+            'schema_version': EPISODE_SCHEMA_VERSION,
+            'uid': uuid.uuid4().hex,
+            'created_ts_ns': created_ts_ns or time.time_ns(),
+        }
         self._meta['writer'] = _cached_env_writer_info()
         self._meta['writer']['name'] = f'{self.__class__.__module__}.{self.__class__.__qualname__}'
         self._meta['path'] = str(self._path.resolve(strict=True))
@@ -291,15 +297,20 @@ class DiskEpisode(Episode):
     All signals in an episode share a common timeline.
     """
 
-    def __init__(self, directory: Path) -> None:
+    def __init__(self, directory: Path, *, static_overrides: dict[str, Any] | None = None) -> None:
         """Initialize episode reader from a directory (lazy).
 
         - Defers loading of signal data, static items, and meta until accessed.
         - Prepares lightweight factories for signals discovered on disk.
+
+        Args:
+            directory: Episode directory to read from
+            static_overrides: Edited static items merged over the recorded ones on access
         """
         if (directory / UNFINISHED_MARKER).exists():
             raise ValueError(f'Cannot read unfinished episode at {directory}')
         self._dir = directory
+        self._static_overrides = static_overrides or {}
         # WeakValueDictionary: signals are recreated from factories on demand, so caching
         # them strongly would leak resources (e.g. VideoSignal holds an open av.Container).
         # With weak refs, signals stay alive while callers hold them and get GC'd otherwise.
@@ -358,6 +369,10 @@ class DiskEpisode(Episode):
                     self._static.update(data)
                 else:
                     raise ValueError('static.json must contain a JSON object (mapping)')
+            collisions = self._static_overrides.keys() & self._signal_factories.keys()
+            if collisions:
+                raise ValueError(f'Edited static items {sorted(collisions)} collide with signals in {self._dir}')
+            self._static.update(self._static_overrides)
         return self._static
 
     def __iter__(self) -> Iterator[str]:
@@ -444,6 +459,37 @@ class DiskEpisode(Episode):
         return dict(self._static_data)
 
 
+def _episode_uid(ep_dir: Path) -> str | None:
+    meta_json = ep_dir / 'meta.json'
+    if not meta_json.exists():
+        return None
+    with meta_json.open('r', encoding='utf-8') as f:
+        return json.load(f).get('uid')
+
+
+def _load_edits(root: Path) -> dict[str, dict[str, Any]]:
+    """Read the edit log and return merged static overrides per episode uid.
+
+    Records apply in log order; the last write per key wins.
+    """
+    edits_path = root / EDITS_FILE
+    overrides: dict[str, dict[str, Any]] = {}
+    if not edits_path.exists():
+        return overrides
+    with edits_path.open('r', encoding='utf-8') as f:
+        for line_no, line in enumerate(f, start=1):
+            try:
+                record = json.loads(line, object_hook=_static_decode_hook)
+            except json.JSONDecodeError as e:
+                raise ValueError(f'Corrupt edit record at {edits_path}:{line_no}') from e
+            match record:
+                case {'op': 'set_static', 'v': 1, 'ep': str(ep_uid), 'data': dict(data)}:
+                    overrides.setdefault(ep_uid, {}).update(data)
+                case _:
+                    raise ValueError(f'Unsupported edit record at {edits_path}:{line_no}: {line.strip()}')
+    return overrides
+
+
 class LocalDataset(Dataset):
     """Filesystem-backed dataset of Episodes.
 
@@ -467,6 +513,7 @@ class LocalDataset(Dataset):
             )
         self._episodes: list[tuple[int, Path]] = []
         self._build_episode_list()
+        self._static_overrides = _load_edits(self.root)
 
     def _build_episode_list(self) -> None:
         self._episodes.clear()
@@ -488,7 +535,10 @@ class LocalDataset(Dataset):
     def _get_episode(self, index: int) -> DiskEpisode:
         if not (0 <= index < len(self)):
             raise IndexError(f'Index {index} out of range for {self.root} dataset with {len(self)} episodes')
-        return DiskEpisode(self._episodes[index][1])
+        ep_dir = self._episodes[index][1]
+        if not self._static_overrides:
+            return DiskEpisode(ep_dir)
+        return DiskEpisode(ep_dir, static_overrides=self._static_overrides.get(_episode_uid(ep_dir)))
 
 
 class LocalDatasetWriter(DatasetWriter):
@@ -535,6 +585,22 @@ class LocalDatasetWriter(DatasetWriter):
 
         writer = DiskEpisodeWriter(ep_dir, created_ts_ns=created_ts_ns)
         return writer
+
+    def set_static(self, uid: str, data: dict[str, Any]) -> None:
+        """Append a `set_static` edit for the episode with the given uid.
+
+        The edit is applied when the dataset is opened: the given items are merged over the episode's recorded
+        static items. The episode recording itself is never modified.
+
+        Args:
+            uid: The target episode's `meta['uid']`
+            data: Static items to set; values follow the same restrictions as `EpisodeWriter.set_static`
+        """
+        if not _is_valid_static_value(data):
+            raise ValueError(f'Static items must be JSON-serializable: dict/list over numbers and strings\n{data=!r}')
+        record = {'op': 'set_static', 'v': 1, 'ep': uid, 'data': data}
+        with (self.root / EDITS_FILE).open('a', encoding='utf-8') as f:
+            f.write(json.dumps(record, cls=_StaticEncoder) + '\n')
 
     def __exit__(self, exc_type, exc, tb) -> None:
         pass

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -521,7 +521,9 @@ class LocalDataset(Dataset):
             )
         self._episodes: list[tuple[int, Path]] = []
         self._build_episode_list()
-        self._static_overrides = _load_edits(self.root)
+        # An edit log binds to a dataset: a directory without episodes is not one, and discovery
+        # (load_all_datasets) probes arbitrary directories that may hold an unrelated edits.jsonl
+        self._static_overrides = _load_edits(self.root) if self._episodes else {}
 
     def _build_episode_list(self) -> None:
         self._episodes.clear()

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -404,6 +404,11 @@ class DiskEpisode(Episode):
             # Extract it as a private cache for DiskEpisode.duration_ns.
             self._cached_duration_ns = meta.pop('duration_ns', None)
 
+            # Episodes without a stamped uid derive a stable identity from the recording timestamp,
+            # which is immutable and travels with the episode across copies
+            if 'uid' not in meta and 'created_ts_ns' in meta:
+                meta['uid'] = f'ts-{meta["created_ts_ns"]}'
+
             meta['path'] = str(self._dir.expanduser().resolve(strict=False))
 
             lazy_getters: dict[str, Any] = {}

--- a/positronic/dataset/tests/test_dataset.py
+++ b/positronic/dataset/tests/test_dataset.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import numpy as np
 
 from positronic.dataset.dataset import ConcatDataset, FilterDataset
+from positronic.dataset.edits import EditedDataset
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 
 
@@ -17,6 +18,20 @@ def build_dataset_with_signal(root: Path, values: list[int]) -> LocalDataset:
                 ew.set_static('id', value)
                 ew.append('signal', np.array([value], dtype=np.float32), ts_ns=10_000 + i)
     return LocalDataset(root)
+
+
+# --- EditedDataset tests ---
+
+
+def test_edited_dataset_applies_edits_by_uid(tmp_path):
+    ds = build_dataset_with_signal(tmp_path / 'ds', [0, 1])
+    edited = EditedDataset(ds, {ds[0].meta['uid']: {'id': 100, 'verdict': 'success'}})
+
+    assert len(edited) == 2
+    assert edited[0]['id'] == 100
+    assert edited[0]['verdict'] == 'success'
+    assert edited[1]['id'] == 1
+    assert 'verdict' not in edited[1]
 
 
 # --- ConcatDataset tests ---

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -424,6 +425,21 @@ def test_new_episode_carries_provided_uid(tmp_path):
         with w.new_episode(uid='source-uid') as ew:
             ew.set_static('id', 0)
     assert LocalDataset(tmp_path / 'ds')[0].meta['uid'] == 'source-uid'
+
+
+def test_episode_without_stamped_uid_derives_one_from_created_ts(tmp_path):
+    root = tmp_path / 'ds'
+    build_dataset_with_signal(root, [0])
+    meta_path = root / '000000000000' / '000000000000' / 'meta.json'
+    meta = json.loads(meta_path.read_text(encoding='utf-8'))
+    del meta['uid']
+    meta_path.write_text(json.dumps(meta), encoding='utf-8')
+
+    uid = LocalDataset(root)[0].meta['uid']
+    assert uid == f'ts-{meta["created_ts_ns"]}'
+
+    edits.set_static(root, uid, {'verdict': 'success'})
+    assert load_dataset(root)[0]['verdict'] == 'success'
 
 
 def test_set_static_edit_applies_on_read(tmp_path):

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -479,6 +479,8 @@ def test_set_static_edit_rejects_invalid_values(tmp_path):
     w = LocalDatasetWriter(tmp_path / 'ds')
     with pytest.raises(ValueError, match='JSON-serializable'):
         w.set_static('uid', {'bad': object()})
+    with pytest.raises(ValueError, match='must be a mapping'):
+        w.set_static('uid', ['not', 'a', 'mapping'])
     with pytest.raises(ValueError, match='non-empty string'):
         w.set_static(None, {'verdict': 'ok'})
 

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -463,7 +463,7 @@ def test_set_static_edit_colliding_with_signal_raises(tmp_path):
 
     ds = LocalDataset(root)
     with pytest.raises(ValueError, match='collide with signals'):
-        _ = ds[0].static
+        _ = ds[0]
 
 
 def test_set_static_edit_for_unknown_uid_is_inert(tmp_path):

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -4,14 +4,14 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from positronic.dataset import Episode
+from positronic.dataset import Episode, edits
 from positronic.dataset.local_dataset import (
-    EDITS_FILE,
     UNFINISHED_MARKER,
     DiskEpisode,
     LocalDataset,
     LocalDatasetWriter,
     load_all_datasets,
+    load_dataset,
 )
 
 from .test_dataset import build_dataset_with_signal, episode_ids
@@ -431,9 +431,9 @@ def test_set_static_edit_applies_on_read(tmp_path):
     ds = build_dataset_with_signal(root, [0, 1])
     uid = ds[0].meta['uid']
 
-    LocalDatasetWriter(root).set_static(uid, {'id': 100, 'verdict': 'success', 'blob': b'\x00\x01'})
+    edits.set_static(root, uid, {'id': 100, 'verdict': 'success', 'blob': b'\x00\x01'})
 
-    ds = LocalDataset(root)
+    ds = load_dataset(root)
     assert ds[0]['id'] == 100
     assert ds[0]['verdict'] == 'success'
     assert ds[0]['blob'] == b'\x00\x01'
@@ -447,11 +447,10 @@ def test_set_static_edit_last_write_wins(tmp_path):
     ds = build_dataset_with_signal(root, [0])
     uid = ds[0].meta['uid']
 
-    w = LocalDatasetWriter(root)
-    w.set_static(uid, {'verdict': 'fail', 'notes': 'first'})
-    w.set_static(uid, {'verdict': 'success'})
+    edits.set_static(root, uid, {'verdict': 'fail', 'notes': 'first'})
+    edits.set_static(root, uid, {'verdict': 'success'})
 
-    ds = LocalDataset(root)
+    ds = load_dataset(root)
     assert ds[0]['verdict'] == 'success'
     assert ds[0]['notes'] == 'first'
 
@@ -459,9 +458,9 @@ def test_set_static_edit_last_write_wins(tmp_path):
 def test_set_static_edit_colliding_with_signal_raises(tmp_path):
     root = tmp_path / 'ds'
     ds = build_dataset_with_signal(root, [0])
-    LocalDatasetWriter(root).set_static(ds[0].meta['uid'], {'signal': 1})
+    edits.set_static(root, ds[0].meta['uid'], {'signal': 1})
 
-    ds = LocalDataset(root)
+    ds = load_dataset(root)
     with pytest.raises(ValueError, match='collide with signals'):
         _ = ds[0]
 
@@ -469,58 +468,57 @@ def test_set_static_edit_colliding_with_signal_raises(tmp_path):
 def test_set_static_edit_for_unknown_uid_is_inert(tmp_path):
     root = tmp_path / 'ds'
     build_dataset_with_signal(root, [0])
-    LocalDatasetWriter(root).set_static('no-such-uid', {'verdict': 'success'})
+    edits.set_static(root, 'no-such-uid', {'verdict': 'success'})
 
-    ds = LocalDataset(root)
+    ds = load_dataset(root)
     assert ds[0].static == {'id': 0}
 
 
 def test_set_static_edit_rejects_invalid_values(tmp_path):
-    w = LocalDatasetWriter(tmp_path / 'ds')
     with pytest.raises(ValueError, match='JSON-serializable'):
-        w.set_static('uid', {'bad': object()})
+        edits.set_static(tmp_path, 'uid', {'bad': object()})
     with pytest.raises(ValueError, match='must be a mapping'):
-        w.set_static('uid', ['not', 'a', 'mapping'])
+        edits.set_static(tmp_path, 'uid', ['not', 'a', 'mapping'])
     with pytest.raises(ValueError, match='non-empty string'):
-        w.set_static(None, {'verdict': 'ok'})
+        edits.set_static(tmp_path, None, {'verdict': 'ok'})
 
 
 def test_corrupt_edit_record_raises(tmp_path):
     root = tmp_path / 'ds'
     build_dataset_with_signal(root, [0])
-    (root / EDITS_FILE).write_text('{"op": "set_static", "v": 1, "ep": "x", "data": {', encoding='utf-8')
+    (root / edits.EDITS_FILE).write_text('{"op": "set_static", "v": 1, "ep": "x", "data": {', encoding='utf-8')
     with pytest.raises(ValueError, match='Corrupt edit record'):
-        LocalDataset(root)
+        load_dataset(root)
 
 
 def test_unsupported_edit_record_raises(tmp_path):
     root = tmp_path / 'ds'
     build_dataset_with_signal(root, [0])
-    (root / EDITS_FILE).write_text('{"op": "trim", "v": 1, "ep": "x", "start": 0}\n', encoding='utf-8')
+    (root / edits.EDITS_FILE).write_text('{"op": "trim", "v": 1, "ep": "x", "start": 0}\n', encoding='utf-8')
     with pytest.raises(ValueError, match='Unsupported edit record'):
-        LocalDataset(root)
+        load_dataset(root)
 
 
 def test_edit_record_with_invalid_static_values_raises(tmp_path):
     root = tmp_path / 'ds'
     build_dataset_with_signal(root, [0])
-    (root / EDITS_FILE).write_text(
+    (root / edits.EDITS_FILE).write_text(
         '{"op": "set_static", "v": 1, "ep": "x", "data": {"maybe": null}}\n', encoding='utf-8'
     )
     with pytest.raises(ValueError, match='Invalid static values'):
-        LocalDataset(root)
+        load_dataset(root)
 
 
 def test_load_all_datasets_propagates_corrupt_edit_log(tmp_path):
     build_dataset_with_signal(tmp_path / 'ds1', [0, 1])
     build_dataset_with_signal(tmp_path / 'ds2', [2])
-    (tmp_path / 'ds2' / EDITS_FILE).write_text('garbage', encoding='utf-8')
+    (tmp_path / 'ds2' / edits.EDITS_FILE).write_text('garbage', encoding='utf-8')
     with pytest.raises(ValueError, match='Corrupt edit record'):
         load_all_datasets(tmp_path)
 
 
 def test_load_all_datasets_ignores_edit_log_outside_datasets(tmp_path):
     build_dataset_with_signal(tmp_path / 'ds1', [0, 1])
-    (tmp_path / EDITS_FILE).write_text('garbage', encoding='utf-8')
+    (tmp_path / edits.EDITS_FILE).write_text('garbage', encoding='utf-8')
     result = load_all_datasets(tmp_path)
     assert episode_ids(result[:]) == [0, 1]

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -419,6 +419,13 @@ def test_episode_meta_has_unique_uid(tmp_path):
     assert uids[0] != uids[1]
 
 
+def test_new_episode_carries_provided_uid(tmp_path):
+    with LocalDatasetWriter(tmp_path / 'ds') as w:
+        with w.new_episode(uid='source-uid') as ew:
+            ew.set_static('id', 0)
+    assert LocalDataset(tmp_path / 'ds')[0].meta['uid'] == 'source-uid'
+
+
 def test_set_static_edit_applies_on_read(tmp_path):
     root = tmp_path / 'ds'
     ds = build_dataset_with_signal(root, [0, 1])
@@ -483,3 +490,11 @@ def test_unsupported_edit_record_raises(tmp_path):
     (tmp_path / EDITS_FILE).write_text('{"op": "trim", "v": 1, "ep": "x", "start": 0}\n', encoding='utf-8')
     with pytest.raises(ValueError, match='Unsupported edit record'):
         LocalDataset(tmp_path)
+
+
+def test_load_all_datasets_propagates_corrupt_edit_log(tmp_path):
+    build_dataset_with_signal(tmp_path / 'ds1', [0, 1])
+    build_dataset_with_signal(tmp_path / 'ds2', [2])
+    (tmp_path / 'ds2' / EDITS_FILE).write_text('garbage', encoding='utf-8')
+    with pytest.raises(ValueError, match='Corrupt edit record'):
+        load_all_datasets(tmp_path)

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -497,6 +497,14 @@ def test_unsupported_edit_record_raises(tmp_path):
         LocalDataset(tmp_path)
 
 
+def test_edit_record_with_invalid_static_values_raises(tmp_path):
+    (tmp_path / EDITS_FILE).write_text(
+        '{"op": "set_static", "v": 1, "ep": "x", "data": {"maybe": null}}\n', encoding='utf-8'
+    )
+    with pytest.raises(ValueError, match='Invalid static values'):
+        LocalDataset(tmp_path)
+
+
 def test_load_all_datasets_propagates_corrupt_edit_log(tmp_path):
     build_dataset_with_signal(tmp_path / 'ds1', [0, 1])
     build_dataset_with_signal(tmp_path / 'ds2', [2])

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -1,10 +1,18 @@
+import tempfile
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from positronic.dataset import Episode
-from positronic.dataset.local_dataset import UNFINISHED_MARKER, LocalDataset, LocalDatasetWriter, load_all_datasets
+from positronic.dataset.local_dataset import (
+    EDITS_FILE,
+    UNFINISHED_MARKER,
+    DiskEpisode,
+    LocalDataset,
+    LocalDatasetWriter,
+    load_all_datasets,
+)
 
 from .test_dataset import build_dataset_with_signal, episode_ids
 
@@ -153,8 +161,6 @@ def test_array_indexing_errors(tmp_path):
 
 def test_homedir_resolution(tmp_path):
     # Create a test dataset under home directory
-    import tempfile
-
     home = Path.home()
     with tempfile.TemporaryDirectory(dir=home) as tmpdir:
         actual_root = Path(tmpdir) / 'ds'
@@ -384,8 +390,6 @@ def test_load_all_datasets_no_valid_datasets(tmp_path):
 
 def test_load_all_datasets_with_tilde_path(tmp_path):
     """Test that tilde paths are expanded correctly."""
-    import tempfile
-
     home = Path.home()
     with tempfile.TemporaryDirectory(dir=home) as tmpdir:
         actual_root = Path(tmpdir) / 'datasets'
@@ -403,3 +407,79 @@ def test_load_all_datasets_with_tilde_path(tmp_path):
 
         assert len(result) == 4
         assert episode_ids(result[:]) == [0, 1, 2, 3]
+
+
+# --- Edit log tests ---
+
+
+def test_episode_meta_has_unique_uid(tmp_path):
+    ds = build_dataset_with_signal(tmp_path / 'ds', [0, 1])
+    uids = [ds[i].meta['uid'] for i in range(2)]
+    assert all(isinstance(uid, str) and uid for uid in uids)
+    assert uids[0] != uids[1]
+
+
+def test_set_static_edit_applies_on_read(tmp_path):
+    root = tmp_path / 'ds'
+    ds = build_dataset_with_signal(root, [0, 1])
+    uid = ds[0].meta['uid']
+
+    LocalDatasetWriter(root).set_static(uid, {'id': 100, 'verdict': 'success', 'blob': b'\x00\x01'})
+
+    ds = LocalDataset(root)
+    assert ds[0]['id'] == 100
+    assert ds[0]['verdict'] == 'success'
+    assert ds[0]['blob'] == b'\x00\x01'
+    assert ds[1].static == {'id': 1}
+    # The recording itself stays untouched: the edit lives only in the log
+    assert DiskEpisode(root / '000000000000' / '000000000000').static == {'id': 0}
+
+
+def test_set_static_edit_last_write_wins(tmp_path):
+    root = tmp_path / 'ds'
+    ds = build_dataset_with_signal(root, [0])
+    uid = ds[0].meta['uid']
+
+    w = LocalDatasetWriter(root)
+    w.set_static(uid, {'verdict': 'fail', 'notes': 'first'})
+    w.set_static(uid, {'verdict': 'success'})
+
+    ds = LocalDataset(root)
+    assert ds[0]['verdict'] == 'success'
+    assert ds[0]['notes'] == 'first'
+
+
+def test_set_static_edit_colliding_with_signal_raises(tmp_path):
+    root = tmp_path / 'ds'
+    ds = build_dataset_with_signal(root, [0])
+    LocalDatasetWriter(root).set_static(ds[0].meta['uid'], {'signal': 1})
+
+    ds = LocalDataset(root)
+    with pytest.raises(ValueError, match='collide with signals'):
+        _ = ds[0].static
+
+
+def test_set_static_edit_for_unknown_uid_is_inert(tmp_path):
+    root = tmp_path / 'ds'
+    build_dataset_with_signal(root, [0])
+    LocalDatasetWriter(root).set_static('no-such-uid', {'verdict': 'success'})
+
+    ds = LocalDataset(root)
+    assert ds[0].static == {'id': 0}
+
+
+def test_set_static_edit_rejects_invalid_values(tmp_path):
+    with pytest.raises(ValueError, match='JSON-serializable'):
+        LocalDatasetWriter(tmp_path / 'ds').set_static('uid', {'bad': object()})
+
+
+def test_corrupt_edit_record_raises(tmp_path):
+    (tmp_path / EDITS_FILE).write_text('{"op": "set_static", "v": 1, "ep": "x", "data": {', encoding='utf-8')
+    with pytest.raises(ValueError, match='Corrupt edit record'):
+        LocalDataset(tmp_path)
+
+
+def test_unsupported_edit_record_raises(tmp_path):
+    (tmp_path / EDITS_FILE).write_text('{"op": "trim", "v": 1, "ep": "x", "start": 0}\n', encoding='utf-8')
+    with pytest.raises(ValueError, match='Unsupported edit record'):
+        LocalDataset(tmp_path)

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -486,23 +486,29 @@ def test_set_static_edit_rejects_invalid_values(tmp_path):
 
 
 def test_corrupt_edit_record_raises(tmp_path):
-    (tmp_path / EDITS_FILE).write_text('{"op": "set_static", "v": 1, "ep": "x", "data": {', encoding='utf-8')
+    root = tmp_path / 'ds'
+    build_dataset_with_signal(root, [0])
+    (root / EDITS_FILE).write_text('{"op": "set_static", "v": 1, "ep": "x", "data": {', encoding='utf-8')
     with pytest.raises(ValueError, match='Corrupt edit record'):
-        LocalDataset(tmp_path)
+        LocalDataset(root)
 
 
 def test_unsupported_edit_record_raises(tmp_path):
-    (tmp_path / EDITS_FILE).write_text('{"op": "trim", "v": 1, "ep": "x", "start": 0}\n', encoding='utf-8')
+    root = tmp_path / 'ds'
+    build_dataset_with_signal(root, [0])
+    (root / EDITS_FILE).write_text('{"op": "trim", "v": 1, "ep": "x", "start": 0}\n', encoding='utf-8')
     with pytest.raises(ValueError, match='Unsupported edit record'):
-        LocalDataset(tmp_path)
+        LocalDataset(root)
 
 
 def test_edit_record_with_invalid_static_values_raises(tmp_path):
-    (tmp_path / EDITS_FILE).write_text(
+    root = tmp_path / 'ds'
+    build_dataset_with_signal(root, [0])
+    (root / EDITS_FILE).write_text(
         '{"op": "set_static", "v": 1, "ep": "x", "data": {"maybe": null}}\n', encoding='utf-8'
     )
     with pytest.raises(ValueError, match='Invalid static values'):
-        LocalDataset(tmp_path)
+        LocalDataset(root)
 
 
 def test_load_all_datasets_propagates_corrupt_edit_log(tmp_path):
@@ -511,3 +517,10 @@ def test_load_all_datasets_propagates_corrupt_edit_log(tmp_path):
     (tmp_path / 'ds2' / EDITS_FILE).write_text('garbage', encoding='utf-8')
     with pytest.raises(ValueError, match='Corrupt edit record'):
         load_all_datasets(tmp_path)
+
+
+def test_load_all_datasets_ignores_edit_log_outside_datasets(tmp_path):
+    build_dataset_with_signal(tmp_path / 'ds1', [0, 1])
+    (tmp_path / EDITS_FILE).write_text('garbage', encoding='utf-8')
+    result = load_all_datasets(tmp_path)
+    assert episode_ids(result[:]) == [0, 1]

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -476,8 +476,11 @@ def test_set_static_edit_for_unknown_uid_is_inert(tmp_path):
 
 
 def test_set_static_edit_rejects_invalid_values(tmp_path):
+    w = LocalDatasetWriter(tmp_path / 'ds')
     with pytest.raises(ValueError, match='JSON-serializable'):
-        LocalDatasetWriter(tmp_path / 'ds').set_static('uid', {'bad': object()})
+        w.set_static('uid', {'bad': object()})
+    with pytest.raises(ValueError, match='non-empty string'):
+        w.set_static(None, {'verdict': 'ok'})
 
 
 def test_corrupt_edit_record_raises(tmp_path):

--- a/positronic/dataset/tests/test_remote.py
+++ b/positronic/dataset/tests/test_remote.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 import threading
 import time
 
@@ -137,8 +138,6 @@ def test_episode_sample_endpoint(test_client):
 
 
 def find_free_port():
-    import socket
-
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(('', 0))
         return s.getsockname()[1]
@@ -274,6 +273,7 @@ def test_migrate_remote_dataset_numeric_only(tmp_path):
     dest_ds = LocalDataset(dest_root)
     assert len(dest_ds) == 2
     assert dest_ds[0]['id'] == 0
+    assert dest_ds[0].meta['uid'] == source_ds[0].meta['uid']
     signal = dest_ds[0]['signal']
     assert len(signal) == 3
     np.testing.assert_allclose(signal[0][0], [0])

--- a/positronic/dataset/tests/test_remote.py
+++ b/positronic/dataset/tests/test_remote.py
@@ -12,6 +12,7 @@ import pytest
 import uvicorn
 from fastapi.testclient import TestClient
 
+from positronic.dataset.edits import EditedDataset
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.remote import RemoteDataset
 from positronic.dataset.remote_server import server as remote_server
@@ -182,6 +183,14 @@ def test_remote_dataset_episode_static(running_server):
         ep = ds[0]
         assert ep['task'] == 'task_0'
         assert ep['episode_id'] == 0
+
+
+def test_edited_dataset_over_remote_base(running_server):
+    with RemoteDataset(running_server) as ds:
+        edited = EditedDataset(ds, {ds[0].meta['uid']: {'verdict': 'success'}})
+        assert edited[0]['verdict'] == 'success'
+        assert edited[0]['task'] == 'task_0'
+        assert 'verdict' not in edited[1]
 
 
 def test_remote_dataset_signal_access(running_server):

--- a/positronic/dataset/utilities/migrate_remote.py
+++ b/positronic/dataset/utilities/migrate_remote.py
@@ -38,8 +38,8 @@ def migrate_dataset(source: Dataset, dest_path: str, profile=None) -> int:
 
     with LocalDatasetWriter(resolved_path) as writer:
         for episode in tqdm.tqdm(source, total=len(source), desc=f'Migrating → {dest_path}'):
-            created_ts_ns = episode.meta.get('created_ts_ns')
-            with writer.new_episode(created_ts_ns=created_ts_ns) as ew:
+            meta = episode.meta
+            with writer.new_episode(created_ts_ns=meta.get('created_ts_ns'), uid=meta.get('uid')) as ew:
                 for key, value in episode.static.items():
                     ew.set_static(key, value)
 


### PR DESCRIPTION
## Summary
- **Identity: `meta['uid']`.** Every episode is stamped with a uuid4 hex at recording; episodes lacking one (recorded earlier) derive a stable `ts-<created_ts_ns>` uid from their recording timestamp. The uid is carried through copies (`migrate_dataset`, `new_episode(uid=...)`) and passes through transforms and the remote protocol untouched — position in a dataset is access, the uid is reference.
- **The edit layer lives in its own module, `positronic/dataset/edits.py`.** Recordings are immutable; post-hoc facts (operator verdicts, analysis scores) are *edits*: records appended to `edits.jsonl` in the dataset directory — one JSON record per line, `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}`, log order with last-write-wins per key. `edits.set_static(root, uid, data)` appends; `load_edits(root)` parses.
- **Application is composition.** `EditedDataset(base, edits)` / `EditedEpisode` wrap any `Dataset`/`Episode` — local, remote — merging each episode's edits over its recorded statics. The one-liner loaders `load_dataset(root)`, `load_all_datasets(root)`, and `cfg.ds.local` compose `LocalDataset` + a discovered log automatically; `LocalDataset` itself always reads the raw recordings.
- **The record contract is enforced at every boundary**: write-side rejects bad uids, non-mapping payloads, and non-static values; read-side fails loudly on corrupt lines, unknown ops/versions, and invalid values; an edit key colliding with a signal name raises at episode load; a stray log in a non-dataset directory never aborts discovery.
- Docs: `positronic/dataset/AGENTS.md` gains the layering principles (one API over many backends; backend → edits → transforms → consumer); `README.md` gains a user-facing Layers section, the uid meta entry, and the editing guide.

## Test plan
- `uv run --locked pytest --no-cov`: 567 passed, 7 skipped locally. New tests cover uid stamping/carry-over/derivation, edit application and recording immutability, last-write-wins, signal-name collision, unknown-uid inertness, write/read validation, discovery behavior with corrupt and stray logs, and `EditedDataset` over both local and remote bases.