### PR TITLE
Add privileged `done` stop-signal for early trial termination

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -96,7 +96,10 @@ def main(
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
     with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
         privileged = task.privileged if task is not None else {}
-        ds_agent = wire.wire_embodiment(world, harness, embodiment, dataset_writer, time_mode, privileged=privileged)
+        done = task.done if task is not None else None
+        ds_agent = wire.wire_embodiment(
+            world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
+        )
         if gui is not None:
             # HACK: GUI cameras are matched to observations by the `image.` name prefix, which
             # hard-binds GUI wiring to the observation naming convention. TODO: resolve this

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -81,6 +81,11 @@ class Task:
     runner derives per-trial seeds from it into the trial plan. ``reset`` re-randomizes
     the scene for a new trial from a per-trial seed; ``None`` on real embodiments,
     where reset is physical/human.
+
+    ``done`` is the optional terminating signal: a source that delivers a dict payload when the
+    trial ends. The Harness reads it to stop the trial early and records the payload into the
+    episode's static data; ``None`` for tasks with no programmatic terminator (real evals, where
+    the operator stops).
     """
 
     instruction: str
@@ -88,6 +93,7 @@ class Task:
     privileged: dict[str, Observation] = field(default_factory=dict)
     seed: int | None = None
     reset: Callable[[int | None], None] | None = None
+    done: pimm.SignalEmitter | None = None
 
 
 @dataclass

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -84,8 +84,7 @@ class Task:
 
     ``done`` is the optional terminating signal: a source that delivers a dict payload when the
     trial ends. The Harness reads it to stop the trial early and records the payload into the
-    episode's static data; ``None`` for tasks with no programmatic terminator (real evals, where
-    the operator stops).
+    episode's static data.
     """
 
     instruction: str

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -126,11 +126,8 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
-        # Privileged stop-signal for self-driven trials: a fresh delivery within a trial's budget ends it,
+        # Privileged stop-signal: any delivery within a trial's time budget ends it,
         # recording ``eval.terminated`` True plus the delivered dict in the episode's static data.
