### PR TITLE
Document the DreamZero wan2.2 convert→train→serve pipeline

### DIFF
--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -23,9 +23,9 @@ Pick the backbone with `--backbone` at both train and serve time; **it must matc
 | **Inference** | 1× H100 (80GB) | wan2.2 (5B) ≈ half the VRAM of wan2.1 (14B, ~52GB bf16) |
 | **Training** | 1× or 8× H100 | Full fine-tune or LoRA, DeepSpeed ZeRO-2. Single-H100 full fine-tune works (see presets) |
 
-Train and serve run on an H100 box you reach through a Docker context (see
-[`docker/CONTEXTS.md`](../../../docker/CONTEXTS.md)). The examples below call it `--context <h100>` —
-substitute your own context name. (The Nebius serverless alternative is in the [Appendix](#appendix-nebius-serverless).)
+Train and serve run on an H100 box you reach through a Docker context. The examples below call it
+`--context <h100>` — substitute your own context name. (The Nebius serverless alternative is in the
+[Appendix](#appendix-nebius-serverless).)
 
 ## Zero-shot inference (wan2.1 DROID checkpoint)
 
@@ -58,14 +58,13 @@ the Docker Compose services in [`docker/docker-compose.yml`](../../../docker/doc
 H100 box. Run the `docker compose` commands from the `docker/` directory.
 
 **Prerequisites:**
-- An H100 box reachable via a Docker context ([`docker/CONTEXTS.md`](../../../docker/CONTEXTS.md)); set
-  `CACHE_ROOT` to that box's home so the `~/.cache` and `~/.aws` mounts resolve (S3 credentials come from
-  the mounted `~/.aws`).
-- **Images** are pulled pre-built and do **not** mount local source, so a code change needs a rebuild +
-  push first: convert runs on `positro/positronic` (rebuild with `make push-training`); train and serve run
-  on `positro/dreamzero` (rebuild with `make push-dreamzero-base` then `make push-dreamzero`). A change to
-  `codecs.py` touches both. CI pushes `:latest` and the `main` commit SHA; pin a SHA via `IMAGE_TAG`
-  (e.g. `IMAGE_TAG=dc5e837`) for a reproducible run. See [`docker/Makefile`](../../../docker/Makefile).
+- An H100 box reachable via a Docker context; set `CACHE_ROOT` to that box's home so the `~/.cache` and
+  `~/.aws` mounts resolve (S3 credentials come from the mounted `~/.aws`).
+- **Images**: the commands pull the public prebuilt images by default — `positro/positronic` (convert) and
+  `positro/dreamzero` (train/serve) at the production `:latest` tag — so there is nothing to build. Only if
+  you have **local repo changes** to test do you build and push your own image and pass `IMAGE_TAG=<your-tag>`;
+  otherwise omit it. A `codecs.py` change affects both images. (Maintainer build targets:
+  [`docker/Makefile`](../../../docker/Makefile).)
 - The `s3://interim/…` / `s3://checkpoints/…` paths below are Positronic-internal buckets — substitute your own.
 
 ### 1. Convert the dataset
@@ -87,6 +86,10 @@ CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm lerobot-0_3_3-c
 `dreamzero-train` runs `python -m positronic.vendors.dreamzero.train`, streaming the dataset from
 `--input_path`. Presets (defined in [`train.py`](./train.py)) fix backbone + architecture + GPU count:
 
+> **Only `wan22_full` (wan2.2 full fine-tune) is validated** — that is the configuration these docs were
+> built from. We did **not** get LoRA working, and the `wan2.1` presets are untested here. The other presets
+> exist in code but should be treated as unverified.
+
 | Preset | Backbone | Arch | GPUs | Resumable |
 |--------|----------|------|------|-----------|
 | `wan22_full_h100x1` | wan2.2 (5B) | full | 1 | No — warm-start to continue |
@@ -99,7 +102,7 @@ CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm lerobot-0_3_3-c
 
 ```bash
 cd docker
-CACHE_ROOT=/home/vertix IMAGE_TAG=dc5e837 docker --context <h100> compose run --rm dreamzero-train \
+CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm dreamzero-train \
   wan22_full_h100x1 \
   --input_path=s3://interim/sim_stack/dreamzero/joints_ik \
   --output_path=s3://checkpoints/sim_stack/dreamzero/ \
@@ -128,7 +131,7 @@ API on `8000`:
 
 ```bash
 cd docker
-CACHE_ROOT=/home/vertix IMAGE_TAG=dc5e837 docker --context <h100> compose run --rm --service-ports dreamzero-server \
+CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm --service-ports dreamzero-server \
   --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
   --backbone=wan2.2
 ```
@@ -190,8 +193,8 @@ that decodes to a `JointPosition` command. They differ only in how **training la
 If you run on Nebius serverless instead of your own H100 box, the **same recipe** (same presets, codec, and
 args) goes through the `workflows/nebius/*.sh` wrappers — Jobs for convert/train, an Endpoint for serving.
 See [`workflows/nebius/README.md`](../../../workflows/nebius/README.md) for the one-time setup (Nebius CLI
-auth, S3 / MysteryBox credentials, the shared cache filesystem) and `NEBIUS_*` overrides; pin the image with
-`NEBIUS_IMAGE_TAG=<sha>`.
+auth, S3 / MysteryBox credentials, the shared cache filesystem) and `NEBIUS_*` overrides. It uses the
+production image by default; set `NEBIUS_IMAGE_TAG=<tag>` only to test a specific build.
 
 ```bash
 # Convert (CPU job)
@@ -201,7 +204,7 @@ bash workflows/nebius/convert.sh lerobot_0_3_3 \
   --output_dir=s3://interim/sim_stack/dreamzero/joints_ik/
 
 # Train (H100 job; ~3 days for 30k steps on one H100 — size the timeout accordingly)
-NEBIUS_IMAGE_TAG=dc5e837 NEBIUS_JOB_TIMEOUT=96h \
+NEBIUS_JOB_TIMEOUT=96h \
 bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
   --input_path=s3://interim/sim_stack/dreamzero/joints_ik \
   --output_path=s3://checkpoints/sim_stack/dreamzero/ \
@@ -209,7 +212,7 @@ bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
   --max_steps=30000 --save_steps=2500 --gradient_accumulation_steps=4 --save_total_limit=9999
 
 # Serve (H100 endpoint; the public endpoint is exposed on :8000)
-NEBIUS_IMAGE_TAG=dc5e837 bash workflows/nebius/serve.sh dreamzero <endpoint-name> \
+bash workflows/nebius/serve.sh dreamzero <endpoint-name> \
   --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
   --backbone=wan2.2
 # ... infer against the printed endpoint IP with --policy.port=8000, then tear down:

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -177,7 +177,9 @@ that decodes to a `JointPosition` command. They differ only in how **training la
 
 ## Technical Details
 
-- **Action space**: absolute joint positions (7 DoF) + gripper (1)
+- **Action space**: 7-DoF joint targets + gripper. DreamZero predicts the joints **relative to the current
+  state** (`relative_action: true` on `joint_position` in the `droid_relative_wan22` data config); the
+  absolute joint target is reconstructed from the current state at serve time and decoded to a `JointPosition`.
 - **Observation**: 3 cameras (2 exterior + 1 wrist) + joint state + language prompt; 320×160 (wan2.2),
   320×176 (wan2.1). The wan2.2 trainer sets `image_resolution_height=160` and resizes at load, so the
   codec's intermediate `(320, 176)` does not need a per-backbone override.

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -1,58 +1,178 @@
 # DreamZero in Positronic
 
-> **Status: Work in Progress** – DreamZero integration is functional for inference and training but has not been validated in production evaluations. Not included in PhAIL v1.0 results.
+> **Status: Work in Progress** – DreamZero integration is functional for inference and training but
+> has not been validated in production evaluations. Not included in PhAIL v1.0 results.
 
 ## What is DreamZero?
 
-[DreamZero](https://github.com/dreamzero0/dreamzero) is NVIDIA's 14B-parameter World Action Model that jointly predicts actions and future video frames, enabling zero-shot generalization to new tasks and environments. The pretrained checkpoint (`GEAR-Dreams/DreamZero-DROID`) is trained on the DROID dataset.
+[DreamZero](https://github.com/dreamzero0/dreamzero) is NVIDIA's World Action Model: it jointly
+predicts actions and future video frames, conditioning on a short window of past frames (an
+autoregressive video context). Two backbones are wired up here:
+
+| Backbone | Params | Image (W×H) | Notes |
+|----------|--------|-------------|-------|
+| `wan2.1` | 14B | 320×176 | Default server checkpoint `GEAR-Dreams/DreamZero-DROID` (trained on DROID); DiT caching supported |
+| `wan2.2` | 5B | 320×160 | Causal chunked inference; what the Positronic fine-tunes below use |
+
+Pick the backbone with `--backbone` at both train and serve time; **it must match between the two**.
 
 ## Hardware Requirements
 
 | Phase | Requirement | Notes |
 |-------|-------------|-------|
-| **Inference** | 1× H100 (80GB) | ~52GB VRAM in bf16; multi-GPU via `--num_gpus=N` |
-| **Training** | 4-8× H100 | LoRA or full fine-tune with DeepSpeed ZeRO-2 |
+| **Inference** | 1× H100 (80GB) | wan2.2 (5B) ≈ half the VRAM of wan2.1 (14B, ~52GB bf16) |
+| **Training** | 1× or 8× H100 | Full fine-tune or LoRA, DeepSpeed ZeRO-2. Single-H100 full fine-tune works (see presets) |
 
-## Quick Start
+## Zero-shot inference (wan2.1 DROID checkpoint)
+
+To try the pretrained DROID model with no training:
 
 ```bash
-# 1. Start an H100 VM
-../internal/scripts/start.sh dreamzero
-
-# 2. Start DreamZero server (checkpoint auto-downloaded on first start)
+# 1. Start an H100 box (see ../internal/scripts/start.sh) or use the Nebius serve path below.
+# 2. Serve the default checkpoint (auto-downloaded on first start, ~10-20 min via HuggingFace).
 cd docker
 CACHE_ROOT=/home/vertix docker --context vm-dreamzero compose run --rm --service-ports dreamzero-server
 
-# 3. Run sim inference locally
-uv run positronic-inference sim \
-  --policy=.remote \
-  --policy.host=vm-dreamzero \
-  --policy.port=8000 \
+# 3. Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
+uv run --locked positronic-inference sim \
+  --policy=.remote --policy.host=vm-dreamzero --policy.port=8000 \
   --wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers \
-  --eval.timeout=20 \
-  --show_gui=True
+  --trial_count=2 --show_gui=True
 ```
 
-The server owns the codec (`server` defaults to `codec=joints`), so the client sends raw
-observations and receives decoded joint commands — don't pass `--policy.codec` here or it
-double-encodes and the first request fails. `--wrap` is client-side: it supplies the AR video
-context (`TemporalFrameStack`), which must run every control tick to record frames, so without it
-the model loses the multi-frame history it conditions on.
+The server owns the codec (`server` defaults to `codec=joints`), so the client sends raw observations
+and receives decoded joint commands — **don't** pass `--policy.codec` here or it double-encodes and the
+first request fails. `--wrap` is client-side: it supplies the AR video context (`TemporalFrameStack`),
+which must run every control tick to record frames, so without it the model loses the multi-frame
+history it conditions on.
 
-First start downloads the 14B checkpoint via HuggingFace (~10-20 min). Subsequent starts use cache.
+## Full pipeline (fine-tune your own checkpoint)
 
-## Available Codecs
+The end-to-end loop is **convert → train → serve → infer → view**. Convert runs on CPU; train and
+serve run on H100. The cloud wrappers live in `workflows/nebius/` (see the `remote-training` skill and
+`workflows/nebius/README.md`); pass `NEBIUS_IMAGE_TAG=<tag>` to pin the image (CI pushes `:latest` and
+the commit SHA from `main` — pin to a SHA, e.g. `dc5e837`, for a reproducible long run).
 
-| Codec | Observation | Action | Use Case |
-|-------|-------------|--------|----------|
-| `joints` | Joint positions + grip + 3 cameras | Absolute joint position | Default for DROID checkpoint |
-| `joints_traj` | Same (320×176) | Trajectory (recorded state) | Training data conversion and trajectory inference |
+### 1. Convert the dataset
+
+The DreamZero codecs reuse the shared `lerobot_0_3_3` converter. The sim stack-cubes dataset is
+converted with the `joints_ik_sim` codec (joint targets reconstructed from recorded EE-pose targets
+via the `dm_control` IK solver):
+
+```bash
+bash workflows/nebius/convert.sh lerobot_0_3_3 \
+  --dataset.dataset=@positronic.cfg.ds.sim.sim_stack_cubes \
+  --dataset.codec=@positronic.vendors.dreamzero.codecs.joints_ik_sim \
+  --output_dir=s3://interim/sim_stack/dreamzero/joints_ik/
+```
+
+### 2. Train
+
+`train.sh dreamzero <preset> [args]` runs `python -m positronic.vendors.dreamzero.train` as an H100
+job, streaming the dataset from `--input_path` via `pos3`. Presets fix backbone + architecture + GPU
+count:
+
+| Preset | Backbone | Arch | GPUs | Resumable |
+|--------|----------|------|------|-----------|
+| `wan22_full_h100x1` | wan2.2 (5B) | full | 1 | No — warm-start to continue |
+| `wan22_full_h100x8` | wan2.2 (5B) | full | 8 | Optimizer state not restored |
+| `wan22_lora_h100x1` | wan2.2 (5B) | LoRA | 1 | LoRA trains from zero |
+| `wan22_lora_h100x8` | wan2.2 (5B) | LoRA | 8 | Yes (optimizer restored) |
+| `wan21_*` | wan2.1 (14B) | full / LoRA | 1 / 8 | As above |
+
+Multi-GPU presets need a matching Nebius preset (`*_h100x8` runs `torchrun --nproc_per_node=8`, so set
+`NEBIUS_PRESET=8gpu-128vcpu-1600gb`).
+
+**Fresh run** (from the base backbone):
+
+```bash
+NEBIUS_IMAGE_TAG=dc5e837 NEBIUS_JOB_TIMEOUT=96h \
+bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
+  --input_path=s3://interim/sim_stack/dreamzero/joints_ik \
+  --output_path=s3://checkpoints/sim_stack/dreamzero/ \
+  --exp_name=<exp_name> \
+  --max_steps=30000 --save_steps=2500 --gradient_accumulation_steps=4 --save_total_limit=9999
+```
+
+Checkpoints land at `s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step>`.
+
+**Warm-start** from a prior run's weights (fresh optimizer + schedule) — the only way to extend an
+`h100x1` full fine-tune, since it can't restore DeepSpeed state:
+
+```bash
+  ... wan22_full_h100x1 ... \
+  --init_from_checkpoint=s3://checkpoints/sim_stack/dreamzero/<prior_exp>/checkpoint-<step>
+```
+
+`h100x1` full fine-tune uses `save_only_model=true` (skips DeepSpeed's ~91GB native checkpoint), so a
+run must reach `--max_steps` in one shot — size `NEBIUS_JOB_TIMEOUT` accordingly (~3 days for 30k
+steps on one H100 at the observed throughput).
+
+### 3. Serve a checkpoint
+
+The server downloads `--model_path` (an `s3://` checkpoint or HF repo) via `pos3` and **needs
+`--backbone` to match training**. Two paths:
+
+```bash
+# A. Nebius serverless endpoint (public IP, auto-released on stop)
+NEBIUS_IMAGE_TAG=dc5e837 bash workflows/nebius/serve.sh dreamzero <endpoint-name> \
+  --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
+  --backbone=wan2.2
+# ... run inference against the printed IP, then:
+bash workflows/nebius/stop.sh <endpoint-name>
+
+# B. Docker compose on a GPU box (no per-hour serverless cost)
+cd docker
+CACHE_ROOT=/home/vertix IMAGE_TAG=dc5e837 \
+docker --context vm-dreamzero compose run --rm --service-ports dreamzero-server \
+  --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
+  --backbone=wan2.2
+```
+
+Sanity-check once warm: `curl http://<host>:8000/api/v1/models` → `{"models": ["<model_path>"]}`.
+
+### 4. Run sim inference
+
+```bash
+uv run --locked positronic-inference sim \
+  --policy=.remote --policy.host=<host> --policy.port=8000 \
+  --wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers \
+  --trial_count=<N> --output_dir=<dir-or-s3-path>
+```
+
+`<host>` is the Nebius endpoint IP or the docker context hostname (`vm-dreamzero`). Each episode records
+3 camera views + joint/EE/grip signals under `<output_dir>`.
+
+### 5. View results
+
+```bash
+uv run --locked python -m positronic.cfg.analysis sim \
+  --dataset.base.path=<output_dir> --port=5001 --https --reset_cache
+# → https://localhost:5001
+```
+
+Point `--dataset.base.path` at a parent directory to compare several runs side by side.
+
+## Codecs
+
+All four share the same observation encoder (3 cameras + joint state) and the same inference decode —
+the model emits a flat `(joints+grip)` vector that decodes to a `JointPosition` command. They differ
+only in how **training labels** are built:
+
+| Codec | Training label | Use case |
+|-------|----------------|----------|
+| `joints` | Commanded joints (`robot_command.joints`) + grip | Default; commanded-action targets |
+| `joints_traj` | Recorded state (`robot_state.q`) + grip | Trajectory / executed-state targets |
+| `joints_ik` | Joints solved from recorded EE-pose targets via IK (`dls_limits` solver) | EE-driven datasets |
+| `joints_ik_sim` | `joints_ik` with the `dm_control` IK solver | Sim datasets (used for `sim_stack_cubes`) |
 
 ## Technical Details
 
-- **Action space**: Absolute joint positions (7 DoF) + gripper (1)
-- **Observation**: 3 cameras (2 exterior + 1 wrist) at 320×176 + joint state + language prompt
-- **Action horizon**: 24 timesteps per inference
+- **Action space**: absolute joint positions (7 DoF) + gripper (1)
+- **Observation**: 3 cameras (2 exterior + 1 wrist) + joint state + language prompt; 320×160 (wan2.2),
+  320×176 (wan2.1)
+- **Action horizon**: 24 timesteps per inference; the `dreamzero_wrappers` re-query aligns the
+  chunk schedule with the AR frame-stack window
 - **Wire protocol**: roboarena WebSocket + msgpack-numpy
-- **Inference latency**: ~5s on 1× H100 (with DiT caching)
-- **No fork needed**: Uses Hydra YAML configs, injectable from outside
+- **DiT caching**: wan2.1 only (skipped for wan2.2)
+- **No fork needed**: Hydra YAML configs, injectable from outside

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -23,24 +23,23 @@ Pick the backbone with `--backbone` at both train and serve time; **it must matc
 | **Inference** | 1× H100 (80GB) | wan2.2 (5B) ≈ half the VRAM of wan2.1 (14B, ~52GB bf16) |
 | **Training** | 1× or 8× H100 | Full fine-tune or LoRA, DeepSpeed ZeRO-2. Single-H100 full fine-tune works (see presets) |
 
+Train and serve run on an H100 box you reach through a Docker context (see
+[`docker/CONTEXTS.md`](../../../docker/CONTEXTS.md)). The examples below call it `--context <h100>` —
+substitute your own context name. (The Nebius serverless alternative is in the [Appendix](#appendix-nebius-serverless).)
+
 ## Zero-shot inference (wan2.1 DROID checkpoint)
 
-To try the pretrained DROID model with no training. `vm-dreamzero` is a Positronic-internal Docker
-context for an H100 box; external users provision their own H100 and add a context (see
-[`docker/CONTEXTS.md`](../../../docker/CONTEXTS.md)), or use the [Nebius serve path](#3-serve-a-checkpoint)
-below. `CACHE_ROOT` must be the **remote** box's home directory. `positronic-inference` comes from
-`uv sync` (see [Installation](../../../README.md#installation)).
+To try the pretrained DROID model with no training. `positronic-inference` comes from `uv sync` (see
+[Installation](../../../README.md#installation)); `CACHE_ROOT` must be the **remote** box's home directory.
 
 ```bash
-# 1. Start an H100 box (Positronic-internal: ../internal/scripts/start.sh dreamzero; otherwise
-#    provision your own H100 and add a docker context).
-# 2. Serve the default checkpoint (auto-downloaded on first start, ~10-20 min via HuggingFace).
+# Serve the default checkpoint on your H100 box (auto-downloaded on first start, ~10-20 min via HuggingFace).
 cd docker
-CACHE_ROOT=/home/vertix docker --context vm-dreamzero compose run --rm --service-ports dreamzero-server
+CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm --service-ports dreamzero-server
 
-# 3. Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
+# Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
 uv run --locked positronic-inference sim \
-  --policy=.remote --policy.host=vm-dreamzero --policy.port=8000 \
+  --policy=.remote --policy.host=<h100> --policy.port=8000 \
   --wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers \
   --trial_count=2 --show_gui=True
 ```
@@ -54,27 +53,30 @@ so omitting it strips the multi-frame history the model conditions on. (Server c
 
 ## Full pipeline (fine-tune your own checkpoint)
 
-This is Positronic's standard [convert → train → serve → infer](../../../docs/training-workflow.md) loop.
-Convert runs on CPU; train and serve run on H100. The cloud wrappers live in `workflows/nebius/` — see
-[`workflows/nebius/README.md`](../../../workflows/nebius/README.md) for the one-time setup it assumes
-(Nebius CLI auth, S3 / MysteryBox credentials, the shared cache filesystem) and the `NEBIUS_*` overrides.
-The `s3://interim/…` and `s3://checkpoints/…` paths below are Positronic-internal buckets — substitute
-your own.
+The end-to-end loop — [convert → train → serve → infer](../../../docs/training-workflow.md) — runs through
+the Docker Compose services in [`docker/docker-compose.yml`](../../../docker/docker-compose.yml) on your
+H100 box. Run the `docker compose` commands from the `docker/` directory.
 
-**Image:** the wrappers pull `positro/dreamzero:${NEBIUS_IMAGE_TAG:-latest}`, which does not mount local
-source, so a code change needs a rebuild + push first — `make push-dreamzero-base` then
-`make push-dreamzero IMAGE_TAG=<tag>` (see [`docker/README.md`](../../../docker/README.md) /
-[`docker/Makefile`](../../../docker/Makefile)). CI pushes `:latest` and the `main` commit SHA
-(e.g. `dc5e837`); pin a SHA via `NEBIUS_IMAGE_TAG` for a reproducible long run.
+**Prerequisites:**
+- An H100 box reachable via a Docker context ([`docker/CONTEXTS.md`](../../../docker/CONTEXTS.md)); set
+  `CACHE_ROOT` to that box's home so the `~/.cache` and `~/.aws` mounts resolve (S3 credentials come from
+  the mounted `~/.aws`).
+- **Images** are pulled pre-built and do **not** mount local source, so a code change needs a rebuild +
+  push first: convert runs on `positro/positronic` (rebuild with `make push-training`); train and serve run
+  on `positro/dreamzero` (rebuild with `make push-dreamzero-base` then `make push-dreamzero`). A change to
+  `codecs.py` touches both. CI pushes `:latest` and the `main` commit SHA; pin a SHA via `IMAGE_TAG`
+  (e.g. `IMAGE_TAG=dc5e837`) for a reproducible run. See [`docker/Makefile`](../../../docker/Makefile).
+- The `s3://interim/…` / `s3://checkpoints/…` paths below are Positronic-internal buckets — substitute your own.
 
 ### 1. Convert the dataset
 
-The DreamZero codecs reuse the shared `lerobot_0_3_3` converter. The sim stack-cubes dataset is
-converted with the `joints_ik_sim` codec (joint targets reconstructed from recorded EE-pose targets
-via the `dm_control` IK solver):
+The DreamZero codecs reuse the shared `lerobot_0_3_3` converter (a CPU step — run it on any box, or locally
+with `uv run`). The sim stack-cubes dataset is converted with the `joints_ik_sim` codec (joint targets
+reconstructed from recorded EE-pose targets via the `dm_control` IK solver):
 
 ```bash
-bash workflows/nebius/convert.sh lerobot_0_3_3 \
+cd docker
+CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm lerobot-0_3_3-convert convert \
   --dataset.dataset=@positronic.cfg.ds.sim.sim_stack_cubes \
   --dataset.codec=@positronic.vendors.dreamzero.codecs.joints_ik_sim \
   --output_dir=s3://interim/sim_stack/dreamzero/joints_ik/
@@ -82,9 +84,8 @@ bash workflows/nebius/convert.sh lerobot_0_3_3 \
 
 ### 2. Train
 
-`train.sh dreamzero <preset> [args]` runs `python -m positronic.vendors.dreamzero.train` as an H100
-job, streaming the dataset from `--input_path`. Presets (defined in [`train.py`](./train.py)) fix
-backbone + architecture + GPU count:
+`dreamzero-train` runs `python -m positronic.vendors.dreamzero.train`, streaming the dataset from
+`--input_path`. Presets (defined in [`train.py`](./train.py)) fix backbone + architecture + GPU count:
 
 | Preset | Backbone | Arch | GPUs | Resumable |
 |--------|----------|------|------|-----------|
@@ -94,14 +95,12 @@ backbone + architecture + GPU count:
 | `wan22_lora_h100x8` | wan2.2 (5B) | LoRA | 8 | Yes (optimizer restored) |
 | `wan21_*` | wan2.1 (14B) | full / LoRA | 1 / 8 | As above |
 
-Multi-GPU presets need a matching Nebius preset (`*_h100x8` runs `torchrun --nproc_per_node=8`, so set
-`NEBIUS_PRESET=8gpu-128vcpu-1600gb`).
-
 **Fresh run** (from the base backbone):
 
 ```bash
-NEBIUS_IMAGE_TAG=dc5e837 NEBIUS_JOB_TIMEOUT=96h \
-bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
+cd docker
+CACHE_ROOT=/home/vertix IMAGE_TAG=dc5e837 docker --context <h100> compose run --rm dreamzero-train \
+  wan22_full_h100x1 \
   --input_path=s3://interim/sim_stack/dreamzero/joints_ik \
   --output_path=s3://checkpoints/sim_stack/dreamzero/ \
   --exp_name=<exp_name> \
@@ -111,53 +110,43 @@ bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
 Checkpoints land at `s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step>`.
 
 **Warm-start** from a prior run's weights (fresh optimizer + schedule) — the only way to extend an
-`h100x1` full fine-tune, since it can't restore DeepSpeed state:
+`h100x1` full fine-tune, which uses `save_only_model=true` and can't restore DeepSpeed state, so a run must
+reach `--max_steps` in one shot:
 
 ```bash
-  ... wan22_full_h100x1 ... \
+  ... dreamzero-train wan22_full_h100x1 ... \
   --init_from_checkpoint=s3://checkpoints/sim_stack/dreamzero/<prior_exp>/checkpoint-<step>
 ```
 
-`h100x1` full fine-tune uses `save_only_model=true` (skips DeepSpeed's ~91GB native checkpoint), so a
-run must reach `--max_steps` in one shot — size `NEBIUS_JOB_TIMEOUT` accordingly (~3 days for 30k
-steps on one H100 at the observed throughput).
+Multi-GPU presets (`*_h100x8`) run `torchrun --nproc_per_node=8`, so use them on an 8-GPU box.
 
 ### 3. Serve a checkpoint
 
-The server downloads `--model_path` (an `s3://` checkpoint or HF repo) and **needs `--backbone` to
-match training** (`server` config + defaults: [`server.py`](./server.py); the `dreamzero-server`
-compose service: [`docker/docker-compose.yml`](../../../docker/docker-compose.yml)). Two paths:
+`dreamzero-server` downloads `--model_path` (an `s3://` checkpoint or HF repo) and **needs `--backbone` to
+match training** (config + defaults: [`server.py`](./server.py)). `--service-ports` publishes the WebSocket
+API on `8000`:
 
 ```bash
-# A. Nebius serverless endpoint (public IP, auto-released on stop)
-NEBIUS_IMAGE_TAG=dc5e837 bash workflows/nebius/serve.sh dreamzero <endpoint-name> \
-  --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
-  --backbone=wan2.2
-# ... run inference against the printed IP, then:
-bash workflows/nebius/stop.sh <endpoint-name>
-
-# B. Docker compose on a GPU box (no per-hour serverless cost)
 cd docker
-CACHE_ROOT=/home/vertix IMAGE_TAG=dc5e837 \
-docker --context vm-dreamzero compose run --rm --service-ports dreamzero-server \
+CACHE_ROOT=/home/vertix IMAGE_TAG=dc5e837 docker --context <h100> compose run --rm --service-ports dreamzero-server \
   --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
   --backbone=wan2.2
 ```
 
-Sanity-check once warm: `curl http://<host>:8000/api/v1/models` → `{"models": ["<model_path>"]}`.
+Sanity-check once warm: `curl http://<h100>:8000/api/v1/models` → `{"models": ["<model_path>"]}`.
 
 ### 4. Run sim inference
 
 ```bash
 uv run --locked positronic-inference sim \
-  --policy=.remote --policy.host=<host> --policy.port=8000 \
+  --policy=.remote --policy.host=<h100> --policy.port=8000 \
   --wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers \
   --trial_count=<N> --output_dir=<dir-or-s3-path>
 ```
 
-`<host>` is the Nebius endpoint IP or the docker context hostname (`vm-dreamzero`). Each episode records
-3 camera views + joint/EE/grip signals under `<output_dir>`. See the
-[Inference Guide](../../../docs/inference.md) for the remote-policy protocol and options.
+Sim runs locally on your machine; only inference is remote. Each episode records 3 camera views +
+joint/EE/grip signals under `<output_dir>`. See the [Inference Guide](../../../docs/inference.md) for the
+remote-policy protocol and options.
 
 ### 5. View results
 
@@ -187,10 +176,42 @@ that decodes to a `JointPosition` command. They differ only in how **training la
 
 - **Action space**: absolute joint positions (7 DoF) + gripper (1)
 - **Observation**: 3 cameras (2 exterior + 1 wrist) + joint state + language prompt; 320×160 (wan2.2),
-  320×176 (wan2.1)
+  320×176 (wan2.1). The wan2.2 trainer sets `image_resolution_height=160` and resizes at load, so the
+  codec's intermediate `(320, 176)` does not need a per-backbone override.
 - **Action horizon**: 24 timesteps per inference; the `dreamzero_wrappers` re-query aligns the
   chunk schedule with the AR frame-stack window
 - **Wire protocol**: roboarena WebSocket + msgpack-numpy
 - **DiT caching**: wan2.1 only (skipped for wan2.2)
 - **No Positronic fork**: upstream DreamZero is used unmodified (pinned SHA in [`Dockerfile`](./Dockerfile));
   configs are injected via Hydra YAML. No sibling `../dreamzero` checkout is needed — the image bakes it in.
+
+## Appendix: Nebius serverless
+
+If you run on Nebius serverless instead of your own H100 box, the **same recipe** (same presets, codec, and
+args) goes through the `workflows/nebius/*.sh` wrappers — Jobs for convert/train, an Endpoint for serving.
+See [`workflows/nebius/README.md`](../../../workflows/nebius/README.md) for the one-time setup (Nebius CLI
+auth, S3 / MysteryBox credentials, the shared cache filesystem) and `NEBIUS_*` overrides; pin the image with
+`NEBIUS_IMAGE_TAG=<sha>`.
+
+```bash
+# Convert (CPU job)
+bash workflows/nebius/convert.sh lerobot_0_3_3 \
+  --dataset.dataset=@positronic.cfg.ds.sim.sim_stack_cubes \
+  --dataset.codec=@positronic.vendors.dreamzero.codecs.joints_ik_sim \
+  --output_dir=s3://interim/sim_stack/dreamzero/joints_ik/
+
+# Train (H100 job; ~3 days for 30k steps on one H100 — size the timeout accordingly)
+NEBIUS_IMAGE_TAG=dc5e837 NEBIUS_JOB_TIMEOUT=96h \
+bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
+  --input_path=s3://interim/sim_stack/dreamzero/joints_ik \
+  --output_path=s3://checkpoints/sim_stack/dreamzero/ \
+  --exp_name=<exp_name> \
+  --max_steps=30000 --save_steps=2500 --gradient_accumulation_steps=4 --save_total_limit=9999
+
+# Serve (H100 endpoint; the public endpoint is exposed on :8000)
+NEBIUS_IMAGE_TAG=dc5e837 bash workflows/nebius/serve.sh dreamzero <endpoint-name> \
+  --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
+  --backbone=wan2.2
+# ... infer against the printed endpoint IP with --policy.port=8000, then tear down:
+bash workflows/nebius/stop.sh <endpoint-name>
+```

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -45,13 +45,12 @@ uv run --locked positronic-inference sim \
   --trial_count=2 --show_gui=True
 ```
 
-The server owns the codec (`server` defaults to `codec=joints`), so the client sends raw observations
-and receives decoded joint commands — **don't** pass `--policy.codec` here or it double-encodes and the
-first request fails. `--wrap` is client-side: it supplies the AR video context (`TemporalFrameStack`),
-which must run every control tick to record frames, so without it the model loses the multi-frame
-history it conditions on. (`codec`/`backbone` defaults live in [`server.py`](./server.py);
-`dreamzero_wrappers` / `TemporalFrameStack` in [`codecs.py`](./codecs.py).) The
-[Inference Guide](../../../docs/inference.md) explains how `--policy=.remote` reaches a WebSocket server.
+The server owns the codec, so you don't pass one client-side — it takes raw observations and returns
+decoded joint commands. The client-side piece that matters is `--wrap`: it supplies the model's
+autoregressive video context (`TemporalFrameStack`) and must run every control tick to record frames,
+so omitting it strips the multi-frame history the model conditions on. (Server config and defaults:
+[`server.py`](./server.py); wrappers: [`codecs.py`](./codecs.py); remote-policy protocol:
+[Inference Guide](../../../docs/inference.md).)
 
 ## Full pipeline (fine-tune your own checkpoint)
 

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -30,12 +30,14 @@ Train and serve run on an H100 box you reach through a Docker context. The examp
 ## Zero-shot inference (wan2.1 DROID checkpoint)
 
 To try the pretrained DROID model with no training. `positronic-inference` comes from `uv sync` (see
-[Installation](../../../README.md#installation)); `CACHE_ROOT` must be the **remote** box's home directory.
+[Installation](../../../README.md#installation)). Replace `<user>` with your username on the H100 box —
+`CACHE_ROOT` is that box's home, where the mounted `~/.cache` and `~/.aws` live (more in
+[Prerequisites](#full-pipeline-fine-tune-your-own-checkpoint) below).
 
 ```bash
 # Serve the default checkpoint on your H100 box (auto-downloaded on first start, ~10-20 min via HuggingFace).
 cd docker
-CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm --service-ports dreamzero-server
+CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server
 
 # Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
 uv run --locked positronic-inference sim \
@@ -58,8 +60,10 @@ the Docker Compose services in [`docker/docker-compose.yml`](../../../docker/doc
 H100 box. Run the `docker compose` commands from the `docker/` directory.
 
 **Prerequisites:**
-- An H100 box reachable via a Docker context; set `CACHE_ROOT` to that box's home so the `~/.cache` and
-  `~/.aws` mounts resolve (S3 credentials come from the mounted `~/.aws`).
+- An H100 box reachable via a Docker context. The compose services mount `~/.cache` and `~/.aws` from
+  `CACHE_ROOT` (defaults to `$HOME`). With a **remote** context `$HOME` expands to *your* machine, so set
+  `CACHE_ROOT` to the box's home — `/home/<user>` for your account on the box (e.g. `/home/ubuntu`). Run the
+  commands on the box itself and you can omit it. S3 credentials come from the mounted `~/.aws`.
 - **Images**: the commands pull the public prebuilt images by default — `positro/positronic` (convert) and
   `positro/dreamzero` (train/serve) at the production `:latest` tag — so there is nothing to build. Only if
   you have **local repo changes** to test do you build and push your own image and pass `IMAGE_TAG=<your-tag>`;
@@ -75,7 +79,7 @@ reconstructed from recorded EE-pose targets via the `dm_control` IK solver):
 
 ```bash
 cd docker
-CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm lerobot-0_3_3-convert convert \
+CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm lerobot-0_3_3-convert convert \
   --dataset.dataset=@positronic.cfg.ds.sim.sim_stack_cubes \
   --dataset.codec=@positronic.vendors.dreamzero.codecs.joints_ik_sim \
   --output_dir=s3://interim/sim_stack/dreamzero/joints_ik/
@@ -102,7 +106,7 @@ CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm lerobot-0_3_3-c
 
 ```bash
 cd docker
-CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm dreamzero-train \
+CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm dreamzero-train \
   wan22_full_h100x1 \
   --input_path=s3://interim/sim_stack/dreamzero/joints_ik \
   --output_path=s3://checkpoints/sim_stack/dreamzero/ \
@@ -131,7 +135,7 @@ API on `8000`:
 
 ```bash
 cd docker
-CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm --service-ports dreamzero-server \
+CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server \
   --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
   --backbone=wan2.2
 ```

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -112,9 +112,9 @@ CACHE_ROOT=/home/vertix docker --context <h100> compose run --rm dreamzero-train
 
 Checkpoints land at `s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step>`.
 
-**Warm-start** from a prior run's weights (fresh optimizer + schedule) — the only way to extend an
-`h100x1` full fine-tune, which uses `save_only_model=true` and can't restore DeepSpeed state, so a run must
-reach `--max_steps` in one shot:
+**Warm-start** from a prior run's weights to continue training. The DreamZero trainer does not persist
+optimizer state, so resuming restarts Adam from scratch (the optimizer state is lost) — warm-starting just
+loads the weights and accepts a fresh optimizer + schedule, so aim to reach `--max_steps` in one run:
 
 ```bash
   ... dreamzero-train wan22_full_h100x1 ... \
@@ -183,8 +183,7 @@ that decodes to a `JointPosition` command. They differ only in how **training la
   codec's intermediate `(320, 176)` does not need a per-backbone override.
 - **Action horizon**: 24 timesteps per inference; the `dreamzero_wrappers` re-query aligns the
   chunk schedule with the AR frame-stack window
-- **Wire protocol**: roboarena WebSocket + msgpack-numpy
-- **DiT caching**: wan2.1 only (skipped for wan2.2)
+- **Wire protocol**: Positronic's standard WebSocket protocol — see [Connect Your Model](../../../docs/connect-your-model.md)
 - **No Positronic fork**: upstream DreamZero is used unmodified (pinned SHA in [`Dockerfile`](./Dockerfile));
   configs are injected via Hydra YAML. No sibling `../dreamzero` checkout is needed — the image bakes it in.
 

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -25,10 +25,15 @@ Pick the backbone with `--backbone` at both train and serve time; **it must matc
 
 ## Zero-shot inference (wan2.1 DROID checkpoint)
 
-To try the pretrained DROID model with no training:
+To try the pretrained DROID model with no training. `vm-dreamzero` is a Positronic-internal Docker
+context for an H100 box; external users provision their own H100 and add a context (see
+[`docker/CONTEXTS.md`](../../../docker/CONTEXTS.md)), or use the [Nebius serve path](#3-serve-a-checkpoint)
+below. `CACHE_ROOT` must be the **remote** box's home directory. `positronic-inference` comes from
+`uv sync` (see [Installation](../../../README.md#installation)).
 
 ```bash
-# 1. Start an H100 box (see ../internal/scripts/start.sh) or use the Nebius serve path below.
+# 1. Start an H100 box (Positronic-internal: ../internal/scripts/start.sh dreamzero; otherwise
+#    provision your own H100 and add a docker context).
 # 2. Serve the default checkpoint (auto-downloaded on first start, ~10-20 min via HuggingFace).
 cd docker
 CACHE_ROOT=/home/vertix docker --context vm-dreamzero compose run --rm --service-ports dreamzero-server
@@ -44,14 +49,24 @@ The server owns the codec (`server` defaults to `codec=joints`), so the client s
 and receives decoded joint commands — **don't** pass `--policy.codec` here or it double-encodes and the
 first request fails. `--wrap` is client-side: it supplies the AR video context (`TemporalFrameStack`),
 which must run every control tick to record frames, so without it the model loses the multi-frame
-history it conditions on.
+history it conditions on. (`codec`/`backbone` defaults live in [`server.py`](./server.py);
+`dreamzero_wrappers` / `TemporalFrameStack` in [`codecs.py`](./codecs.py).) The
+[Inference Guide](../../../docs/inference.md) explains how `--policy=.remote` reaches a WebSocket server.
 
 ## Full pipeline (fine-tune your own checkpoint)
 
-The end-to-end loop is **convert → train → serve → infer → view**. Convert runs on CPU; train and
-serve run on H100. The cloud wrappers live in `workflows/nebius/` (see the `remote-training` skill and
-`workflows/nebius/README.md`); pass `NEBIUS_IMAGE_TAG=<tag>` to pin the image (CI pushes `:latest` and
-the commit SHA from `main` — pin to a SHA, e.g. `dc5e837`, for a reproducible long run).
+This is Positronic's standard [convert → train → serve → infer](../../../docs/training-workflow.md) loop.
+Convert runs on CPU; train and serve run on H100. The cloud wrappers live in `workflows/nebius/` — see
+[`workflows/nebius/README.md`](../../../workflows/nebius/README.md) for the one-time setup it assumes
+(Nebius CLI auth, S3 / MysteryBox credentials, the shared cache filesystem) and the `NEBIUS_*` overrides.
+The `s3://interim/…` and `s3://checkpoints/…` paths below are Positronic-internal buckets — substitute
+your own.
+
+**Image:** the wrappers pull `positro/dreamzero:${NEBIUS_IMAGE_TAG:-latest}`, which does not mount local
+source, so a code change needs a rebuild + push first — `make push-dreamzero-base` then
+`make push-dreamzero IMAGE_TAG=<tag>` (see [`docker/README.md`](../../../docker/README.md) /
+[`docker/Makefile`](../../../docker/Makefile)). CI pushes `:latest` and the `main` commit SHA
+(e.g. `dc5e837`); pin a SHA via `NEBIUS_IMAGE_TAG` for a reproducible long run.
 
 ### 1. Convert the dataset
 
@@ -69,8 +84,8 @@ bash workflows/nebius/convert.sh lerobot_0_3_3 \
 ### 2. Train
 
 `train.sh dreamzero <preset> [args]` runs `python -m positronic.vendors.dreamzero.train` as an H100
-job, streaming the dataset from `--input_path` via `pos3`. Presets fix backbone + architecture + GPU
-count:
+job, streaming the dataset from `--input_path`. Presets (defined in [`train.py`](./train.py)) fix
+backbone + architecture + GPU count:
 
 | Preset | Backbone | Arch | GPUs | Resumable |
 |--------|----------|------|------|-----------|
@@ -110,8 +125,9 @@ steps on one H100 at the observed throughput).
 
 ### 3. Serve a checkpoint
 
-The server downloads `--model_path` (an `s3://` checkpoint or HF repo) via `pos3` and **needs
-`--backbone` to match training**. Two paths:
+The server downloads `--model_path` (an `s3://` checkpoint or HF repo) and **needs `--backbone` to
+match training** (`server` config + defaults: [`server.py`](./server.py); the `dreamzero-server`
+compose service: [`docker/docker-compose.yml`](../../../docker/docker-compose.yml)). Two paths:
 
 ```bash
 # A. Nebius serverless endpoint (public IP, auto-released on stop)
@@ -141,7 +157,8 @@ uv run --locked positronic-inference sim \
 ```
 
 `<host>` is the Nebius endpoint IP or the docker context hostname (`vm-dreamzero`). Each episode records
-3 camera views + joint/EE/grip signals under `<output_dir>`.
+3 camera views + joint/EE/grip signals under `<output_dir>`. See the
+[Inference Guide](../../../docs/inference.md) for the remote-policy protocol and options.
 
 ### 5. View results
 
@@ -155,9 +172,10 @@ Point `--dataset.base.path` at a parent directory to compare several runs side b
 
 ## Codecs
 
-All four share the same observation encoder (3 cameras + joint state) and the same inference decode —
-the model emits a flat `(joints+grip)` vector that decodes to a `JointPosition` command. They differ
-only in how **training labels** are built:
+A [codec](../../../docs/codecs.md) maps raw recordings into the state/action space a model expects.
+DreamZero's codecs (source: [`codecs.py`](./codecs.py)) all share the same observation encoder
+(3 cameras + joint state) and the same inference decode — the model emits a flat `(joints+grip)` vector
+that decodes to a `JointPosition` command. They differ only in how **training labels** are built:
 
 | Codec | Training label | Use case |
 |-------|----------------|----------|
@@ -175,4 +193,5 @@ only in how **training labels** are built:
   chunk schedule with the AR frame-stack window
 - **Wire protocol**: roboarena WebSocket + msgpack-numpy
 - **DiT caching**: wan2.1 only (skipped for wan2.2)
-- **No fork needed**: Hydra YAML configs, injectable from outside
+- **No Positronic fork**: upstream DreamZero is used unmodified (pinned SHA in [`Dockerfile`](./Dockerfile));
+  configs are injected via Hydra YAML. No sibling `../dreamzero` checkout is needed — the image bakes it in.


### PR DESCRIPTION
## Summary
- Rewrite `positronic/vendors/dreamzero/README.md` to document the full **convert → train → serve → infer → view** pipeline, so the wan2.2 fine-tune flow is reproducible end-to-end.
- Pivot the doc to **wan2.2 (5B) primary**, keeping wan2.1 (14B) as a labeled variant; make `--backbone` (and the requirement that it match between train and serve) explicit.
- Add a **Training** section (presets table, fresh + warm-start commands, the `h100x1` `save_only_model`/non-resumable caveat) and a **serve** section covering both the Nebius serverless and docker-compose paths with `--model_path` + `--backbone`.
- Complete the **codecs** table to all four (`joints`, `joints_traj`, `joints_ik`, `joints_ik_sim`) and note inference decode is identical across them.
- Fix stale wan2.1-only facts: training hardware (single H100 works, not "4–8×"), image dims (320×160 for wan2.2), VRAM, and DiT-cache being wan2.1-only.

The convert step is anchored on the dataset's `run_metadata` (codec `joints_ik_sim`, output `s3://interim/sim_stack/dreamzero/joints_ik/`), but uses the **current** config path `@positronic.cfg.ds.sim.sim_stack_cubes` — the metadata's `cfg.ds.phail` path has since moved, so the doc is runnable rather than literal.

## Test plan
Docs-only change (no code). The documented commands were exercised in practice this session: convert command verified against the dataset `run_metadata`; train/serve/infer/view commands match runs executed against `checkpoint-15000`; the dataset config path was confirmed to resolve (`@positronic.cfg.ds.sim.sim_stack_cubes`).