### PR TITLE
Drop `JointDelta` command; add `droid` config for public `pi05_droid`

### DIFF
--- a/positronic/policy/action.py
+++ b/positronic/policy/action.py
@@ -180,6 +180,13 @@ class JointDeltaAction(Codec):
     into a ``JointDelta`` command; the driver integrates each delta onto the live measured joints.
     """
 
+    # General DROID form scales each normalized velocity by its own per-joint delta limit and
+    # renorms the velocity vector against those limits:
+    #     RELATIVE_MAX_JOIN_DELTA = np.array([0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
+    #     MAX_JOINT_DELTA = RELATIVE_MAX_JOIN_DELTA.max()
+    #     MAX_JOINT_VEL = RELATIVE_MAX_JOIN_DELTA / MAX_JOINT_DELTA
+    # All seven limits are equal, so MAX_JOINT_VEL is all ones (the renorm is the identity on the
+    # [-1, 1]-clipped velocities) and the scaling collapses to one multiply by the scalar below.
     MAX_JOINT_DELTA = 0.2
 
     def __init__(self, num_joints: int = 7):

--- a/positronic/policy/action.py
+++ b/positronic/policy/action.py
@@ -174,16 +174,16 @@ class RelativePositionAction(Codec):
 
 
 class JointDeltaAction(Codec):
-    """DROID-style joint velocity action decoder (inference only)."""
+    """DROID-style joint-delta action decoder (inference only).
 
