### PR TITLE
Make public PhAIL teleop convertible under canonical `robot_command.pose`

### DIFF
--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -52,14 +52,19 @@ _SIM_ROBOT_DERIVES = {
     'pose_signals': FromValue(['robot_state.ee_pose', 'robot_command.pose']),
 }
 
-# Expose the arm command under its new canonical name. Datasets on S3 recorded it as the
-# plural `robot_commands.pose`; this surfaces the same signal as `robot_command.pose` for free
-# (lazy, zero-copy). `Get` reads from the old data; on data already using the new name the
-# passthrough Identity wins (it precedes this alias in the Group).
+# Canonical arm-command name is `robot_command.pose`. Recordings already using it pass straight
+# through the Identity (Group prefers the earlier transform on a key clash); this alias backfills
+# the canonical name from the plural `robot_commands.pose` that older recordings stored on disk.
+# The plural is dropped from the output via the Identity `remove` so it never reaches consumers.
 _RENAME_ROBOT_COMMAND = Derive(**{'robot_command.pose': Get('robot_commands.pose', None)})
+_REMOVE_SIGNALS_WITH_LEGACY = [*_REMOVE_SIGNALS, 'robot_commands.pose']
 
-REAL_ROBOT_TRANSFORM = Group(Derive(**_REAL_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS), _RENAME_ROBOT_COMMAND)
-SIM_ROBOT_TRANSFORM = Group(Derive(**_SIM_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS), _RENAME_ROBOT_COMMAND)
+REAL_ROBOT_TRANSFORM = Group(
+    Derive(**_REAL_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS_WITH_LEGACY), _RENAME_ROBOT_COMMAND
+)
+SIM_ROBOT_TRANSFORM = Group(
+    Derive(**_SIM_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS_WITH_LEGACY), _RENAME_ROBOT_COMMAND
+)
 
 RECOVERY_TASK = 'Recovery cases.'
 

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -35,7 +35,10 @@ REAL_URDF = (Path(__file__).resolve().parents[2] / 'drivers' / 'roboarm' / 'fr3.
 _JOINT_NAMES = [f'joint{i}' for i in range(1, 8)]
 _MESH_DIR = Path(package_assets_path('assets/fr3_collision'))
 
-_REMOVE_SIGNALS = ['controller_positions.right']
+# Dropped from the transform output. `robot_commands.pose` is the legacy plural name older
+# recordings used for the arm command; `_RENAME_ROBOT_COMMAND` re-surfaces it as the canonical
+# `robot_command.pose`, so the plural itself should not reach consumers.
+_REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
 _REAL_ROBOT_DERIVES = {
     'urdf': FromValue(REAL_URDF),
     'joint_names': FromValue(_JOINT_NAMES),
@@ -52,19 +55,13 @@ _SIM_ROBOT_DERIVES = {
     'pose_signals': FromValue(['robot_state.ee_pose', 'robot_command.pose']),
 }
 
-# Canonical arm-command name is `robot_command.pose`. Recordings already using it pass straight
-# through the Identity (Group prefers the earlier transform on a key clash); this alias backfills
-# the canonical name from the plural `robot_commands.pose` that older recordings stored on disk.
-# The plural is dropped from the output via the Identity `remove` so it never reaches consumers.
+# Backfill the canonical `robot_command.pose` from the plural name older recordings stored on
+# disk. Recordings already using the canonical name pass through the Identity, which wins on the
+# key clash (Group prefers the earlier transform), so this alias is a no-op for them.
 _RENAME_ROBOT_COMMAND = Derive(**{'robot_command.pose': Get('robot_commands.pose', None)})
-_REMOVE_SIGNALS_WITH_LEGACY = [*_REMOVE_SIGNALS, 'robot_commands.pose']
 
-REAL_ROBOT_TRANSFORM = Group(
-    Derive(**_REAL_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS_WITH_LEGACY), _RENAME_ROBOT_COMMAND
-)
-SIM_ROBOT_TRANSFORM = Group(
-    Derive(**_SIM_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS_WITH_LEGACY), _RENAME_ROBOT_COMMAND
-)
+REAL_ROBOT_TRANSFORM = Group(Derive(**_REAL_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS), _RENAME_ROBOT_COMMAND)
+SIM_ROBOT_TRANSFORM = Group(Derive(**_SIM_ROBOT_DERIVES), Identity(remove=_REMOVE_SIGNALS), _RENAME_ROBOT_COMMAND)
 
 RECOVERY_TASK = 'Recovery cases.'
 

--- a/positronic/cfg/phail/v1_0.py
+++ b/positronic/cfg/phail/v1_0.py
@@ -14,6 +14,7 @@ import configuronic as cfn
 import pos3
 
 from positronic.cfg.ds import group, local_all, transform
+from positronic.cfg.ds.internal import REAL_ROBOT_TRANSFORM
 from positronic.cfg.eval.real.tasks import UNIFIED_TASK
 from positronic.dataset import Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Identity
@@ -41,7 +42,8 @@ models = types.SimpleNamespace(
 )
 
 teleop_unified = transform.override(
-    base=ds.teleop, transforms=[group.override(transforms=[Derive(task=FromValue(UNIFIED_TASK)), Identity()])]
+    base=ds.teleop,
+    transforms=[group.override(transforms=[Derive(task=FromValue(UNIFIED_TASK)), Identity()]), REAL_ROBOT_TRANSFORM],
 )
 
 


### PR DESCRIPTION
## Summary
- `teleop_unified` now applies `REAL_ROBOT_TRANSFORM` (mirroring how `ds/sim.py` enriches `sim_stack_cubes` with `SIM_ROBOT_TRANSFORM`), so the public teleop split carries the FR3 robot-meta (`urdf`/`joint_names`/`control_frame`) and the `robot_command.pose` signal that joint/IK codecs need (DreamZero `joints_ik`, and the EE codecs). Without it, converting the public teleop split failed with `KeyError: 'robot_command.pose'`.
- `REAL_ROBOT_TRANSFORM`/`SIM_ROBOT_TRANSFORM` now **drop the legacy plural `robot_commands.pose`** from their output. Older recordings store the arm command under that name; the transform still backfills the canonical `robot_command.pose` from it (a hard rename would `KeyError` on newer singular recordings), but the legacy name no longer leaks to consumers.

### Why the read-time bridge stays
The public v1.0 dataset was exported 2026-05-25, before the `robot_command.pose` rename (#418, 2026-06-09), so its recordings are plural on disk and immutable. The backfill is the designed read-time bridge for such legacy data — no re-export required. The change only affects `teleop_unified` (the server uses `phail_with_started`).

## Test plan
- Local A/B on a real public teleop episode: without the change → `KeyError: 'robot_command.pose'`; with it → `action.joint_position (T, 7)` derives with valid FR3 joints, and `robot_commands.pose` is absent from the output.
- Singular (sim) data unaffected: `sim_stack_cubes` `joints_ik` conversion derives identical joints.
- Full serverless convert of all 449 public teleop episodes via DreamZero `joints_ik` succeeded → `s3://interim/phail/dreamzero/joints_ik/` (449 episode parquets, correct `info.json`/`modality.json`, unified task label).
- `pytest positronic/dataset/transforms` → 48 passed.