### PR TITLE
Generalize DreamZero eval wrap into `video_context_wrappers`

### DIFF
--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -1,10 +1,17 @@
 import configuronic as cfn
 
 from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery, TemporalFrameStack
+from positronic.policy.wrappers import default_wrappers as _default_wrappers
 
 chunked_schedule = cfn.Config(ChunkedSchedule)
 error_recovery = cfn.Config(ErrorRecovery)
 temporal_frame_stack = cfn.Config(TemporalFrameStack)
+
+
+@cfn.config()
+def default_wrappers():
+    """Eval ``wrap`` default: error recovery + chunked scheduling, no video frame stack."""
+    return _default_wrappers
 
 
 def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[float, ...]:

--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -1,7 +1,6 @@
 import configuronic as cfn
 
 from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery, TemporalFrameStack
-from positronic.policy.wrappers import default_wrappers as _default_wrappers
 
 chunked_schedule = cfn.Config(ChunkedSchedule)
 error_recovery = cfn.Config(ErrorRecovery)
@@ -11,7 +10,7 @@ temporal_frame_stack = cfn.Config(TemporalFrameStack)
 @cfn.config()
 def default_wrappers():
     """Eval ``wrap`` default: error recovery + chunked scheduling, no video frame stack."""
-    return _default_wrappers
+    return ErrorRecovery() | ChunkedSchedule()
 
 
 def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[float, ...]:

--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -5,3 +5,40 @@ from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery, TemporalF
 chunked_schedule = cfn.Config(ChunkedSchedule)
 error_recovery = cfn.Config(ErrorRecovery)
 temporal_frame_stack = cfn.Config(TemporalFrameStack)
+
+
+def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[float, ...]:
+    """Frame-stack offsets in ascending negative seconds for a strided video-context window.
+
+    ``history_frames`` is the oldest look-back in frames (the magnitude of the most-negative offset).
+    Samples the current frame (offset 0) and every ``stride``-th frame back from it, then always pins
+    the oldest sample to ``-history_frames``: when ``stride`` divides ``history_frames`` that pin lands
+    on the regular grid, otherwise the final gap is shorter than ``stride`` (DreamZero's ``(23, 8)``
+    yields frames 23, 16, 8, 0 — the trained -23 oldest, not the stride's -24).
+
+    To reproduce a model trained on contiguous, non-overlapping windows (DreamZero's ACTION_HORIZON /
+    RELATIVE_OFFSETS in test_client_AR.py), pass ``history_frames = ACTION_HORIZON - 1`` so the oldest
+    frame lands on the window start; the full width would push it one frame back and overlap the prior
+    window (out of distribution).
+    """
+    frames = list(range(0, history_frames, stride)) + [history_frames]
+    return tuple(-f / fps for f in reversed(frames))
+
+
+@cfn.config(image_keys=('image.wrist', 'image.exterior'), fps=15.0)
+def video_context_wrappers(history_frames: int, stride: int, image_keys: tuple[str, ...], fps: float):
+    """Eval ``wrap`` for video-conditioned policies: error recovery, strided frame-stack context, scheduling.
+
+    The frame stack sits outside the scheduler so it records the named cameras every control tick and
+    substitutes a temporal stack sampled per ``history_frames``/``stride``; pair it with a codec whose
+    ``horizon`` plays the full returned chunk so the re-query aligns with the frame-stack window.
+    """
+    frame_stack = TemporalFrameStack(
+        image_keys=tuple(image_keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps)
+    )
+    return ErrorRecovery() | frame_stack | ChunkedSchedule()
+
+
+# gyros chunk-causal bridge: 25 frames (24 history + current) at 15 fps spanning the just-executed K=6
+# chunk, dense (stride 1) so the bridge encodes them as 6 contiguous subsequent-latents (its context window).
+gyros_wrappers = video_context_wrappers.override(history_frames=24, stride=1)

