### PR TITLE
Add `droid` server preset for the pretrained DreamZero DROID checkpoint

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -244,7 +244,7 @@ services:
   dreamzero-server:
     <<: *dreamzero-common
     container_name: dreamzero-server
-    entrypoint: ["uv", "run", "--python", "3.13", "python", "-m", "positronic.vendors.dreamzero.server"]
+    entrypoint: ["uv", "run", "--python", "3.13", "--extra", "dreamzero", "python", "-m", "positronic.vendors.dreamzero.server"]
     ports:
       - "8000:8000"
     shm_size: 16g

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -11,7 +11,7 @@ autoregressive video context). Two backbones are wired up here:
 
 | Backbone | Params | Image (W×H) | Notes |
 |----------|--------|-------------|-------|
-| `wan2.1` | 14B | 320×176 | Default server checkpoint `GEAR-Dreams/DreamZero-DROID` (trained on DROID); DiT caching supported |
+| `wan2.1` | 14B | 320×180 | Public pretrained `GEAR-Dreams/DreamZero-DROID` checkpoint (the `droid` server preset); DiT caching supported |
 | `wan2.2` | 5B | 320×160 | Causal chunked inference; what the Positronic fine-tunes below use |
 
 Pick the backbone with `--backbone` at both train and serve time; **it must match between the two**.
@@ -36,9 +36,10 @@ To try the pretrained DROID model with no training. `positronic-inference` comes
 [Prerequisites](#full-pipeline-fine-tune-your-own-checkpoint) below).
 
 ```bash
-# Serve the default checkpoint on your H100 box (auto-downloaded on first start, ~10-20 min via HuggingFace).
+# Serve the public pretrained DROID checkpoint on your H100 box (auto-downloaded on first start,
+# ~10-20 min via HuggingFace). The `droid` preset pins the checkpoint, wan2.1 backbone, and codec.
 cd docker
-CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server
+CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server droid
 
 # Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
 uv run --locked positronic-inference sim \
@@ -130,13 +131,13 @@ Multi-GPU presets (`*_h100x8`) run `torchrun --nproc_per_node=8`, so use them on
 
 ### 3. Serve a checkpoint
 
-`dreamzero-server` downloads `--model_path` (an `s3://` checkpoint or HF repo) and **needs `--backbone` to
-match training** (config + defaults: [`server.py`](./server.py)). `--service-ports` publishes the WebSocket
-API on `8000`:
+`dreamzero-server serve` downloads `--model_path` (an `s3://` checkpoint or HF repo) and **needs `--backbone`
+to match training** (config + defaults: [`server.py`](./server.py)). `--service-ports` publishes the
+WebSocket API on `8000`:
 
 ```bash
 cd docker
-CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server \
+CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server serve \
   --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
   --backbone=wan2.2
 ```
@@ -185,9 +186,9 @@ that decodes to a `JointPosition` command. They differ only in how **training la
 - **Action space**: 7-DoF joint targets + gripper. DreamZero predicts the joints **relative to the current
   state** (`relative_action: true` on `joint_position` in the `droid_relative_wan22` data config); the
   absolute joint target is reconstructed from the current state at serve time and decoded to a `JointPosition`.
-- **Observation**: 3 cameras (2 exterior + 1 wrist) + joint state + language prompt; 320×160 (wan2.2),
-  320×176 (wan2.1). The wan2.2 trainer sets `image_resolution_height=160` and resizes at load, so the
-  codec's intermediate `(320, 176)` does not need a per-backbone override.
+- **Observation**: 3 cameras (2 exterior + 1 wrist) + joint state + language prompt. The wan2.2 fine-tunes
+  use the `(320, 176)` codec and the trainer resizes to 160 at load; the pretrained DROID model (wan2.1)
+  asserts exactly `(320, 180)`, so the `droid` codec (`codecs.droid`) feeds that resolution.
 - **Action horizon**: 24 timesteps per inference; the `dreamzero_wrappers` re-query aligns the
   chunk schedule with the AR frame-stack window
 - **Wire protocol**: Positronic's standard WebSocket protocol — see [Connect Your Model](../../../docs/connect-your-model.md)
@@ -218,7 +219,7 @@ bash workflows/nebius/train.sh dreamzero wan22_full_h100x1 \
   --max_steps=30000 --save_steps=2500 --gradient_accumulation_steps=4 --save_total_limit=9999
 
 # Serve (H100 endpoint; the public endpoint is exposed on :8000)
-bash workflows/nebius/serve.sh dreamzero <endpoint-name> \
+bash workflows/nebius/serve.sh dreamzero <endpoint-name> serve \
   --model_path=s3://checkpoints/sim_stack/dreamzero/<exp_name>/checkpoint-<step> \
   --backbone=wan2.2
 # ... infer against the printed endpoint IP with --policy.port=8000, then tear down:

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -223,6 +223,10 @@ def dreamzero_action(tgt_joints_key: str, tgt_grip_key: str, num_joints: int):
 _action = dreamzero_action.override(tgt_joints_key='robot_command.joints', tgt_grip_key='target_grip')
 joints = codecs.compose.override(obs=dreamzero_obs, action=_action, fps=15.0)
 
+# The pretrained DROID model (wan2.1) asserts exactly 320x180 frames; the wan2.2 fine-tunes resize the
+# 176-tall codec output at load, so only the DROID-serving codec needs the taller image.
+droid = codecs.compose.override(obs=dreamzero_obs.override(image_size=(IMAGE_WIDTH, 180)), action=_action, fps=15.0)
+
 _traj_action = dreamzero_action.override(tgt_joints_key='robot_state.q', tgt_grip_key='grip')
 joints_traj = codecs.compose.override(obs=dreamzero_obs, action=_traj_action, fps=15.0)
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -13,21 +13,37 @@ import configuronic as cfn
 import numpy as np
 import pos3
 from fastapi import WebSocket
+from huggingface_hub import snapshot_download
 
 from positronic.offboard.server_utils import monitor_async_task, wait_for_subprocess_ready
 from positronic.offboard.vendor_server import VendorServer
 from positronic.policy import Codec, Policy, Session
+from positronic.utils.checkpoints import get_latest_checkpoint
 from positronic.utils.logging import init_logging
 from positronic.utils.serialization import deserialize, serialize
 from positronic.vendors.dreamzero import codecs
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HF_REPO = 'GEAR-Dreams/DreamZero-DROID'
-
 
 def _dreamzero_root():
     return Path(__file__).parents[4] / 'dreamzero'
+
+
+def _download_checkpoint(model_path: str) -> Path:
+    """Local checkpoint dir for ``model_path``: an ``s3://`` URL or local path via pos3, else a HuggingFace repo."""
+    if model_path.startswith('s3://') or os.path.exists(model_path):
+        return pos3.download(model_path)
+    return Path(snapshot_download(model_path))
+
+
+def _resolve_checkpoint_path(model_path: str) -> str:
+    """Latest ``checkpoint-N`` under an ``s3://`` run directory; a pinned checkpoint dir, a HuggingFace repo,
+    or a local path is returned unchanged."""
+    last = model_path.rstrip('/').split('/')[-1]
+    if not model_path.startswith('s3://') or last.startswith('checkpoint-'):
+        return model_path
+    return f'{model_path.rstrip("/")}/{get_latest_checkpoint(model_path, "checkpoint-")}'
 
 
 # TODO: Extract RoboarenaClient to positronic/offboard/ — roboarena is a cross-vendor
@@ -217,7 +233,7 @@ class InferenceServer(VendorServer):
         super().__init__(
             codec=codec, host=host, port=port, recording_dir=recording_dir, idle_timeout_min=idle_timeout_min
         )
-        self.model_path = model_path
+        self.model_path = _resolve_checkpoint_path(model_path)
         self.dreamzero_venv = Path(dreamzero_venv)
         self.backbone = backbone
         self.num_gpus = num_gpus
@@ -231,7 +247,7 @@ class InferenceServer(VendorServer):
             'port': port,
             'type': 'dreamzero',
             'backbone': backbone,
-            'model_path': model_path,
+            'model_path': self.model_path,
             'num_gpus': num_gpus,
         }
 
