### PR TITLE
Authenticate inference endpoints in-process; add `secure_remote`/`modal_remote` configs

### DIFF
--- a/.claude/skills/remote-training/SKILL.md
+++ b/.claude/skills/remote-training/SKILL.md
@@ -171,8 +171,9 @@ The first job after a dependency change pays the full `uv`/HF cold-download
 Endpoint on H100 port 8000, blocks until a public IP is allocated, and prints a
 banner containing `Endpoint URL:  http://<IP>` (the endpoint IP), the endpoint
 ID/name, and the teardown command. The container then takes ~10–15 min more
-to `uv sync` and load the model. Endpoints are authenticated by default
-(`NEBIUS_AUTH_TOKEN_SECRET`); callers send `Authorization: Bearer <token>`, and
+to `uv sync` and load the model. Endpoints are authenticated by default — the
+server validates a bearer token (`NEBIUS_AUTH_TOKEN_SECRET`, injected as the
+container's `AUTH_TOKEN`); callers send `Authorization: Bearer <token>`, and
 `NEBIUS_AUTH_TOKEN_SECRET=` creates an open endpoint.
 
 ```bash

--- a/.claude/skills/remote-training/SKILL.md
+++ b/.claude/skills/remote-training/SKILL.md
@@ -171,7 +171,9 @@ The first job after a dependency change pays the full `uv`/HF cold-download
 Endpoint on H100 port 8000, blocks until a public IP is allocated, and prints a
 banner containing `Endpoint URL:  http://<IP>` (the endpoint IP), the endpoint
 ID/name, and the teardown command. The container then takes ~10–15 min more
-to `uv sync` and load the model.
+to `uv sync` and load the model. Endpoints are authenticated by default
+(`NEBIUS_AUTH_TOKEN_SECRET`); callers send `Authorization: Bearer <token>`, and
+`NEBIUS_AUTH_TOKEN_SECRET=` creates an open endpoint.
 
 ```bash
 # Named preset — checkpoint path comes from the vendor's server.py config
@@ -190,10 +192,12 @@ bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d \
   --checkpoints_dir=<ckpt-dir>
 ```
 
-Sanity-check once warm:
+Sanity-check once warm (load `POSITRONIC_INFERENCE_TOKEN` first — see
+`workflows/nebius/README.md`, "Authenticated inference"):
 
 ```bash
-curl http://<endpoint-ip>:8000/api/v1/models   # → {"models": ["<step>"]}
+curl -H "Authorization: Bearer $POSITRONIC_INFERENCE_TOKEN" \
+  http://<endpoint-ip>:8000/api/v1/models   # → {"models": ["<step>"]}
 ```
 
 Tear down (releases compute + public IP):
@@ -217,11 +221,12 @@ nebius ai endpoint list --parent-id "$NEBIUS_PARENT_ID" --format json \
 # → the public IP; the endpoint serves on port 8000
 ```
 
-Point the `positronic-inference` CLI at the endpoint IP:
+Point the `positronic-inference` CLI at the endpoint IP (`.secure_remote` reads the bearer token
+from `POSITRONIC_INFERENCE_TOKEN`):
 
 ```bash
 uv run --locked positronic-inference sim \
-  --policy=.remote --policy.host=<endpoint-ip> --policy.port=8000 \
+  --policy=.secure_remote --policy.host=<endpoint-ip> \
   --output_dir=s3://inference/sim_stack_validation/<run_name>/<vendor>/
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # Contributor behavior
 - Don't restore code that you wrote and I deleted
-- Don't make commits or git changes unprompted; an invoked PR workflow skill (e.g. `/polish`, `/push-pr`)
-  authorizes its commits and pushes
 - Don't hide errors with try-catch blocks; let failures surface until asked otherwise
 - Stay scoped: no features beyond the request. Structure of the code you touch is governed by Design
   discipline below — bringing it to the end state is in scope, refactoring unrelated code is not
@@ -62,7 +60,8 @@
 - Comments wrap at 120 columns, same as code
 
 # Testing
-- Don't add new test files unless explicitly asked
+- Prefer few test files: add cases to the existing test file for the functionality under test; create a new
+  test file only when none fits — don't grow the file count by default
 
 # Commit messages
 - Short, imperative sentences (e.g., "Fix wrong type", not "Fixed wrong type")

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -1,3 +1,5 @@
+import os
+
 import configuronic as cfn
 import pos3
 
@@ -91,6 +93,32 @@ def remote(
             return rec.tap('raw').wrap(policy)
         return (rec.tap('raw') | codec | rec.tap('server')).wrap(policy)
     return codec.wrap(policy) if codec else policy
+
+
+@cfn.config(env_var='POSITRONIC_INFERENCE_TOKEN')
+def bearer_headers(env_var: str):
+    token = os.environ.get(env_var)
+    if not token:
+        raise ValueError(f'{env_var} is not set; export the endpoint auth token before running inference.')
+    return {'Authorization': f'Bearer {token}'}
+
+
+@cfn.config(id_env='MODAL_PROXY_TOKEN_ID', secret_env='MODAL_PROXY_TOKEN_SECRET')
+def modal_headers(id_env: str, secret_env: str):
+    key, secret = os.environ.get(id_env), os.environ.get(secret_env)
+    missing = [name for name, value in [(id_env, key), (secret_env, secret)] if not value]
+    if missing:
+        raise ValueError(f'Modal proxy credentials not set; export {" and ".join(missing)} before running inference.')
+    return {'Modal-Key': key, 'Modal-Secret': secret}
+
+
+# Our own Nebius endpoints answer plain HTTP on :8000; for an endpoint served with Nebius
+# `--auth token`, the bearer token is the access control. Front it with TLS instead by adding
+# --policy.secure=True --policy.port=443.
+secure_remote = remote.override(headers=bearer_headers)
+
+# Modal fronts every endpoint with TLS on :443, gated on its proxy key/secret pair.
+modal_remote = remote.override(port=443, secure=True, headers=modal_headers)
 
 
 @cfn.config(

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -112,8 +112,9 @@ def modal_headers(id_env: str, secret_env: str):
     return {'Modal-Key': key, 'Modal-Secret': secret}
 
 
-# Our own Nebius endpoints answer plain HTTP on :8000 and validate the bearer token in-process.
-# Front them with TLS instead by adding --policy.secure=True --policy.port=443.
+# Our own Nebius endpoints are bare-IP plain HTTP on :8000 (Nebius serves no TLS), so the bearer token
+# rides the client-to-endpoint path in cleartext and is capturable there. Harden by fronting the endpoint
+# with a TLS terminator and adding --policy.secure=True --policy.port=443.
 secure_remote = remote.override(headers=bearer_headers)
 
 # Modal fronts every endpoint with TLS on :443, gated on its proxy key/secret pair.

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -112,9 +112,8 @@ def modal_headers(id_env: str, secret_env: str):
     return {'Modal-Key': key, 'Modal-Secret': secret}
 
 
-# Our own Nebius endpoints answer plain HTTP on :8000; for an endpoint served with Nebius
-# `--auth token`, the bearer token is the access control. Front it with TLS instead by adding
-# --policy.secure=True --policy.port=443.
+# Our own Nebius endpoints answer plain HTTP on :8000 and validate the bearer token in-process.
+# Front them with TLS instead by adding --policy.secure=True --policy.port=443.
 secure_remote = remote.override(headers=bearer_headers)
 
 # Modal fronts every endpoint with TLS on :443, gated on its proxy key/secret pair.

--- a/positronic/offboard/tests/test_vendor_server.py
+++ b/positronic/offboard/tests/test_vendor_server.py
@@ -5,8 +5,10 @@ import time
 from collections.abc import Generator
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 import uvicorn
+from websockets.exceptions import InvalidStatus
 
 from positronic.offboard.client import InferenceClient
 from positronic.offboard.vendor_server import VendorServer
@@ -188,5 +190,44 @@ def test_codec_wrapping(codec_server):
         assert session.metadata['codec'] == 'identity'
         result = session.infer({'obs': 'data'})
         assert result == [{'action': [1, 2, 3]}]
+    finally:
+        session.close()
+
+
+_TEST_TOKEN = 'test-secret-token'
+
+
+@pytest.fixture
+def authed_server(monkeypatch) -> Generator[tuple[str, int], None, None]:
+    monkeypatch.setenv('AUTH_TOKEN', _TEST_TOKEN)
+    host, port, _ = _start_server(_StubVendorServer(host='localhost', port=find_free_port()))
+    yield host, port
+
+
+def test_auth_rejects_missing_token(authed_server):
+    host, port = authed_server
+    client = InferenceClient(host, port)
+    with pytest.raises(InvalidStatus):
+        client.new_session()
+    with pytest.raises(httpx.HTTPStatusError):
+        client.list_models()
+
+
+def test_auth_rejects_wrong_token(authed_server):
+    host, port = authed_server
+    client = InferenceClient(host, port, headers={'Authorization': 'Bearer wrong'})
+    with pytest.raises(InvalidStatus):
+        client.new_session()
+    with pytest.raises(httpx.HTTPStatusError):
+        client.list_models()
+
+
+def test_auth_accepts_valid_token(authed_server):
+    host, port = authed_server
+    client = InferenceClient(host, port, headers={'Authorization': f'Bearer {_TEST_TOKEN}'})
+    assert client.list_models() == ['stub']
+    session = client.new_session()
+    try:
+        assert session.metadata['type'] == 'stub'
     finally:
         session.close()

--- a/positronic/offboard/tests/test_vendor_server.py
+++ b/positronic/offboard/tests/test_vendor_server.py
@@ -231,3 +231,9 @@ def test_auth_accepts_valid_token(authed_server):
         assert session.metadata['type'] == 'stub'
     finally:
         session.close()
+
+
+def test_empty_auth_token_fails_closed(monkeypatch):
+    monkeypatch.setenv('AUTH_TOKEN', '')
+    with pytest.raises(ValueError, match='AUTH_TOKEN is set but empty'):
+        _StubVendorServer(host='localhost', port=find_free_port())

--- a/positronic/offboard/vendor_server.py
+++ b/positronic/offboard/vendor_server.py
@@ -1,7 +1,9 @@
 """Base class for vendor inference servers (GR00T, OpenPI, DreamZero, LeRobot)."""
 
 import asyncio
+import hmac
 import logging
+import os
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -9,7 +11,7 @@ from typing import Any
 
 import pos3
 import uvicorn
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect, WebSocketException, status
 
 from positronic.policy import Codec, Policy, Recorder
 from positronic.utils.checkpoints import get_latest_checkpoint, list_checkpoints
@@ -146,10 +148,17 @@ class VendorServer(ABC):
 
         self.metadata: dict[str, Any] = {}
 
+        # Bearer token gating every endpoint, injected as the container's AUTH_TOKEN env var by
+        # serve.sh. Absent -> the server is open. Validated in-process because Nebius `--auth token`
+        # gates HTTP but does not proxy the inference WebSocket.
+        self._auth_token = os.environ.get('AUTH_TOKEN') or None
+
         self.app = FastAPI()
-        self.app.get('/api/v1/models')(self.get_models)
-        self.app.websocket('/api/v1/session')(self.websocket_endpoint)
-        self.app.websocket('/api/v1/session/{model_id}')(self.websocket_endpoint)
+        http_auth = [Depends(self._require_http_auth)]
+        ws_auth = [Depends(self._require_ws_auth)]
+        self.app.get('/api/v1/models', dependencies=http_auth)(self.get_models)
+        self.app.websocket('/api/v1/session', dependencies=ws_auth)(self.websocket_endpoint)
+        self.app.websocket('/api/v1/session/{model_id}', dependencies=ws_auth)(self.websocket_endpoint)
 
     @abstractmethod
     async def resolve_model(self, model_id: str | None, websocket: WebSocket | None) -> tuple[Any, dict]:
@@ -192,6 +201,19 @@ class VendorServer(ABC):
                 await websocket.send_bytes(serialise({'status': 'loading', 'message': msg}))
 
         return send_progress
+
+    def _authorized(self, authorization: str | None) -> bool:
+        if self._auth_token is None:
+            return True
+        return authorization is not None and hmac.compare_digest(authorization, f'Bearer {self._auth_token}')
+
+    def _require_http_auth(self, authorization: str | None = Header(default=None)):
+        if not self._authorized(authorization):
+            raise HTTPException(status_code=401, detail='Invalid or missing bearer token')
+
+    async def _require_ws_auth(self, websocket: WebSocket):
+        if not self._authorized(websocket.headers.get('authorization')):
+            raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
 
     async def websocket_endpoint(self, websocket: WebSocket, model_id: str | None = None):
         await websocket.accept()

--- a/positronic/offboard/vendor_server.py
+++ b/positronic/offboard/vendor_server.py
@@ -149,9 +149,12 @@ class VendorServer(ABC):
         self.metadata: dict[str, Any] = {}
 
         # Bearer token gating every endpoint, injected as the container's AUTH_TOKEN env var by
-        # serve.sh. Absent -> the server is open. Validated in-process because Nebius `--auth token`
+        # serve.sh. Unset -> the server is open; set-but-empty means a misconfigured secret, so fail
+        # closed rather than silently serve open. Validated in-process because Nebius `--auth token`
         # gates HTTP but does not proxy the inference WebSocket.
-        self._auth_token = os.environ.get('AUTH_TOKEN') or None
+        self._auth_token = os.environ.get('AUTH_TOKEN')
+        if self._auth_token == '':
+            raise ValueError('AUTH_TOKEN is set but empty; unset it for an open endpoint or inject a real token')
 
         self.app = FastAPI()
         http_auth = [Depends(self._require_http_auth)]

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -22,12 +22,14 @@ This page mirrors all three cloud-side steps of
 
 ## One-time setup
 
-Create up to four MysteryBox secrets that the jobs will reference by name. AWS keys are read
-from your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`. The first three
-are single-key payloads consumed via `--env-secret`. The fourth is a two-key payload consumed
-by `--volume` for Mountpoint-S3 authentication (Nebius requires the keys to be named
-`S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`). The wandb secret is optional — skip it if you
-don't use Weights & Biases.
+Create up to five MysteryBox secrets that the jobs and endpoints reference by name. AWS keys are
+read from your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb`. The first
+three are single-key payloads consumed via `--env-secret`. The fourth is a two-key payload
+consumed by `--volume` for Mountpoint-S3 authentication (Nebius requires the keys to be named
+`S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`). The fifth holds the bearer token gating served
+endpoints — `serve.sh` authenticates by default and reads it via `--token-secret`, so its
+payload key must be `AUTH_TOKEN`. The wandb secret is optional — skip it if you don't use
+Weights & Biases.
 
 ```bash
 PARENT_ID=project-e00f38wexevrr52b8j  # adjust to your own project
@@ -65,6 +67,13 @@ nebius mysterybox secret create \
     --arg k "$(aws configure get aws_access_key_id --profile "$AWS_PROFILE_FOR_S3")" \
     --arg s "$(aws configure get aws_secret_access_key --profile "$AWS_PROFILE_FOR_S3")" \
     '[{key:"S3_ACCESS_KEY_ID",string_value:$k},{key:"S3_SECRET_ACCESS_KEY",string_value:$s}]')"
+
+nebius mysterybox secret create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-inference-token \
+  --description "Bearer token gating authenticated inference endpoints" \
+  --secret-version-payload "$(jq -nc \
+    --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
 ```
 
 The names matter — `convert.sh`, `train.sh`, and `serve.sh` reference the secrets by name. If a
@@ -207,6 +216,11 @@ port 8000. Endpoints don't have managed DNS yet, so the IP is the contact addres
 across endpoint stop/start, but new endpoints get new IPs. Supported vendors:
 `lerobot_0_3_3`, `lerobot`, `openpi`, `gr00t`.
 
+Endpoints are **authenticated by default** — Nebius gates them behind a bearer token, so the
+sanity check and inference below send `Authorization: Bearer <token>` (loaded under
+[Authenticated inference](#authenticated-inference)). Pass `NEBIUS_AUTH_TOKEN_SECRET=` to
+`serve.sh` for an open endpoint.
+
 Take a vendor and a unique endpoint name as the first two arguments; remaining arguments forward
 to the server CLI. Example using the public ACT demo checkpoint at
 `s3://positronic-public/checkpoints/sim_stack_cubes/act/` (no S3 credentials needed inside the
@@ -240,21 +254,22 @@ bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \
 `serve.sh` blocks until the public IP is allocated (typically <1 min), then prints a banner with
 the URL, endpoint ID, and the commands to follow logs and tear down. The container takes another
 ~10–15 min to finish `uv sync` and load the model into GPU memory; once `INFO Started server
-process` appears in `nebius ai endpoint logs`, sanity-check with:
+process` appears in `nebius ai endpoint logs`, sanity-check with (after exporting
+`POSITRONIC_INFERENCE_TOKEN`, see [Authenticated inference](#authenticated-inference)):
 
 ```bash
-curl http://<endpoint-ip>:8000/api/v1/models
+curl -H "Authorization: Bearer $POSITRONIC_INFERENCE_TOKEN" http://<endpoint-ip>:8000/api/v1/models
 # → {"models": ["050000"]}
 ```
 
 Run inference from your laptop or robot host using the existing `positronic-inference` CLI
-([docs/inference.md](../../docs/inference.md)):
+([docs/inference.md](../../docs/inference.md)); `.secure_remote` reads the token from
+`POSITRONIC_INFERENCE_TOKEN`:
 
 ```bash
 uv run positronic-inference sim \
-  --policy=.remote \
+  --policy=.secure_remote \
   --policy.host=<endpoint-ip> \
-  --policy.port=8000 \
   --output_dir=.data/inference/<run-name>/
 ```
 
@@ -269,9 +284,9 @@ later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
 
 ## Authenticated inference
 
-A bare endpoint answers anyone who learns its address. Two policy configs attach an auth header
-so a served policy only responds to callers holding the right credential, and each reads that
-credential from the environment — so the only argument you pass at the CLI is the host:
+`serve.sh` authenticates endpoints by default. Two policy configs send the matching auth header,
+each reading the credential from the environment — so the only argument you pass at the CLI is
+the host:
 
 | Policy config | Target endpoint | Header sent | Environment variable |
 |---|---|---|---|
@@ -290,38 +305,10 @@ whole envelope).
 
 ### Our own Nebius endpoint
 
-**One-time:** create a MysteryBox secret holding the bearer token. The payload key must be
-`AUTH_TOKEN` — Nebius's `--token-secret` looks for exactly that name:
-
-```bash
-nebius mysterybox secret create \
-  --parent-id "$PARENT_ID" \
-  --name positronic-serverless-inference-token \
-  --description "Bearer token gating authenticated inference endpoints" \
-  --secret-version-payload "$(jq -nc \
-    --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
-```
-
-Rotate it later by adding a new primary version (clients re-read it on their next run):
-
-```bash
-SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
-  | jq -r '.items[] | select(.metadata.name=="positronic-serverless-inference-token") | .metadata.id')
-nebius mysterybox secret-version create --parent-id "$SECRET_ID" --set-primary \
-  --payload "$(jq -nc --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
-```
-
-**Serve** with `NEBIUS_AUTH_TOKEN_SECRET` set, so `serve.sh` adds `--auth token` and the platform
-rejects tokenless requests at the ingress, before they reach the container:
-
-```bash
-NEBIUS_AUTH_TOKEN_SECRET=positronic-serverless-inference-token \
-  bash workflows/nebius/serve.sh lerobot_0_3_3 act-server serve \
-  --checkpoints_dir=s3://<your-bucket>/checkpoints/lerobot/<exp_name>/
-```
-
-**Run inference** by loading that same token into the environment, then pointing `.secure_remote`
-at the endpoint IP — the host is the only argument:
+The token secret (`positronic-serverless-inference-token`) is created in
+[One-time setup](#one-time-setup) and `serve.sh` reads it by default, so serving needs no extra
+flags. Load the token into the environment, then point `.secure_remote` at the endpoint IP — the
+host is the only argument:
 
 ```bash
 SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
@@ -333,6 +320,15 @@ uv run positronic-inference sim \
   --policy=.secure_remote \
   --policy.host=<endpoint-ip> \
   --output_dir=.data/inference/<run-name>/
+```
+
+Rotate the token by adding a new primary version (clients re-read it on their next run):
+
+```bash
+SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
+  | jq -r '.items[] | select(.metadata.name=="positronic-serverless-inference-token") | .metadata.id')
+nebius mysterybox secret-version create --parent-id "$SECRET_ID" --set-primary \
+  --payload "$(jq -nc --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
 ```
 
 ### A Modal endpoint
@@ -368,7 +364,7 @@ override them** with their own project + subnet IDs:
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
 | `WANDB_SECRET` | `positronic-serverless-wandb-api-key` | MysteryBox secret name for the WandB key. Set empty (`WANDB_SECRET=`) to skip wandb entirely. |
-| `NEBIUS_AUTH_TOKEN_SECRET` | _(empty — open endpoint)_ | `serve.sh` only. MysteryBox secret name (payload key `AUTH_TOKEN`) for `--auth token`; when set, the endpoint rejects requests without `Authorization: Bearer <token>`. See [Authenticated inference](#authenticated-inference). |
+| `NEBIUS_AUTH_TOKEN_SECRET` | `positronic-serverless-inference-token` | `serve.sh` only. MysteryBox secret name (payload key `AUTH_TOKEN`) for `--auth token`; the endpoint rejects requests without `Authorization: Bearer <token>`. Set empty (`NEBIUS_AUTH_TOKEN_SECRET=`) for an open endpoint. See [Authenticated inference](#authenticated-inference). |
 | `NEBIUS_CACHE_FS` | `computefilesystem-e00f6jyfr5wkawyrab` | Shared filesystem **ID** (not name — `--volume` rejects names) mounted RW at `/cache` for the `uv`/HF/openpi caches (`UV_CACHE_DIR`, `HF_HOME`, `OPENPI_DATA_HOME`). Not used by pos3. The default is Positronic-internal; external users must override with their own filesystem ID. |
 | `NEBIUS_IMAGE_TAG` | `latest` | Docker image tag the job/endpoint pulls (`positro/<image>:<tag>`). `cd docker && make push-* IMAGE_TAG=<branch>` pushes that tag unconditionally; set `NEBIUS_IMAGE_TAG=<branch>` to run a branch build remotely without clobbering `:latest`. `make push-*` only updates `:latest` when run with `CI` set. Note `convert.sh openpi` chains a stats job on the `positro/openpi` image, so with `NEBIUS_IMAGE_TAG=<branch>` you must also have pushed `positro/openpi:<branch>` (not just `positro/positronic:<branch>`); otherwise leave `NEBIUS_IMAGE_TAG` unset so stats uses `:latest`. |
 

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -285,31 +285,10 @@ later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
 
 ## Authenticated inference
 
-`serve.sh` authenticates endpoints by default. Two policy configs send the matching auth header,
-each reading the credential from the environment — so the only argument you pass at the CLI is
-the host:
-
-| Policy config | Target endpoint | Header sent | Environment variable |
-|---|---|---|---|
-| `.secure_remote` | Our own Nebius endpoint (the server validates the token) | `Authorization: Bearer <token>` | `POSITRONIC_INFERENCE_TOKEN` |
-| `.modal_remote` | A Modal endpoint (e.g. the Gyros policy servers under Runway) | `Modal-Key` / `Modal-Secret` | `MODAL_PROXY_TOKEN_ID`, `MODAL_PROXY_TOKEN_SECRET` |
-
-`.secure_remote` keeps the plain-HTTP `:8000` contact address of a Nebius endpoint — the bearer
-token, validated by the server in-process, is the access control. `.modal_remote` defaults to TLS
-on `:443`, where Modal terminates and checks the proxy
-pair. Both raise immediately if their environment variable is unset, rather than sending an
-unauthenticated request.
-
-A bare value retrieved from MysteryBox comes wrapped in a small JSON envelope — extract the raw
-token with `--format json | jq -r '.data.string_value'` (not `--format text`, which returns the
-whole envelope).
-
-### Our own Nebius endpoint
-
-The token secret (`positronic-serverless-inference-token`) is created in
-[One-time setup](#one-time-setup) and `serve.sh` reads it by default, so serving needs no extra
-flags. Load the token into the environment, then point `.secure_remote` at the endpoint IP — the
-host is the only argument:
+`serve.sh` authenticates endpoints by default; the server validates `Authorization: Bearer <token>` on
+every request. `.secure_remote` attaches that header from `POSITRONIC_INFERENCE_TOKEN` (the only CLI
+argument is then the host) and raises immediately if the variable is unset. The token secret
+(`positronic-serverless-inference-token`) is created in [One-time setup](#one-time-setup); load it and run:
 
 ```bash
 SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
@@ -326,28 +305,8 @@ uv run positronic-inference sim \
 Rotate the token by adding a new primary version (clients re-read it on their next run):
 
 ```bash
-SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
-  | jq -r '.items[] | select(.metadata.name=="positronic-serverless-inference-token") | .metadata.id')
 nebius mysterybox secret-version create --parent-id "$SECRET_ID" --set-primary \
   --payload "$(jq -nc --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
-```
-
-### A Modal endpoint
-
-Modal fronts every endpoint with proxy auth on `:443`. Load the proxy token pair from the Runway
-MysteryBox secret (`runway-modal-proxy`), then point `.modal_remote` at the `*.modal.run` host —
-no `--policy.port` or `--policy.secure` needed, those are baked in:
-
-```bash
-export MODAL_PROXY_TOKEN_ID=$(nebius mysterybox payload get-by-key \
-  --secret-id mbsec-e00zw9csj016v0t01h --key token-id --format json | jq -r '.data.string_value')
-export MODAL_PROXY_TOKEN_SECRET=$(nebius mysterybox payload get-by-key \
-  --secret-id mbsec-e00zw9csj016v0t01h --key token-secret --format json | jq -r '.data.string_value')
-
-uv run positronic-inference phail \
-  --policy=.modal_remote \
-  --policy.host=runway-pythagoras-dev--gyros-positronic-serve-2-gyrosserver-web.modal.run \
-  --output_dir=s3://runway/inference/phail/<DDMMYY>/rollouts/
 ```
 
 ## What changed vs. running on a VM

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -267,6 +267,92 @@ bash workflows/nebius/stop.sh my-act-demo
 To pause an endpoint without releasing its static IP (useful if you want to reuse the same IP
 later), use `nebius ai endpoint stop <id>` directly — `start` resumes it.
 
+## Authenticated inference
+
+A bare endpoint answers anyone who learns its address. Two policy configs attach an auth header
+so a served policy only responds to callers holding the right credential, and each reads that
+credential from the environment — so the only argument you pass at the CLI is the host:
+
+| Policy config | Target endpoint | Header sent | Environment variable |
+|---|---|---|---|
+| `.secure_remote` | Our own Nebius endpoint served with `--auth token` | `Authorization: Bearer <token>` | `POSITRONIC_INFERENCE_TOKEN` |
+| `.modal_remote` | A Modal endpoint (e.g. the Gyros policy servers under Runway) | `Modal-Key` / `Modal-Secret` | `MODAL_PROXY_TOKEN_ID`, `MODAL_PROXY_TOKEN_SECRET` |
+
+`.secure_remote` keeps the plain-HTTP `:8000` contact address of a Nebius endpoint — the bearer
+token, enforced by the Nebius ingress before the request reaches the container, is the access
+control. `.modal_remote` defaults to TLS on `:443`, where Modal terminates and checks the proxy
+pair. Both raise immediately if their environment variable is unset, rather than sending an
+unauthenticated request.
+
+A bare value retrieved from MysteryBox comes wrapped in a small JSON envelope — extract the raw
+token with `--format json | jq -r '.data.string_value'` (not `--format text`, which returns the
+whole envelope).
+
+### Our own Nebius endpoint
+
+**One-time:** create a MysteryBox secret holding the bearer token. The payload key must be
+`AUTH_TOKEN` — Nebius's `--token-secret` looks for exactly that name:
+
+```bash
+nebius mysterybox secret create \
+  --parent-id "$PARENT_ID" \
+  --name positronic-serverless-inference-token \
+  --description "Bearer token gating authenticated inference endpoints" \
+  --secret-version-payload "$(jq -nc \
+    --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
+```
+
+Rotate it later by adding a new primary version (clients re-read it on their next run):
+
+```bash
+SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
+  | jq -r '.items[] | select(.metadata.name=="positronic-serverless-inference-token") | .metadata.id')
+nebius mysterybox secret-version create --parent-id "$SECRET_ID" --set-primary \
+  --payload "$(jq -nc --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
+```
+
+**Serve** with `NEBIUS_AUTH_TOKEN_SECRET` set, so `serve.sh` adds `--auth token` and the platform
+rejects tokenless requests at the ingress, before they reach the container:
+
+```bash
+NEBIUS_AUTH_TOKEN_SECRET=positronic-serverless-inference-token \
+  bash workflows/nebius/serve.sh lerobot_0_3_3 act-server serve \
+  --checkpoints_dir=s3://<your-bucket>/checkpoints/lerobot/<exp_name>/
+```
+
+**Run inference** by loading that same token into the environment, then pointing `.secure_remote`
+at the endpoint IP — the host is the only argument:
+
+```bash
+SECRET_ID=$(nebius mysterybox secret list --parent-id "$PARENT_ID" --format json \
+  | jq -r '.items[] | select(.metadata.name=="positronic-serverless-inference-token") | .metadata.id')
+export POSITRONIC_INFERENCE_TOKEN=$(nebius mysterybox payload get-by-key \
+  --secret-id "$SECRET_ID" --key AUTH_TOKEN --format json | jq -r '.data.string_value')
+
+uv run positronic-inference sim \
+  --policy=.secure_remote \
+  --policy.host=<endpoint-ip> \
+  --output_dir=.data/inference/<run-name>/
+```
+
+### A Modal endpoint
+
+Modal fronts every endpoint with proxy auth on `:443`. Load the proxy token pair from the Runway
+MysteryBox secret (`runway-modal-proxy`), then point `.modal_remote` at the `*.modal.run` host —
+no `--policy.port` or `--policy.secure` needed, those are baked in:
+
+```bash
+export MODAL_PROXY_TOKEN_ID=$(nebius mysterybox payload get-by-key \
+  --secret-id mbsec-e00zw9csj016v0t01h --key token-id --format json | jq -r '.data.string_value')
+export MODAL_PROXY_TOKEN_SECRET=$(nebius mysterybox payload get-by-key \
+  --secret-id mbsec-e00zw9csj016v0t01h --key token-secret --format json | jq -r '.data.string_value')
+
+uv run positronic-inference phail \
+  --policy=.modal_remote \
+  --policy.host=runway-pythagoras-dev--gyros-positronic-serve-2-gyrosserver-web.modal.run \
+  --output_dir=s3://runway/inference/phail/<DDMMYY>/rollouts/
+```
+
 ## What changed vs. running on a VM
 
 No VM to provision, SSH into, or remember to shut down. Credentials stay in MysteryBox instead
@@ -282,6 +368,7 @@ override them** with their own project + subnet IDs:
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
 | `WANDB_SECRET` | `positronic-serverless-wandb-api-key` | MysteryBox secret name for the WandB key. Set empty (`WANDB_SECRET=`) to skip wandb entirely. |
+| `NEBIUS_AUTH_TOKEN_SECRET` | _(empty — open endpoint)_ | `serve.sh` only. MysteryBox secret name (payload key `AUTH_TOKEN`) for `--auth token`; when set, the endpoint rejects requests without `Authorization: Bearer <token>`. See [Authenticated inference](#authenticated-inference). |
 | `NEBIUS_CACHE_FS` | `computefilesystem-e00f6jyfr5wkawyrab` | Shared filesystem **ID** (not name — `--volume` rejects names) mounted RW at `/cache` for the `uv`/HF/openpi caches (`UV_CACHE_DIR`, `HF_HOME`, `OPENPI_DATA_HOME`). Not used by pos3. The default is Positronic-internal; external users must override with their own filesystem ID. |
 | `NEBIUS_IMAGE_TAG` | `latest` | Docker image tag the job/endpoint pulls (`positro/<image>:<tag>`). `cd docker && make push-* IMAGE_TAG=<branch>` pushes that tag unconditionally; set `NEBIUS_IMAGE_TAG=<branch>` to run a branch build remotely without clobbering `:latest`. `make push-*` only updates `:latest` when run with `CI` set. Note `convert.sh openpi` chains a stats job on the `positro/openpi` image, so with `NEBIUS_IMAGE_TAG=<branch>` you must also have pushed `positro/openpi:<branch>` (not just `positro/positronic:<branch>`); otherwise leave `NEBIUS_IMAGE_TAG` unset so stats uses `:latest`. |
 

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -27,8 +27,9 @@ read from your local `~/.aws/credentials`; the WandB key from `docker/.env.wandb
 three are single-key payloads consumed via `--env-secret`. The fourth is a two-key payload
 consumed by `--volume` for Mountpoint-S3 authentication (Nebius requires the keys to be named
 `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`). The fifth holds the bearer token gating served
-endpoints — `serve.sh` authenticates by default and reads it via `--token-secret`, so its
-payload key must be `AUTH_TOKEN`. The wandb secret is optional — skip it if you don't use
+endpoints — `serve.sh` authenticates by default and injects it as the container's `AUTH_TOKEN`
+env var (via `--env-secret`), where the server validates it, so its payload key must be
+`AUTH_TOKEN`. The wandb secret is optional — skip it if you don't use
 Weights & Biases.
 
 ```bash
@@ -216,7 +217,7 @@ port 8000. Endpoints don't have managed DNS yet, so the IP is the contact addres
 across endpoint stop/start, but new endpoints get new IPs. Supported vendors:
 `lerobot_0_3_3`, `lerobot`, `openpi`, `gr00t`.
 
-Endpoints are **authenticated by default** — Nebius gates them behind a bearer token, so the
+Endpoints are **authenticated by default** — the server validates a bearer token, so the
 sanity check and inference below send `Authorization: Bearer <token>` (loaded under
 [Authenticated inference](#authenticated-inference)). Pass `NEBIUS_AUTH_TOKEN_SECRET=` to
 `serve.sh` for an open endpoint.
@@ -290,12 +291,12 @@ the host:
 
 | Policy config | Target endpoint | Header sent | Environment variable |
 |---|---|---|---|
-| `.secure_remote` | Our own Nebius endpoint served with `--auth token` | `Authorization: Bearer <token>` | `POSITRONIC_INFERENCE_TOKEN` |
+| `.secure_remote` | Our own Nebius endpoint (the server validates the token) | `Authorization: Bearer <token>` | `POSITRONIC_INFERENCE_TOKEN` |
 | `.modal_remote` | A Modal endpoint (e.g. the Gyros policy servers under Runway) | `Modal-Key` / `Modal-Secret` | `MODAL_PROXY_TOKEN_ID`, `MODAL_PROXY_TOKEN_SECRET` |
 
 `.secure_remote` keeps the plain-HTTP `:8000` contact address of a Nebius endpoint — the bearer
-token, enforced by the Nebius ingress before the request reaches the container, is the access
-control. `.modal_remote` defaults to TLS on `:443`, where Modal terminates and checks the proxy
+token, validated by the server in-process, is the access control. `.modal_remote` defaults to TLS
+on `:443`, where Modal terminates and checks the proxy
 pair. Both raise immediately if their environment variable is unset, rather than sending an
 unauthenticated request.
 
@@ -364,7 +365,7 @@ override them** with their own project + subnet IDs:
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
 | `WANDB_SECRET` | `positronic-serverless-wandb-api-key` | MysteryBox secret name for the WandB key. Set empty (`WANDB_SECRET=`) to skip wandb entirely. |
-| `NEBIUS_AUTH_TOKEN_SECRET` | `positronic-serverless-inference-token` | `serve.sh` only. MysteryBox secret name (payload key `AUTH_TOKEN`) for `--auth token`; the endpoint rejects requests without `Authorization: Bearer <token>`. Set empty (`NEBIUS_AUTH_TOKEN_SECRET=`) for an open endpoint. See [Authenticated inference](#authenticated-inference). |
+| `NEBIUS_AUTH_TOKEN_SECRET` | `positronic-serverless-inference-token` | `serve.sh` only. MysteryBox secret name (payload key `AUTH_TOKEN`) injected as the container's `AUTH_TOKEN` env var; the server rejects requests without `Authorization: Bearer <token>`. Set empty (`NEBIUS_AUTH_TOKEN_SECRET=`) for an open endpoint. See [Authenticated inference](#authenticated-inference). |
 | `NEBIUS_CACHE_FS` | `computefilesystem-e00f6jyfr5wkawyrab` | Shared filesystem **ID** (not name — `--volume` rejects names) mounted RW at `/cache` for the `uv`/HF/openpi caches (`UV_CACHE_DIR`, `HF_HOME`, `OPENPI_DATA_HOME`). Not used by pos3. The default is Positronic-internal; external users must override with their own filesystem ID. |
 | `NEBIUS_IMAGE_TAG` | `latest` | Docker image tag the job/endpoint pulls (`positro/<image>:<tag>`). `cd docker && make push-* IMAGE_TAG=<branch>` pushes that tag unconditionally; set `NEBIUS_IMAGE_TAG=<branch>` to run a branch build remotely without clobbering `:latest`. `make push-*` only updates `:latest` when run with `CI` set. Note `convert.sh openpi` chains a stats job on the `positro/openpi` image, so with `NEBIUS_IMAGE_TAG=<branch>` you must also have pushed `positro/openpi:<branch>` (not just `positro/positronic:<branch>`); otherwise leave `NEBIUS_IMAGE_TAG` unset so stats uses `:latest`. |
 

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -302,12 +302,16 @@ uv run positronic-inference sim \
   --output_dir=.data/inference/<run-name>/
 ```
 
-Rotate the token by adding a new primary version (clients re-read it on their next run):
+Rotate the token by adding a new primary version:
 
 ```bash
 nebius mysterybox secret-version create --parent-id "$SECRET_ID" --set-primary \
   --payload "$(jq -nc --arg v "$(openssl rand -hex 32)" '[{key:"AUTH_TOKEN",string_value:$v}]')"
 ```
+
+Clients re-read the secret on their next run, but a running endpoint keeps validating the token it read
+at container start. Re-run `serve.sh` for each live endpoint after rotating, or the new clients hit
+401/1008 against the old token.
 
 ## What changed vs. running on a VM
 

--- a/workflows/nebius/e2e.sh
+++ b/workflows/nebius/e2e.sh
@@ -152,7 +152,8 @@ wait_job "$TRAIN_ID" "train" || exit 1
 
 # ---- 3. Serve ----
 note "serve -> $ENDPOINT_NAME"
-SERVE_OUT=$(bash "$SCRIPT_DIR/serve.sh" "$VENDOR" "$ENDPOINT_NAME" "${SERVE_SUBCMD[@]}" 2>&1)
+# Open endpoint: the pipeline test's smoke curl below is unauthenticated.
+SERVE_OUT=$(NEBIUS_AUTH_TOKEN_SECRET= bash "$SCRIPT_DIR/serve.sh" "$VENDOR" "$ENDPOINT_NAME" "${SERVE_SUBCMD[@]}" 2>&1)
 echo "$SERVE_OUT" >> "$LOG"
 SERVE_URL=$(echo "$SERVE_OUT" | awk '/Endpoint URL:/ {print $3; exit}')
 [ -z "$SERVE_URL" ] && { note "FAIL: no serve URL"; exit 1; }

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -23,10 +23,10 @@ IMAGE_TAG="${NEBIUS_IMAGE_TAG:-latest}"
 # Nebius GPU preset. Default is one H100; multi-GPU presets must match the server's GPU count
 # (DreamZero's --num_gpus runs torchrun --nproc_per_node, so an 8-GPU server needs an 8-GPU preset).
 PRESET="${NEBIUS_PRESET:-1gpu-16vcpu-200gb}"
-# Authenticated endpoint (opt-in). Point NEBIUS_AUTH_TOKEN_SECRET at a MysteryBox secret whose
+# Authenticated endpoint (default). NEBIUS_AUTH_TOKEN_SECRET names a MysteryBox secret whose
 # payload key is AUTH_TOKEN; Nebius then rejects any request lacking `Authorization: Bearer <token>`
-# at the ingress, before it reaches the container. Empty (the default) leaves the endpoint open.
-AUTH_TOKEN_SECRET="${NEBIUS_AUTH_TOKEN_SECRET:-}"
+# at the ingress, before it reaches the container. Set it empty to create an open endpoint.
+AUTH_TOKEN_SECRET="${NEBIUS_AUTH_TOKEN_SECRET-positronic-serverless-inference-token}"
 AUTH_FLAGS=""  # word-splits into the create call below; MysteryBox selectors carry no spaces
 [ -n "$AUTH_TOKEN_SECRET" ] && AUTH_FLAGS="--auth token --token-secret $AUTH_TOKEN_SECRET"
 

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -23,12 +23,14 @@ IMAGE_TAG="${NEBIUS_IMAGE_TAG:-latest}"
 # Nebius GPU preset. Default is one H100; multi-GPU presets must match the server's GPU count
 # (DreamZero's --num_gpus runs torchrun --nproc_per_node, so an 8-GPU server needs an 8-GPU preset).
 PRESET="${NEBIUS_PRESET:-1gpu-16vcpu-200gb}"
-# Authenticated endpoint (default). NEBIUS_AUTH_TOKEN_SECRET names a MysteryBox secret whose
-# payload key is AUTH_TOKEN; Nebius then rejects any request lacking `Authorization: Bearer <token>`
-# at the ingress, before it reaches the container. Set it empty to create an open endpoint.
+# Authenticated endpoint (default). The server validates `Authorization: Bearer <token>` in-process
+# on both the HTTP and WebSocket routes — Nebius `--auth token` gates HTTP but drops the inference
+# WebSocket upgrade, so auth lives in the server. NEBIUS_AUTH_TOKEN_SECRET names a MysteryBox secret
+# whose AUTH_TOKEN payload is injected as the container's AUTH_TOKEN env var. Set it empty to create
+# an open endpoint.
 AUTH_TOKEN_SECRET="${NEBIUS_AUTH_TOKEN_SECRET-positronic-serverless-inference-token}"
 AUTH_FLAGS=""  # word-splits into the create call below; MysteryBox selectors carry no spaces
-[ -n "$AUTH_TOKEN_SECRET" ] && AUTH_FLAGS="--auth token --token-secret $AUTH_TOKEN_SECRET"
+[ -n "$AUTH_TOKEN_SECRET" ] && AUTH_FLAGS="--env-secret AUTH_TOKEN=$AUTH_TOKEN_SECRET"
 
 if [ $# -lt 2 ]; then
   cat >&2 <<'EOF'
@@ -166,9 +168,10 @@ BANNER
 
 if [ -n "$AUTH_TOKEN_SECRET" ]; then
   cat <<AUTHNOTE
-Auth: enabled (Nebius --auth token via secret '$AUTH_TOKEN_SECRET'). Callers must send
-'Authorization: Bearer <token>' — run inference with --policy=.secure_remote after loading the
-token into POSITRONIC_INFERENCE_TOKEN (see workflows/nebius/README.md, "Authenticated inference").
+Auth: enabled (server validates the bearer token from secret '$AUTH_TOKEN_SECRET', injected as
+AUTH_TOKEN). Callers must send 'Authorization: Bearer <token>' — run inference with
+--policy=.secure_remote after loading the token into POSITRONIC_INFERENCE_TOKEN (see
+workflows/nebius/README.md, "Authenticated inference").
 
 AUTHNOTE
 fi

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -23,6 +23,12 @@ IMAGE_TAG="${NEBIUS_IMAGE_TAG:-latest}"
 # Nebius GPU preset. Default is one H100; multi-GPU presets must match the server's GPU count
 # (DreamZero's --num_gpus runs torchrun --nproc_per_node, so an 8-GPU server needs an 8-GPU preset).
 PRESET="${NEBIUS_PRESET:-1gpu-16vcpu-200gb}"
+# Authenticated endpoint (opt-in). Point NEBIUS_AUTH_TOKEN_SECRET at a MysteryBox secret whose
+# payload key is AUTH_TOKEN; Nebius then rejects any request lacking `Authorization: Bearer <token>`
+# at the ingress, before it reaches the container. Empty (the default) leaves the endpoint open.
+AUTH_TOKEN_SECRET="${NEBIUS_AUTH_TOKEN_SECRET:-}"
+AUTH_FLAGS=""  # word-splits into the create call below; MysteryBox selectors carry no spaces
+[ -n "$AUTH_TOKEN_SECRET" ] && AUTH_FLAGS="--auth token --token-secret $AUTH_TOKEN_SECRET"
 
 if [ $# -lt 2 ]; then
   cat >&2 <<'EOF'
@@ -104,6 +110,7 @@ nebius ai endpoint create \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
   --env AWS_DEFAULT_REGION=eu-north1 \
+  $AUTH_FLAGS \
   --public >/dev/null
 
 ID=$(nebius ai endpoint list --parent-id "$PARENT_ID" --format json \
@@ -130,6 +137,9 @@ if [ -z "$IP" ]; then
   exit 1
 fi
 
+SANITY="curl http://$IP/api/v1/models"
+[ -n "$AUTH_TOKEN_SECRET" ] && SANITY="$SANITY -H \"Authorization: Bearer \$POSITRONIC_INFERENCE_TOKEN\""
+
 cat <<BANNER
 
 ==============================================================
@@ -146,10 +156,19 @@ The container is still warming up (image pull + uv sync + checkpoint load,
 
 Once the model is loaded, sanity-check with:
 
-  curl http://$IP/api/v1/models
+  $SANITY
 
 To release the endpoint and its public IP:
 
   bash workflows/nebius/stop.sh $NAME
 
 BANNER
+
+if [ -n "$AUTH_TOKEN_SECRET" ]; then
+  cat <<AUTHNOTE
+Auth: enabled (Nebius --auth token via secret '$AUTH_TOKEN_SECRET'). Callers must send
+'Authorization: Bearer <token>' — run inference with --policy=.secure_remote after loading the
+token into POSITRONIC_INFERENCE_TOKEN (see workflows/nebius/README.md, "Authenticated inference").
+
+AUTHNOTE
+fi


### PR DESCRIPTION
## Summary

Authenticated access to served inference endpoints, on by default. Auth is enforced **in the server**,
not at the Nebius ingress: a live test showed Nebius `--auth token` gates plain HTTP but **drops the
inference WebSocket upgrade** (`/api/v1/session` → 404 even with a valid token), so it can't protect
the actual inference path. Instead `VendorServer` validates the bearer token itself, and endpoints are
served open at the Nebius layer.

- **In-process auth (default on):** `VendorServer` reads `AUTH_TOKEN` from the environment and validates
  `Authorization: Bearer <token>` on the HTTP route (`/api/v1/models`) and the WebSocket routes
  (`/api/v1/session[/{model_id}]`) — constant-time compare, rejecting a missing/invalid token on the WS
  before `accept()`. Absent token ⇒ open server. Read once in the base class, so no per-vendor churn.
- **`serve.sh`:** injects the token as the container's `AUTH_TOKEN` via `--env-secret`
  (`NEBIUS_AUTH_TOKEN_SECRET`, default `positronic-serverless-inference-token`), replacing `--auth token`.
  `NEBIUS_AUTH_TOKEN_SECRET=` serves an open endpoint; `e2e.sh` opts out for its smoke check.
- **Two client policy configs** over `remote` that attach the auth header from the environment, so
  callers pass only `--policy.host`:
  - `.secure_remote` → `Authorization: Bearer` from `POSITRONIC_INFERENCE_TOKEN` (our Nebius endpoints, HTTP `:8000`)
  - `.modal_remote` → `Modal-Key`/`Modal-Secret` from `MODAL_PROXY_TOKEN_ID`/`MODAL_PROXY_TOKEN_SECRET`, TLS `:443`
  - Each raises immediately if its environment variable is unset.
- **Docs:** the bearer-token secret joins the one-time setup; `workflows/nebius/README.md` and the
  `remote-training` skill describe the in-process-auth flow.
- Also includes a small unrelated `CLAUDE.md` tweak (allow autonomous commits; prefer fewer test files).

## Test plan

Verified:
- **Auth logic (local):** FastAPI `TestClient` matrix — authed server rejects missing/wrong token (HTTP 401,
  WS rejected) and accepts a valid token (HTTP 200, WS → ready); open server passes through. Regression
  cases added to `test_vendor_server.py` exercise the same over real uvicorn + websockets.
- **Full suite:** `pytest --no-cov` → 598 passed, 7 skipped. `ruff check`/`format` clean; `bash -n` clean.
- **Live Nebius control:** deployed an open endpoint — raw WS upgrade → 101 and real
  `InferenceClient.new_session()` → ready. A prior authed (`--auth token`) endpoint showed tokenless
  HTTP → 401, authed HTTP → 200, but authed WS → 404 — confirming the ingress drops the WS upgrade.

Not verified (needs an image rebuild + deploy): the `--env-secret AUTH_TOKEN=` injection inside a live
Nebius container — it mirrors the existing, working `--env-secret AWS_ACCESS_KEY_ID=` line.