-        # Edge-triggered on the message's ``updated`` flag, so a consumed value can't re-fire; the run loop
-        # reads it only while a deadline is live, so it never terminates (or leaks into) an attended episode.
-        # Unconnected, it never fires.
         self.done = pimm.ControlSystemReceiver[dict](self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -59,6 +59,9 @@ class Harness(pimm.ControlSystem):
     plan is exhausted, so the unattended path needs no driver at all. Attended drivers own episode
     termination themselves; directive-driven trials get no deadline.
 
+    Either path ends early when the privileged ``done`` stop-signal goes truthy: a trial that ends
+    on it records ``eval.terminated`` True, a timed-out one False.
+
     The ``Embodiment`` provides the observation serializers (which own the canonical key names),
     the command channels, and the home action; the harness reads them to assemble inputs and demux
     actions, treating every channel alike.
@@ -122,6 +125,9 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
+        # Privileged stop-signal: a truthy value ends the live trial with ``eval.terminated`` True
+        # (the timeout path sets it False). Defaults False, so an unconnected port never terminates.
+        self.done = pimm.ControlSystemReceiver[bool](self, default=False)
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
         meta = dict(self._embodiment.static_meta)
@@ -330,9 +336,13 @@ class Harness(pimm.ControlSystem):
                 yield from self._handle_directive(Directive.RUN(**trial), clock)
                 self._deadline = clock.now() + self._task.timeout
 
-            if self._running and self._deadline is not None and clock.now() >= self._deadline:
-                # Time budget exhausted: ``eval.terminated`` is False — timed out rather than stop-signal terminated.
-                yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': False}), clock)
+            if self._running:
+                # A live trial ends on the privileged stop-signal or on its time budget (self-driven
+                # only; attended trials carry no deadline). ``eval.terminated`` records which.
+                stop = bool(self.done.value)
+                timed_out = self._deadline is not None and clock.now() >= self._deadline
+                if stop or timed_out:
+                    yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': stop}), clock)
 
             try:
                 if self._running:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -59,8 +59,8 @@ class Harness(pimm.ControlSystem):
     plan is exhausted, so the unattended path needs no driver at all. Attended drivers own episode
     termination themselves; directive-driven trials get no deadline.
 
-    Either path ends early when the privileged ``done`` stop-signal goes truthy: a trial that ends
-    on it records ``eval.terminated`` True, a timed-out one False.
+    Either path ends early when the privileged ``done`` signal is delivered: the trial records
+    ``eval.terminated`` True and the delivered payload in its static data, a timed-out one False.
 
     The ``Embodiment`` provides the observation serializers (which own the canonical key names),
     the command channels, and the home action; the harness reads them to assemble inputs and demux
@@ -125,10 +125,10 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
-        # Privileged stop-signal, edge-triggered: a freshly emitted truthy value ends the live trial
-        # with ``eval.terminated`` True (the timeout path sets it False). A value latched from a prior
-        # trial reads as not-updated and cannot re-fire. Defaults False, so an unconnected port is inert.
-        self.done = pimm.ControlSystemReceiver[bool](self, default=False)
+        # Privileged stop-signal, edge-triggered: delivering it (a fresh ``updated`` message) ends the
+        # live trial and records ``eval.terminated`` True plus the delivered dict in the episode's static
+        # data. A latch from a prior trial reads as not-updated and cannot re-fire; unconnected, it never fires.
+        self.done = pimm.ControlSystemReceiver[dict](self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
         meta = dict(self._embodiment.static_meta)
@@ -338,13 +338,15 @@ class Harness(pimm.ControlSystem):
                 self._deadline = clock.now() + self._task.timeout
 
             if self._running:
-                # A live trial ends on a freshly emitted stop-signal or on its time budget (self-driven
-                # only; attended trials carry no deadline). ``eval.terminated`` records which.
-                stop_msg = self.done.read()
-                stop = stop_msg.updated and bool(stop_msg.data)
+                # A live trial ends when ``done`` is delivered (a fresh message) or on its time budget
+                # (self-driven only; attended trials carry no deadline). A delivered ``done`` records
+                # ``eval.terminated`` True plus its payload; a timeout records False.
+                done_msg = self.done.read()
                 timed_out = self._deadline is not None and clock.now() >= self._deadline
-                if stop or timed_out:
-                    yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': stop}), clock)
+                if done_msg.updated or timed_out:
+                    payload = dict(done_msg.data) if done_msg.updated else {}
+                    payload['eval.terminated'] = done_msg.updated
+                    yield from self._handle_directive(Directive.FINISH(**payload), clock)
 
             try:
                 if self._running:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -59,8 +59,9 @@ class Harness(pimm.ControlSystem):
     plan is exhausted, so the unattended path needs no driver at all. Attended drivers own episode
     termination themselves; directive-driven trials get no deadline.
 
-    Either path ends early when the privileged ``done`` signal is delivered: the trial records
-    ``eval.terminated`` True and the delivered payload in its static data, a timed-out one False.
+    A self-driven trial also ends early when the privileged ``done`` signal is delivered within its
+    budget: it records ``eval.terminated`` True and the delivered payload in its static data, a
+    timed-out one False. Attended episodes ignore ``done`` — the operator's directives end them.
 
     The ``Embodiment`` provides the observation serializers (which own the canonical key names),
     the command channels, and the home action; the harness reads them to assemble inputs and demux
@@ -125,9 +126,11 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
-        # Privileged stop-signal: a fresh delivery during a live trial ends it, recording ``eval.terminated``
-        # True plus the delivered dict in the episode's static data. Edge-triggered on the message's
-        # ``updated`` flag, so a value consumed by a prior trial can't re-fire. Unconnected, it never fires.
+        # Privileged stop-signal for self-driven trials: a fresh delivery within a trial's budget ends it,
+        # recording ``eval.terminated`` True plus the delivered dict in the episode's static data.
+        # Edge-triggered on the message's ``updated`` flag, so a consumed value can't re-fire; the run loop
+        # reads it only while a deadline is live, so it never terminates (or leaks into) an attended episode.
+        # Unconnected, it never fires.
         self.done = pimm.ControlSystemReceiver[dict](self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -337,19 +340,17 @@ class Harness(pimm.ControlSystem):
                 yield from self._handle_directive(Directive.RUN(**trial), clock)
                 self._deadline = clock.now() + self._task.timeout
 
-            if self._running:
-                # A live trial ends on a ``done`` delivered within the time budget, or on the budget
-                # itself (self-driven only; attended trials carry no deadline). The deadline is hard: a
-                # ``done`` that lands after it is a timeout, not a late success. A fresh in-budget delivery
-                # records ``eval.terminated`` True plus its payload; a timeout records only False.
+            # Trial termination is the self-driven mechanism: a live trial ends on a ``done`` delivered
+            # within its budget, or on the budget itself. The deadline is hard, so a ``done`` past it is a
+            # timeout, not a late success — an in-budget delivery records ``eval.terminated`` True plus its
+            # payload, a timeout records only False. Attended episodes carry no deadline and are ended by
+            # the operator's directives, so ``done`` never terminates (or leaks across) them.
+            if self._running and self._deadline is not None:
                 done_msg = self.done.read()
-                delivered_in_budget = done_msg.updated and (
-                    self._deadline is None or done_msg.ts <= self._deadline * 1e9
-                )
-                if delivered_in_budget:
+                if done_msg.updated and done_msg.ts <= self._deadline * 1e9:
                     payload = {**done_msg.data, 'eval.terminated': True}
                     yield from self._handle_directive(Directive.FINISH(**payload), clock)
-                elif self._deadline is not None and clock.now() >= self._deadline:
+                elif clock.now() >= self._deadline:
                     yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': False}), clock)
 
             try:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -338,12 +338,15 @@ class Harness(pimm.ControlSystem):
                 self._deadline = clock.now() + self._task.timeout
 
             if self._running:
-                # A live trial ends when ``done`` is delivered or on its time budget (self-driven only;
-                # attended trials carry no deadline). A fresh delivery records ``eval.terminated`` True plus
-                # its payload; a timeout records only False — never the receiver's last value, which may be
-                # a stale payload from a prior trial.
+                # A live trial ends on a ``done`` delivered within the time budget, or on the budget
+                # itself (self-driven only; attended trials carry no deadline). The deadline is hard: a
+                # ``done`` that lands after it is a timeout, not a late success. A fresh in-budget delivery
+                # records ``eval.terminated`` True plus its payload; a timeout records only False.
                 done_msg = self.done.read()
-                if done_msg.updated:
+                delivered_in_budget = done_msg.updated and (
+                    self._deadline is None or done_msg.ts <= self._deadline * 1e9
+                )
+                if delivered_in_budget:
                     payload = {**done_msg.data, 'eval.terminated': True}
                     yield from self._handle_directive(Directive.FINISH(**payload), clock)
                 elif self._deadline is not None and clock.now() >= self._deadline:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -113,9 +113,6 @@ class Harness(pimm.ControlSystem):
         # Self-driven trials are bounded by ``task.timeout``; attended drivers own termination
         # themselves, so directive-driven trials get no deadline.
         self._deadline: float | None = None
-        # A ``done`` delivered during the live trial, latched here with its recorded payload so the run
-        # loop and a mid-step recheck observe the same stop. None means no stop pending for this trial.
-        self._pending_stop: dict[str, Any] | None = None
 
         self._descriptor = embodiment.descriptor
         self.observations = pimm.ReceiverDict(self)
@@ -128,9 +125,9 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
-        # Privileged stop-signal: delivered (a fresh message) during a live trial, it ends the trial and
-        # records ``eval.terminated`` True plus the delivered dict in the episode's static data.
-        # Unconnected, it never fires.
+        # Privileged stop-signal: a fresh delivery during a live trial ends it, recording ``eval.terminated``
+        # True plus the delivered dict in the episode's static data. Edge-triggered on the message's
+        # ``updated`` flag, so a value consumed by a prior trial can't re-fire. Unconnected, it never fires.
         self.done = pimm.ControlSystemReceiver[dict](self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -195,20 +192,6 @@ class Harness(pimm.ControlSystem):
         self._cancel_trajectories()
         self.ds_command.emit(DsWriterCommand.STOP(payload))
 
-    def _poll_done(self) -> None:
-        """Latch a freshly delivered ``done`` into ``_pending_stop`` so the run loop and a mid-step recheck
-        observe the same stop. A non-fresh read (nothing delivered, or a value latched earlier) is ignored."""
-        msg = self.done.read()
-        if msg.updated:
-            self._pending_stop = dict(msg.data)
-
-    def _reset_stop_signal(self) -> None:
-        """Begin a trial with no pending stop: forget the prior payload and discard any ``done`` queued
-        while idle, so only a delivery during the live trial terminates it."""
-        self._pending_stop = None
-        while self.done.read().updated:
-            pass
-
     def _handle_directive(self, directive: Directive, clock: pimm.Clock) -> Generator[pimm.Command, None, None]:
         """Handle a directive, yielding any necessary pauses; updates ``_running``."""
         match directive.type:
@@ -228,7 +211,6 @@ class Harness(pimm.ControlSystem):
                 # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
                 self._inference_latency = self.context.get('inference_latency', False)
                 self._deadline = None  # set by the run loop for self-driven trials only
-                self._reset_stop_signal()
                 if self._session:
                     self._session.close()
                 self._session = self.policy.new_session(self.context)
@@ -327,12 +309,11 @@ class Harness(pimm.ControlSystem):
             yield pimm.Sleep(delay)
             actions = [{**a, 'timestamp': a['timestamp'] + delay} for a in actions]
             self._bump_schedule_end(delay)
-            self._poll_done()  # a ``done`` delivered during the latency sleep must drop this chunk
 
-        # Recheck termination: the latency sleep (or a slow inference call on a real clock) may have
-        # crossed the deadline or seen a ``done`` delivery. Drop the chunk rather than emit past the
-        # trial's end — the run loop fires the FINISH on its next cycle.
-        if self._pending_stop is not None or (self._deadline is not None and clock.now() >= self._deadline):
+        # Recheck the deadline: the latency sleep (or a slow inference call on a real clock) may have
+        # crossed it. Drop the chunk rather than emit past the advertised self-termination point —
+        # the run loop fires the timeout FINISH on its next cycle.
+        if self._deadline is not None and clock.now() >= self._deadline:
             return
 
         self._emit_commands(actions)
@@ -360,11 +341,11 @@ class Harness(pimm.ControlSystem):
                 # A live trial ends when ``done`` is delivered or on its time budget (self-driven only;
                 # attended trials carry no deadline). A delivered ``done`` records ``eval.terminated`` True
                 # plus its payload; a timeout records False.
-                self._poll_done()
+                done_msg = self.done.read()
                 timed_out = self._deadline is not None and clock.now() >= self._deadline
-                stopped = self._pending_stop is not None
-                if stopped or timed_out:
-                    payload = {**(self._pending_stop or {}), 'eval.terminated': stopped}
+                if done_msg.updated or timed_out:
+                    payload = dict(done_msg.data) if done_msg.updated else {}
+                    payload['eval.terminated'] = done_msg.updated
                     yield from self._handle_directive(Directive.FINISH(**payload), clock)
 
             try:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -125,8 +125,9 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
-        # Privileged stop-signal: a truthy value ends the live trial with ``eval.terminated`` True
-        # (the timeout path sets it False). Defaults False, so an unconnected port never terminates.
+        # Privileged stop-signal, edge-triggered: a freshly emitted truthy value ends the live trial
+        # with ``eval.terminated`` True (the timeout path sets it False). A value latched from a prior
+        # trial reads as not-updated and cannot re-fire. Defaults False, so an unconnected port is inert.
         self.done = pimm.ControlSystemReceiver[bool](self, default=False)
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -337,9 +338,10 @@ class Harness(pimm.ControlSystem):
                 self._deadline = clock.now() + self._task.timeout
 
             if self._running:
-                # A live trial ends on the privileged stop-signal or on its time budget (self-driven
+                # A live trial ends on a freshly emitted stop-signal or on its time budget (self-driven
                 # only; attended trials carry no deadline). ``eval.terminated`` records which.
-                stop = bool(self.done.value)
+                stop_msg = self.done.read()
+                stop = stop_msg.updated and bool(stop_msg.data)
                 timed_out = self._deadline is not None and clock.now() >= self._deadline
                 if stop or timed_out:
                     yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': stop}), clock)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -113,6 +113,9 @@ class Harness(pimm.ControlSystem):
         # Self-driven trials are bounded by ``task.timeout``; attended drivers own termination
         # themselves, so directive-driven trials get no deadline.
         self._deadline: float | None = None
+        # A ``done`` delivered during the live trial, latched here with its recorded payload so the run
+        # loop and a mid-step recheck observe the same stop. None means no stop pending for this trial.
+        self._pending_stop: dict[str, Any] | None = None
 
         self._descriptor = embodiment.descriptor
         self.observations = pimm.ReceiverDict(self)
@@ -125,9 +128,9 @@ class Harness(pimm.ControlSystem):
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
-        # Privileged stop-signal, edge-triggered: delivering it (a fresh ``updated`` message) ends the
-        # live trial and records ``eval.terminated`` True plus the delivered dict in the episode's static
-        # data. A latch from a prior trial reads as not-updated and cannot re-fire; unconnected, it never fires.
+        # Privileged stop-signal: delivered (a fresh message) during a live trial, it ends the trial and
+        # records ``eval.terminated`` True plus the delivered dict in the episode's static data.
+        # Unconnected, it never fires.
         self.done = pimm.ControlSystemReceiver[dict](self, default={})
 
     def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -192,6 +195,20 @@ class Harness(pimm.ControlSystem):
         self._cancel_trajectories()
         self.ds_command.emit(DsWriterCommand.STOP(payload))
 
+    def _poll_done(self) -> None:
+        """Latch a freshly delivered ``done`` into ``_pending_stop`` so the run loop and a mid-step recheck
+        observe the same stop. A non-fresh read (nothing delivered, or a value latched earlier) is ignored."""
+        msg = self.done.read()
+        if msg.updated:
+            self._pending_stop = dict(msg.data)
+
+    def _reset_stop_signal(self) -> None:
+        """Begin a trial with no pending stop: forget the prior payload and discard any ``done`` queued
+        while idle, so only a delivery during the live trial terminates it."""
+        self._pending_stop = None
+        while self.done.read().updated:
+            pass
+
     def _handle_directive(self, directive: Directive, clock: pimm.Clock) -> Generator[pimm.Command, None, None]:
         """Handle a directive, yielding any necessary pauses; updates ``_running``."""
         match directive.type:
@@ -211,6 +228,7 @@ class Harness(pimm.ControlSystem):
                 # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
                 self._inference_latency = self.context.get('inference_latency', False)
                 self._deadline = None  # set by the run loop for self-driven trials only
+                self._reset_stop_signal()
                 if self._session:
                     self._session.close()
                 self._session = self.policy.new_session(self.context)
@@ -309,11 +327,12 @@ class Harness(pimm.ControlSystem):
             yield pimm.Sleep(delay)
             actions = [{**a, 'timestamp': a['timestamp'] + delay} for a in actions]
             self._bump_schedule_end(delay)
+            self._poll_done()  # a ``done`` delivered during the latency sleep must drop this chunk
 
-        # Recheck the deadline: the latency sleep (or a slow inference call on a real clock) may have
-        # crossed it. Drop the chunk rather than emit past the advertised self-termination point —
-        # the run loop fires the timeout FINISH on its next cycle.
-        if self._deadline is not None and clock.now() >= self._deadline:
+        # Recheck termination: the latency sleep (or a slow inference call on a real clock) may have
+        # crossed the deadline or seen a ``done`` delivery. Drop the chunk rather than emit past the
+        # trial's end — the run loop fires the FINISH on its next cycle.
+        if self._pending_stop is not None or (self._deadline is not None and clock.now() >= self._deadline):
             return
 
         self._emit_commands(actions)
@@ -338,14 +357,14 @@ class Harness(pimm.ControlSystem):
                 self._deadline = clock.now() + self._task.timeout
 
             if self._running:
-                # A live trial ends when ``done`` is delivered (a fresh message) or on its time budget
-                # (self-driven only; attended trials carry no deadline). A delivered ``done`` records
-                # ``eval.terminated`` True plus its payload; a timeout records False.
-                done_msg = self.done.read()
+                # A live trial ends when ``done`` is delivered or on its time budget (self-driven only;
+                # attended trials carry no deadline). A delivered ``done`` records ``eval.terminated`` True
+                # plus its payload; a timeout records False.
+                self._poll_done()
                 timed_out = self._deadline is not None and clock.now() >= self._deadline
-                if done_msg.updated or timed_out:
-                    payload = dict(done_msg.data) if done_msg.updated else {}
-                    payload['eval.terminated'] = done_msg.updated
+                stopped = self._pending_stop is not None
+                if stopped or timed_out:
+                    payload = {**(self._pending_stop or {}), 'eval.terminated': stopped}
                     yield from self._handle_directive(Directive.FINISH(**payload), clock)
 
             try:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -339,14 +339,15 @@ class Harness(pimm.ControlSystem):
 
             if self._running:
                 # A live trial ends when ``done`` is delivered or on its time budget (self-driven only;
-                # attended trials carry no deadline). A delivered ``done`` records ``eval.terminated`` True
-                # plus its payload; a timeout records False.
+                # attended trials carry no deadline). A fresh delivery records ``eval.terminated`` True plus
+                # its payload; a timeout records only False — never the receiver's last value, which may be
+                # a stale payload from a prior trial.
                 done_msg = self.done.read()
-                timed_out = self._deadline is not None and clock.now() >= self._deadline
-                if done_msg.updated or timed_out:
-                    payload = dict(done_msg.data) if done_msg.updated else {}
-                    payload['eval.terminated'] = done_msg.updated
+                if done_msg.updated:
+                    payload = {**done_msg.data, 'eval.terminated': True}
                     yield from self._handle_directive(Directive.FINISH(**payload), clock)
+                elif self._deadline is not None and clock.now() >= self._deadline:
+                    yield from self._handle_directive(Directive.FINISH(**{'eval.terminated': False}), clock)
 
             try:
                 if self._running:

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -497,6 +497,35 @@ def test_trial_stop_signal_terminates(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_stop_signal_does_not_latch_across_trials(world):
+    """A ``done`` that ended one trial must not instantly finalize the next: the stop-signal is
+    edge-triggered, so the value latched in the receiver from trial 0 cannot re-fire on trial 1."""
+    policy = StubPolicy()
+    harness = Harness(policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{}, {}])
+    p = _pair_all(world, harness)
+    done_em = world.pair(harness.done)
+
+    def stop_count():
+        return len([c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE])
+
+    scheduler = world.start([harness])
+    drive_scheduler(scheduler, steps=5)
+    done_em.emit(True)  # end trial 0
+    drive_scheduler(scheduler, steps=10)
+    assert stop_count() == 1
+
+    # Trial 1 has auto-started with trial 0's True still latched in the receiver; it must keep running.
+    drive_scheduler(scheduler, steps=10)
+    assert stop_count() == 1
+
+    done_em.emit(True)  # end trial 1
+    drive_scheduler(scheduler, steps=10)
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 2
+    assert all(s.static_data['eval.terminated'] is True for s in stops)
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
     """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
     eval-identity block land in episode meta."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -574,6 +574,34 @@ def test_task_done_terminates_through_wire_embodiment(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_done_after_deadline_is_a_timeout(world):
+    """The deadline is hard: a ``done`` delivered past it (here during the latency sleep) records as a
+    timeout — ``eval.terminated`` False, payload dropped — not a late stop-signal success."""
+    policy = StubPolicy()
+    harness = Harness(
+        policy, make_embodiment(), task=Task(instruction='t', timeout=0.05), trials=[{'inference_latency': 0.2}]
+    )
+    p = _pair_all(world, harness)
+    done_em = world.pair(harness.done)
+
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    # Obs starts inference + the 0.2s latency sleep; the 0.05s deadline lapses during it, and done is
+    # delivered at ~0.1s — past the deadline but before the harness next polls. The timeout must win.
+    driver = ManualDriver([
+        (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.1),
+        (partial(done_em.emit, {'eval.success': True}), 0.3),
+        (None, 0.0),
+    ])
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=200)
+
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.terminated'] is False
+    assert 'eval.success' not in stops[0].static_data
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
     """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
     eval-identity block land in episode meta."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -528,6 +528,66 @@ def test_stop_signal_does_not_latch_across_trials(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_idle_done_does_not_terminate_next_trial(world):
+    """A ``done`` delivered while the harness is idle is drained on RUN, not carried into the trial
+    that starts after it; the fresh episode keeps running until its own stop-signal or timeout."""
+    policy = StubPolicy()
+    harness = Harness(policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{}])
+    p = _pair_all(world, harness)
+    done_em = world.pair(harness.done)
+
+    scheduler = world.start([harness])
+    done_em.emit({})  # delivered before the trial starts — must not finalize it
+    drive_scheduler(scheduler, steps=15)
+
+    starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(starts) == 1
+    assert len(stops) == 0
+
+
+@pytest.mark.timeout(3.0)
+def test_done_during_latency_sleep_drops_chunk(world):
+    """A ``done`` delivered during the inference-latency sleep drops the in-flight chunk: the recheck
+    after the sleep must observe the stop, so no post-termination action reaches the drivers."""
+    policy = StubPolicy()
+    harness = Harness(
+        policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{'inference_latency': 0.2}]
+    )
+    cmd_recorder = RecordingEmitter()
+    grip_recorder = RecordingEmitter()
+    ds_recorder = RecordingEmitter()
+    harness.commands['robot_command']._bind(cmd_recorder)
+    harness.commands['target_grip']._bind(grip_recorder)
+    harness.ds_command._bind(ds_recorder)
+
+    frame_em = world.pair(harness.observations['image.cam'])
+    robot_em = world.pair(harness.observations['robot_state'])
+    grip_em = world.pair(harness.observations['grip'])
+    done_em = world.pair(harness.done)
+
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+
+    # Complete obs starts inference and the 0.2s latency sleep; done is delivered at 0.1s — during the
+    # sleep, after the pre-step poll. The just-computed chunk must be dropped, never emitted.
+    driver = ManualDriver([
+        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
+        (partial(done_em.emit, {}), 0.1),
+        (None, 0.3),
+    ])
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=200)
+
+    stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.terminated'] is True
+    # The post-termination chunk must not reach the drivers: the only non-empty emissions are the
+    # homing Reset / 0.0 grip from the FINISH.
+    assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))
+    assert _emitted_grips(grip_recorder) == [0.0]
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
     """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
     eval-identity block land in episode meta."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -475,7 +475,7 @@ def test_trial_timeout_self_terminates(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_stop_signal_terminates(world):
-    """The privileged ``done`` signal ends a self-driven trial early: terminated=True, robot homed."""
+    """Delivering the privileged ``done`` ends a trial early: terminated=True, payload recorded, homed."""
     policy = StubPolicy()
     # Timeout far in the future so the stop-signal, not the clock, ends the trial.
     harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=100.0), trials=[{}])
@@ -487,19 +487,21 @@ def test_trial_stop_signal_terminates(world):
     # Trial is live and unbounded by the clock: nothing committed yet.
     assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
 
-    done_em.emit(True)
+    done_em.emit({'eval.success': True})
     drive_scheduler(scheduler, steps=10)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
     assert stops[0].static_data['eval.terminated'] is True
+    assert stops[0].static_data['eval.success'] is True  # the delivered payload lands in static data
     assert isinstance(_last_command(p), Reset)
 
 
 @pytest.mark.timeout(3.0)
 def test_stop_signal_does_not_latch_across_trials(world):
-    """A ``done`` that ended one trial must not instantly finalize the next: the stop-signal is
-    edge-triggered, so the value latched in the receiver from trial 0 cannot re-fire on trial 1."""
+    """A ``done`` that ended one trial must not instantly finalize the next: termination is the
+    delivery edge, so the message latched in the receiver from trial 0 cannot re-fire on trial 1.
+    An empty payload still terminates — delivery, not truthiness, is the signal."""
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{}, {}])
     p = _pair_all(world, harness)
@@ -510,15 +512,15 @@ def test_stop_signal_does_not_latch_across_trials(world):
 
     scheduler = world.start([harness])
     drive_scheduler(scheduler, steps=5)
-    done_em.emit(True)  # end trial 0
+    done_em.emit({})  # end trial 0
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
-    # Trial 1 has auto-started with trial 0's True still latched in the receiver; it must keep running.
+    # Trial 1 has auto-started with trial 0's message still latched in the receiver; it must keep running.
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
-    done_em.emit(True)  # end trial 1
+    done_em.emit({})  # end trial 1
     drive_scheduler(scheduler, steps=10)
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -528,66 +528,6 @@ def test_stop_signal_does_not_latch_across_trials(world):
 
 
 @pytest.mark.timeout(3.0)
-def test_idle_done_does_not_terminate_next_trial(world):
-    """A ``done`` delivered while the harness is idle is drained on RUN, not carried into the trial
-    that starts after it; the fresh episode keeps running until its own stop-signal or timeout."""
-    policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{}])
-    p = _pair_all(world, harness)
-    done_em = world.pair(harness.done)
-
-    scheduler = world.start([harness])
-    done_em.emit({})  # delivered before the trial starts — must not finalize it
-    drive_scheduler(scheduler, steps=15)
-
-    starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
-    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert len(starts) == 1
-    assert len(stops) == 0
-
-
-@pytest.mark.timeout(3.0)
-def test_done_during_latency_sleep_drops_chunk(world):
-    """A ``done`` delivered during the inference-latency sleep drops the in-flight chunk: the recheck
-    after the sleep must observe the stop, so no post-termination action reaches the drivers."""
-    policy = StubPolicy()
-    harness = Harness(
-        policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{'inference_latency': 0.2}]
-    )
-    cmd_recorder = RecordingEmitter()
-    grip_recorder = RecordingEmitter()
-    ds_recorder = RecordingEmitter()
-    harness.commands['robot_command']._bind(cmd_recorder)
-    harness.commands['target_grip']._bind(grip_recorder)
-    harness.ds_command._bind(ds_recorder)
-
-    frame_em = world.pair(harness.observations['image.cam'])
-    robot_em = world.pair(harness.observations['robot_state'])
-    grip_em = world.pair(harness.observations['grip'])
-    done_em = world.pair(harness.done)
-
-    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
-
-    # Complete obs starts inference and the 0.2s latency sleep; done is delivered at 0.1s — during the
-    # sleep, after the pre-step poll. The just-computed chunk must be dropped, never emitted.
-    driver = ManualDriver([
-        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
-        (partial(done_em.emit, {}), 0.1),
-        (None, 0.3),
-    ])
-    scheduler = world.start([harness, driver])
-    drive_scheduler(scheduler, steps=200)
-
-    stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
-    assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is True
-    # The post-termination chunk must not reach the drivers: the only non-empty emissions are the
-    # homing Reset / 0.0 grip from the FINISH.
-    assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))
-    assert _emitted_grips(grip_recorder) == [0.0]
-
-
-@pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
     """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
     eval-identity block land in episode meta."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import pimm