@@ -245,7 +261,7 @@ class InferenceServer(VendorServer):
             if self.subprocess is not None:
                 return self.subprocess, {}
 
-            download_task = asyncio.create_task(asyncio.to_thread(pos3.download, self.model_path))
+            download_task = asyncio.create_task(asyncio.to_thread(_download_checkpoint, self.model_path))
             await monitor_async_task(
                 download_task, description='Downloading DreamZero checkpoint', on_progress=send_progress
             )
@@ -278,7 +294,6 @@ class InferenceServer(VendorServer):
 
 @cfn.config(
     codec=codecs.joints,
-    model_path=DEFAULT_HF_REPO,
     dreamzero_venv='/.venv/',
     backbone='wan2.1',
     num_gpus=1,
@@ -313,6 +328,11 @@ def server(
         ).serve()
 
 
+# Public pretrained DROID checkpoint: wan2.1 backbone (the base server default) paired with the DROID
+# codec that feeds its required 320x180 frames.
+droid = server.override(model_path='GEAR-Dreams/DreamZero-DROID', codec=codecs.droid)
+
+
 if __name__ == '__main__':
     init_logging()
-    cfn.cli(server)
+    cfn.cli({'serve': server, 'droid': droid})

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -32,8 +32,9 @@ def _dreamzero_root():
 
 def _download_checkpoint(model_path: str) -> Path:
     """Local checkpoint dir for ``model_path``: an ``s3://`` URL or local path via pos3, else a HuggingFace repo."""
-    if model_path.startswith('s3://') or os.path.exists(model_path):
-        return pos3.download(model_path)
+    local = os.path.expanduser(model_path)
+    if model_path.startswith('s3://') or os.path.exists(local):
+        return pos3.download(local)
     return Path(snapshot_download(model_path))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "jinja2",
     "fire",
     "httpx",
+    "huggingface-hub",
     "msgpack",
     "mujoco",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "jinja2",
     "fire",
     "httpx",
-    "huggingface-hub",
     "msgpack",
     "mujoco",
     "numpy",
@@ -88,6 +87,9 @@ molmoact2 = [
     "requests",
     "protobuf",
     "sentencepiece",
+]
+dreamzero = [
+    "huggingface-hub",
 ]
 lance = [
     "pylance",

--- a/uv.lock
+++ b/uv.lock
@@ -4219,6 +4219,10 @@ dev = [
     { name = "rerun-sdk" },
     { name = "ruff" },
 ]
+dreamzero = [
+    { name = "huggingface-hub", version = "0.35.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot' or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "huggingface-hub", version = "1.19.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-positronic-lerobot-0-3-3' or extra == 'extra-10-positronic-molmoact2' or extra != 'extra-10-positronic-lerobot'" },
+]
 hardware = [
     { name = "feetech-servo-sdk" },
     { name = "linuxpy" },
@@ -4272,6 +4276,7 @@ requires-dist = [
     { name = "feetech-servo-sdk", marker = "extra == 'hardware'" },
     { name = "fire" },
     { name = "httpx" },
+    { name = "huggingface-hub", marker = "extra == 'dreamzero'" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "jinja2" },
     { name = "jupyter", marker = "extra == 'dev'" },
@@ -4325,7 +4330,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=15.0.1" },
     { name = "zmq" },
 ]
-provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2", "lance", "dev"]
+provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2", "dreamzero", "lance", "dev"]
 
 [[package]]
 name = "positronic-franka"

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -67,7 +67,8 @@ case "$VENDOR" in
   # openpi.server imports `openpi_client` at module top → needs --extra openpi
   openpi)        IMAGE="positro/openpi:${IMAGE_TAG}";     EXTRA="--extra openpi " ;;
   gr00t)         IMAGE="positro/gr00t:${IMAGE_TAG}";      EXTRA="" ;;
-  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="" ;;
+  # dreamzero.server imports `huggingface_hub` at module top → needs --extra dreamzero
+  dreamzero)     IMAGE="positro/dreamzero:${IMAGE_TAG}";  EXTRA="--extra dreamzero " ;;
   molmoact2)     IMAGE="positro/positronic:${IMAGE_TAG}"; EXTRA="--extra molmoact2 " ;;
   *)
     echo "Unknown vendor: '$VENDOR'. Supported: lerobot_0_3_3 | lerobot | openpi | gr00t | dreamzero | molmoact2" >&2


