### PR TITLE
Tighten MolmoAct2 README hardware note

### DIFF
--- a/positronic/vendors/molmoact2/README.md
+++ b/positronic/vendors/molmoact2/README.md
@@ -12,8 +12,7 @@ no convert or train step.
 
 ## Hardware
 
-A ~5B-parameter model loaded in `bfloat16` (~10 GB of weights), so plan for a **16 GB+ GPU** — the 12 GB
-desktop context is too small. First start downloads the checkpoint from HuggingFace.
+A ~5B-parameter model loaded in `bfloat16` (~10 GB of weights), so plan for a **16 GB+ GPU**. First start downloads the checkpoint from HuggingFace.
 
 ## Serve
 


### PR DESCRIPTION
## Summary
Follow-up to #453: trim a one-clause aside from the MolmoAct2 vendor README's Hardware
note. `16 GB+ GPU` already implies the 12 GB desktop context won't fit, so the explicit
clause is redundant.

## Test plan
Docs-only change.