### PR TITLE
Warm up policy endpoints at inference startup

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -85,6 +85,8 @@ def main(
     # surface come up: opening a session blocks on the server handshake, which returns only once the
     # model is loaded, and a SampledPolicy reaches every sub-policy. The first episode then begins
     # warm instead of stalling on an on-request endpoint's model load while the robot waits.
+    # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
+    # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
     logger.info('Warming up policy endpoints')
     policy.new_session().close()
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -80,6 +80,14 @@ def main(
     ``show_gui`` applies to the unattended path (attended surfaces bring their own).
     """
     assert (driver is None) != (trials is None), 'Provide exactly one of driver or trials'
+
+    # Drive the policy's remote endpoints through their cold start before hardware and the operator
+    # surface come up: opening a session blocks on the server handshake, which returns only once the
+    # model is loaded, and a SampledPolicy reaches every sub-policy. The first episode then begins
+    # warm instead of stalling on an on-request endpoint's model load while the robot waits.
+    logger.info('Warming up policy endpoints')
+    policy.new_session().close()
+
     harness = Harness(
         policy, embodiment, task=task, trials=trials, wrap=wrap, on_episode_complete=_completion_sink(policy)
     )

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -90,7 +90,7 @@ class InferenceClient:
         self.api_url = f'{http_scheme}://{netloc}/api/v1'
 
     def new_session(
-        self, model_id: str | None = None, open_timeout: float = 10.0, connect_deadline: float = 180.0
+        self, model_id: str | None = None, open_timeout: float = 10.0, connect_deadline: float = 900.0
     ) -> InferenceSession:
         """
         Creates a new inference session.


### PR DESCRIPTION
## Summary
- Inference only contacted the remote policy server on the **first** `RUN` directive — so an on-request / scale-to-zero endpoint cold-started while the robot was already homed and the operator waiting.
- `main()` now opens and immediately closes a throwaway session before the harness, hardware, and operator surface come up. The server handshake returns only once the model is loaded, so the first episode begins warm.
- For a `SampledPolicy` (e.g. `phail`), a single `new_session()` reaches every sub-policy via `_get_keys()`, so the whole endpoint fleet is warmed in one call.
- If an endpoint is unreachable, this raises here — failing fast before any hardware is touched, instead of mid-session.

## Test plan
Verified with an integration check against live `InferenceServer`s (deliberately slow to load):
- One warmup call on a 2-endpoint `SampledPolicy` caches `_server_meta` for **both** sub-policies, and blocks for the full serial load (proving every endpoint was awaited).
- A dead endpoint raises `ConnectionRefusedError` promptly.
- `main()` opens **and** closes the warmup session before constructing the `Harness` (patched `Harness` to assert ordering).
- Regression: `pytest positronic/offboard/tests positronic/policy` → 159 passed.