### PR TITLE
Add `bundled_franka_model()` for the 3D viewer; record only `mjSTATE_INTEGRATION`

### DIFF
--- a/positronic/assets/mujoco/panda.urdf
+++ b/positronic/assets/mujoco/panda.urdf
@@ -28,7 +28,7 @@
     <parent link="link0" />
     <child link="link1" />
     <axis xyz="0 0 1" />
-    <limit effort="87.0" lower="-2.7437" upper="2.7437" velocity="2.62" />
+    <limit effort="87.0" lower="-2.8973" upper="2.8973" velocity="2.62" />
   </joint>
 
   <link name="link2">
@@ -44,7 +44,7 @@
     <parent link="link1" />
     <child link="link2" />
     <axis xyz="0 0 1" />
-    <limit effort="87.0" lower="-1.7837" upper="1.7837" velocity="2.62" />
+    <limit effort="87.0" lower="-1.7628" upper="1.7628" velocity="2.62" />
   </joint>
 
   <link name="link3">
@@ -60,7 +60,7 @@
     <parent link="link2" />
     <child link="link3" />
     <axis xyz="0 0 1" />
-    <limit effort="87.0" lower="-2.9007" upper="2.9007" velocity="2.62" />
+    <limit effort="87.0" lower="-2.8973" upper="2.8973" velocity="2.62" />
   </joint>
 
   <link name="link4">
@@ -76,7 +76,7 @@
     <parent link="link3" />
     <child link="link4" />
     <axis xyz="0 0 1" />
-    <limit effort="87.0" lower="-3.0421" upper="-0.1518" velocity="2.62" />
+    <limit effort="87.0" lower="-3.0718" upper="-0.0698" velocity="2.62" />
   </joint>
 
   <link name="link5">
@@ -94,7 +94,7 @@
     <parent link="link4" />
     <child link="link5" />
     <axis xyz="0 0 1" />
-    <limit effort="12.0" lower="-2.8065" upper="2.8065" velocity="5.26" />
+    <limit effort="12.0" lower="-2.8973" upper="2.8973" velocity="5.26" />
   </joint>
 
   <link name="link6">
@@ -110,7 +110,7 @@
     <parent link="link5" />
     <child link="link6" />
     <axis xyz="0 0 1" />
-    <limit effort="12.0" lower="0.5445" upper="4.5169" velocity="4.18" />
+    <limit effort="12.0" lower="-0.0175" upper="3.7525" velocity="4.18" />
   </joint>
 
   <link name="link7">
@@ -126,7 +126,7 @@
     <parent link="link6" />
     <child link="link7" />
     <axis xyz="0 0 1" />
-    <limit effort="12.0" lower="-3.0159" upper="3.0159" velocity="5.26" />
+    <limit effort="12.0" lower="-2.8973" upper="2.8973" velocity="5.26" />
   </joint>
 
   <link name="hand">

--- a/positronic/assets/mujoco/panda.urdf
+++ b/positronic/assets/mujoco/panda.urdf
@@ -139,21 +139,35 @@
   </joint>
 
   <link name="left_finger">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0" />
+      <mass value="0.015" />
+      <inertia ixx="2.375e-6" ixy="0" ixz="0" iyy="2.375e-6" iyz="0" izz="7.5e-7" />
+    </inertial>
     <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
   </link>
-  <joint name="left_finger_joint" type="fixed">
+  <joint name="finger_joint1" type="prismatic">
     <origin rpy="0 0 0" xyz="0 0 0.0584" />
     <parent link="hand" />
     <child link="left_finger" />
+    <axis xyz="0 1 0" />
+    <limit effort="20" lower="0" upper="0.04" velocity="0.2" />
   </joint>
 
   <link name="right_finger">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0" />
+      <mass value="0.015" />
+      <inertia ixx="2.375e-6" ixy="0" ixz="0" iyy="2.375e-6" iyz="0" izz="7.5e-7" />
+    </inertial>
     <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
   </link>
-  <joint name="right_finger_joint" type="fixed">
+  <joint name="finger_joint2" type="prismatic">
     <origin rpy="0 0 3.141592653589793" xyz="0 0 0.0584" />
     <parent link="hand" />
     <child link="right_finger" />
+    <axis xyz="0 1 0" />
+    <limit effort="20" lower="0" upper="0.04" velocity="0.2" />
   </joint>
 
   <link name="end_effector" />

--- a/positronic/assets/mujoco/panda.urdf
+++ b/positronic/assets/mujoco/panda.urdf
@@ -162,11 +162,14 @@
     </inertial>
     <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
   </link>
+  <!-- HACK: the slide axis is given in the parent frame (0 -1 0), not the joint frame (0 1 0),
+       because rerun's prismatic compute_transform adds axis*q without rotating it by the joint
+       origin. The 180-deg origin still mirrors the mesh. Mirrors franka_table.xml's right finger. -->
   <joint name="finger_joint2" type="prismatic">
     <origin rpy="0 0 3.141592653589793" xyz="0 0 0.0584" />
     <parent link="hand" />
     <child link="right_finger" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 -1 0" />
     <limit effort="20" lower="0" upper="0.04" velocity="0.2" />
   </joint>
 