-    RELATIVE_MAX_JOIN_DELTA = np.array([0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
-    MAX_JOINT_DELTA = RELATIVE_MAX_JOIN_DELTA.max()
-    MAX_JONIT_VEL = RELATIVE_MAX_JOIN_DELTA / MAX_JOINT_DELTA
+    Scales the model's per-step joint velocities (clipped to ``[-1, 1]``) by ``MAX_JOINT_DELTA``
+    into a ``JointDelta`` command; the driver integrates each delta onto the live measured joints.
+    """
+
+    MAX_JOINT_DELTA = 0.2
 
     def __init__(self, num_joints: int = 7):
         self.num_joints = num_joints
-
-        self._training_meta = {'lerobot_features': {'action': lerobot_action(num_joints + 1)}}
 
     def encode(self, data):
         return {}
@@ -194,11 +194,6 @@ class JointDeltaAction(Codec):
             raise ValueError(f'Expected action vector of size {self.num_joints + 1}, got {action_vector.shape[-1]}')
 
         action_vector = action_vector.clip(-1.0, 1.0)
-        velocities = action_vector[: self.num_joints]
+        velocities = action_vector[: self.num_joints] * self.MAX_JOINT_DELTA
         grip = 1.0 if action_vector[self.num_joints].item() > 0.5 else 0.0
-
-        max_vel_norm = (np.abs(velocities) / self.MAX_JONIT_VEL).max()
-        if max_vel_norm > 1.0:
-            velocities = velocities / max_vel_norm
-
-        return {'robot_command': command.JointDelta(velocities=velocities * self.MAX_JOINT_DELTA), 'target_grip': grip}
+        return {'robot_command': command.JointDelta(velocities=velocities), 'target_grip': grip}

--- a/positronic/policy/action.py
+++ b/positronic/policy/action.py
@@ -180,13 +180,17 @@ class JointDeltaAction(Codec):
     into a ``JointDelta`` command; the driver integrates each delta onto the live measured joints.
     """
 
-    # General DROID form scales each normalized velocity by its own per-joint delta limit and
-    # renorms the velocity vector against those limits:
+    # General DROID form scales each normalized velocity by its own per-joint delta limit, then
+    # renorms the velocity vector so no joint exceeds its limit:
     #     RELATIVE_MAX_JOIN_DELTA = np.array([0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     #     MAX_JOINT_DELTA = RELATIVE_MAX_JOIN_DELTA.max()
     #     MAX_JOINT_VEL = RELATIVE_MAX_JOIN_DELTA / MAX_JOINT_DELTA
-    # All seven limits are equal, so MAX_JOINT_VEL is all ones (the renorm is the identity on the
-    # [-1, 1]-clipped velocities) and the scaling collapses to one multiply by the scalar below.
+    #     max_vel_norm = (np.abs(velocities) / MAX_JOINT_VEL).max()
+    #     if max_vel_norm > 1.0:
+    #         velocities = velocities / max_vel_norm
+    # All seven limits are equal, so MAX_JOINT_VEL is all ones and, on the [-1, 1]-clipped
+    # velocities, max_vel_norm <= 1 — the renorm never fires and the scaling collapses to one
+    # multiply by the scalar below.
     MAX_JOINT_DELTA = 0.2
 
     def __init__(self, num_joints: int = 7):

--- a/positronic/policy/observation.py
+++ b/positronic/policy/observation.py
@@ -17,11 +17,15 @@ class ObservationCodec(Codec):
     Args:
         state: mapping from output state key to an ordered dict of {episode_key: dim} to concatenate.
         images: mapping from output image name to tuple (input_key, (width, height)).
+        task_field: output key carrying the language prompt at inference; LeRobot training always uses ``task``.
     """
 
-    def __init__(self, state: dict[str, dict[str, int]], images: dict[str, tuple[str, tuple[int, int]]]):
+    def __init__(
+        self, state: dict[str, dict[str, int]], images: dict[str, tuple[str, tuple[int, int]]], task_field: str = 'task'
+    ):
         self._state = state
         self._image_configs = images
+        self._task_field = task_field
 
         self._derive_transforms = {k: partial(self._derive_state, k) for k in state.keys()}
         self._derive_transforms.update({k: partial(self._derive_image, k) for k in images.keys()})
@@ -50,7 +54,7 @@ class ObservationCodec(Codec):
         obs: dict[str, Any] = {}
 
         if 'task' in inputs:
-            obs['task'] = inputs['task']
+            obs[self._task_field] = inputs['task']
 
         for out_name, (input_key, (width, height)) in self._image_configs.items():
             if input_key not in inputs:
@@ -79,7 +83,7 @@ class ObservationCodec(Codec):
             obs[out_name] = np.zeros(sum(features.values()), dtype=np.float32)
         for out_name, (_input_key, (width, height)) in self._image_configs.items():
             obs[out_name] = np.zeros((height, width, 3), dtype=np.uint8)
-        obs['task'] = 'warmup'
+        obs[self._task_field] = 'warmup'
         return obs
 
     @property

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -30,7 +30,7 @@ import rerun.blueprint as rrb
 import positronic.cfg.ds
 import positronic.cfg.policy as policy_cfg
 from positronic.dataset.dataset import Dataset
-from positronic.drivers.roboarm.command import CartesianPosition
+from positronic.drivers.roboarm.command import CartesianPosition, JointDelta
 from positronic.policy import Policy, Recorder
 from positronic.utils.logging import init_logging
 
@@ -66,21 +66,32 @@ def _meta_doc(name: str, meta: dict) -> str:
     return f'## {name}\n\n{rows}'
 
 
-def _log_commands(actions: list[dict], wall_ns: int, inf_ns: int) -> None:
-    """Log the Cartesian chunk's fields as one named time-series on the obs's live timelines.
+def _is_cartesian_chunk(actions: list[dict] | None) -> bool:
+    """Whether every action carries a Cartesian end-effector command (so a 3D trajectory exists)."""
+    return bool(actions) and all(isinstance(a.get('robot_command'), CartesianPosition) for a in actions)
 
-    The tap already logs this on ``action_time``, but a rerun time-series view plots only the
-    active timeline, and the images live on ``wall_time`` — so to read the chunk on the same
-    timeline as the scene we re-stamp each waypoint on ``wall_time`` / ``obs_time``
-    (offset by its horizon), with a relative ``chunk_time`` axis alongside.
+
+def _log_commands(actions: list[dict], wall_ns: int, inf_ns: int) -> None:
+    """Log the chunk's per-step fields as one named time-series on the obs's live timelines.
+
+    Plots EE pose fields for a Cartesian chunk or joint velocities for a DROID chunk. The tap
+    already logs this on ``action_time``, but a rerun time-series view plots only the active
+    timeline, and the images live on ``wall_time`` — so to read the chunk on the same timeline as
+    the scene we re-stamp each waypoint on ``wall_time`` / ``obs_time`` (offset by its horizon),
+    with a relative ``chunk_time`` axis alongside.
     """
-    commands = [a['robot_command'] for a in actions]
-    if not all(isinstance(c, CartesianPosition) for c in commands):
+    if _is_cartesian_chunk(actions):
+        commands = [a['robot_command'] for a in actions]
+        labels = ['tx', 'ty', 'tz', 'qw', 'qx', 'qy', 'qz']
+        rows = [[*c.pose.translation, *c.pose.rotation.as_quat] for c in commands]
+    elif all(isinstance(a.get('robot_command'), JointDelta) for a in actions):
+        deltas = [a['robot_command'].velocities for a in actions]
+        labels = [f'dq{i}' for i in range(len(deltas[0]))]
+        rows = [list(d) for d in deltas]
+    else:
         return
     horizon = np.array([float(a.get('timestamp', i)) for i, a in enumerate(actions)])
     horizon -= horizon[0]
-    labels = ['tx', 'ty', 'tz', 'qw', 'qx', 'qy', 'qz']
-    rows = [[*c.pose.translation, *c.pose.rotation.as_quat] for c in commands]
     if all('target_grip' in a for a in actions):
         labels.append('target_grip')
         rows = [row + [a['target_grip']] for row, a in zip(rows, actions, strict=True)]
@@ -95,14 +106,14 @@ def _log_commands(actions: list[dict], wall_ns: int, inf_ns: int) -> None:
         rr.log('commands', rr.Scalars(data[i]))
 
 
-def _blueprint(image_keys: list[str]) -> rrb.Blueprint:
-    """Images + server meta on top; 3D trajectory + commands time-series below."""
+def _blueprint(image_keys: list[str], has_trajectory: bool) -> rrb.Blueprint:
+    """Images + server meta on top; the commands time-series below, with the 3D trajectory beside it
+    only for a Cartesian chunk (a velocity chunk has none, so the view is omitted)."""
     images = [rrb.Spatial2DView(origin=f'{_TAP}/{key}', name=key) for key in image_keys]
     top = rrb.Horizontal(*images, rrb.TextDocumentView(origin='meta', name='server'))
-    bottom = rrb.Horizontal(
-        rrb.Spatial3DView(origin=f'{_TAP}/robot_command/trajectory', name='trajectory'),
-        rrb.TimeSeriesView(origin='commands', name='commands'),
-    )
+    commands = rrb.TimeSeriesView(origin='commands', name='commands')
+    trajectory = rrb.Spatial3DView(origin=f'{_TAP}/robot_command/trajectory', name='trajectory')
+    bottom = rrb.Horizontal(trajectory, commands) if has_trajectory else commands
     return rrb.Blueprint(rrb.Vertical(top, bottom))
 
 
@@ -121,7 +132,7 @@ def main(
     obs = _build_wire_obs(sample, task, now_ns, ts)
     image_keys = [k for k in obs if k.startswith('image.')]
 
-    rec = Recorder(pos3.sync(output_dir), blueprint=_blueprint(image_keys))
+    rec = Recorder(pos3.sync(output_dir))
     session = rec.tap(_TAP).wrap(policy).new_session({'task': task} if task else None)
     meta = dict(session.meta)
     name = label or _recording_name(meta)
@@ -134,6 +145,9 @@ def main(
             rr.log('meta', rr.TextDocument(_meta_doc(name, meta), media_type=rr.MediaType.MARKDOWN), static=True)
             if actions:
                 _log_commands(actions, now_ns, ts)
+            # Sent here, not at Recorder construction: the layout depends on the chunk type, which is
+            # only known after inference — a velocity chunk drops the 3D trajectory view.
+            rr.send_blueprint(_blueprint(image_keys, _is_cartesian_chunk(actions)))
     finally:
         session.close()
 

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -15,13 +15,13 @@ OpenPI supports multiple codecs for different use cases:
 | `ee_traj` | EE pose + grip | Absolute EE trajectory (binarized grip) | Training on actual robot trajectory |
 | `ee_joints_traj` | EE pose + grip + joints | Absolute EE trajectory (binarized grip) | Trajectory training with joint feedback |
 | `joints_traj` | Joints + grip (no EE pose) | Absolute joint trajectory (binarized grip) | Pure joint-space trajectory training |
-| `droid` | Joint positions + grip | Joint delta (velocity) | Inference with pretrained DROID models |
+| `droid` | Joint positions + grip | Per-step `JointDelta` | Inference with pretrained DROID models |
 
 **Key notes:**
 - **`ee`**: The primary codec. Handles both training data generation (LeRobot format) and inference (OpenPI format) automatically.
 - **`ee_joints`**: Same as `ee` but includes joint positions in the observation for richer state feedback.
 - **`_traj` variants**: Train on actual robot trajectory instead of commanded targets, with binarized grip signals.
-- **`droid`**: Inference-only codec for using pretrained DROID checkpoints. Uses joint delta actions instead of absolute position.
+- **`droid`**: Inference-only codec for pretrained DROID checkpoints. The model predicts per-step joint velocities; the codec scales each into a `JointDelta` command (grip binarized) and truncates each chunk to DROID's 8-step open-loop horizon. The driver applies each delta to the live measured joints (`set_target_joints(st.q + delta)`), reproducing the DROID controller with no special client wrap. Serve with `droid` and run inference normally.
 
 ## 1. Prepare Data
 
@@ -108,12 +108,14 @@ docker compose run --rm --service-ports -v ~/checkpoints:/checkpoints openpi-ser
   --codec=@positronic.vendors.openpi.codecs.ee_joints \
   --checkpoints_dir=/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/
 
-# DROID codec (for pretrained DROID models)
-docker compose run --rm --service-ports -v ~/checkpoints:/checkpoints openpi-server serve \
-  --codec=@positronic.vendors.openpi.codecs.droid \
-  --config_name=pi05_droid \
-  --checkpoints_dir=/checkpoints/openpi/pi05_droid/experiment_v1/
+# Pretrained DROID model (pi05_droid) — preset codec, config, and public checkpoint
+docker compose run --rm --service-ports openpi-server droid
 ```
+
+The `droid` config serves the public `pi05_droid` checkpoint from
+`s3://positronic-public/checkpoints/openpi/pi05_droid/` (downloaded on first request);
+no local checkpoint mount is needed. The server emits per-step `JointDelta` commands (grip
+binarized); the driver applies each delta to the live joints, so no special client wrap is needed.
 
 **Parameters:**
 - `--codec`: Codec for observation/action encoding (default: `@positronic.vendors.openpi.codecs.ee`).
@@ -201,6 +203,9 @@ uv run --locked positronic-inference sim \
 - `--policy.host`: The machine that runs the inference server.
 - `--policy.port`: The port that the inference server exposes.
 
+A `droid` server emits `JointDelta` commands; the driver applies each to the live joints, so no
+special client wrap is needed.
+
 ## Troubleshooting
 
 ### Server fails to start
@@ -240,7 +245,7 @@ uv run --locked positronic-inference sim \
 **Solutions:**
 1. Verify codec matches the model training config:
    - Positronic models need `ee` codec (default)
-   - DROID models need `droid` codec (joint delta actions)
+   - DROID models need the `droid` codec
 2. Check observation format matches codec requirements
 3. Verify image shapes are correct (will be resized to 224x224)
 4. Check action space dimensions match expected values

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -28,6 +28,7 @@ from positronic.dataset.episode import Episode
 from positronic.dataset.transforms import image
 from positronic.dataset.transforms.episode import Derive, Get
 from positronic.policy.codec import Codec, lerobot_image, lerobot_state
+from positronic.policy.observation import ObservationCodec
 
 
 class OpenpiObservationCodec(Codec):
@@ -133,14 +134,16 @@ def observation(state_features: dict[str, int], exterior_camera: str, wrist_came
 ee_obs = observation
 ee_joints_obs = observation.override(state_features={'robot_state.ee_pose': 7, 'grip': 1, 'robot_state.q': 7})
 
-droid_obs = codecs.general_obs.override(
-    state_name='observation/joint_position',
-    state_features={'robot_state.q': 7, 'grip': 1},
-    image_mappings={
-        'observation/wrist_image_left': 'image.wrist',
-        'observation/exterior_image_1_left': 'image.exterior',
+
+# Pretrained DROID models read joints and gripper as separate observation keys and the language
+# prompt under `prompt` (see openpi `droid_policy.DroidInputs`).
+droid_obs = cfn.Config(
+    ObservationCodec,
+    state={'observation/joint_position': {'robot_state.q': 7}, 'observation/gripper_position': {'grip': 1}},
+    images={
+        'observation/wrist_image_left': ('image.wrist', (224, 224)),
+        'observation/exterior_image_1_left': ('image.exterior', (224, 224)),
     },
-    image_size=(224, 224),
     task_field='prompt',
 )
 
@@ -162,4 +165,6 @@ joints_traj = codecs.compose.override(
 joints_ik = codecs.compose.override(obs=joints_obs, action=codecs.ik_joints_action)
 joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 
-droid = codecs.compose.override(obs=droid_obs, action=codecs.joint_delta_action)
+# DROID re-queries after its 8-step open-loop horizon; truncate the served chunk to match (8/15 s
+# at 15 fps) so the client re-queries every 8 steps instead of playing the full chunk open-loop.
+droid = codecs.compose.override(obs=droid_obs, action=codecs.joint_delta_action, horizon=8 / 15)

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -339,10 +339,15 @@ sim_stack = server.override(
     checkpoints_dir='s3://checkpoints/sim_stack/openpi/ee/pi05_positronic_lowmem/230226/',
     recording_dir='s3://inference/sim_stack/server_recordings/openpi/230226/',
 )
+droid = server.override(
+    codec=codecs.droid,
+    config_name='pi05_droid',
+    checkpoints_dir='s3://PUBLIC@positronic-public/checkpoints/openpi/pi05_droid/',
+)
 
 
 if __name__ == '__main__':
     init_logging()
     ensure_paligemma_tokenizer()
     with pos3.mirror():
-        cfn.cli({'serve': server, 'phail': phail, 'sim_stack': sim_stack})
+        cfn.cli({'serve': server, 'phail': phail, 'sim_stack': sim_stack, 'droid': droid})


### PR DESCRIPTION
## Summary
- Remove the `JointDelta` robot command. The delta is now a codec concern: `JointDeltaAction` integrates the model's per-step joint velocities onto the current joints (accumulating across the action chunk) and emits absolute `JointPosition` commands. Drops `JointDelta` from the command type, both driver `match`es (Franka, MuJoCo sim), wire (de)serialization (`to_wire`/`from_wire` and the legacy command-type set), and the recording serializer.
- Add a `droid` openpi server config (mirrors `phail`/`sim_stack`) that serves the public pretrained `pi05_droid` checkpoint from `s3://positronic-public/checkpoints/openpi/pi05_droid/` with the `droid` codec preset. Launch with `openpi-server droid`.

## Test plan
- `uv run --locked --extra dev pytest --no-cov -q positronic/offboard/tests/test_offboard.py positronic/policy/tests/test_policy_io.py positronic/dataset/tests/test_ds_writer_agent.py positronic/drivers/roboarm positronic/utils` → 91 passed
- `pi05_droid` checkpoint is live in S3 and resolves via `list_checkpoints`; end-to-end serving needs a GPU host and was not run here.