### PR DESCRIPTION
## Summary
- Add a `droid` preset to the DreamZero inference server that serves the public pretrained
  `GEAR-Dreams/DreamZero-DROID` checkpoint (wan2.1), mirroring how openpi exposes a named `droid` config.
- Add a `droid` codec (320×180) — the pretrained DROID model asserts exactly that resolution, vs the
  176-tall codec the wan2.2 fine-tunes resize at load.
- The server now downloads HuggingFace repos at serve time via `snapshot_download` (the upstream VLA
  loader reads `model_path` as a local dir, so the repo must be fetched by our wrapper); `s3://`/local
  paths still go through `pos3`.
- Support latest-checkpoint discovery: a bare `s3://` run directory resolves to its newest `checkpoint-N`
  via the shared `positronic.utils.checkpoints.get_latest_checkpoint`, so `serve.sh` can take a run-dir
  instead of a pinned checkpoint path. A path already ending in `checkpoint-N`, a HuggingFace repo, or a
  local path passes through unchanged.
- The base `server` config no longer defaults `model_path` to the DROID repo — `droid` owns that identity.

Note: `uv.lock` is regenerated to add `huggingface-hub`; the repo pins no `uv` version, so a full
`uv lock` also re-normalizes some platform markers (equivalent, passes `uv sync --locked`).

## Test plan
- Probed both presets end-to-end against live H100 endpoints with `positronic/probe.py`: `serve` (wan2.2
  fine-tune) and `droid` (wan2.1 pretrained) each returned a 24-action chunk.
- Verified checkpoint resolution against real S3: a run dir resolves to the latest `checkpoint-N`; a pinned
  checkpoint, a HuggingFace repo, and a local path each pass through unchanged.
- `ruff check`/`ruff format` clean; `dreamzero/tests/test_codecs.py` + `utils/tests/test_checkpoints.py` pass.