### PR TITLE
Move the lerobot vendor path to Python 3.13

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -75,7 +75,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv venv --python 3.11
+        run: uv venv --python 3.13
 
       - name: Install dependencies
         run: uv sync --locked --extra dev --extra lerobot_0_3_3
@@ -95,7 +95,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv venv --python 3.11
+        run: uv venv --python 3.13
 
       - name: Install dependencies
         run: uv sync --locked --extra dev --extra lerobot

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ ENV LD_LIBRARY_PATH=${ROBOTPKG_PREFIX}/lib:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=${ROBOTPKG_PREFIX}/lib/pkgconfig
 
 ENV UV_LINK_MODE=copy
-RUN uv venv --python 3.11
+RUN uv venv --python 3.13
 
 # activate venv to be used in docker run
 ENV VIRTUAL_ENV=/.venv/

--- a/docker/Dockerfile.training
+++ b/docker/Dockerfile.training
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 ENV UV_LINK_MODE=copy
 ENV PIP_DEFAULT_TIMEOUT=600
 ENV UV_HTTP_TIMEOUT=600
-RUN uv venv --python 3.11
+RUN uv venv --python 3.13
 ENV VIRTUAL_ENV=/.venv
 ENV PATH=/$VIRTUAL_ENV/bin:$PATH
 COPY pyproject.toml uv.lock ./

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -79,30 +79,30 @@ services:
   lerobot-0_3_3-convert:
     <<: *positronic-common
     container_name: lerobot-0_3_3-convert
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lerobot_0_3_3", "python", "-m", "positronic.vendors.lerobot_0_3_3.to_lerobot"]
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lerobot_0_3_3", "python", "-m", "positronic.vendors.lerobot_0_3_3.to_lerobot"]
 
   lerobot-0_3_3-train:
     <<: *positronic-common
     container_name: lerobot-0_3_3-train
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lerobot_0_3_3", "python", "-m", "positronic.vendors.lerobot_0_3_3.train"]
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lerobot_0_3_3", "python", "-m", "positronic.vendors.lerobot_0_3_3.train"]
 
   lerobot-0_3_3-server:
     <<: *positronic-common
     container_name: lerobot-0_3_3-server
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lerobot_0_3_3", "python", "-m", "positronic.vendors.lerobot_0_3_3.server"]
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lerobot_0_3_3", "python", "-m", "positronic.vendors.lerobot_0_3_3.server"]
     ports:
       - "8000:8000"
 
   lerobot-convert:
     <<: *positronic-common
     container_name: lerobot-convert
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lerobot", "python", "-m",
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lerobot", "python", "-m",
                  "positronic.vendors.lerobot.to_lerobot"]
 
   lance-convert:
     <<: *positronic-common
     container_name: lance-convert
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lance", "python", "-m",
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lance", "python", "-m",
                  "positronic.vendors.lance.convert"]
 
   lerobot-train:
@@ -110,13 +110,13 @@ services:
     container_name: lerobot-train
     shm_size: 8g
     ipc: host
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lerobot", "python", "-m",
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lerobot", "python", "-m",
                  "positronic.vendors.lerobot.train"]
 
   lerobot-server:
     <<: *positronic-common
     container_name: lerobot-server
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "lerobot", "python", "-m",
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "lerobot", "python", "-m",
                  "positronic.vendors.lerobot.server"]
     ports:
       - "8000:8000"
@@ -124,7 +124,7 @@ services:
   positronic-inference:
     <<: *positronic-common
     container_name: positronic-inference
-    entrypoint: ["uv", "run", "--python", "3.11", "positronic-inference"]
+    entrypoint: ["uv", "run", "--python", "3.13", "positronic-inference"]
 
     devices:
       - /dev/dri:/dev/dri
@@ -136,7 +136,7 @@ services:
   positronic-server:
     <<: *positronic-common  # We need internal package for datasets
     container_name: positronic-server
-    entrypoint: ["uv", "run", "--python", "3.11", "positronic-server"]
+    entrypoint: ["uv", "run", "--python", "3.13", "positronic-server"]
     ports:
       - "8400:8400"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,12 +69,12 @@ services:
   openpi-train:
     <<: *openpi-common
     container_name: openpi-train
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.openpi.train"]
+    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.openpi.train"]
 
   openpi-stats:
     <<: *openpi-common
     container_name: openpi-stats
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.openpi.stats"]
+    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.openpi.stats"]
 
   lerobot-0_3_3-convert:
     <<: *positronic-common
@@ -143,7 +143,7 @@ services:
   openpi-server: &openpi-server-common
     <<: *openpi-common
     container_name: openpi-server
-    entrypoint: ["uv", "run", "--python", "3.11", "--extra", "openpi", "python", "-m", "positronic.vendors.openpi.server"]
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "openpi", "python", "-m", "positronic.vendors.openpi.server"]
     ports:
       - "8000:8000"
 