--- a/positronic/assets/mujoco/panda.urdf
+++ b/positronic/assets/mujoco/panda.urdf
@@ -1,0 +1,165 @@
+<?xml version="1.0" ?>
+<!-- Franka Emika Panda (arm + hand) for the MuJoCo sim: the robot the 3D viewer renders and the
+     IK action codec reconstructs joints against. Kinematics mirror panda.xml exactly; geometry uses
+     the panda collision meshes in assets/. `end_effector` is the grasp frame the sim measures
+     `robot_state.ee_pose` at (hand + 0.0584 m), so the viewer and `ik_joints_from_episode` share one
+     consistent model. The real arm uses drivers/roboarm/fr3.urdf, whose end_effector sits at the
+     physical flange instead. -->
+<robot name="panda">
+  <link name="link0">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-0.0172 0.0004 0.0745" />
+      <mass value="2.3966" />
+      <inertia ixx="0.009" ixy="0.0" ixz="0.002" iyy="0.0115" iyz="0.0" izz="0.0085" />
+    </inertial>
+    <visual><geometry><mesh filename="link0.stl" /></geometry></visual>
+  </link>
+
+  <link name="link1">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0000004128 -0.0181251324 -0.0386035970" />
+      <mass value="2.9274653454" />
+      <inertia ixx="0.023927316485107913" ixy="1.3317903455714081e-05" ixz="-0.00011404774918616684" iyy="0.0224821613275756" iyz="-0.0019950320628240115" izz="0.006350098258530016" />
+    </inertial>
+    <visual><geometry><mesh filename="link1.stl" /></geometry></visual>
+  </link>
+  <joint name="joint1" type="revolute">
+    <origin rpy="0 0 0" xyz="0 0 0.333" />
+    <parent link="link0" />
+    <child link="link1" />
+    <axis xyz="0 0 1" />
+    <limit effort="87.0" lower="-2.7437" upper="2.7437" velocity="2.62" />
+  </joint>
+
+  <link name="link2">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0031828864 -0.0743221644 0.0088146084" />
+      <mass value="2.9355370338" />
+      <inertia ixx="0.041938946257609425" ixy="0.00020257331521090626" ixz="0.004077784227179924" iyy="0.02514514885014724" iyz="-0.0042252158006570156" izz="0.06170214472888839" />
+    </inertial>
+    <visual><geometry><mesh filename="link2.stl" /></geometry></visual>
+  </link>
+  <joint name="joint2" type="revolute">
+    <origin rpy="-1.570796326794897 0 0" xyz="0 0 0" />
+    <parent link="link1" />
+    <child link="link2" />
+    <axis xyz="0 0 1" />
+    <limit effort="87.0" lower="-1.7837" upper="1.7837" velocity="2.62" />
+  </joint>
+
+  <link name="link3">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0407015686 -0.0048200565 -0.0289730823" />
+      <mass value="2.2449013699" />
+      <inertia ixx="0.02410142547240885" ixy="0.002404694559042109" ixz="-0.002856269270114313" iyy="0.01974053266708178" iyz="-0.002104212683891874" izz="0.019044494482244823" />
+    </inertial>
+    <visual><geometry><mesh filename="link3.stl" /></geometry></visual>
+  </link>
+  <joint name="joint3" type="revolute">
+    <origin rpy="1.570796326794897 0 0" xyz="0 -0.316 0" />
+    <parent link="link2" />
+    <child link="link3" />
+    <axis xyz="0 0 1" />
+    <limit effort="87.0" lower="-2.9007" upper="2.9007" velocity="2.62" />
+  </joint>
+
+  <link name="link4">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-0.0459100965 0.0630492960 -0.0085187868" />
+      <mass value="2.6155955791" />
+      <inertia ixx="0.03452998321913202" ixy="0.01322552265982813" ixz="0.01015142998484113" iyy="0.028881621933049058" iyz="-0.0009762833870704552" izz="0.04125471171146641" />
+    </inertial>
+    <visual><geometry><mesh filename="link4.stl" /></geometry></visual>
+  </link>
+  <joint name="joint4" type="revolute">
+    <origin rpy="1.570796326794897 0 0" xyz="0.0825 0 0" />
+    <parent link="link3" />
+    <child link="link4" />
+    <axis xyz="0 0 1" />
+    <limit effort="87.0" lower="-3.0421" upper="-0.1518" velocity="2.62" />
+  </joint>
+
+  <link name="link5">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-0.0016039605 0.0292536262 -0.0972965990" />
+      <mass value="2.3271207594" />
+      <inertia ixx="0.051610278463662895" ixy="-0.005715173387783472" ixz="-0.0035673167625872135" iyy="0.04787729713371481" iyz="0.010673985108535986" izz="0.016423625579357254" />
+    </inertial>
+    <visual><geometry><mesh filename="link5_collision_0.obj" /></geometry></visual>
+    <visual><geometry><mesh filename="link5_collision_1.obj" /></geometry></visual>
+    <visual><geometry><mesh filename="link5_collision_2.obj" /></geometry></visual>
+  </link>
+  <joint name="joint5" type="revolute">
+    <origin rpy="-1.570796326794897 0 0" xyz="-0.0825 0.384 0" />
+    <parent link="link4" />
+    <child link="link5" />
+    <axis xyz="0 0 1" />
+    <limit effort="12.0" lower="-2.8065" upper="2.8065" velocity="5.26" />
+  </joint>
+
+  <link name="link6">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0597131221 -0.0410294666 -0.0101692726" />
+      <mass value="1.8170376524" />
+      <inertia ixx="0.005412333594383447" ixy="0.006193456360285834" ixz="0.0014219289306117652" iyy="0.014058329545509979" iyz="-0.0013140753741120031" izz="0.016080817924212554" />
+    </inertial>
+    <visual><geometry><mesh filename="link6.stl" /></geometry></visual>
+  </link>
+  <joint name="joint6" type="revolute">
+    <origin rpy="1.570796326794897 0 0" xyz="0 0 0" />
+    <parent link="link5" />
+    <child link="link6" />
+    <axis xyz="0 0 1" />
+    <limit effort="12.0" lower="0.5445" upper="4.5169" velocity="4.18" />
+  </joint>
+
+  <link name="link7">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0045225817 0.0086261921 -0.0161633251" />
+      <mass value="0.6271432862" />
+      <inertia ixx="0.00021092389150104718" ixy="-2.433299114461931e-05" ixz="4.564480393778983e-05" iyy="0.00017718568002411474" iyz="8.744070223226438e-05" izz="5.993190599659971e-05" />
+    </inertial>
+    <visual><geometry><mesh filename="link7.stl" /></geometry></visual>
+  </link>
+  <joint name="joint7" type="revolute">
+    <origin rpy="1.570796326794897 0 0" xyz="0.088 0 0" />
+    <parent link="link6" />
+    <child link="link7" />
+    <axis xyz="0 0 1" />
+    <limit effort="12.0" lower="-3.0159" upper="3.0159" velocity="5.26" />
+  </joint>
+
+  <link name="hand">
+    <visual><geometry><mesh filename="hand.stl" /></geometry></visual>
+  </link>
+  <joint name="hand_joint" type="fixed">
+    <origin rpy="0 0 -0.7853981633974483" xyz="0 0 0.107" />
+    <parent link="link7" />
+    <child link="hand" />
+  </joint>
+
+  <link name="left_finger">
+    <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
+  </link>
+  <joint name="left_finger_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.0584" />
+    <parent link="hand" />
+    <child link="left_finger" />
+  </joint>
+
+  <link name="right_finger">
+    <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
+  </link>
+  <joint name="right_finger_joint" type="fixed">
+    <origin rpy="0 0 3.141592653589793" xyz="0 0 0.0584" />
+    <parent link="hand" />
+    <child link="right_finger" />
+  </joint>
+
+  <link name="end_effector" />
+  <joint name="hand_to_end_effector" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.0584" />
+    <parent link="hand" />
+    <child link="end_effector" />
+  </joint>
+</robot>

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -38,12 +38,8 @@ _JOINT_NAMES = [f'joint{i}' for i in range(1, 8)]
 # recordings used for the arm command; `_RENAME_ROBOT_COMMAND` re-surfaces it as the canonical
 # `robot_command.pose`, so the plural itself should not reach consumers.
 _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
-_FRANKA_MODEL = bundled_franka_model()
 _REAL_ROBOT_DERIVES = {
-    'urdf': FromValue(_FRANKA_MODEL['urdf']),
-    'joint_names': FromValue(_FRANKA_MODEL['joint_names']),
-    'meshes': FromValue(_FRANKA_MODEL['meshes']),
-    'control_frame': FromValue(_FRANKA_MODEL['control_frame']),
+    **{key: FromValue(value) for key, value in bundled_franka_model().items()},
     'joint_signal': FromValue('robot_state.q'),
     'pose_signals': FromValue(['robot_state.ee_pose', 'robot_command.pose']),
 }

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -20,6 +20,7 @@ from positronic.dataset.local_dataset import load_all_datasets
 from positronic.dataset.transforms import TransformedDataset, agg_fraction_true, agg_max, agg_percentile
 from positronic.dataset.transforms.episode import Concat, Derive, FromValue, Get, Group, Identity, Rename
 from positronic.dataset.transforms.quality import cmd_lag, cmd_velocity, idle_mask, jerk