--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -37,8 +37,3 @@ def video_context_wrappers(history_frames: int, stride: int, image_keys: tuple[s
         image_keys=tuple(image_keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps)
     )
     return ErrorRecovery() | frame_stack | ChunkedSchedule()
-
-
-# gyros chunk-causal bridge: 25 frames (24 history + current) at 15 fps spanning the just-executed K=6
-# chunk, dense (stride 1) so the bridge encodes them as 6 contiguous subsequent-latents (its context window).
-gyros_wrappers = video_context_wrappers.override(history_frames=24, stride=1)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -143,15 +143,7 @@ def main(
 @cfn.config(
     eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=wrappers_cfg.default_wrappers
 )
-def run(
-    eval: Eval,
-    policy,
-    trial_count,
-    show_gui,
-    output_dir=None,
-    inference_latency=False,
-    wrap=wrappers_cfg.default_wrappers,
-):
+def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, *, wrap):
     """Run a selected eval (embodiment + task) through the shared inference harness."""
     # The trial plan: one RUN context per trial, consumed by the self-driving Harness. Per-trial seeds
     # are known upfront — ``--eval.seed`` + trial index, or an independent random draw per trial when

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -18,7 +18,7 @@ from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datase
 from positronic.eval import Embodiment, Eval, Task
 from positronic.gui.dpg import DearpyguiUi
 from positronic.policy.base import SampledPolicy
-from positronic.policy.harness import Harness, default_wrappers
+from positronic.policy.harness import Harness
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,8 @@ def main(
     task: Task | None = None,
     trials: list[dict] | None = None,
     show_gui: bool = False,
-    wrap=default_wrappers,
+    *,
+    wrap,
 ):
     """Run inference for an embodiment, real or simulated.
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -10,6 +10,7 @@ import pos3
 
 import pimm
 import positronic.cfg.policy as policy_cfg
+import positronic.cfg.wrappers as wrappers_cfg
 from positronic import utils, wire
 from positronic.cfg.eval import placeholder
 from positronic.dataset.ds_writer_agent import TimeMode
@@ -138,8 +139,18 @@ def main(
             world.run([harness, *foreground], [*producers, ds_agent, gui])
 
 
-@cfn.config(eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=default_wrappers)
-def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, wrap=default_wrappers):
+@cfn.config(
+    eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=wrappers_cfg.default_wrappers
+)
+def run(
+    eval: Eval,
+    policy,
+    trial_count,
+    show_gui,
+    output_dir=None,
+    inference_latency=False,
+    wrap=wrappers_cfg.default_wrappers,
+):
     """Run a selected eval (embodiment + task) through the shared inference harness."""
     # The trial plan: one RUN context per trial, consumed by the self-driving Harness. Per-trial seeds
     # are known upfront — ``--eval.seed`` + trial index, or an independent random draw per trial when

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -9,6 +9,7 @@ import pos3
 import pimm
 import positronic.cfg.embodiment
 import positronic.cfg.policy as policy_cfg
+import positronic.cfg.wrappers as wrappers_cfg
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.cli.eval.run import Driver, main, run
 from positronic.dataset.local_dataset import load_all_datasets
@@ -59,7 +60,13 @@ def keyboard(show_gui, task):
     return make
 
 
-run_cfg = cfn.Config(main, embodiment=positronic.cfg.embodiment.droid, policy=policy_cfg.placeholder, driver=keyboard)
+run_cfg = cfn.Config(
+    main,
+    embodiment=positronic.cfg.embodiment.droid,
+    policy=policy_cfg.placeholder,
+    driver=keyboard,
+    wrap=wrappers_cfg.default_wrappers,
+)
 
 
 # Console entry point for [project.scripts].

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -9,7 +9,7 @@ from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.eval import Embodiment, Task
 from positronic.policy.base import Policy, PolicyWrapper, Session
-from positronic.policy.wrappers import ChunkedSchedule, default_wrappers
+from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils import flatten_dict, frozen_view
 
 
@@ -71,8 +71,8 @@ class Harness(pimm.ControlSystem):
     The scheduling wrapper (``ChunkedSchedule``, or a swap-in like RTC) anchors the chunk's
     relative timestamps to absolute time, reading the clock the harness binds in at ``wrap``.
 
-    By default, wraps the given policy with ``ErrorRecovery | ChunkedSchedule``. Pass ``wrap=None``
-    to skip auto-wrapping (if you've already composed your own pipeline).
+    Applies the given ``wrap`` pipeline to the policy; with ``wrap=None`` (the default) it runs the raw
+    policy unwrapped. The eval entry points supply the standard ``ErrorRecovery | ChunkedSchedule`` wrap.
     """
 
     def __init__(
@@ -83,7 +83,7 @@ class Harness(pimm.ControlSystem):
         task: Task | None = None,
         trials: Iterable[dict[str, Any]] | None = None,
         static_meta: dict[str, Any] | None = None,
-        wrap: PolicyWrapper | None = default_wrappers,
+        wrap: PolicyWrapper | None = None,
         on_episode_complete: Callable[[Session, dict[str, Any]], None] | None = None,
     ):
         assert trials is None or task is not None, 'A trial plan needs a task: its timeout bounds each trial'

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -43,6 +43,7 @@ from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
 from positronic.policy.codec import ActionTiming
 from positronic.policy.harness import Directive, Harness
+from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery
 from positronic.tests.testing_coutils import ManualDriver, drive_scheduler
 
 GOLDEN_FILE = Path(__file__).parent / 'golden_pipeline.json.gz'
@@ -197,7 +198,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
             static_meta=dict(ROBOT_STATIC_META),
             meta_source=robot.robot_meta,
         )