@@ -193,12 +193,12 @@ services:
     container_name: groot-train
     shm_size: 8g
     ipc: host  # Enable shared memory access for training
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.gr00t.train"]
+    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.gr00t.train"]
 
   groot-server: &groot-server-common
     <<: *groot-common
     container_name: groot-server
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.gr00t.server"]
+    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.gr00t.server"]
     ports:
       - "8000:8000"
 
@@ -236,7 +236,7 @@ services:
   dreamzero-server:
     <<: *dreamzero-common
     container_name: dreamzero-server
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.dreamzero.server"]
+    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.dreamzero.server"]
     ports:
       - "8000:8000"
     shm_size: 16g
@@ -247,4 +247,4 @@ services:
     container_name: dreamzero-train
     shm_size: 16g
     ipc: host
-    entrypoint: ["uv", "run", "--python", "3.11", "python", "-m", "positronic.vendors.dreamzero.train"]
+    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.dreamzero.train"]

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -86,7 +86,7 @@ if [ "$VENDOR" = "openpi" ] && [ -z "$OUTPUT_DIR" ]; then
 fi
 
 JOB_NAME="${VENDOR//_/-}-convert-$(date +%Y%m%d-%H%M%S)"
-CONVERT_ARGS="run --python 3.11 ${EXTRA}python -m ${CONVERTER_MODULE} convert $*"
+CONVERT_ARGS="run --python 3.13 ${EXTRA}python -m ${CONVERTER_MODULE} convert $*"
 
 CREATE_OUT=$(nebius ai job create \
   --parent-id "$PARENT_ID" \

--- a/workflows/nebius/convert.sh
+++ b/workflows/nebius/convert.sh
@@ -150,7 +150,7 @@ done
 DATASET_TRIM="${OUTPUT_DIR%/}"
 STATS_PATH="${DATASET_TRIM%/*}/stats/"
 STATS_JOB_NAME="openpi-stats-$(date +%Y%m%d-%H%M%S)"
-STATS_ARGS="run --python 3.11 python -m positronic.vendors.openpi.stats --input_path=${OUTPUT_DIR} --output_path=${STATS_PATH}"
+STATS_ARGS="run --python 3.13 python -m positronic.vendors.openpi.stats --input_path=${OUTPUT_DIR} --output_path=${STATS_PATH}"
 
 echo
 echo "Submitting openpi stats job (image positro/openpi)..."

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -62,12 +62,12 @@ NAME="$2"
 shift 2
 
 case "$VENDOR" in
-  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 " ;;
-  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot " ;;
+  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 "; PYVER=3.13 ;;
+  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot "; PYVER=3.13 ;;
   # openpi.server imports `openpi_client` at module top → needs --extra openpi
-  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="--extra openpi " ;;
-  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA="" ;;
-  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="" ;;
+  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="--extra openpi "; PYVER=3.11 ;;
+  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA=""; PYVER=3.11 ;;
+  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA=""; PYVER=3.11 ;;
   *)
     echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero" >&2
     exit 1
@@ -82,7 +82,7 @@ case " $* " in
   *) set -- "$@" "--idle_timeout_min=${NEBIUS_IDLE_TIMEOUT_MIN:-20}" ;;
 esac
 
-SERVER_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
+SERVER_ARGS="run --python ${PYVER} ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
 
 echo "Creating $VENDOR endpoint '$NAME'..."
 nebius ai endpoint create \

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -62,12 +62,12 @@ NAME="$2"
 shift 2
 
 case "$VENDOR" in
-  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 "; PYVER=3.13 ;;
-  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot "; PYVER=3.13 ;;
+  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 " ;;
+  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot " ;;
   # openpi.server imports `openpi_client` at module top → needs --extra openpi
-  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="--extra openpi "; PYVER=3.11 ;;
-  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA=""; PYVER=3.11 ;;
-  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA=""; PYVER=3.11 ;;
+  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="--extra openpi " ;;
+  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA="" ;;
+  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="" ;;
   *)
     echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero" >&2
     exit 1
@@ -82,7 +82,7 @@ case " $* " in
   *) set -- "$@" "--idle_timeout_min=${NEBIUS_IDLE_TIMEOUT_MIN:-20}" ;;
 esac
 
-SERVER_ARGS="run --python ${PYVER} ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
+SERVER_ARGS="run --python 3.13 ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
 
 echo "Creating $VENDOR endpoint '$NAME'..."
 nebius ai endpoint create \

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -55,11 +55,11 @@ VENDOR="$1"
 shift
 
 case "$VENDOR" in
