### PR TITLE
Add `molmoact2` vendor for serving MolmoAct2-DROID

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -121,6 +121,14 @@ services:
     ports:
       - "8000:8000"
 
+  molmoact2-server:
+    <<: *positronic-common
+    container_name: molmoact2-server
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "molmoact2", "python", "-m",
+                 "positronic.vendors.molmoact2.server"]
+    ports:
+      - "8000:8000"
+
   positronic-inference:
     <<: *positronic-common
     container_name: positronic-inference

--- a/positronic/vendors/molmoact2/README.md
+++ b/positronic/vendors/molmoact2/README.md
@@ -1,0 +1,95 @@
+# MolmoAct2 in Positronic
+
+> **Status: Work in Progress** – the in-process server loads the pretrained `allenai/MolmoAct2-DROID`
+> checkpoint and runs `predict_action` end-to-end, but the policy has **not** been validated in evaluations.
+> Sim eval also hits a known gripper-convention gap (the MuJoCo sim's grip is inverted relative to the
+> DROID convention this model uses — [#456](https://github.com/Positronic-Robotics/positronic/issues/456)).
+
+## What is MolmoAct2?
+
+[MolmoAct2](https://huggingface.co/allenai/MolmoAct2-DROID) is AllenAI's vision-language-action model. The
+`MolmoAct2-DROID` variant is a pretrained checkpoint for the DROID action space (3 cameras + joint/gripper
+state). It is a HuggingFace `transformers` model loaded with `trust_remote_code=True`; Positronic serves it
+**in-process** by calling its `predict_action` method — there is no Positronic fork.
+
+This integration is **inference-only**: it serves a fixed pretrained checkpoint. There is no convert or train
+step (and nothing on the Nebius pipeline) — you serve the public checkpoint and run a client against it.
+
+## Hardware
+
+A CUDA GPU. The model loads in `bfloat16` with `device_map='auto'`; first start downloads the checkpoint from
+HuggingFace.
+
+## Serve
+
+The `molmoact2` extra conflicts with the `lerobot` / `lerobot_0_3_3` extras (incompatible `transformers`
+pins), so it is installed and run on its own with `--extra molmoact2`.
+
+Via Docker Compose ([`docker/docker-compose.yml`](../../../docker/docker-compose.yml)), publishing the
+WebSocket API on `8000`:
+
+```bash
+cd docker
+docker compose run --rm --service-ports molmoact2-server
+```
+
+Or from a checkout:
+
+```bash
+uv run --python 3.13 --extra molmoact2 python -m positronic.vendors.molmoact2.server
+```
+
+The server owns the codec, so clients send raw observations and receive decoded joint commands. Config and
+defaults (`hf_repo`, `num_steps`, `norm_tag`, `port`, …) are in [`server.py`](./server.py). Sanity-check once
+warm:
+
+```bash
+curl http://localhost:8000/api/v1/models
+# {"models": ["MolmoAct2-DROID"]}
+```
+
+## Run inference
+
+Point the unified `.remote` client at the server (same client as every other vendor):
+
+```bash
+uv run --locked positronic-inference sim \
+  --policy=.remote --policy.host=localhost --policy.port=8000 \
+  --show_gui=True --output_dir=~/datasets/molmoact2_run
+```
+
+The model is DROID-pretrained, so its native target is a real franka_droid-style robot. **Sim eval grips
+backwards** until the convention is unified ([#456](https://github.com/Positronic-Robotics/positronic/issues/456)).
+See the [Inference Guide](../../../docs/inference.md) for the remote-policy protocol and options.
+
+## Codec
+
+A [codec](../../../docs/codecs.md) maps raw recordings into the state/action space the model expects. MolmoAct2
+ships one, `droid` (source: [`codecs.py`](./codecs.py)):
+
+| Codec | Observation | Action |
+|-------|-------------|--------|
+| `droid` | 3 cameras (raw RGB, ordered `[exterior_1, exterior_2, wrist]`) + 8-D state `[joints(7), grip(1)]` + language task | Absolute joint positions (7) + grip → `JointPosition` command |
+
+The observation encoder is dedicated (`MolmoAct2ObservationCodec`) rather than a config variant of the shared
+`ObservationCodec`: `predict_action` takes images as a single **ordered positional list** of **raw** frames
+(the model tiles/resizes to 378×378 itself), whereas `ObservationCodec` emits separate named, pre-resized
+image keys. The action side reuses the shared `absolute_joints_action`.
+
+## Technical details
+
+- **Action space**: absolute joint positions (7) + gripper (1), in raw robot units; the 8-vector decodes
+  straight into a `JointPosition` command (no IK at runtime).
+- **Observation**: 3 cameras (2 exterior + 1 wrist) + 8-D state + language prompt. A single exterior camera is
+  duplicated to fill DROID's two exterior slots.
+- **Inference**: `norm_tag='franka_droid'`, `num_steps=10` sampling steps, continuous action mode. The model
+  emits a 15-step action chunk at 15 Hz (1 s of motion); the default client executes the whole chunk, so no
+  client-side `--wrap` is needed.
+- **Server**: subclasses `VendorServer` ([`positronic/offboard/vendor_server.py`](../../../positronic/offboard/vendor_server.py))
+  and loads the model **in-process** on a worker thread, streaming `{"status": "loading"}` so the WebSocket
+  handshake doesn't time out during the (minutes-long) load. Single model; `model_id` is the repo leaf
+  (`MolmoAct2-DROID`).
+- **Gripper convention**: the codec passes grip through unchanged on the DROID convention (`0=open, 1=closed`),
+  matching Positronic's real Robotiq/DH drivers. The MuJoCo sim uses the opposite convention, so sim eval is
+  inverted until [#456](https://github.com/Positronic-Robotics/positronic/issues/456) unifies them.
+- **Wire protocol**: Positronic's standard WebSocket protocol — see [Connect Your Model](../../../docs/connect-your-model.md).

--- a/positronic/vendors/molmoact2/README.md
+++ b/positronic/vendors/molmoact2/README.md
@@ -1,29 +1,21 @@
 # MolmoAct2 in Positronic
 
-> **Status: Work in Progress** – the in-process server loads the pretrained `allenai/MolmoAct2-DROID`
-> checkpoint and runs `predict_action` end-to-end, but the policy has **not** been validated in evaluations.
-> Sim eval also hits a known gripper-convention gap (the MuJoCo sim's grip is inverted relative to the
-> DROID convention this model uses — [#456](https://github.com/Positronic-Robotics/positronic/issues/456)).
+> **Status: Work in Progress** – serving is wired up and runs end-to-end, but the policy has **not** been
+> validated in evaluations.
 
 ## What is MolmoAct2?
 
-[MolmoAct2](https://huggingface.co/allenai/MolmoAct2-DROID) is AllenAI's vision-language-action model. The
-`MolmoAct2-DROID` variant is a pretrained checkpoint for the DROID action space (3 cameras + joint/gripper
-state). It is a HuggingFace `transformers` model loaded with `trust_remote_code=True`; Positronic serves it
-**in-process** by calling its `predict_action` method — there is no Positronic fork.
-
-This integration is **inference-only**: it serves a fixed pretrained checkpoint. There is no convert or train
-step (and nothing on the Nebius pipeline) — you serve the public checkpoint and run a client against it.
+[MolmoAct2](https://huggingface.co/allenai/MolmoAct2-DROID) is AllenAI's open vision-language-action model for
+robot control. The `MolmoAct2-DROID` variant is fine-tuned on the DROID Franka dataset for absolute joint-pose
+control. Positronic serves it directly from HuggingFace `transformers` (no fork), **inference-only** — there is
+no convert or train step.
 
 ## Hardware
 
-A CUDA GPU. The model loads in `bfloat16` with `device_map='auto'`; first start downloads the checkpoint from
-HuggingFace.
+A ~5B-parameter model loaded in `bfloat16` (~10 GB of weights), so plan for a **16 GB+ GPU** — the 12 GB
+desktop context is too small. First start downloads the checkpoint from HuggingFace.
 
 ## Serve
-
-The `molmoact2` extra conflicts with the `lerobot` / `lerobot_0_3_3` extras (incompatible `transformers`
-pins), so it is installed and run on its own with `--extra molmoact2`.
 
 Via Docker Compose ([`docker/docker-compose.yml`](../../../docker/docker-compose.yml)), publishing the
 WebSocket API on `8000`:
@@ -71,25 +63,11 @@ ships one, `droid` (source: [`codecs.py`](./codecs.py)):
 |-------|-------------|--------|
 | `droid` | 3 cameras (raw RGB, ordered `[exterior_1, exterior_2, wrist]`) + 8-D state `[joints(7), grip(1)]` + language task | Absolute joint positions (7) + grip → `JointPosition` command |
 
-The observation encoder is dedicated (`MolmoAct2ObservationCodec`) rather than a config variant of the shared
-`ObservationCodec`: `predict_action` takes images as a single **ordered positional list** of **raw** frames
-(the model tiles/resizes to 378×378 itself), whereas `ObservationCodec` emits separate named, pre-resized
-image keys. The action side reuses the shared `absolute_joints_action`.
-
 ## Technical details
 
-- **Action space**: absolute joint positions (7) + gripper (1), in raw robot units; the 8-vector decodes
-  straight into a `JointPosition` command (no IK at runtime).
-- **Observation**: 3 cameras (2 exterior + 1 wrist) + 8-D state + language prompt. A single exterior camera is
-  duplicated to fill DROID's two exterior slots.
-- **Inference**: `norm_tag='franka_droid'`, `num_steps=10` sampling steps, continuous action mode. The model
-  emits a 15-step action chunk at 15 Hz (1 s of motion); the default client executes the whole chunk, so no
-  client-side `--wrap` is needed.
-- **Server**: subclasses `VendorServer` ([`positronic/offboard/vendor_server.py`](../../../positronic/offboard/vendor_server.py))
-  and loads the model **in-process** on a worker thread, streaming `{"status": "loading"}` so the WebSocket
-  handshake doesn't time out during the (minutes-long) load. Single model; `model_id` is the repo leaf
-  (`MolmoAct2-DROID`).
-- **Gripper convention**: the codec passes grip through unchanged on the DROID convention (`0=open, 1=closed`),
-  matching Positronic's real Robotiq/DH drivers. The MuJoCo sim uses the opposite convention, so sim eval is
-  inverted until [#456](https://github.com/Positronic-Robotics/positronic/issues/456) unifies them.
+- **Action space**: absolute joint positions (7) + gripper (1), decoded straight into a `JointPosition`
+  command (no IK at runtime).
+- **Observation**: 3 cameras (2 exterior + 1 wrist) + 8-D state + language prompt.
+- **Inference**: `norm_tag='franka_droid'`, continuous action mode; the model emits a 15-step action chunk at
+  15 Hz, executed in full by the default client (no client-side `--wrap`).
 - **Wire protocol**: Positronic's standard WebSocket protocol — see [Connect Your Model](../../../docs/connect-your-model.md).

--- a/positronic/vendors/molmoact2/codecs.py
+++ b/positronic/vendors/molmoact2/codecs.py
@@ -1,0 +1,70 @@
+"""MolmoAct2 observation codec for the DROID action space (3 cameras + joint/grip state)."""
+
+from typing import Any
+
+import configuronic as cfn
+import numpy as np
+
+from positronic.cfg import codecs
+from positronic.policy.codec import Codec
+
+# MolmoAct2 resizes and tiles every image to 378x378 internally, so the codec forwards camera
+# frames untouched; this placeholder size is only for warmup observations.
+_DUMMY_IMAGE_SIZE = (256, 256)
+
+
+class MolmoAct2ObservationCodec(Codec):
+    """Encodes positronic observations into MolmoAct2 ``predict_action`` inputs.
+
+    Emits the ordered camera list ``[exterior_1, exterior_2, wrist]`` (uint8 HWC RGB), the raw
+    8-D state ``[joint_positions(7), grip(1)]``, and the bare language task. MolmoAct2 normalizes
+    the state and resizes the images itself.
+    """
+
+    def __init__(
+        self,
+        wrist_camera: str = 'image.wrist',
+        exterior_camera_1: str = 'image.exterior',
+        exterior_camera_2: str | None = None,
+        joint_key: str = 'robot_state.q',
+        grip_key: str = 'grip',
+    ):
+        self._cameras = (exterior_camera_1, exterior_camera_2 or exterior_camera_1, wrist_camera)
+        self._joint_key = joint_key
+        self._grip_key = grip_key
+
+    def _image(self, key: str, inputs: dict[str, Any]) -> np.ndarray:
+        frame = np.asarray(inputs[key])
+        if frame.ndim != 3 or frame.shape[2] != 3:
+            raise ValueError(f"Image '{key}' must be HWC with 3 channels, got {frame.shape}")
+        return frame
+
+    def encode(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        joints = np.asarray(inputs[self._joint_key], dtype=np.float32).reshape(-1)
+        grip = np.asarray(inputs[self._grip_key], dtype=np.float32).reshape(-1)
+        return {
+            'images': [self._image(k, inputs) for k in self._cameras],
+            'state': np.concatenate([joints, grip]).astype(np.float32),
+            'task': inputs.get('task', ''),
+        }
+
+    def dummy_encoded(self, data=None) -> dict[str, Any]:
+        return {
+            'images': [np.zeros((*_DUMMY_IMAGE_SIZE, 3), dtype=np.uint8) for _ in self._cameras],
+            'state': np.zeros(8, dtype=np.float32),
+            'task': 'warmup',
+        }
+
+
+molmoact2_obs = cfn.Config(MolmoAct2ObservationCodec)
+
+
+# MolmoAct2 returns absolute joint positions (7) + gripper (1) already in raw robot units, so the
+# 8-vector decodes straight into a JointPosition command. ``tgt_*_key`` are training-only on
+# AbsoluteJointsAction; serving reads the 8-vector directly.
+# Its gripper follows the DROID convention (0=open, 1=closed), matching positronic's Robotiq/DH
+# drivers, so the grip passes through unchanged on both state-in and target_grip-out.
+_action = codecs.absolute_joints_action.override(tgt_joints_key='robot_command.joints', tgt_grip_key='target_grip')
+
+# franka_droid runs at 15 Hz; the model emits a 15-step horizon and compose executes all steps by default.
+droid = codecs.compose.override(obs=molmoact2_obs, action=_action, fps=15.0)

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+import numpy as np
+import torch
+from transformers import AutoModelForImageTextToText, AutoProcessor
+
+from positronic.policy import Policy, Session
+
+
+class _MolmoAct2Session(Session):
+    def __init__(self, model, processor, norm_tag: str, num_steps: int, meta: dict[str, Any]):
+        self._model = model
+        self._processor = processor
+        self._norm_tag = norm_tag
+        self._num_steps = num_steps
+        self._meta = meta
+
+    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
+        out = self._model.predict_action(
+            processor=self._processor,
+            images=obs['images'],
+            task=obs.get('task', ''),
+            state=np.asarray(obs['state'], dtype=np.float32),
+            norm_tag=self._norm_tag,
+            inference_action_mode='continuous',
+            enable_depth_reasoning=False,
+            num_steps=self._num_steps,
+            normalize_language=True,
+            enable_cuda_graph=False,
+        )
+        actions = out.actions[0].float().cpu().numpy()
+        return [{'action': action} for action in actions]
+
+    @property
+    def meta(self) -> dict[str, Any]:
+        return self._meta
+
+
+class MolmoAct2Policy(Policy):
+    def __init__(
+        self,
+        model_id: str,
+        *,
+        device_map: str = 'auto',
+        norm_tag: str = 'franka_droid',
+        num_steps: int = 10,
+        extra_meta: dict[str, Any] | None = None,
+    ):
+        self._processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+        self._model = AutoModelForImageTextToText.from_pretrained(
+            model_id, trust_remote_code=True, dtype=torch.bfloat16, device_map=device_map
+        ).eval()
+        self._norm_tag = norm_tag
+        self._num_steps = num_steps
+        self._meta = {**(extra_meta or {}), 'type': 'molmoact2', 'norm_tag': norm_tag}
+
+    def new_session(self, context=None) -> Session:
+        return _MolmoAct2Session(self._model, self._processor, self._norm_tag, self._num_steps, self._meta)
+
+    @property
+    def meta(self) -> dict[str, Any]:
+        return self._meta.copy()
+
+    def close(self):
+        if self._model is not None:
+            del self._model
+            self._model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -16,6 +16,9 @@ class _MolmoAct2Session(Session):
         self._meta = meta
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
+        # predict_action is decorated @torch.no_grad(), so the forward builds no autograd graph and the
+        # returned actions carry no grad — wrapping this in torch.inference_mode() or adding detach()
+        # would be redundant.
         out = self._model.predict_action(
             processor=self._processor,
             images=obs['images'],

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -16,9 +16,9 @@ class _MolmoAct2Session(Session):
         self._meta = meta
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
-        # predict_action is decorated @torch.no_grad(), so the forward builds no autograd graph and the
-        # returned actions carry no grad — wrapping this in torch.inference_mode() or adding detach()
-        # would be redundant.
+        # predict_action is decorated @torch.no_grad() and manages its own precision: the model loads
+        # in bfloat16 and runs bf16 throughout (its autocast path only guards fp32 inputs), so an
+        # external torch.inference_mode() / torch.autocast wrap or a detach() would all be redundant.
         out = self._model.predict_action(
             processor=self._processor,
             images=obs['images'],

--- a/positronic/vendors/molmoact2/server.py
+++ b/positronic/vendors/molmoact2/server.py
@@ -1,0 +1,112 @@
+import asyncio
+import logging
+from typing import Any
+
+import configuronic as cfn
+from fastapi import WebSocket
+
+from positronic.offboard.vendor_server import VendorServer
+from positronic.policy import Codec, Policy
+from positronic.utils.logging import init_logging
+from positronic.vendors.molmoact2 import codecs as molmoact2_codecs
+from positronic.vendors.molmoact2.policy import MolmoAct2Policy
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HF_REPO = 'allenai/MolmoAct2-DROID'
+
+
+class InferenceServer(VendorServer):
+    """In-process MolmoAct2 inference server for a single pretrained DROID checkpoint."""
+
+    def __init__(
+        self,
+        codec: Codec | None,
+        model_id: str = DEFAULT_HF_REPO,
+        *,
+        device_map: str = 'auto',
+        norm_tag: str = 'franka_droid',
+        num_steps: int = 10,
+        host: str = '0.0.0.0',
+        port: int = 8000,
+        recording_dir: str | None = None,
+        idle_timeout_min: float | None = None,
+    ):
+        super().__init__(
+            codec=codec, host=host, port=port, recording_dir=recording_dir, idle_timeout_min=idle_timeout_min
+        )
+        self.model_id = model_id
+        self.device_map = device_map
+        self.norm_tag = norm_tag
+        self.num_steps = num_steps
+        self._policy: Policy | None = None
+        self.metadata = {'host': host, 'port': port, 'model_id': model_id}
+
+    def _load_policy(self) -> Policy:
+        logger.info(f'Loading MolmoAct2 model {self.model_id} (device_map={self.device_map})')
+        return MolmoAct2Policy(
+            self.model_id,
+            device_map=self.device_map,
+            norm_tag=self.norm_tag,
+            num_steps=self.num_steps,
+            extra_meta=self.metadata,
+        )
+
+    async def resolve_model(self, model_id: str | None, websocket: WebSocket | None) -> tuple[Any, dict]:
+        if model_id is not None and model_id != self.model_id:
+            raise ValueError(f'Unknown model: {model_id}. Available: {self.model_id}')
+        if self._policy is None:
+            self._policy = await asyncio.to_thread(self._load_policy)
+        return self._policy, {'model_id': self.model_id}
+
+    def create_policy(self, model_handle: Any) -> Policy:
+        return model_handle
+
+    async def get_models(self) -> dict:
+        return {'models': [self.model_id]}
+
+    def shutdown_model(self):
+        if self._policy is not None:
+            self._policy.close()
+            self._policy = None
+
+
+@cfn.config(
+    codec=molmoact2_codecs.droid,
+    model_id=DEFAULT_HF_REPO,
+    device_map='auto',
+    norm_tag='franka_droid',
+    num_steps=10,
+    port=8000,
+    host='0.0.0.0',
+    recording_dir=None,
+    idle_timeout_min=None,
+)
+def server(
+    codec: Codec | None,
+    model_id: str,
+    device_map: str,
+    norm_tag: str,
+    num_steps: int,
+    port: int,
+    host: str,
+    recording_dir: str | None,
+    idle_timeout_min: float | None,
+):
+    """Starts the in-process MolmoAct2 inference server."""
+    InferenceServer(
+        codec=codec,
+        model_id=model_id,
+        device_map=device_map,
+        norm_tag=norm_tag,
+        num_steps=num_steps,
+        host=host,
+        port=port,
+        recording_dir=recording_dir,
+        idle_timeout_min=idle_timeout_min,
+    ).serve()
+
+
+if __name__ == '__main__':
+    init_logging()
+    cfn.cli(server)

--- a/positronic/vendors/molmoact2/server.py
+++ b/positronic/vendors/molmoact2/server.py
@@ -22,7 +22,7 @@ class InferenceServer(VendorServer):
     def __init__(
         self,
         codec: Codec | None,
-        model_id: str = DEFAULT_HF_REPO,
+        hf_repo: str = DEFAULT_HF_REPO,
         *,
         device_map: str = 'auto',
         norm_tag: str = 'franka_droid',
@@ -35,17 +35,20 @@ class InferenceServer(VendorServer):
         super().__init__(
             codec=codec, host=host, port=port, recording_dir=recording_dir, idle_timeout_min=idle_timeout_min
         )
-        self.model_id = model_id
+        self.hf_repo = hf_repo
+        # Clients echo the advertised id onto the single-segment session route
+        # (/api/v1/session/{model_id}), so it must be slash-free — derive it from the repo name.
+        self.model_id = hf_repo.split('/')[-1]
         self.device_map = device_map
         self.norm_tag = norm_tag
         self.num_steps = num_steps
         self._policy: Policy | None = None
-        self.metadata = {'host': host, 'port': port, 'model_id': model_id}
+        self.metadata = {'host': host, 'port': port, 'model_id': self.model_id, 'hf_repo': hf_repo}
 
     def _load_policy(self) -> Policy:
-        logger.info(f'Loading MolmoAct2 model {self.model_id} (device_map={self.device_map})')
+        logger.info(f'Loading MolmoAct2 model {self.hf_repo} (device_map={self.device_map})')
         return MolmoAct2Policy(
-            self.model_id,
+            self.hf_repo,
             device_map=self.device_map,
             norm_tag=self.norm_tag,
             num_steps=self.num_steps,
@@ -73,7 +76,7 @@ class InferenceServer(VendorServer):
 
 @cfn.config(
     codec=molmoact2_codecs.droid,
-    model_id=DEFAULT_HF_REPO,
+    hf_repo=DEFAULT_HF_REPO,
     device_map='auto',
     norm_tag='franka_droid',
     num_steps=10,
@@ -84,7 +87,7 @@ class InferenceServer(VendorServer):
 )
 def server(
     codec: Codec | None,
-    model_id: str,
+    hf_repo: str,
     device_map: str,
     norm_tag: str,
     num_steps: int,
@@ -96,7 +99,7 @@ def server(
     """Starts the in-process MolmoAct2 inference server."""
     InferenceServer(
         codec=codec,
-        model_id=model_id,
+        hf_repo=hf_repo,
         device_map=device_map,
         norm_tag=norm_tag,
         num_steps=num_steps,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,17 @@ lerobot = [
     "lerobot[smolvla]==0.4.3",
     "torch",
 ]
+molmoact2 = [
+    "transformers>=5.3,<6",
+    "torch",
+    "torchvision",
+    "accelerate",
+    "pillow",
+    "einops",
+    "requests",
+    "protobuf",
+    "sentencepiece",
+]
 lance = [
     "pylance",
 ]
@@ -98,19 +109,24 @@ dev = [
 # lerobot_0_3_3 extra pulls in lerobot==0.3.3 which declares rerun-sdk<0.23,
 # but our usage of lerobot doesn't need rerun — override to unblock resolution.
 override-dependencies = ["rerun-sdk==0.30.0"]
-# cmake 4.3.1 is missing x86_64 Linux wheels on PyPI
-constraint-dependencies = ["cmake<4.3"]
+# cmake 4.3.1 is missing x86_64 Linux wheels on PyPI.
+# evdev>=1.9 regenerates its C bindings from whatever input-event-codes.h is reachable on the
+# include path, so a newer header leaking in (stale build cache / CPATH) bakes in macros the
+# ubuntu22.04 (kernel-5.15) compile headers lack and the build fails. 1.8.x reads the canonical
+# /usr/include and is structurally immune; pynput only needs evdev>=1.3.
+constraint-dependencies = ["cmake<4.3", "evdev<1.9"]
 # Pin third-party resolution to a fixed point in time so `uv sync --locked` is
 # reproducible across machines and CI regardless of contributors' personal uv
 # config. `uv lock` reads this date, so the lockfile can never drift ahead of
 # it; bump the date and re-run `uv lock` in the same commit to refresh deps.
 # Our own packages (exclude-newer-package below) are exempt so they always
 # resolve to the latest release.
-exclude-newer = "2026-05-21T00:00:00Z"
+exclude-newer = "2026-06-12T00:00:00Z"
 conflicts = [
     [
         {extra = "lerobot"},
         {extra = "lerobot-0-3-3"},
+        {extra = "molmoact2"},
     ],
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -42,10 +42,11 @@ resolution-markers = [
 conflicts = [[
     { package = "positronic", extra = "lerobot" },
     { package = "positronic", extra = "lerobot-0-3-3" },
+    { package = "positronic", extra = "molmoact2" },
 ]]
 
 [options]
-exclude-newer = "2026-05-21T00:00:00Z"
+exclude-newer = "2026-06-12T00:00:00Z"
 
 [options.exclude-newer-package]
 configuronic = false
@@ -54,7 +55,10 @@ positronic = false
 positronic-franka = false
 
 [manifest]
-constraints = [{ name = "cmake", specifier = "<4.3" }]
+constraints = [
+    { name = "cmake", specifier = "<4.3" },
+    { name = "evdev", specifier = "<1.9" },
+]
 overrides = [{ name = "rerun-sdk", specifier = "==0.30.0" }]
 
 [[package]]
@@ -71,9 +75,11 @@ name = "accelerate"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-molmoact2' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3')" },
     { name = "numpy" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-molmoact2' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3')" },
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
@@ -98,13 +104,13 @@ name = "aiohttp"
 version = "3.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "aiosignal", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "attrs", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "frozenlist", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "multidict", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "propcache", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "yarl", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
 wheels = [
@@ -166,8 +172,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "frozenlist" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -198,7 +204,7 @@ version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -292,24 +298,36 @@ name = "av"
 version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/c3/83e6e73d1592bc54436eae0bc61704ae0cff0c3cfbde7b58af9ed67ebb49/av-15.1.0.tar.gz", hash = "sha256:39cda2dc810e11c1938f8cb5759c41d6b630550236b3365790e67a313660ec85", size = 3774192, upload-time = "2025-08-30T04:41:56.076Z" }
 wheels = [
@@ -353,6 +371,24 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
@@ -482,7 +518,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -593,14 +629,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -617,24 +653,36 @@ name = "cmake"
 version = "4.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/17/f8f42ae205604319cc36f46d9929bd9bfbd83d3d02d6314c44fa97c42006/cmake-4.1.3.tar.gz", hash = "sha256:89f48ddc2570eb62447e33311cffc6dfeb09631bd0a19423d8a59cec8af030f1", size = 34998, upload-time = "2025-11-19T22:41:27.312Z" }
 wheels = [
@@ -663,18 +711,36 @@ name = "cmake"
 version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/f5/e4f5a35864293a8605bf6e9366d406ee11565b91a22f38f8b8665096c718/cmake-4.2.1.tar.gz", hash = "sha256:a07a790ca65946667c0fb286549e8e0b5a850e2f8170ae60d3418573011ca218", size = 37060, upload-time = "2025-12-21T11:23:47.499Z" }
 wheels = [
@@ -1027,7 +1093,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 
 [[package]]
@@ -1126,24 +1192,42 @@ name = "datasets"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
-    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "huggingface-hub", version = "1.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" } },
     { name = "multiprocess" },
     { name = "numpy" },
     { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" } },
@@ -1164,29 +1248,41 @@ name = "datasets"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
-    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-10-positronic-lerobot'" },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" } },
     { name = "multiprocess" },
     { name = "numpy" },
@@ -1254,7 +1350,7 @@ name = "deepdiff"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "orderly-set", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "orderly-set" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/76/36c9aab3d5c19a94091f7c6c6e784efca50d87b124bf026c36e94719f33c/deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a", size = 634054, upload-time = "2025-09-03T19:40:41.461Z" }
 wheels = [
@@ -1275,24 +1371,36 @@ name = "diffusers"
 version = "0.35.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "filelock" },
@@ -1314,23 +1422,41 @@ name = "diffusers"
 version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "filelock" },
     { name = "httpx" },
-    { name = "huggingface-hub", version = "1.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" } },
     { name = "importlib-metadata" },
     { name = "numpy" },
     { name = "pillow" },
@@ -1401,11 +1527,11 @@ name = "draccus"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mergedeep", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "pyyaml", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "pyyaml-include", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "toml", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "typing-inspect", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "mergedeep" },
+    { name = "pyyaml" },
+    { name = "pyyaml-include" },
+    { name = "toml" },
+    { name = "typing-inspect" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/e2/f5012fda17ee5d1eaf3481b6ca3e11dffa5348e5e08ab745538fdc8041bb/draccus-0.10.0.tar.gz", hash = "sha256:8dd08304219becdcd66cd16058ba98e9c3e6b7bfe48ccb9579dae39f8d37ae19", size = 62243, upload-time = "2025-02-05T07:27:48.182Z" }
 wheels = [
@@ -1494,9 +1620,9 @@ epath = [
 
 [[package]]
 name = "evdev"
-version = "1.9.3"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz", hash = "sha256:2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9", size = 32723, upload-time = "2026-02-05T21:54:24.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/eb/b8900082a13a47bb9f69f415174d03cbf12ce95d07345722e1f4ef0e2093/evdev-1.8.0.tar.gz", hash = "sha256:45598eee1ae3876a3122ca1dc0ec8049c01931672d12478b5c610afc24e47d75", size = 32557, upload-time = "2025-01-25T17:02:19.592Z" }
 
 [[package]]
 name = "executing"
@@ -1681,7 +1807,7 @@ wheels = [
 
 [package.optional-dependencies]
 http = [
-    { name = "aiohttp", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -1689,7 +1815,7 @@ name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smmap", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "smmap" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
 wheels = [
@@ -1701,7 +1827,7 @@ name = "gitpython"
 version = "3.1.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gitdb", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "gitdb" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
 wheels = [
@@ -1745,18 +1871,36 @@ name = "gymnasium"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "cloudpickle" },
@@ -1774,24 +1918,36 @@ name = "gymnasium"
 version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "cloudpickle" },
@@ -1847,24 +2003,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
 ]
 
 [[package]]
@@ -1929,34 +2087,46 @@ name = "huggingface-hub"
 version = "0.35.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "fsspec", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "hf-xet", marker = "(platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'amd64' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'arm64' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and extra == 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyyaml", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "requests", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "tqdm", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "typing-extensions", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/7e/a0a97de7c73671863ca6b3f61fa12518caf35db37825e43d63a70956738c/huggingface_hub-0.35.3.tar.gz", hash = "sha256:350932eaa5cc6a4747efae85126ee220e4ef1b54e29d31c3b45c5612ddf0b32a", size = 461798, upload-time = "2025-09-29T14:29:58.625Z" }
 wheels = [
@@ -1973,37 +2143,61 @@ hf-transfer = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.4.1"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyyaml" },
-    { name = "shellingham" },
-    { name = "tqdm" },
-    { name = "typer-slim" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "filelock", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "fsspec", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and extra != 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and extra != 'extra-10-positronic-lerobot') or (platform_machine == 'amd64' and extra != 'extra-10-positronic-lerobot') or (platform_machine == 'arm64' and extra != 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "httpx", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "pyyaml", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "tqdm", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "typer", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "typing-extensions", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/27/629cfe58c582f92ded066c4a07d1a057ff617118ab7973200f770bd853cb/huggingface_hub-1.19.0.tar.gz", hash = "sha256:fd771622182d40977272a923953ee3b1b13538f9f8a7f5d78398f10af0f1c0bd", size = 824721, upload-time = "2026-06-11T12:33:18.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a5/558da89f66464d8d0229ff497e8b8666977de2d8cf48c28a2862ecf1250f/huggingface_hub-1.19.0-py3-none-any.whl", hash = "sha256:1dc72e1f6b4d6df6b30eb72e57d00514ef453d660f04af2b87f0e67267f31ee0", size = 693398, upload-time = "2026-06-11T12:33:16.695Z" },
 ]
 
 [[package]]
@@ -2011,7 +2205,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -2041,8 +2235,8 @@ name = "imageio"
 version = "2.37.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "pillow", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "numpy" },
+    { name = "pillow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/606be632e37bf8d05b253e8626c2291d74c691ddc7bcdf7d6aaf33b32f6a/imageio-2.37.2.tar.gz", hash = "sha256:0212ef2727ac9caa5ca4b2c75ae89454312f440a756fcfc8ef1993e718f50f8a", size = 389600, upload-time = "2025-11-04T14:29:39.898Z" }
 wheels = [
@@ -2051,8 +2245,8 @@ wheels = [
 
 [package.optional-dependencies]
 ffmpeg = [
-    { name = "imageio-ffmpeg", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "psutil", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "imageio-ffmpeg" },
+    { name = "psutil" },
 ]
 
 [[package]]
@@ -2074,7 +2268,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -2117,7 +2311,7 @@ name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2125,8 +2319,8 @@ dependencies = [
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
     { name = "nest-asyncio" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "psutil" },
     { name = "pyzmq" },
     { name = "tornado" },
@@ -2142,17 +2336,17 @@ name = "ipython"
 version = "9.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "decorator" },
     { name = "ipython-pygments-lexers" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "prompt-toolkit" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2264,7 +2458,7 @@ name = "jsonlines"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "attrs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/87/bcda8e46c88d0e34cad2f09ee2d0c7f5957bccdb9791b0b934ec84d84be4/jsonlines-4.0.0.tar.gz", hash = "sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74", size = 11359, upload-time = "2023-09-01T12:34:44.187Z" }
 wheels = [
@@ -2391,8 +2585,8 @@ version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema", extra = ["format-nongpl"] },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "referencing" },
@@ -2431,11 +2625,11 @@ dependencies = [
     { name = "jupyter-server-terminals" },
     { name = "nbconvert" },
     { name = "nbformat" },
-    { name = "overrides", marker = "python_full_version < '3.12' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "overrides", marker = "python_full_version < '3.12' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-positronic-lerobot') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-positronic-lerobot') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -2453,7 +2647,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "(os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-positronic-lerobot') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-positronic-lerobot') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -2475,10 +2669,10 @@ dependencies = [
     { name = "jupyter-server" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
-    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
@@ -2506,8 +2700,8 @@ dependencies = [
     { name = "json5" },
     { name = "jsonschema" },
     { name = "jupyter-server" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
@@ -2565,18 +2759,36 @@ name = "lerobot"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "av", version = "16.1.0", source = { registry = "https://pypi.org/simple" } },
@@ -2588,8 +2800,8 @@ dependencies = [
     { name = "einops" },
     { name = "flask" },
     { name = "gymnasium", version = "0.29.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "huggingface-hub", version = "1.4.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "jsonlines" },
     { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" } },
@@ -2612,24 +2824,36 @@ name = "lerobot"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "accelerate" },
@@ -2641,8 +2865,8 @@ dependencies = [
     { name = "draccus" },
     { name = "einops" },
     { name = "gymnasium", version = "1.2.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" }, extra = ["cli", "hf-transfer"], marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-10-positronic-lerobot'" },
+    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" }, extra = ["cli", "hf-transfer"], marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "jsonlines" },
     { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
@@ -2666,7 +2890,7 @@ smolvla = [
     { name = "accelerate" },
     { name = "num2words" },
     { name = "safetensors" },
-    { name = "transformers" },
+    { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -2711,7 +2935,7 @@ name = "linuxpy"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f7/66d76bb3099bce8a952e6114e654d1199d7a02aec90a300294919bd17f77/linuxpy-0.24.0.tar.gz", hash = "sha256:2b44434d28d49257e859a4830267a25aa4b51b1d229f95f79d025ae7f1a5d30e", size = 451602, upload-time = "2026-02-19T14:13:50.47Z" }
 wheels = [
@@ -2743,7 +2967,7 @@ name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -3057,7 +3281,7 @@ name = "multiprocess"
 version = "0.70.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "dill" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz", hash = "sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1", size = 1772603, upload-time = "2024-01-28T18:52:34.85Z" }
 wheels = [
@@ -3116,8 +3340,8 @@ dependencies = [
     { name = "mistune" },
     { name = "nbclient" },
     { name = "nbformat" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "pandocfilters" },
     { name = "pygments" },
     { name = "traitlets" },
@@ -3341,7 +3565,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/93/a201a12d3ec1caa8c6ac34c1c2f9eeb696b886f0c36ff23c638b46603bd0/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def", size = 570523509, upload-time = "2024-10-25T19:53:03.148Z" },
@@ -3354,7 +3578,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/37/c50d2b2f2c07e146776389e3080f4faf70bcc4fa6e19d65bb54ca174ebc3/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6", size = 200164144, upload-time = "2024-11-20T17:40:58.288Z" },
@@ -3390,9 +3614,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/17/dbe1aa865e4fdc7b6d4d0dd308fdd5aaab60f939abfc0ea1954eac4fb113/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0", size = 157833628, upload-time = "2024-10-01T17:05:05.591Z" },
@@ -3407,7 +3631,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/eb/6681efd0aa7df96b4f8067b3ce7246833dd36830bb4cec8896182773db7d/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887", size = 216451147, upload-time = "2024-11-20T17:44:18.055Z" },
@@ -3481,27 +3705,39 @@ name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot'" },
+    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
 wheels = [
@@ -3530,6 +3766,24 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
@@ -3538,7 +3792,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
@@ -3587,24 +3841,36 @@ name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
@@ -3628,6 +3894,24 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
@@ -3645,9 +3929,9 @@ name = "pandas"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "python-dateutil", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "tzdata", marker = "(sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -3707,7 +3991,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3855,8 +4139,8 @@ version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "narwhals" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/4f/8a10a9b9f5192cb6fdef62f1d77fa7d834190b2c50c0cd256bd62879212b/plotly-6.5.2.tar.gz", hash = "sha256:7478555be0198562d1435dee4c308268187553cc15516a2f4dd034453699e393", size = 7015695, upload-time = "2026-01-14T21:26:51.222Z" }
 wheels = [
@@ -3890,8 +4174,8 @@ name = "positronic"
 version = "0.2.1"
 source = { editable = "." }
 dependencies = [
-    { name = "av", version = "15.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "av", version = "16.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "av", version = "15.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "av", version = "16.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "coloredlogs" },
     { name = "configuronic" },
     { name = "cvxopt" },
@@ -3903,8 +4187,8 @@ dependencies = [
     { name = "msgpack" },
     { name = "mujoco" },
     { name = "numpy" },
-    { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "plotly" },
     { name = "pos3" },
     { name = "pyarrow" },
@@ -3939,19 +4223,19 @@ hardware = [
     { name = "feetech-servo-sdk" },
     { name = "linuxpy" },
     { name = "placo" },
-    { name = "positronic-franka", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyaudio", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "positronic-franka", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyaudio", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "pymodbus" },
     { name = "pyserial" },
-    { name = "pyzed", version = "5.0", source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl" }, marker = "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyzed", version = "5.0", source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp312-cp312-linux_x86_64.whl" }, marker = "(python_full_version == '3.12.*' and sys_platform == 'linux') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyzed", version = "5.0", source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl" }, marker = "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pyzed", version = "5.0", source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl" }, marker = "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyzed", version = "5.0", source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp312-cp312-linux_x86_64.whl" }, marker = "(python_full_version == '3.12.*' and sys_platform == 'linux') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyzed", version = "5.0", source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl" }, marker = "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 lance = [
     { name = "pylance" },
 ]
 lerobot = [
-    { name = "lerobot", version = "0.4.3", source = { registry = "https://pypi.org/simple" }, extra = ["smolvla"], marker = "extra == 'extra-10-positronic-lerobot'" },
+    { name = "lerobot", version = "0.4.3", source = { registry = "https://pypi.org/simple" }, extra = ["smolvla"], marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "torch" },
 ]
 lerobot-0-3-3 = [
@@ -3959,18 +4243,31 @@ lerobot-0-3-3 = [
     { name = "timm" },
     { name = "torch" },
 ]
+molmoact2 = [
+    { name = "accelerate" },
+    { name = "einops" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "transformers", version = "5.11.0", source = { registry = "https://pypi.org/simple" } },
+]
 openpi = [
     { name = "openpi-client" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'molmoact2'" },
     { name = "av" },
     { name = "coloredlogs", specifier = ">=15.0.1" },
     { name = "configuronic", specifier = ">=0.5.0" },
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "cvxopt" },
     { name = "dearpygui" },
+    { name = "einops", marker = "extra == 'molmoact2'" },
     { name = "fastapi" },
     { name = "feetech-servo-sdk", marker = "extra == 'hardware'" },
     { name = "fire" },
@@ -3987,11 +4284,13 @@ requires-dist = [
     { name = "opencv-python", marker = "extra == 'dev'" },
     { name = "opencv-python-headless" },
     { name = "openpi-client", marker = "extra == 'openpi'", git = "https://github.com/Positronic-Robotics/openpi.git?subdirectory=packages%2Fopenpi-client&rev=main-positronic" },
+    { name = "pillow", marker = "extra == 'molmoact2'" },
     { name = "placo", marker = "extra == 'hardware'" },
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pos3", specifier = ">=0.3.1" },
     { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "protobuf", marker = "extra == 'molmoact2'" },
     { name = "pyarrow" },
     { name = "pyaudio", marker = "sys_platform == 'linux' and extra == 'hardware'" },
     { name = "pydantic" },
@@ -4007,28 +4306,33 @@ requires-dist = [
     { name = "pyzed", marker = "python_full_version == '3.12.*' and sys_platform == 'linux' and extra == 'hardware'", url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp312-cp312-linux_x86_64.whl" },
     { name = "pyzed", marker = "python_full_version < '3.12' and sys_platform == 'linux' and extra == 'hardware'", url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl" },
     { name = "pyzed", marker = "python_full_version >= '3.13' and sys_platform == 'linux' and extra == 'hardware'", url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl" },
+    { name = "requests", marker = "extra == 'molmoact2'" },
     { name = "rerun-sdk", specifier = "==0.30.0" },
     { name = "rerun-sdk", extras = ["notebook"], marker = "extra == 'dev'" },
     { name = "robosuite" },
     { name = "ruckig" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scipy" },
+    { name = "sentencepiece", marker = "extra == 'molmoact2'" },
     { name = "starlette", specifier = ">=1.0.0" },
     { name = "timm", marker = "extra == 'lerobot-0-3-3'" },
     { name = "torch", marker = "extra == 'lerobot'" },
     { name = "torch", marker = "extra == 'lerobot-0-3-3'" },
+    { name = "torch", marker = "extra == 'molmoact2'" },
+    { name = "torchvision", marker = "extra == 'molmoact2'" },
+    { name = "transformers", marker = "extra == 'molmoact2'", specifier = ">=5.3,<6" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "websockets", specifier = ">=15.0.1" },
     { name = "zmq" },
 ]
-provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "lance", "dev"]
+provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2", "lance", "dev"]
 
 [[package]]
 name = "positronic-franka"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b6/ce86bfa8526c4ca9ca848333499ebe71ad3548677c21e62ae8a719515e8e/positronic_franka-0.4.0.tar.gz", hash = "sha256:276a6c42b054f3b9dcfade2d47387d7bca70dc1b3ef6ed05db8d734e76b5d56f", size = 1792844, upload-time = "2026-03-17T19:05:18.249Z" }
 
@@ -4383,10 +4687,10 @@ name = "pynput"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "evdev", marker = "'linux' in sys_platform or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "python-xlib", marker = "'linux' in sys_platform or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "evdev", marker = "'linux' in sys_platform or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "python-xlib", marker = "'linux' in sys_platform or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/c3/dccf44c68225046df5324db0cc7d563a560635355b3e5f1d249468268a6f/pynput-1.8.1.tar.gz", hash = "sha256:70d7c8373ee98911004a7c938742242840a5628c004573d84ba849d4601df81e", size = 82289, upload-time = "2025-03-17T17:12:01.481Z" }
@@ -4411,10 +4715,10 @@ name = "pyobjc-framework-applicationservices"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-coretext", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-coretext", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/6a/d4e613c8e926a5744fc47a9e9fea08384a510dc4f27d844f7ad7a2d793bd/pyobjc_framework_applicationservices-12.1.tar.gz", hash = "sha256:c06abb74f119bc27aeb41bf1aef8102c0ae1288aec1ac8665ea186a067a8945b", size = 103247, upload-time = "2025-11-14T10:08:52.18Z" }
 wheels = [
@@ -4429,7 +4733,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -4444,9 +4748,9 @@ name = "pyobjc-framework-coretext"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/da/682c9c92a39f713bd3c56e7375fa8f1b10ad558ecb075258ab6f1cdd4a6d/pyobjc_framework_coretext-12.1.tar.gz", hash = "sha256:e0adb717738fae395dc645c9e8a10bb5f6a4277e73cba8fa2a57f3b518e71da5", size = 90124, upload-time = "2025-11-14T10:14:38.596Z" }
 wheels = [
@@ -4461,8 +4765,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' or (sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot') or (sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -4504,10 +4808,10 @@ name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "iniconfig" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "pluggy" },
     { name = "pygments" },
 ]
@@ -4522,7 +4826,7 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
@@ -4664,7 +4968,7 @@ name = "pyyaml-include"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
 wheels = [
@@ -4676,14 +4980,41 @@ name = "pyzed"
 version = "5.0"
 source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl" }
 resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "cython", marker = "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "numpy", marker = "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "cython", marker = "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "numpy", marker = "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl", hash = "sha256:ace1b1087201ba2a3632e9fb978edaf098994b2127d94519d986fe52c52b9793" },
@@ -4703,14 +5034,41 @@ name = "pyzed"
 version = "5.0"
 source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp312-cp312-linux_x86_64.whl" }
 resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "cython", marker = "(python_full_version == '3.12.*' and sys_platform == 'linux') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "numpy", marker = "(python_full_version == '3.12.*' and sys_platform == 'linux') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "cython", marker = "(python_full_version == '3.12.*' and sys_platform == 'linux') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "numpy", marker = "(python_full_version == '3.12.*' and sys_platform == 'linux') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version != '3.12.*' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp312-cp312-linux_x86_64.whl", hash = "sha256:0f0a70fa30c974dd07cd60dbf7ef030c345dec6f8b6384657658a90792447fb4" },
@@ -4731,13 +5089,40 @@ version = "5.0"
 source = { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
-    { name = "cython", marker = "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "numpy", marker = "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "cython", marker = "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "numpy", marker = "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (python_full_version < '3.13' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl", hash = "sha256:b3bf0988dc89f5a6bb12323a8c9845be2b1be432035e1582be0ac8e0ad02ebce" },
@@ -4757,7 +5142,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -4825,7 +5210,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -5010,8 +5395,8 @@ name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
+    { name = "markdown-it-py", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "pygments", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
@@ -5245,12 +5630,52 @@ wheels = [
 ]
 
 [[package]]
+name = "sentencepiece"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/15/2e7a025fc62d764b151ae6d0f2a92f8081755ebe8d4a64099accc6f77ba6/sentencepiece-0.2.1.tar.gz", hash = "sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad", size = 3228515, upload-time = "2025-08-12T07:00:51.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/15/46afbab00733d81788b64be430ca1b93011bb9388527958e26cc31832de5/sentencepiece-0.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6356d0986b8b8dc351b943150fcd81a1c6e6e4d439772e8584c64230e58ca987", size = 1942560, upload-time = "2025-08-12T06:59:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/7c01b8ef98a0567e9d84a4e7a910f8e7074fcbf398a5cd76f93f4b9316f9/sentencepiece-0.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f8ba89a3acb3dc1ae90f65ec1894b0b9596fdb98ab003ff38e058f898b39bc7", size = 1325385, upload-time = "2025-08-12T06:59:27.722Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/88/2b41e07bd24f33dcf2f18ec3b74247aa4af3526bad8907b8727ea3caba03/sentencepiece-0.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:02593eca45440ef39247cee8c47322a34bdcc1d8ae83ad28ba5a899a2cf8d79a", size = 1253319, upload-time = "2025-08-12T06:59:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/54/38a1af0c6210a3c6f95aa46d23d6640636d020fba7135cd0d9a84ada05a7/sentencepiece-0.2.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a0d15781a171d188b661ae4bde1d998c303f6bd8621498c50c671bd45a4798e", size = 1316162, upload-time = "2025-08-12T06:59:30.914Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/66/fb191403ade791ad2c3c1e72fe8413e63781b08cfa3aa4c9dfc536d6e795/sentencepiece-0.2.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f5a3e0d9f445ed9d66c0fec47d4b23d12cfc858b407a03c194c1b26c2ac2a63", size = 1387785, upload-time = "2025-08-12T06:59:32.491Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2d/3bd9b08e70067b2124518b308db6a84a4f8901cc8a4317e2e4288cdd9b4d/sentencepiece-0.2.1-cp311-cp311-win32.whl", hash = "sha256:6d297a1748d429ba8534eebe5535448d78b8acc32d00a29b49acf28102eeb094", size = 999555, upload-time = "2025-08-12T06:59:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b8/f709977f5fda195ae1ea24f24e7c581163b6f142b1005bc3d0bbfe4d7082/sentencepiece-0.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:82d9ead6591015f009cb1be1cb1c015d5e6f04046dbb8c9588b931e869a29728", size = 1054617, upload-time = "2025-08-12T06:59:36.461Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/40/a1fc23be23067da0f703709797b464e8a30a1c78cc8a687120cd58d4d509/sentencepiece-0.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:39f8651bd10974eafb9834ce30d9bcf5b73e1fc798a7f7d2528f9820ca86e119", size = 1033877, upload-time = "2025-08-12T06:59:38.391Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/be/32ce495aa1d0e0c323dcb1ba87096037358edee539cac5baf8755a6bd396/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57cae326c8727de58c85977b175af132a7138d84c764635d7e71bbee7e774133", size = 1943152, upload-time = "2025-08-12T06:59:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7e/ff23008899a58678e98c6ff592bf4d368eee5a71af96d0df6b38a039dd4f/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56dd39a3c4d6493db3cdca7e8cc68c6b633f0d4195495cbadfcf5af8a22d05a6", size = 1325651, upload-time = "2025-08-12T06:59:41.536Z" },
+    { url = "https://files.pythonhosted.org/packages/19/84/42eb3ce4796777a1b5d3699dfd4dca85113e68b637f194a6c8d786f16a04/sentencepiece-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9381351182ff9888cc80e41c632e7e274b106f450de33d67a9e8f6043da6f76", size = 1253645, upload-time = "2025-08-12T06:59:42.903Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fa/d3d5ebcba3cb9e6d3775a096251860c41a6bc53a1b9461151df83fe93255/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99f955df238021bf11f0fc37cdb54fd5e5b5f7fd30ecc3d93fb48b6815437167", size = 1316273, upload-time = "2025-08-12T06:59:44.476Z" },
+    { url = "https://files.pythonhosted.org/packages/04/88/14f2f4a2b922d8b39be45bf63d79e6cd3a9b2f248b2fcb98a69b12af12f5/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cdfecef430d985f1c2bcbfff3defd1d95dae876fbd0173376012d2d7d24044b", size = 1387881, upload-time = "2025-08-12T06:59:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b8/903e5ccb77b4ef140605d5d71b4f9e0ad95d456d6184688073ed11712809/sentencepiece-0.2.1-cp312-cp312-win32.whl", hash = "sha256:a483fd29a34c3e34c39ac5556b0a90942bec253d260235729e50976f5dba1068", size = 999540, upload-time = "2025-08-12T06:59:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/81/92df5673c067148c2545b1bfe49adfd775bcc3a169a047f5a0e6575ddaca/sentencepiece-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4cdc7c36234fda305e85c32949c5211faaf8dd886096c7cea289ddc12a2d02de", size = 1054671, upload-time = "2025-08-12T06:59:49.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/02/c5e3bc518655d714622bec87d83db9cdba1cd0619a4a04e2109751c4f47f/sentencepiece-0.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:daeb5e9e9fcad012324807856113708614d534f596d5008638eb9b40112cd9e4", size = 1033923, upload-time = "2025-08-12T06:59:51.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4a/85fbe1706d4d04a7e826b53f327c4b80f849cf1c7b7c5e31a20a97d8f28b/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dcd8161eee7b41aae57ded06272905dbd680a0a04b91edd0f64790c796b2f706", size = 1943150, upload-time = "2025-08-12T06:59:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/4cfb393e287509fc2155480b9d184706ef8d9fa8cbf5505d02a5792bf220/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c6c8f42949f419ff8c7e9960dbadcfbc982d7b5efc2f6748210d3dd53a7de062", size = 1325651, upload-time = "2025-08-12T06:59:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/de/5a007fb53b1ab0aafc69d11a5a3dd72a289d5a3e78dcf2c3a3d9b14ffe93/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:097f3394e99456e9e4efba1737c3749d7e23563dd1588ce71a3d007f25475fff", size = 1253641, upload-time = "2025-08-12T06:59:56.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d2/f552be5928105588f4f4d66ee37dd4c61460d8097e62d0e2e0eec41bc61d/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b670879c370d350557edabadbad1f6561a9e6968126e6debca4029e5547820", size = 1316271, upload-time = "2025-08-12T06:59:58.109Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/0cfe748ace5485be740fed9476dee7877f109da32ed0d280312c94ec259f/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7f0fd2f2693309e6628aeeb2e2faf6edd221134dfccac3308ca0de01f8dab47", size = 1387882, upload-time = "2025-08-12T07:00:00.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dd/f7774d42a881ced8e1739f393ab1e82ece39fc9abd4779e28050c2e975b5/sentencepiece-0.2.1-cp313-cp313-win32.whl", hash = "sha256:92b3816aa2339355fda2c8c4e021a5de92180b00aaccaf5e2808972e77a4b22f", size = 999541, upload-time = "2025-08-12T07:00:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e9/932b9eae6fd7019548321eee1ab8d5e3b3d1294df9d9a0c9ac517c7b636d/sentencepiece-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:10ed3dab2044c47f7a2e7b4969b0c430420cdd45735d78c8f853191fa0e3148b", size = 1054669, upload-time = "2025-08-12T07:00:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3a/76488a00ea7d6931689cda28726a1447d66bf1a4837943489314593d5596/sentencepiece-0.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac650534e2251083c5f75dde4ff28896ce7c8904133dc8fef42780f4d5588fcd", size = 1033922, upload-time = "2025-08-12T07:00:06.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b6/08fe2ce819e02ccb0296f4843e3f195764ce9829cbda61b7513f29b95718/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dd4b477a7b069648d19363aad0cab9bad2f4e83b2d179be668efa672500dc94", size = 1946052, upload-time = "2025-08-12T07:00:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d9/1ea0e740591ff4c6fc2b6eb1d7510d02f3fb885093f19b2f3abd1363b402/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0c0f672da370cc490e4c59d89e12289778310a0e71d176c541e4834759e1ae07", size = 1327408, upload-time = "2025-08-12T07:00:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/1fb26e8a21613f6200e1ab88824d5d203714162cf2883248b517deb500b7/sentencepiece-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ad8493bea8432dae8d6830365352350f3b4144415a1d09c4c8cb8d30cf3b6c3c", size = 1254857, upload-time = "2025-08-12T07:00:11.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/85/c72fd1f3c7a6010544d6ae07f8ddb38b5e2a7e33bd4318f87266c0bbafbf/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b81a24733726e3678d2db63619acc5a8dccd074f7aa7a54ecd5ca33ca6d2d596", size = 1315722, upload-time = "2025-08-12T07:00:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e8/661e5bd82a8aa641fd6c1020bd0e890ef73230a2b7215ddf9c8cd8e941c2/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81799d0a68d618e89063fb423c3001a034c893069135ffe51fee439ae474d6", size = 1387452, upload-time = "2025-08-12T07:00:15.088Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5e/ae66c361023a470afcbc1fbb8da722c72ea678a2fcd9a18f1a12598c7501/sentencepiece-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:89a3ea015517c42c0341d0d962f3e6aaf2cf10d71b1932d475c44ba48d00aa2b", size = 1002501, upload-time = "2025-08-12T07:00:16.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/03/d332828c4ff764e16c1b56c2c8f9a33488bbe796b53fb6b9c4205ddbf167/sentencepiece-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:33f068c9382dc2e7c228eedfd8163b52baa86bb92f50d0488bf2b7da7032e484", size = 1057555, upload-time = "2025-08-12T07:00:18.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/14/5aee0bf0864df9bd82bd59e7711362908e4935e3f9cdc1f57246b5d5c9b9/sentencepiece-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b3616ad246f360e52c85781e47682d31abfb6554c779e42b65333d4b5f44ecc0", size = 1036042, upload-time = "2025-08-12T07:00:20.209Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "urllib3", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "certifi" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/06/66c8b705179bc54087845f28fd1b72f83751b6e9a195628e2e9af9926505/sentry_sdk-2.53.0.tar.gz", hash = "sha256:6520ef2c4acd823f28efc55e43eb6ce2e6d9f954a95a3aa96b6fd14871e92b77", size = 412369, upload-time = "2026-02-16T11:11:14.743Z" }
 wheels = [
@@ -5262,24 +5687,36 @@ name = "setuptools"
 version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
@@ -5303,6 +5740,24 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
     "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
@@ -5371,7 +5826,7 @@ version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
@@ -5392,7 +5847,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -5413,8 +5868,8 @@ name = "terminado"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "os_name != 'nt' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-positronic-lerobot') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "ptyprocess", marker = "os_name != 'nt' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-positronic-lerobot') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (os_name != 'nt' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
@@ -5427,7 +5882,7 @@ name = "timm"
 version = "1.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "1.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pyyaml" },
     { name = "safetensors" },
     { name = "torch" },
@@ -5455,7 +5910,8 @@ name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-molmoact2' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -5526,29 +5982,29 @@ name = "torch"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "fsspec", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "jinja2", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "networkx", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "sympy", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine != 'x86_64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "typing-extensions", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/56/2eae3494e3d375533034a8e8cf0ba163363e996d85f0629441fa9d9843fe/torch-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:236f501f2e383f1cb861337bdf057712182f910f10aeaf509065d54d339e49b2", size = 99093039, upload-time = "2025-06-04T17:39:06.963Z" },
@@ -5587,9 +6043,9 @@ name = "torchvision"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "pillow", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "torch", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/00/bdab236ef19da050290abc2b5203ff9945c84a1f2c7aab73e8e9c8c85669/torchvision-0.22.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4addf626e2b57fc22fd6d329cf1346d474497672e6af8383b7b5b636fba94a53", size = 1947827, upload-time = "2025-06-04T17:43:10.84Z" },
@@ -5634,7 +6090,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -5654,6 +6110,38 @@ wheels = [
 name = "transformers"
 version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+]
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" } },
@@ -5672,14 +6160,72 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "5.11.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and extra != 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+]
+dependencies = [
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/4a/2ee05f9a06bb2dd34cac951548553738a826762fb7adfa7ce256daeaeac8/transformers-5.11.0.tar.gz", hash = "sha256:1dbecade5b8a09bdf3e9e8fdfc9d312cb9eccf5a201080dc894b373f0f3eb5f4", size = 8874363, upload-time = "2026-06-10T16:31:52.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/40/30fdefda9b8aff8d36054dbb37d8e1464cc1130c29623403c3c2147bdee1/transformers-5.11.0-py3-none-any.whl", hash = "sha256:06d0a34eab529955f8e704b530663c7d6bd6f9c7a9e47a05cddb4a44e7b6566b", size = 11094597, upload-time = "2026-06-10T16:31:49.08Z" },
+]
+
+[[package]]
 name = "tree"
 version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "pillow" },
-    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot'" },
-    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
     { name = "svgwrite" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/3f/63cbed2909786f0e5ac30a4ae5791ad597c6b5fec7167e161c55bba511ce/Tree-0.2.4.tar.gz", hash = "sha256:f84d8ec9bf50dd69f551da78925a23d110864e7706551f590cdade27646f7883", size = 6489, upload-time = "2018-07-03T20:49:29.918Z" }
@@ -5689,8 +6235,8 @@ name = "triton"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
-    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_machine == 'aarch64' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform != 'linux' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "setuptools", version = "82.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/2f/3e56ea7b58f80ff68899b1dbe810ff257c9d177d288c6b0f55bf2fe4eb50/triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b", size = 155689937, upload-time = "2025-05-29T23:39:44.182Z" },
@@ -5704,26 +6250,14 @@ name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "click", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "rich", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+    { name = "shellingham", marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]
@@ -5740,8 +6274,8 @@ name = "typing-inspect"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mypy-extensions", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "typing-extensions", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [
@@ -5811,11 +6345,11 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "httptools" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'cygwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3')" },
+    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'cygwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'cygwin' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'cygwin' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]
@@ -5865,24 +6399,36 @@ name = "wandb"
 version = "0.24.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "click" },
@@ -5914,18 +6460,36 @@ name = "wandb"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-positronic-lerobot' and extra != 'extra-10-positronic-lerobot-0-3-3'",
 ]
 dependencies = [
     { name = "click" },
@@ -6231,9 +6795,9 @@ name = "yarl"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "multidict", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
-    { name = "propcache", marker = "extra == 'extra-10-positronic-lerobot' or extra == 'extra-10-positronic-lerobot-0-3-3'" },
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169, upload-time = "2025-10-06T14:12:55.963Z" }
 wheels = [

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -28,7 +28,7 @@ if [ $# -lt 2 ]; then
   cat >&2 <<'EOF'
 Usage: bash workflows/nebius/serve.sh <vendor> <endpoint-name> [server args...]
 
-Vendors: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero
+Vendors: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero | molmoact2
 
 The endpoint name must be unique in the project (lowercase alphanumeric + dashes).
 Remaining arguments forward to positronic.vendors.<vendor>.server.
@@ -68,8 +68,9 @@ case "$VENDOR" in
   openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="--extra openpi " ;;
   gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA="" ;;
   dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="" ;;
+  molmoact2)     IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra molmoact2 " ;;
   *)
-    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero" >&2
+    echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero | molmoact2" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
Adds a `molmoact2` vendor that serves the pretrained `allenai/MolmoAct2-DROID` checkpoint in-process, mirroring the lerobot vendor (`VendorServer` subclass — no subprocess/fork):
- `codecs.py` — ordered 3-camera DROID observation (`[exterior_1, exterior_2, wrist]`, raw uint8; the model tiles to 378² itself) + raw 8-D `[q(7), grip]` state; action decode reuses `absolute_joints_action` (8-vec → `JointPosition(7)` + `target_grip`).
- `policy.py` — loads via transformers `AutoModelForImageTextToText` (`trust_remote_code`) and calls `predict_action`.
- `server.py` — single-model `VendorServer`, `cfn.cli`.
- Wired into `docker/docker-compose.yml` (`molmoact2-server`) and `workflows/nebius/serve.sh` (`molmoact2` runs on `positro/positronic` + `--extra molmoact2`).

**Dependencies:**
- New conflicting `molmoact2` extra (transformers v5; mutually exclusive with the lerobot extras). `exclude-newer` bumped 2026-05-21 → 2026-06-12 so it resolves (re-locks the other extras at the new date).
- Pins `evdev<1.9`: 1.9+ regenerates its C bindings from whatever `input-event-codes.h` is on the include path, so a newer header leaking into a cold build on the ubuntu22.04 (kernel-5.15) base fails the compile; 1.8.x reads `/usr/include` and is structurally immune (pynput needs only `evdev>=1.3`).

**Gripper convention:** MolmoAct2/DROID emits `0=open, 1=closed`, which matches positronic's real Robotiq/DH drivers, so grip passes through with no flip. Note: the MuJoCo sim's grip is inverted (`target_grip=1 → open`), so in-sim eval of this (or any DROID-convention) policy would command the gripper backwards — a pre-existing sim/real split, not handled here.

## Test plan
- End-to-end on a Nebius H100: served the model and ran a `RemotePolicy` inference returning a 15-step horizon of `JointPosition(7)` + grip with sane joint radians. (Post-review tweaks — meta keys, codec config form, the dep pin — are behavior-preserving.)
- Local codec encode/decode roundtrip via `droid.instantiate()` (3 images, 8-D state → `JointPosition(7)` + `target_grip`).
- `evdev` pin verified with real `linux/amd64` docker builds on the cuda-ubuntu22.04 base: 1.9.x fails the compile under a split header, 1.8.0 builds clean.
- `uv lock --check` clean; `molmoact2` + `lerobot` extras resolve; `evdev` → 1.8.0.
- `uv run --locked --extra dev pytest positronic/policy/tests positronic/offboard/tests` → 162 passed.