-        harness = Harness(policy, embodiment)
+        harness = Harness(policy, embodiment, wrap=ErrorRecovery() | ChunkedSchedule())
         ds_agent = wire.wire_embodiment(world, harness, embodiment, ds_writer, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
         directive_em = world.pair(harness.directive)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -15,6 +15,7 @@ from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.harness import Directive, DirectiveType, Harness
+from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
 
 
@@ -1016,7 +1017,7 @@ def test_harness_clears_trajectory_on_run(world):
 def test_harness_recovers_from_error(world):
     """ERROR emits Recover trajectory, skips policy; AVAILABLE resumes with fresh chunk."""
     policy = ChunkPolicy()
-    harness = Harness(policy, make_embodiment())
+    harness = Harness(policy, make_embodiment(), wrap=ErrorRecovery() | ChunkedSchedule())
     p = _pair_all(world, harness)
 
     state_ok = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6], status=RobotStatus.AVAILABLE)
@@ -1081,7 +1082,7 @@ def test_recovery_cancels_gripper_buffer(world):
     the gripper ``TrajectoryPlayer`` keeps draining the interrupted chunk's grip
     waypoints while the robot recovers.
     """
-    harness = Harness(ChunkPolicy(), make_embodiment())
+    harness = Harness(ChunkPolicy(), make_embodiment(), wrap=ErrorRecovery() | ChunkedSchedule())
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands['robot_command']._bind(cmd_recorder)

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -70,7 +70,7 @@ class ErrorRecovery(PolicyWrapper):
 
     TODO: this wrapper is not name-free. It hard-codes the ``robot_state.error`` observation and the
     ``robot_command`` channel (with a Franka ``Recover``), so it only fits Franka-named embodiments;
-    others must disable ``default_wrappers``. How an embodiment should declare its error signal and
+    others must omit it from their ``wrap``. How an embodiment should declare its error signal and
     recovery action is still open.
     """
 
@@ -168,6 +168,3 @@ class TemporalFrameStack(PolicyWrapper):
 
     def wrap_session(self, inner: Session, context, now: Now):
         return TemporalFrameStack._Session(inner, self._image_keys, self._offsets_sec)
-
-
-default_wrappers = ErrorRecovery() | ChunkedSchedule()

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -7,6 +7,7 @@ from positronic.dataset.local_dataset import LocalDataset
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
+from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery
 from positronic.simulator.env_server.adapter import EnvAdapter
 from positronic.simulator.env_server.client import EnvConnection
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
@@ -159,6 +160,7 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
             policy=policy,
             trials=[{'eval.trial_index': 0, 'eval.seed': 100}],
             output_dir=str(tmp_path),
+            wrap=ErrorRecovery() | ChunkedSchedule(),
         )
 
     ds = LocalDataset(tmp_path)

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -16,6 +16,7 @@ from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Task
 from positronic.inference import main
 from positronic.policy.tests.test_harness import StubPolicy
+from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.simulator.mujoco.transforms import AddBox, SetBodyPosition
 from positronic.utils import package_assets_path
@@ -78,6 +79,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             policy=policy,
             trials=[{'eval.trial_index': i, 'eval.seed': 100 + i} for i in range(2)],
             output_dir=str(tmp_path),
+            wrap=ErrorRecovery() | ChunkedSchedule(),
         )
 
     ds = LocalDataset(tmp_path)

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -14,7 +14,6 @@ from positronic.dataset.transforms import image
 from positronic.dataset.transforms.episode import Derive, Get
 from positronic.drivers.roboarm import command
 from positronic.policy.codec import Codec, lerobot_action, lerobot_image, lerobot_state