-  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 "; PYVER=3.13 ;;
-  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot "; PYVER=3.13 ;;
-  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA=""; PYVER=3.11 ;;
-  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA=""; PYVER=3.11 ;;
-  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA=""; PYVER=3.11 ;;
+  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 " ;;
+  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot " ;;
+  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="" ;;
+  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA="" ;;
+  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="" ;;
   *)
     echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero" >&2
     exit 1
@@ -99,7 +99,7 @@ if [ -n "$INPUT_BUCKET" ]; then
 fi
 
 JOB_NAME="${VENDOR//_/-}-train-$(date +%Y%m%d-%H%M%S)"
-TRAIN_ARGS="run --python ${PYVER} ${EXTRA}python -m positronic.vendors.${VENDOR}.train ${NEW_ARGS[*]}"
+TRAIN_ARGS="run --python 3.13 ${EXTRA}python -m positronic.vendors.${VENDOR}.train ${NEW_ARGS[*]}"
 
 WANDB_FLAGS=()
 if [ -n "$WANDB_SECRET" ]; then

--- a/workflows/nebius/train.sh
+++ b/workflows/nebius/train.sh
@@ -55,11 +55,11 @@ VENDOR="$1"
 shift
 
 case "$VENDOR" in
-  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 " ;;
-  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot " ;;
-  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="" ;;
-  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA="" ;;
-  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="" ;;
+  lerobot_0_3_3) IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot_0_3_3 "; PYVER=3.13 ;;
+  lerobot)       IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra lerobot "; PYVER=3.13 ;;
+  openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA=""; PYVER=3.11 ;;
+  gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA=""; PYVER=3.11 ;;
+  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA=""; PYVER=3.11 ;;
   *)
     echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero" >&2
     exit 1
@@ -99,7 +99,7 @@ if [ -n "$INPUT_BUCKET" ]; then
 fi
 
 JOB_NAME="${VENDOR//_/-}-train-$(date +%Y%m%d-%H%M%S)"
-TRAIN_ARGS="run --python 3.11 ${EXTRA}python -m positronic.vendors.${VENDOR}.train ${NEW_ARGS[*]}"
+TRAIN_ARGS="run --python ${PYVER} ${EXTRA}python -m positronic.vendors.${VENDOR}.train ${NEW_ARGS[*]}"
 
 WANDB_FLAGS=()
 if [ -n "$WANDB_SECRET" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #410 (vendor/Docker tail): now that the core package runs on 3.13, move the one
vendor path whose stack supports it — **lerobot** — onto Python 3.13, end to end. The other
vendor stacks stay on 3.11 because they can't move yet:

- **gr00t** is upstream-pinned `requires-python == "3.10.*"` — it can't reach 3.11, let alone 3.13.
- **openpi** / **dreamzero** run from sibling-repo images (`positro/openpi`, `positro/dreamzero`)
  not rebuilt here.

Changes:
- **CI**: the `lerobot` and `lerobot-latest` vendor jobs now run on 3.13 (the only place the
  lerobot extras are exercised; core already matrix-tests 3.11–3.13).
- **`docker-compose.yml`**: the 9 services on the `positro/positronic` image
  (lerobot / lerobot_0_3_3 / lance / inference / server) → `--python 3.13`; openpi/gr00t/dreamzero
  services left at 3.11.
- **`workflows/nebius/{train,serve}.sh`**: add a per-vendor `PYVER` to the existing `case`
  (mirrors `IMAGE`/`EXTRA`) — `lerobot*` → 3.13, `openpi`/`gr00t`/`dreamzero` → 3.11.
  `convert.sh` → 3.13 (it always runs on the `positro/positronic` image via the lerobot
  converter); the chained openpi stats job stays 3.11.
- **`docker/Dockerfile`** (robot/hardware image) and **`docker/Dockerfile.training`** →
  `uv venv --python 3.13`. `Dockerfile.training.cloud` (the `positro/positronic` image) is
  interpreter-agnostic and unchanged.

## Test plan

- **lerobot adapters on 3.13**: real `uv sync --locked --extra dev --extra lerobot_0_3_3`
  (and `--extra lerobot`) on a fresh 3.13.11 venv (`torch==2.7.1`); vendor tests pass
  (`lerobot_0_3_3` 3, `lerobot` 4).
- **hardware image on 3.13**: `docker/Dockerfile` built on native amd64 — `positronic-franka 0.4.0`
  compiles from its sdist under cp313 (with libfranka), and `pyzed`/`placo` resolve to cp313 wheels.
- **lerobot full pipeline on 3.13 (Nebius H100)**: `e2e.sh lerobot_0_3_3` against a
  branch-built `positro/positronic` image — convert → train (200 steps) → serve → `/api/v1/models`
  (`{"models":["000100","000200"]}`) all green; endpoint torn down.
- CI here re-runs the lerobot vendor jobs on 3.13 as the standing linux proof.