+from positronic.drivers.roboarm import bundled_franka_model
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import main as server_main
 from positronic.utils import package_assets_path
@@ -30,20 +31,19 @@ from . import concat_ds, local, transform
 # Robot meta for existing datasets that don't have it stored natively.
 # Future datasets will have per-unit calibrated URDF from Robot.robot_meta.
 SIM_URDF = Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text()
-REAL_URDF = (Path(__file__).resolve().parents[2] / 'drivers' / 'roboarm' / 'fr3.urdf').read_text()
 
 _JOINT_NAMES = [f'joint{i}' for i in range(1, 8)]
-_MESH_DIR = Path(package_assets_path('assets/fr3_collision'))
 
 # Dropped from the transform output. `robot_commands.pose` is the legacy plural name older
 # recordings used for the arm command; `_RENAME_ROBOT_COMMAND` re-surfaces it as the canonical
 # `robot_command.pose`, so the plural itself should not reach consumers.
 _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
+_FRANKA_MODEL = bundled_franka_model()
 _REAL_ROBOT_DERIVES = {
-    'urdf': FromValue(REAL_URDF),
-    'joint_names': FromValue(_JOINT_NAMES),
-    'meshes': FromValue({f.name: f.read_bytes() for f in _MESH_DIR.iterdir() if f.suffix == '.stl'}),
-    'control_frame': FromValue('end_effector'),
+    'urdf': FromValue(_FRANKA_MODEL['urdf']),
+    'joint_names': FromValue(_FRANKA_MODEL['joint_names']),
+    'meshes': FromValue(_FRANKA_MODEL['meshes']),
+    'control_frame': FromValue(_FRANKA_MODEL['control_frame']),
     'joint_signal': FromValue('robot_state.q'),
     'pose_signals': FromValue(['robot_state.ee_pose', 'robot_command.pose']),
 }

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -9,8 +9,6 @@ These datasets remain on the private s3://raw/ bucket and include:
 - Full combined datasets for multi-task training
 """
 
-from pathlib import Path
-
 import configuronic as cfn
 import pos3
 
@@ -20,33 +18,27 @@ from positronic.dataset.local_dataset import load_all_datasets
 from positronic.dataset.transforms import TransformedDataset, agg_fraction_true, agg_max, agg_percentile
 from positronic.dataset.transforms.episode import Concat, Derive, FromValue, Get, Group, Identity, Rename
 from positronic.dataset.transforms.quality import cmd_lag, cmd_velocity, idle_mask, jerk
-from positronic.drivers.roboarm import bundled_franka_model
+from positronic.drivers.roboarm import bundled_franka_model, bundled_panda_model
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import main as server_main
-from positronic.utils import package_assets_path
 from positronic.utils.logging import init_logging
 
 from . import concat_ds, local, transform
-
-# Robot meta for existing datasets that don't have it stored natively.
-# Future datasets will have per-unit calibrated URDF from Robot.robot_meta.
-SIM_URDF = Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text()
-
-_JOINT_NAMES = [f'joint{i}' for i in range(1, 8)]
 
 # Dropped from the transform output. `robot_commands.pose` is the legacy plural name older
 # recordings used for the arm command; `_RENAME_ROBOT_COMMAND` re-surfaces it as the canonical
 # `robot_command.pose`, so the plural itself should not reach consumers.
 _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
+
+# Backfill the robot model for datasets that don't store their own: the real arm and the MuJoCo sim
+# each supply their bundled model (URDF + collision meshes + frames) as static via these derives.
 _REAL_ROBOT_DERIVES = {
     **{key: FromValue(value) for key, value in bundled_franka_model().items()},
     'joint_signal': FromValue('robot_state.q'),
     'pose_signals': FromValue(['robot_state.ee_pose', 'robot_command.pose']),
 }
 _SIM_ROBOT_DERIVES = {
-    'urdf': FromValue(SIM_URDF),
-    'joint_names': FromValue(_JOINT_NAMES),
-    'control_frame': FromValue('end_effector'),
+    **{key: FromValue(value) for key, value in bundled_panda_model().items()},
     'joint_signal': FromValue('robot_state.q'),
     'pose_signals': FromValue(['robot_state.ee_pose', 'robot_command.pose']),
 }

--- a/positronic/dataset/remote.py
+++ b/positronic/dataset/remote.py
@@ -44,7 +44,9 @@ class DatasetClient:
     def get_episode_info(self, index: int) -> dict:
         r = self.session.get(f'/api/v1/episodes/{index}/info')
         r.raise_for_status()
-        return r.json()
+        info = r.json()
+        info['static'] = deserialize(bytes.fromhex(info['static']))
+        return info
 
     def get_signal_timestamps(self, ep: int, sig: str, indices: IndicesLike) -> np.ndarray:
         r = self.session.post(f'/api/v1/episodes/{ep}/signals/{sig}/timestamps', json=_encode_indices(indices))
@@ -72,7 +74,7 @@ class DatasetClient:
         r = self.session.post(f'/api/v1/episodes/{ep}/sample', json={'timestamps': timestamps.tolist()})
         r.raise_for_status()
         data = r.json()
-        result = dict(data['static'])
+        result = deserialize(bytes.fromhex(data['static']))
         for sig_name, sig_data in data['signals'].items():
             result[sig_name] = deserialize(bytes.fromhex(sig_data['values']))
         return result

--- a/positronic/dataset/remote_server/server.py
+++ b/positronic/dataset/remote_server/server.py
@@ -50,7 +50,7 @@ def episode_info(index: int):
             'shape': list(sig.shape) if sig.shape else [],
             'encoding_format': sig.encoding_format if supports_encoded else None,
         }
-    return {'meta': ep.meta, 'static': ep.static, 'signals': signals_meta}
+    return {'meta': ep.meta, 'static': serialize(ep.static).hex(), 'signals': signals_meta}
 
 
 @_app.post('/api/v1/episodes/{ep}/signals/{sig}/timestamps')
@@ -98,7 +98,7 @@ def episode_sample(ep: int, req: TimestampsRequest):
             result_signals[key] = {'timestamps': timestamps.tolist(), 'values': serialize(list(value)).hex()}
         else:
             result_static[key] = value
-    return {'static': result_static, 'signals': result_signals}
+    return {'static': serialize(result_static).hex(), 'signals': result_signals}
 
 
 def _get_dataset() -> Dataset:

--- a/positronic/dataset/tests/test_remote.py
+++ b/positronic/dataset/tests/test_remote.py
@@ -69,8 +69,9 @@ def test_episode_info_endpoint(test_client):
     r = test_client.get('/api/v1/episodes/0/info')
     assert r.status_code == 200
     data = r.json()
-    assert data['static']['task'] == 'task_0'
-    assert data['static']['episode_id'] == 0
+    static = deserialize(bytes.fromhex(data['static']))
+    assert static['task'] == 'task_0'
+    assert static['episode_id'] == 0
     assert 'action' in data['signals']
     assert 'cam' in data['signals']
     assert data['signals']['action']['length'] == 5
@@ -129,7 +130,7 @@ def test_episode_sample_endpoint(test_client):
     r = test_client.post('/api/v1/episodes/0/sample', json={'timestamps': [1000, 1100]})
     assert r.status_code == 200
     data = r.json()
-    assert data['static']['task'] == 'task_0'
+    assert deserialize(bytes.fromhex(data['static']))['task'] == 'task_0'
     assert 'action' in data['signals']
     action_values = deserialize(bytes.fromhex(data['signals']['action']['values']))
     assert len(action_values) == 2

--- a/positronic/drivers/roboarm/__init__.py
+++ b/positronic/drivers/roboarm/__init__.py
@@ -3,6 +3,7 @@
 This package provides drivers for various robot arms including Franka, Kinova, and SO-101.
 """
 