-from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery
 
 IMAGE_WIDTH = 320
 IMAGE_HEIGHT = 176
@@ -246,19 +245,7 @@ joints_ik = codecs.compose.override(obs=dreamzero_obs, action=_ik_dreamzero_acti
 joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 
 
-# offsets_sec: 4 frames spanning the just-executed 24-step chunk at 15 fps, matching DreamZero's
-# reference eval client schedule (frame indices -23, -16, -8, 0).
-_frame_stack = wrappers.temporal_frame_stack.override(
-    image_keys=('image.wrist', 'image.exterior'), offsets_sec=(-23 / 15, -16 / 15, -8 / 15, 0.0)
-)
-
-
-@cfn.config(frame_stack=_frame_stack)
-def dreamzero_wrappers(frame_stack):
-    """Eval ``wrap`` for DreamZero: error recovery, AR video context, chunked scheduling.
-
-    The frame stack sits outside the scheduler so it records the wrist/exterior cameras every control
-    tick and substitutes a stack sampled at the trained cadence; pair it with the DreamZero codec's
-    full-chunk ``horizon``.
-    """
-    return ErrorRecovery() | frame_stack | ChunkedSchedule()
+# DreamZero AR eval schedule: 24-step action horizon → 23-frame look-back (ACTION_HORIZON - 1), sampled
+# at stride 8 from the current frame with the oldest pinned to the window start → trained offsets
+# -23, -16, -8, 0 (test_client_AR.py RELATIVE_OFFSETS; -23 not -24 keeps the oldest inside the window).
+dreamzero_wrappers = wrappers.video_context_wrappers.override(history_frames=23, stride=8)


### PR DESCRIPTION
## Summary
- Collapse DreamZero's frame-stacked eval-`wrap` into one reusable, parameterized config
  `video_context_wrappers` (`ErrorRecovery() | frame_stack | ChunkedSchedule()`) in
  `positronic/cfg/wrappers.py`, expressed in two knobs: `history_frames` (oldest look-back, in frames)
  and `stride`.
- `dreamzero_wrappers` (in `positronic/vendors/dreamzero/codecs.py`) is now a one-line `.override` of it
  — no structural twin; its `--wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers` CLI path is
  unchanged. The schedule matches the upstream *method* (frames at `stride` back from the current frame,
  oldest **pinned to the window start**), reproducing DreamZero's trained offsets
  `(-23/15, -16/15, -8/15, 0.0)` byte-exactly — the deliberate `-23` (not `-24`) emerges from the pin.
- New context-window schedules need no committed code — they are CLI overrides of the generic config.

### Default wrap is now owned by the config layer
- `cfg.wrappers.default_wrappers` is the **single definition** of the default eval wrap
  (`ErrorRecovery() | ChunkedSchedule()`). `positronic/policy/wrappers.py` no longer carries a
  `default_wrappers` constant.
- `Harness` and `main` are mechanism-only: `Harness(wrap=...)` defaults to `None` (runs the raw policy)
  and `main` requires `wrap`. The eval entry points — `run` and inference's `run_cfg` — supply the
  default from `cfg.wrappers.default_wrappers`. Production behaviour is unchanged (eval always goes
  through those entry points).
- Because the default lives in `cfg.wrappers`, configuronic relative resolution works, so a custom
  schedule can be selected with a relative ref:
  `--wrap=.video_context_wrappers --wrap.history_frames=24 --wrap.stride=1` (the full
  `@positronic.cfg.wrappers.video_context_wrappers` form also works).

## Test plan
- `dreamzero_wrappers` instantiates to `offsets_sec == (-23/15, -16/15, -8/15, 0.0)` (byte-exact);
  the generic config + relative ref resolve to the 25-frame dense schedule
  (`tuple((i-24)/15 for i in range(25))`) via both `run.override(...)` and the full configuronic CLI.
- `run`'s default `wrap` instantiates to the no-frame-stack `ErrorRecovery | ChunkedSchedule` pipeline.
- Updated the tests that relied on `Harness`/`main` auto-wrapping to pass `wrap` explicitly; full affected
  suites green: `positronic/policy/tests/`, `vendors/dreamzero/tests/`, `tests/test_inference_integration.py`,
  `simulator/env_server/tests/test_remote_env.py` (136 passed).
- `ruff check` + `ruff format --check` clean on all changed files.