+from positronic import wire
 from positronic.dataset.ds_writer_agent import DsWriterCommand, DsWriterCommandType
 from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
@@ -525,6 +526,51 @@ def test_stop_signal_does_not_latch_across_trials(world):
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2
     assert all(s.static_data['eval.terminated'] is True for s in stops)
+
+
+@pytest.mark.timeout(3.0)
+def test_task_done_terminates_through_wire_embodiment(world):
+    """A Task's ``done`` source reaches ``harness.done`` through ``wire_embodiment`` and ends the
+    trial, recording its payload — the production wiring path, not a direct port pairing."""
+
+    class _Device(pimm.ControlSystem):
+        def __init__(self):
+            self.state = pimm.ControlSystemEmitter(self)
+            self.cmd = pimm.ControlSystemReceiver(self)
+            self.done = pimm.ControlSystemEmitter(self)
+
+        def run(self, should_stop, clock):
+            n = 0
+            while not should_stop.value:
+                self.state.emit(0.0)
+                n += 1
+                if n == 5:
+                    self.done.emit({'eval.success': True})
+                yield pimm.Sleep(0.01)
+
+    device = _Device()
+    embodiment = Embodiment(
+        descriptor='',
+        observations={'x': Observation(device.state, None)},
+        commands={'x': Command(device.cmd, 0.0, None)},
+        static_meta={},
+        meta_source=None,
+    )
+    task = Task(instruction='t', timeout=100.0, done=device.done)
+    # Termination is independent of the policy wrappers; the minimal embodiment has no
+    # ``robot_state``, so skip the default ErrorRecovery/ChunkedSchedule pipeline.
+    harness = Harness(StubPolicy(), embodiment, task=task, trials=[{}], wrap=None)
+    ds_recorder = RecordingEmitter()
+    harness.ds_command._bind(ds_recorder)
+    wire.wire_embodiment(world, harness, embodiment, None, done=task.done)
+
+    scheduler = world.start([harness, device])
+    drive_scheduler(scheduler, steps=60)
+
+    stops = [d for _, d in ds_recorder.emitted if d.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.terminated'] is True
+    assert stops[0].static_data['eval.success'] is True
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -474,6 +474,29 @@ def test_trial_timeout_self_terminates(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_trial_stop_signal_terminates(world):
+    """The privileged ``done`` signal ends a self-driven trial early: terminated=True, robot homed."""
+    policy = StubPolicy()
+    # Timeout far in the future so the stop-signal, not the clock, ends the trial.
+    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=100.0), trials=[{}])
+    p = _pair_all(world, harness)
+    done_em = world.pair(harness.done)
+
+    scheduler = world.start([harness])
+    drive_scheduler(scheduler, steps=5)
+    # Trial is live and unbounded by the clock: nothing committed yet.
+    assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+
+    done_em.emit(True)
+    drive_scheduler(scheduler, steps=10)
+
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.terminated'] is True
+    assert isinstance(_last_command(p), Reset)
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
     """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
     eval-identity block land in episode meta."""

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -67,12 +67,14 @@ def wire_embodiment(
     dataset_writer: DatasetWriter | None,
     time_mode: TimeMode = TimeMode.CLOCK,
     privileged: dict[str, Observation] | None = None,
+    done: pimm.SignalEmitter | None = None,
 ):
     """Wire an embodiment to the Harness for the inference path.
 
     Connects device observation sources -> ``harness.observations`` and
     ``harness.commands`` -> device receivers, and records observations, command
-    chunks, and the task's privileged ground-truth into the dataset. GUI camera wiring
+    chunks, and the task's privileged ground-truth into the dataset. The task's ``done``
+    terminating signal, when present, is connected to ``harness.done``. GUI camera wiring
     stays with the caller — it is a presentation concern, not part of the embodiment contract.
     """
     privileged = privileged or {}