+import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from enum import Enum
 from functools import lru_cache
@@ -32,6 +33,29 @@ def bundled_franka_model() -> dict:
         'meshes': {f.name: f.read_bytes() for f in sorted(meshes) if f.suffix == '.stl'},
         'joint_names': [f'joint{i}' for i in range(1, 8)],
         'control_frame': 'end_effector',
+    }
+
+
+@lru_cache(maxsize=1)
+def bundled_panda_model() -> dict:
+    """The bundled simulated Franka panda (arm + hand) for the 3D viewer and offline IK: the panda
+    URDF, its collision meshes, the joint names, the ``end_effector`` control frame — the grasp site
+    where the sim measures ``robot_state.ee_pose`` — and the ``gripper`` spec that slides the fingers
+    from the recorded ``grip`` signal. Supplied to sim datasets by ``SIM_ROBOT_TRANSFORM``, mirroring
+    how ``bundled_franka_model`` backfills the real arm; its ``end_effector`` sits at the simulated
+    grasp site rather than the FR3 physical flange.
+    """
+    urdf_path = Path(__file__).resolve().parents[2] / 'assets' / 'mujoco' / 'panda.urdf'
+    urdf = urdf_path.read_text()
+    mesh_dir = urdf_path.parent / 'assets'
+    mesh_files = {mesh.get('filename') for mesh in ET.fromstring(urdf).iter('mesh')}
+    return {
+        'urdf': urdf,
+        'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
+        'joint_names': [f'joint{i}' for i in range(1, 8)],
+        'control_frame': 'end_effector',
+        # ``grip`` is recorded in [0, 1] (closed→open); each finger slides 0..0.04 m along its axis.
+        'gripper': {'signal': 'grip', 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
     }
 
 
@@ -87,4 +111,4 @@ class State(ABC):
         return None
 
 
-__all__ = ['RobotStatus', 'State', 'bundled_franka_model', 'command']
+__all__ = ['RobotStatus', 'State', 'bundled_franka_model', 'bundled_panda_model', 'command']

--- a/positronic/drivers/roboarm/__init__.py
+++ b/positronic/drivers/roboarm/__init__.py
@@ -5,6 +5,8 @@ This package provides drivers for various robot arms including Franka, Kinova, a
 
 from abc import ABC, abstractmethod
 from enum import Enum
+from functools import lru_cache
+from pathlib import Path
 
 import numpy as np
 
@@ -12,6 +14,25 @@ from positronic import geom
 
 # Import command submodule to make it accessible as roboarm.command
 from . import command
+
+
+@lru_cache(maxsize=1)
+def bundled_franka_model() -> dict:
+    """The bundled Franka arm model for the 3D viewer: the FR3 URDF, its collision meshes, and the
+    canonical joint names and control frame.
+
+    Used where no live robot reports its own model — the MuJoCo sim and offline dataset transforms.
+    The FR3 arm shares the simulator panda's 7-DOF kinematics exactly, so the rendered robot matches
+    the simulated one (verified by the URDF/MJCF kinematics test).
+    """
+    here = Path(__file__).resolve()
+    meshes = (here.parents[2] / 'assets' / 'fr3_collision').iterdir()
+    return {
+        'urdf': (here.parent / 'fr3.urdf').read_text(),
+        'meshes': {f.name: f.read_bytes() for f in sorted(meshes) if f.suffix == '.stl'},
+        'joint_names': [f'joint{i}' for i in range(1, 8)],
+        'control_frame': 'end_effector',
+    }
 
 
 class RobotStatus(Enum):
@@ -66,4 +87,4 @@ class State(ABC):
         return None
 
 
-__all__ = ['RobotStatus', 'State', 'command']
+__all__ = ['RobotStatus', 'State', 'bundled_franka_model', 'command']

--- a/positronic/drivers/roboarm/__init__.py
+++ b/positronic/drivers/roboarm/__init__.py
@@ -18,12 +18,12 @@ from . import command
 
 @lru_cache(maxsize=1)
 def bundled_franka_model() -> dict:
-    """The bundled Franka arm model for the 3D viewer: the FR3 URDF, its collision meshes, and the
-    canonical joint names and control frame.
+    """The bundled real Franka arm model for the 3D viewer: the FR3 URDF, its collision meshes, and
+    the canonical joint names and control frame.
 
-    Used where no live robot reports its own model — the MuJoCo sim and offline dataset transforms.
-    The FR3 arm shares the simulator panda's 7-DOF kinematics exactly, so the rendered robot matches
-    the simulated one (verified by the URDF/MJCF kinematics test).
+    Backfills real-robot datasets recorded before they stored their own model. Its ``end_effector``
+    is the physical flange frame the driver measures against; the MuJoCo sim measures at a different
+    grasp site and supplies its own model via ``bundled_panda_model``.
     """
     here = Path(__file__).resolve()
     meshes = (here.parents[2] / 'assets' / 'fr3_collision').iterdir()

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -441,13 +441,13 @@ def _log_urdf_robot(
                 _animate_joint(joint, q_ds[:, j_idx], ts_ds, prefix)
                 yield from drainer.drain()
 
-        # The gripper rides a single ``grip`` signal that opens both fingers symmetrically; it is
-        # nominally [0, 1] but recordings overshoot slightly, so clip before scaling to finger travel.
+        # The ``grip`` signal is [0, 1] with 1 fully closed; the finger joints are 0 when closed and
+        # ``travel`` when open, so invert. Recordings overshoot slightly, so clip before inverting.
         gripper = ep.static.get('gripper')
         if gripper and gripper['signal'] in numeric_data:
             grip_ts, grip_vals = numeric_data[gripper['signal']]
             grip_step = max(1, len(grip_ts) // target_samples)
-            finger_pos = np.clip(grip_vals[::grip_step, 0], 0.0, 1.0) * gripper['travel']
+            finger_pos = (1.0 - np.clip(grip_vals[::grip_step, 0], 0.0, 1.0)) * gripper['travel']
             for name in gripper['joints']:
                 joint = tree.get_joint_by_name(name)
                 if joint is not None:

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -331,7 +331,10 @@ def _log_numeric_signals(
     """Log numeric time-series via send_columns. Returns pose/joint data for 3D logging."""
     pose_set = set(signals.poses)
     joint_signal = ep.static.get('joint_signal')
+    gripper = ep.static.get('gripper')
     stash_keys = pose_set | ({joint_signal} if joint_signal else set())
+    if gripper:
+        stash_keys.add(gripper['signal'])
     pose_data = {}
 
     for key in signals.numerics:

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -438,6 +438,18 @@ def _log_urdf_robot(
                 _animate_joint(joint, q_ds[:, j_idx], ts_ds, prefix)
                 yield from drainer.drain()
 
+        # The gripper rides a single [0, 1] ``grip`` signal that opens both fingers symmetrically.
+        gripper = ep.static.get('gripper')
+        if gripper and gripper['signal'] in numeric_data:
+            grip_ts, grip_vals = numeric_data[gripper['signal']]
+            grip_step = max(1, len(grip_ts) // target_samples)
+            finger_pos = grip_vals[::grip_step, 0] * gripper['travel']
+            for name in gripper['joints']:
+                joint = tree.get_joint_by_name(name)
+                if joint is not None:
+                    _animate_joint(joint, finger_pos, grip_ts[::grip_step], prefix)
+                    yield from drainer.drain()
+
     return root_frame
 
 

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -441,13 +441,13 @@ def _log_urdf_robot(
                 _animate_joint(joint, q_ds[:, j_idx], ts_ds, prefix)
                 yield from drainer.drain()
 
-        # The ``grip`` signal is [0, 1] with 1 fully closed; the finger joints are 0 when closed and
-        # ``travel`` when open, so invert. Recordings overshoot slightly, so clip before inverting.
+        # The gripper rides a single ``grip`` signal that opens both fingers symmetrically; it is
+        # nominally [0, 1] but recordings overshoot slightly, so clip before scaling to finger travel.
         gripper = ep.static.get('gripper')
         if gripper and gripper['signal'] in numeric_data:
             grip_ts, grip_vals = numeric_data[gripper['signal']]
             grip_step = max(1, len(grip_ts) // target_samples)
-            finger_pos = (1.0 - np.clip(grip_vals[::grip_step, 0], 0.0, 1.0)) * gripper['travel']
+            finger_pos = np.clip(grip_vals[::grip_step, 0], 0.0, 1.0) * gripper['travel']
             for name in gripper['joints']:
                 joint = tree.get_joint_by_name(name)
                 if joint is not None:

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -136,10 +136,20 @@ def _compute_eye_controls(signals: EpisodeSignals, ep: Episode) -> rrb.EyeContro
     return rrb.EyeControls3D(position=camera_pos.tolist(), look_target=centroid.tolist())
 
 
+# ``sim_state`` is the privileged full physics state: a single wide vector recorded for
+# replay/scoring, not a set of readable channels. Plotting it as one scalar series per channel
+# stalls the viewer, so it is left out of the visualization entirely.
+# TODO: a high-dimensional signal like this has no useful scalar-series view and needs one of its
+# own; the choice of what to hide should not be a hardcoded signal name.
+_HIDDEN_SIGNALS = {'sim_state'}
+
+
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
     pose_set = set(ep.static.get('pose_signals', []))
     signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[])
     for name, sig in ep.signals.items():
+        if name.split('.')[0] in _HIDDEN_SIGNALS:
+            continue
         if sig.kind == Kind.IMAGE:
             try:
                 sig[0]

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -136,19 +136,19 @@ def _compute_eye_controls(signals: EpisodeSignals, ep: Episode) -> rrb.EyeContro
     return rrb.EyeControls3D(position=camera_pos.tolist(), look_target=centroid.tolist())
 
 
-# ``sim_state`` is the privileged full physics state: a single wide vector recorded for
-# replay/scoring, not a set of readable channels. Plotting it as one scalar series per channel
-# stalls the viewer, so it is left out of the visualization entirely.
-# TODO: a high-dimensional signal like this has no useful scalar-series view and needs one of its
-# own; the choice of what to hide should not be a hardcoded signal name.
-_HIDDEN_SIGNALS = {'sim_state'}
+# MuJoCo's privileged full-physics state is a single wide vector recorded for replay/scoring —
+# ``sim_state.mjSTATE_*`` in current recordings, bare ``mjSTATE_*`` in older datasets — not a set of
+# readable channels. Plotting it as one scalar series per channel stalls the viewer, so any signal
+# carrying it is left out of the visualization.
+# TODO: a high-dimensional signal like this has no useful scalar-series view and needs one of its own.
+_HIDDEN_SIGNAL_MARKER = 'mjSTATE'
 
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
     pose_set = set(ep.static.get('pose_signals', []))
     signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[])
     for name, sig in ep.signals.items():
-        if name.split('.')[0] in _HIDDEN_SIGNALS:
+        if _HIDDEN_SIGNAL_MARKER in name:
             continue
         if sig.kind == Kind.IMAGE:
             try:

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -441,12 +441,13 @@ def _log_urdf_robot(
                 _animate_joint(joint, q_ds[:, j_idx], ts_ds, prefix)
                 yield from drainer.drain()
 
-        # The gripper rides a single [0, 1] ``grip`` signal that opens both fingers symmetrically.
+        # The gripper rides a single ``grip`` signal that opens both fingers symmetrically; it is
+        # nominally [0, 1] but recordings overshoot slightly, so clip before scaling to finger travel.
         gripper = ep.static.get('gripper')
         if gripper and gripper['signal'] in numeric_data:
             grip_ts, grip_vals = numeric_data[gripper['signal']]
             grip_step = max(1, len(grip_ts) // target_samples)
-            finger_pos = grip_vals[::grip_step, 0] * gripper['travel']
+            finger_pos = np.clip(grip_vals[::grip_step, 0], 0.0, 1.0) * gripper['travel']
             for name in gripper['joints']:
                 joint = tree.get_joint_by_name(name)
                 if joint is not None:

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -10,7 +10,7 @@ from dm_control.utils import inverse_kinematics as ik
 
 import pimm
 from positronic import geom
-from positronic.drivers.roboarm import RobotStatus, State
+from positronic.drivers.roboarm import RobotStatus, State, bundled_panda_model
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
 
@@ -218,9 +218,9 @@ class MujocoSim(pimm.ControlSystem):
         self._bind_model()
 
     def _emit_robot_meta(self):
-        # The robot model (URDF + meshes + frames) is supplied at read time by SIM_ROBOT_TRANSFORM,
-        # mirroring the real arm; only the per-episode scene travels with the recording.
-        self.robot_meta.emit({'scene_xml': self.scene_xml})
+        # Emit the full robot model (URDF + meshes + frames + gripper) at record time, like franka.py,
+        # plus the per-episode scene_xml that restores the MuJoCo scene.
+        self.robot_meta.emit({**bundled_panda_model(), 'scene_xml': self.scene_xml})
 
     def _bind_model(self):
         """Derive everything that hangs off ``self.model``; runs at construction and on every rebuild."""

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -10,19 +10,16 @@ from dm_control.utils import inverse_kinematics as ik
 
 import pimm
 from positronic import geom
-from positronic.drivers.roboarm import RobotStatus, State
+from positronic.drivers.roboarm import RobotStatus, State, bundled_franka_model
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
-from positronic.utils import package_assets_path
 
 logger = logging.getLogger(__name__)
 
-STATE_SPECS = [
-    mj.mjtState.mjSTATE_FULLPHYSICS,
-    mj.mjtState.mjSTATE_USER,
-    mj.mjtState.mjSTATE_INTEGRATION,
-    mj.mjtState.mjSTATE_WARMSTART,
-]
+# mjSTATE_INTEGRATION is MuJoCo's complete integrable state (qpos, qvel, act, ctrl, warm-start, ...):
+# the minimal subset that restores the sim and reproduces its forward trajectory exactly. The other
+# specs are subsets of it, so recording them too only duplicates these values.
+STATE_SPECS = [mj.mjtState.mjSTATE_INTEGRATION]
 
 
 def save_state(model, data) -> dict[str, np.ndarray]:
@@ -220,12 +217,7 @@ class MujocoSim(pimm.ControlSystem):
         self._bind_model()
 
     def _emit_robot_meta(self):
-        self.robot_meta.emit({
-            'urdf': Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text(),
-            'joint_names': [f'joint{i}' for i in range(1, 8)],
-            'control_frame': 'end_effector',
-            'scene_xml': self.scene_xml,
-        })
+        self.robot_meta.emit({**bundled_franka_model(), 'scene_xml': self.scene_xml})
 
     def _bind_model(self):
         """Derive everything that hangs off ``self.model``; runs at construction and on every rebuild."""

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -1,7 +1,5 @@
 import logging
-import xml.etree.ElementTree as ET
 from collections.abc import Iterator, Sequence
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -15,32 +13,8 @@ from positronic import geom
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
-from positronic.utils import package_assets_path
 
 logger = logging.getLogger(__name__)
-
-
-@lru_cache(maxsize=1)
-def bundled_panda_model() -> dict:
-    """The simulated Franka panda (arm + hand) for the 3D viewer and offline IK reconstruction: the
-    panda URDF, its collision meshes, the joint names, the ``end_effector`` control frame — the grasp
-    site where the sim measures ``robot_state.ee_pose`` — and the ``gripper`` spec that animates the
-    fingers from the recorded ``grip`` signal. The viewer renders this and ``ik_joints_from_episode``
-    inverts against it, so both share one frame-consistent model. The real arm uses
-    ``drivers/roboarm/fr3.urdf``, whose end_effector sits at the physical flange instead.
-    """
-    urdf_path = Path(package_assets_path('assets/mujoco/panda.urdf'))
-    urdf = urdf_path.read_text()
-    mesh_dir = urdf_path.parent / 'assets'
-    mesh_files = {mesh.get('filename') for mesh in ET.fromstring(urdf).iter('mesh')}
-    return {
-        'urdf': urdf,
-        'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
-        'joint_names': [f'joint{i}' for i in range(1, 8)],
-        'control_frame': 'end_effector',
-        # ``grip`` is recorded in [0, 1] (closed→open); each finger slides 0..0.04 m along its axis.
-        'gripper': {'signal': 'grip', 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
-    }
 
 
 # mjSTATE_INTEGRATION is MuJoCo's complete integrable state (qpos, qvel, act, ctrl, warm-start, ...):
@@ -244,7 +218,9 @@ class MujocoSim(pimm.ControlSystem):
         self._bind_model()
 
     def _emit_robot_meta(self):
-        self.robot_meta.emit({**bundled_panda_model(), 'scene_xml': self.scene_xml})
+        # The robot model (URDF + meshes + frames) is supplied at read time by SIM_ROBOT_TRANSFORM,
+        # mirroring the real arm; only the per-episode scene travels with the recording.
+        self.robot_meta.emit({'scene_xml': self.scene_xml})
 
     def _bind_model(self):
         """Derive everything that hangs off ``self.model``; runs at construction and on every rebuild."""

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -23,10 +23,11 @@ logger = logging.getLogger(__name__)
 @lru_cache(maxsize=1)
 def bundled_panda_model() -> dict:
     """The simulated Franka panda (arm + hand) for the 3D viewer and offline IK reconstruction: the
-    panda URDF, its collision meshes, the joint names, and the ``end_effector`` control frame — the
-    grasp site where the sim measures ``robot_state.ee_pose``. The viewer renders this and
-    ``ik_joints_from_episode`` inverts against it, so both share one frame-consistent model. The real
-    arm uses ``drivers/roboarm/fr3.urdf``, whose end_effector sits at the physical flange instead.
+    panda URDF, its collision meshes, the joint names, the ``end_effector`` control frame — the grasp
+    site where the sim measures ``robot_state.ee_pose`` — and the ``gripper`` spec that animates the
+    fingers from the recorded ``grip`` signal. The viewer renders this and ``ik_joints_from_episode``
+    inverts against it, so both share one frame-consistent model. The real arm uses
+    ``drivers/roboarm/fr3.urdf``, whose end_effector sits at the physical flange instead.
     """
     urdf_path = Path(package_assets_path('assets/mujoco/panda.urdf'))
     urdf = urdf_path.read_text()
@@ -37,6 +38,8 @@ def bundled_panda_model() -> dict:
         'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
         'joint_names': [f'joint{i}' for i in range(1, 8)],
         'control_frame': 'end_effector',
+        # ``grip`` is recorded in [0, 1] (closed→open); each finger slides 0..0.04 m along its axis.
+        'gripper': {'signal': 'grip', 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
     }
 
 

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -1,5 +1,7 @@
 import logging
+import xml.etree.ElementTree as ET
 from collections.abc import Iterator, Sequence
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -10,11 +12,33 @@ from dm_control.utils import inverse_kinematics as ik
 
 import pimm
 from positronic import geom
-from positronic.drivers.roboarm import RobotStatus, State, bundled_franka_model
+from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
+from positronic.utils import package_assets_path
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def bundled_panda_model() -> dict:
+    """The simulated Franka panda (arm + hand) for the 3D viewer and offline IK reconstruction: the
+    panda URDF, its collision meshes, the joint names, and the ``end_effector`` control frame — the
+    grasp site where the sim measures ``robot_state.ee_pose``. The viewer renders this and
+    ``ik_joints_from_episode`` inverts against it, so both share one frame-consistent model. The real
+    arm uses ``drivers/roboarm/fr3.urdf``, whose end_effector sits at the physical flange instead.
+    """
+    urdf_path = Path(package_assets_path('assets/mujoco/panda.urdf'))
+    urdf = urdf_path.read_text()
+    mesh_dir = urdf_path.parent / 'assets'
+    mesh_files = {mesh.get('filename') for mesh in ET.fromstring(urdf).iter('mesh')}
+    return {
+        'urdf': urdf,
+        'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
+        'joint_names': [f'joint{i}' for i in range(1, 8)],
+        'control_frame': 'end_effector',
+    }
+
 
 # mjSTATE_INTEGRATION is MuJoCo's complete integrable state (qpos, qvel, act, ctrl, warm-start, ...):
 # the minimal subset that restores the sim and reproduces its forward trajectory exactly. The other
@@ -217,7 +241,7 @@ class MujocoSim(pimm.ControlSystem):
         self._bind_model()
 
     def _emit_robot_meta(self):
-        self.robot_meta.emit({**bundled_franka_model(), 'scene_xml': self.scene_xml})
+        self.robot_meta.emit({**bundled_panda_model(), 'scene_xml': self.scene_xml})
 
     def _bind_model(self):
         """Derive everything that hangs off ``self.model``; runs at construction and on every rebuild."""

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -1,5 +1,4 @@
 import xml.etree.ElementTree as ET
-from pathlib import Path
 
 import mujoco as mj
 import numpy as np
@@ -10,10 +9,9 @@ import tqdm
 import positronic.cfg.simulator
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.dataset.local_dataset import LocalDataset
-from positronic.drivers.roboarm import bundled_franka_model
 from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
-from positronic.simulator.mujoco.sim import MujocoSim
+from positronic.simulator.mujoco.sim import MujocoSim, bundled_panda_model
 from positronic.simulator.mujoco.transforms import AddBox, SetBodyPosition
 from positronic.utils import package_assets_path
 
@@ -200,27 +198,31 @@ def test_sim_state_reconstructs_dynamics():
 
 
 def test_recorded_urdf_matches_sim_kinematics():
-    """The URDF the sim records for the 3D viewer reproduces the arm kinematics of the MuJoCo model
-    the sim runs: for any joint configuration the link frames agree. This is what lets the viewer
-    reuse the bundled FR3 URDF — a divergence between it and the panda model would render a robot
-    that does not match the simulated one.
+    """The model the sim records for the viewer and IK reproduces the MuJoCo model the sim runs:
+    across joint configurations the arm link frames and the ``end_effector`` control frame agree with
+    ``panda.xml``. The control-frame check is the contract that keeps ``ik_joints_from_episode``
+    inverting ``robot_state.ee_pose`` against the grasp site the sim actually measured.
     """
+    joints = [f'joint{i}' for i in range(1, 8)]
 
-    def kinematics(xml: str):
-        root = ET.fromstring(xml)
-        if root.tag == 'robot':  # URDF: drop meshes so MuJoCo compiles without the asset files
-            for link in root.findall('.//link'):
-                for el in link.findall('visual') + link.findall('collision'):
-                    link.remove(el)
-            xml = ET.tostring(root, encoding='unicode')
-        model = mj.MjSpec.from_string(xml).compile()
+    def compiled(spec):
+        # A URDF carries ``end_effector`` as a frame-only body; resolve it to a readable site.
+        if 'end_effector' not in {site.name for body in spec.bodies for site in body.sites}:
+            spec.body('end_effector').add_site().name = 'end_effector'
+        model = spec.compile()
         return model, mj.MjData(model)
 
-    m_urdf, d_urdf = kinematics(bundled_franka_model()['urdf'])
-    m_mjcf, d_mjcf = kinematics(Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text())
-    joints = [f'joint{i}' for i in range(1, 8)]
+    root = ET.fromstring(bundled_panda_model()['urdf'])  # drop meshes so the URDF compiles file-free
+    for link in root.findall('.//link'):
+        for el in link.findall('visual') + link.findall('collision'):
+            link.remove(el)
+    m_urdf, d_urdf = compiled(mj.MjSpec.from_string(ET.tostring(root, encoding='unicode')))
+    m_mjcf, d_mjcf = compiled(mj.MjSpec.from_file(str(package_assets_path('assets/mujoco/panda.xml'))))
+
     qadr_urdf = [m_urdf.joint(n).qposadr.item() for n in joints]
     qadr_mjcf = [m_mjcf.joint(n).qposadr.item() for n in joints]
+    ee_urdf = mj.mj_name2id(m_urdf, mj.mjtObj.mjOBJ_SITE, 'end_effector')
+    ee_mjcf = mj.mj_name2id(m_mjcf, mj.mjtObj.mjOBJ_SITE, 'end_effector')
     rng = np.random.default_rng(0)
     for _ in range(50):
         q = rng.uniform(-1.5, 1.5, len(joints))
@@ -233,3 +235,5 @@ def test_recorded_urdf_matches_sim_kinematics():
             bm = mj.mj_name2id(m_mjcf, mj.mjtObj.mjOBJ_BODY, link)
             np.testing.assert_allclose(d_urdf.xpos[bu], d_mjcf.xpos[bm], atol=1e-6)
             assert abs(float(np.dot(d_urdf.xquat[bu], d_mjcf.xquat[bm]))) > 1 - 1e-6
+        np.testing.assert_allclose(d_urdf.site_xpos[ee_urdf], d_mjcf.site_xpos[ee_mjcf], atol=1e-6)
+        np.testing.assert_allclose(d_urdf.site_xmat[ee_urdf], d_mjcf.site_xmat[ee_mjcf], atol=1e-6)

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -1,3 +1,7 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import mujoco as mj
 import numpy as np
 import pos3
 import pytest
@@ -6,10 +10,12 @@ import tqdm
 import positronic.cfg.simulator
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.dataset.local_dataset import LocalDataset
+from positronic.drivers.roboarm import bundled_franka_model
 from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.simulator.mujoco.transforms import AddBox, SetBodyPosition
+from positronic.utils import package_assets_path
 
 
 # This integration test exercises the unified `main` end-to-end on the sim embodiment.
@@ -90,7 +96,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
     assert 'target_grip' in signals
     assert 'image.wrist' in signals
     # Privileged ground truth: the full sim state is recorded as a time-series signal.
-    assert 'sim_state.mjSTATE_FULLPHYSICS' in signals
+    assert 'sim_state.mjSTATE_INTEGRATION' in signals
 
     camera_samples = list(signals['image.wrist'])
     assert camera_samples, 'Camera signal for handcam_left is empty'
@@ -160,3 +166,70 @@ def test_sim_reset_seed_reproduces_scene():
     np.testing.assert_allclose(replayed.model.body('marker_body').pos, first_marker, rtol=1e-6)
     for name, array in replayed.save_state().items():
         np.testing.assert_array_equal(array, third[name])
+
+
+def test_sim_state_reconstructs_dynamics():
+    """A recorded sim state reconstructs the simulation, not just the instant: restore it and the
+    continued trajectory matches the original step-for-step.
+
+    This is the contract that lets ``STATE_SPECS`` be a minimal subset — it must carry everything a
+    forward step reads (the solver warm-start, the actuator ``ctrl``), or contact-rich motion
+    diverges and the assertions below break.
+    """
+    sim = MujocoSim('positronic/assets/mujoco/franka_table.xml', positronic.cfg.simulator.stack_cubes_loaders())
+    sim.reset(seed=123)
+    # Drive the arm off equilibrium so the saved state carries live velocity and warm-started contact
+    # forces; a settled scene would not exercise the parts a thinned subset drops.
+    sim.data.ctrl[:7] += 0.3
+    for _ in range(200):
+        sim.step()
+
+    saved = sim.save_state()
+    trajectory = []
+    for _ in range(300):
+        sim.step()
+        trajectory.append((sim.data.qpos.copy(), sim.data.qvel.copy()))
+
+    # Restore onto the same model (no ``scene_xml`` → no recompile) so the comparison isolates state
+    # sufficiency from the model's float-printed XML round-trip.
+    sim.load_state(saved, reset_time=False)
+    for qpos, qvel in trajectory:
+        sim.step()
+        np.testing.assert_array_equal(sim.data.qpos, qpos)
+        np.testing.assert_array_equal(sim.data.qvel, qvel)
+
+
+def test_recorded_urdf_matches_sim_kinematics():
+    """The URDF the sim records for the 3D viewer reproduces the arm kinematics of the MuJoCo model
+    the sim runs: for any joint configuration the link frames agree. This is what lets the viewer
+    reuse the bundled FR3 URDF — a divergence between it and the panda model would render a robot
+    that does not match the simulated one.
+    """
+
+    def kinematics(xml: str):
+        root = ET.fromstring(xml)
+        if root.tag == 'robot':  # URDF: drop meshes so MuJoCo compiles without the asset files
+            for link in root.findall('.//link'):
+                for el in link.findall('visual') + link.findall('collision'):
+                    link.remove(el)
+            xml = ET.tostring(root, encoding='unicode')
+        model = mj.MjSpec.from_string(xml).compile()
+        return model, mj.MjData(model)
+
+    m_urdf, d_urdf = kinematics(bundled_franka_model()['urdf'])
+    m_mjcf, d_mjcf = kinematics(Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text())
+    joints = [f'joint{i}' for i in range(1, 8)]
+    qadr_urdf = [m_urdf.joint(n).qposadr.item() for n in joints]
+    qadr_mjcf = [m_mjcf.joint(n).qposadr.item() for n in joints]
+    rng = np.random.default_rng(0)
+    for _ in range(50):
+        q = rng.uniform(-1.5, 1.5, len(joints))
+        d_urdf.qpos[qadr_urdf] = q
+        d_mjcf.qpos[qadr_mjcf] = q
+        mj.mj_forward(m_urdf, d_urdf)
+        mj.mj_forward(m_mjcf, d_mjcf)
+        for link in (f'link{i}' for i in range(1, 8)):
+            bu = mj.mj_name2id(m_urdf, mj.mjtObj.mjOBJ_BODY, link)
+            bm = mj.mj_name2id(m_mjcf, mj.mjtObj.mjOBJ_BODY, link)
+            np.testing.assert_allclose(d_urdf.xpos[bu], d_mjcf.xpos[bm], atol=1e-6)
+            assert abs(float(np.dot(d_urdf.xquat[bu], d_mjcf.xquat[bm]))) > 1 - 1e-6

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -199,9 +199,10 @@ def test_sim_state_reconstructs_dynamics():
 
 def test_recorded_urdf_matches_sim_kinematics():
     """The model the sim records for the viewer and IK reproduces the MuJoCo model the sim runs:
-    across joint configurations the arm link frames and the ``end_effector`` control frame agree with
-    ``panda.xml``. The control-frame check is the contract that keeps ``ik_joints_from_episode``
-    inverting ``robot_state.ee_pose`` against the grasp site the sim actually measured.
+    the arm link frames and the ``end_effector`` control frame agree with ``panda.xml`` across joint
+    configurations, and the joint limits match. The control frame is the contract that keeps
+    ``ik_joints_from_episode`` inverting ``robot_state.ee_pose`` against the grasp site the sim
+    measured; the limits are what ``DLSIKSolverWithLimits`` constrains each solve to.
     """
     joints = [f'joint{i}' for i in range(1, 8)]
 
@@ -223,6 +224,8 @@ def test_recorded_urdf_matches_sim_kinematics():
     qadr_mjcf = [m_mjcf.joint(n).qposadr.item() for n in joints]
     ee_urdf = mj.mj_name2id(m_urdf, mj.mjtObj.mjOBJ_SITE, 'end_effector')
     ee_mjcf = mj.mj_name2id(m_mjcf, mj.mjtObj.mjOBJ_SITE, 'end_effector')
+    for n in joints:
+        np.testing.assert_allclose(m_urdf.joint(n).range, m_mjcf.joint(n).range, atol=1e-6)
     rng = np.random.default_rng(0)
     for _ in range(50):
         q = rng.uniform(-1.5, 1.5, len(joints))

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -9,9 +9,10 @@ import tqdm
 import positronic.cfg.simulator
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.dataset.local_dataset import LocalDataset
+from positronic.drivers.roboarm import bundled_panda_model
 from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
-from positronic.simulator.mujoco.sim import MujocoSim, bundled_panda_model
+from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.simulator.mujoco.transforms import AddBox, SetBodyPosition
 from positronic.utils import package_assets_path
 


### PR DESCRIPTION
## Summary
Sim-viewer fixes, so a recorded sim episode renders a correct robot in the 3D viewer without bloating the recording:

- **`bundled_franka_model()`** (new, in `drivers/roboarm`): the one place that owns the bundled robot model for the viewer — the FR3 URDF, its collision meshes, joint names, and control frame. Used wherever no live robot reports its own model: `MujocoSim._emit_robot_meta` and the offline real-robot dataset transform (`cfg/ds/internal.py`) now both consume it instead of each re-reading the URDF/meshes. The FR3 arm shares the simulator panda's 7-DOF kinematics exactly, so the rendered robot matches the simulated one.
- **`STATE_SPECS = [mjSTATE_INTEGRATION]`**: record only MuJoCo's minimal complete integrable state instead of four overlapping specs (`FULLPHYSICS`/`USER`/`INTEGRATION`/`WARMSTART`), which were subsets duplicating the same values.
- **`_HIDDEN_SIGNALS = {'sim_state'}`** in the viewer: keep the wide privileged `sim_state` vector out of the per-channel signal plots, where it stalls the viewer.

## Test plan
Tested locally:
- `pytest positronic/tests/test_inference_integration.py` — 4 passed, including two new contract tests:
  - `test_sim_state_reconstructs_dynamics` — a restored `mjSTATE_INTEGRATION` reproduces the continued trajectory step-for-step (proves the single spec is sufficient).
  - `test_recorded_urdf_matches_sim_kinematics` — the bundled FR3 URDF and the panda MJCF agree on every link frame across 50 random joint configs (proves the viewer can reuse the FR3 URDF).
- `pytest positronic/simulator positronic/server positronic/dataset positronic/drivers` — 270 passed.
- `ruff check` / `ruff format` clean.