@@ -82,6 +84,8 @@ def wire_embodiment(
         world.connect(harness.commands[name], cmd.dest)
     if embodiment.meta_source is not None:
         world.connect(embodiment.meta_source, harness.robot_meta_in)
+    if done is not None:
+        world.connect(done, harness.done)
 
     ds_agent = None
     if dataset_writer is not None:


### PR DESCRIPTION
## Summary
First PR (10a) of the external-benchmark eval integration chain: the deferred step-4 hook that lets a privileged `done` signal end a trial early.

- `Harness` gains a public `done` receiver (`ControlSystemReceiver[bool]`, default `False`). While a trial is live, a truthy value ends it via `FINISH`, recording `eval.terminated=True`; the existing timeout path records `eval.terminated=False`. The stop-signal works in attended *and* self-driven modes (the timeout remains self-driven-only, since attended trials carry no deadline).
- **Behavior-additive:** no eval has a `done` producer yet, so the port stays unconnected → default `False` → no early termination anywhere today. The real producer is the sim env control system, which lands in a later PR — this PR deliberately adds only the consumer side (no `Task` field, no `wire.py` change).

## Test plan
- `test_trial_stop_signal_terminates` (sibling of `test_trial_timeout_self_terminates`): a synthetic `done` producer fires `True` before a 100s timeout; asserts exactly one `STOP_EPISODE` with `eval.terminated is True` and the robot homed.
- Full suite: `uv run --locked pytest --no-cov` → 579 passed, 7 skipped.