### PR TITLE
Add `CartesianDelta` end-effector-space command

### DIFF
--- a/positronic/dataset/serializers.py
+++ b/positronic/dataset/serializers.py
@@ -7,7 +7,14 @@ import numpy as np
 import pimm
 from positronic import geom
 from positronic.drivers.roboarm import RobotStatus, State
-from positronic.drivers.roboarm.command import CartesianPosition, CommandType, JointDelta, JointPosition, Reset
+from positronic.drivers.roboarm.command import (
+    CartesianDelta,
+    CartesianPosition,
+    CommandType,
+    JointDelta,
+    JointPosition,
+    Reset,
+)
 
 # Serializer contract for values:
 # - Used by `DsWriterAgent.add_signal(name, serializer=None)` (recording) and the
@@ -117,6 +124,8 @@ class Serializers:
         match command:
             case CartesianPosition(pose):
                 return {'.pose': Serializers.transform_3d(pose)}
+            case CartesianDelta(delta):
+                return {'.pose_delta': Serializers.transform_3d(delta)}
             case JointPosition(positions):
                 return {'.joints': positions}
             case JointDelta(delta):

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -411,11 +411,13 @@ def test_robot_command_serializer_variants(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'cmd': Serializers.robot_command}, ds, world)
 
     pose = geom.Transform3D(translation=np.array([0.2, 0.0, -0.1]), rotation=geom.Rotation.identity)
+    delta = geom.Transform3D(translation=np.array([0.01, -0.02, 0.03]), rotation=geom.Rotation.identity)
     joints = np.arange(7, dtype=np.float32) * 0.1
 
     script = [
         (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianPosition(pose)), 0.001),
+        (lambda: emitters['cmd'].emit(rcmd.CartesianDelta(delta)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.Reset()), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
@@ -426,6 +428,7 @@ def test_robot_command_serializer_variants(world):
     w = ds.created[-1]
     items = {name: val for (name, val, _, _) in w.appends}
     np.testing.assert_allclose(items['cmd.pose'], np.concatenate([pose.translation, pose.rotation.as_quat]))
+    np.testing.assert_allclose(items['cmd.pose_delta'], np.concatenate([delta.translation, delta.rotation.as_quat]))
     np.testing.assert_allclose(items['cmd.joints'], joints)
     assert items['cmd.reset'] == 1
 

--- a/positronic/drivers/gripper/dh.py
+++ b/positronic/drivers/gripper/dh.py
@@ -40,7 +40,8 @@ class DHGripper(pimm.ControlSystem):
                 grip_msg = self.target_grip.read()
                 if grip_msg.updated:
                     player.set(grip_msg.data)
-                for grip in player.advance(clock.now_ns()):
+                grip = player.advance(clock.now_ns())
+                if grip is not None:
                     last_grip = grip
                 width = round((1 - max(0, min(last_grip, 1))) * 1000)
                 client.write_register(0x103, c_uint16(width).value, slave=1)

--- a/positronic/drivers/gripper/robotiq.py
+++ b/positronic/drivers/gripper/robotiq.py
@@ -41,7 +41,8 @@ class Robotiq2F(pimm.ControlSystem):
                 pos_msg = self.target_grip.read()
                 if pos_msg.updated:
                     player.set(pos_msg.data)
-                for grip in player.advance(clock.now_ns()):
+                grip = player.advance(clock.now_ns())
+                if grip is not None:
                     pos = int(max(0, min(1, grip)) * 255)
                     spd = int(max(0, min(255, self.speed.value)))
                     frc = int(max(0, min(255, self.force.value)))

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -48,7 +48,30 @@ class JointDelta:
     velocities: np.ndarray
 
 
-CommandType = Reset | Recover | CartesianPosition | JointPosition | JointDelta
+@dataclass
+class CartesianDelta:
+    """Move the end-effector by a world-frame pose delta from its current measured pose.
+
+    A one-shot relative motion: the driver composes ``delta`` onto the pose it measures the moment the
+    command is consumed, never re-applying it. Unlike ``JointDelta`` this is end-effector space, not joint
+    space.
+    """
+
+    TYPE = 'cartesian_delta'
+    delta: geom.Transform3D
+
+
+CommandType = Reset | Recover | CartesianPosition | JointPosition | JointDelta | CartesianDelta
+
+
+def apply_cartesian_delta(current: geom.Transform3D, delta: geom.Transform3D) -> geom.Transform3D:
+    """Compose a world-frame ``delta`` onto a measured ``current`` pose for the absolute target a driver drives to.
+
+    Translation adds in the world frame and rotation left-multiplies (``goal_ori = R(Δrot) @ ee_ori``), the
+    robosuite OSC convention. This is not ``Transform3D.__mul__``, which composes in the body frame and would
+    rotate the translation.
+    """
+    return geom.Transform3D(current.translation + delta.translation, delta.rotation * current.rotation)
 
 
 def to_wire(command: CommandType) -> dict[str, Any]:
@@ -61,6 +84,8 @@ def to_wire(command: CommandType) -> dict[str, Any]:
             return {'type': command.TYPE, 'positions': positions}
         case JointDelta(velocities):
             return {'type': command.TYPE, 'velocities': velocities}
+        case CartesianDelta(delta):
+            return {'type': command.TYPE, 'delta': delta.as_vector(geom.Rotation.Representation.ROTATION_MATRIX)}
 
 
 class TrajectoryPlayer:
@@ -105,5 +130,9 @@ def from_wire(wire: dict[str, Any]) -> CommandType:
             return JointPosition(positions=wire['positions'])
         case 'joint_delta':
             return JointDelta(velocities=wire['velocities'])
+        case 'cartesian_delta':
+            return CartesianDelta(
+                delta=geom.Transform3D.from_vector(wire['delta'], geom.Rotation.Representation.ROTATION_MATRIX)
+            )
         case _:
             raise ValueError(f'Unknown command type: {wire["type"]}')

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -74,6 +74,37 @@ def apply_cartesian_delta(current: geom.Transform3D, delta: geom.Transform3D) ->
     return geom.Transform3D(current.translation + delta.translation, delta.rotation * current.rotation)
 
 
+def _combine(acc: CommandType, cmd: CommandType) -> CommandType:
+    match (acc, cmd):
+        case (CartesianDelta(a), CartesianDelta(b)):
+            return CartesianDelta(apply_cartesian_delta(a, b))
+        case (JointDelta(a), JointDelta(b)):
+            return JointDelta(a + b)
+        case (CartesianDelta() | JointDelta(), _) | (_, CartesianDelta() | JointDelta()):
+            raise ValueError(f'Cannot reduce {type(acc).__name__} then {type(cmd).__name__} in one tick')
+        case _:
+            return cmd
+
+
+def reduce(due: list[tuple[float, CommandType]]) -> CommandType:
+    """Collapse the commands due in one control tick into the single command to execute.
+
+    Folds the batch in timestamp order. A run of same-space deltas accumulates (their motion is summed, so a
+    missed tick is caught up rather than dropped); a run of absolute commands keeps the last. Mixing an absolute
+    with a delta, or two delta spaces, has no faithful single-command form -- a delta binds to the pose measured
+    when it is consumed, which an absolute target or a foreign space cannot supply -- and raises.
+    """
+    result = due[0][1]
+    for _, cmd in due[1:]:
+        result = _combine(result, cmd)
+    return result
+
+
+def _reduce_last(due: list[tuple[float, Any]]) -> Any:
+    """The trailing value wins -- the right collapse for absolute setpoints and gripper targets."""
+    return due[-1][1]
+
+
 def to_wire(command: CommandType) -> dict[str, Any]:
     match command:
         case Reset() | Recover():
@@ -91,13 +122,15 @@ def to_wire(command: CommandType) -> dict[str, Any]:
 class TrajectoryPlayer:
     """Plays back a timestamped trajectory at the driver's control rate.
 
-    Call ``set()`` when a new trajectory arrives, then ``advance(now)`` each tick
-    to yield all commands whose timestamp has been reached.
+    Call ``set()`` when a new trajectory arrives, then ``advance(now)`` each tick to get the single command to
+    apply: every waypoint whose timestamp has been reached is collapsed by ``reduce`` into one value (the last
+    one by default; the arm channels pass ``command.reduce`` to accumulate due deltas instead of dropping them).
     """
 
-    def __init__(self):
+    def __init__(self, reduce=_reduce_last):
         self._trajectory: list[tuple[float, Any]] = []
         self._index: int = 0
+        self._reduce = reduce
 
     def set(self, data):
         if isinstance(data, list):
@@ -107,13 +140,15 @@ class TrajectoryPlayer:
         self._index = 0
 
     def advance(self, current_time: float):
-        """Yield all commands whose timestamp <= current_time."""
+        """Collapse every waypoint whose timestamp <= current_time into the single value to apply, or None."""
+        due = []
         while self._index < len(self._trajectory):
-            ts, cmd = self._trajectory[self._index]
+            ts, value = self._trajectory[self._index]
             if ts > current_time:
                 break
             self._index += 1
-            yield cmd
+            due.append((ts, value))
+        return self._reduce(due) if due else None
 
 
 def from_wire(wire: dict[str, Any]) -> CommandType:

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -219,7 +219,7 @@ class Robot(pimm.ControlSystem):
         self._reset(robot, robot_state)
 
         in_error = False
-        player = command.TrajectoryPlayer()
+        player = command.TrajectoryPlayer(reduce=command.reduce)
 
         while not should_stop.value:
             st = robot.state()
@@ -233,7 +233,8 @@ class Robot(pimm.ControlSystem):
             cmd_msg = self.commands.read()
             if cmd_msg.updated:
                 player.set(cmd_msg.data)
-            for cmd in player.advance(clock.now_ns()):
+            cmd = player.advance(clock.now_ns())
+            if cmd is not None:
                 match cmd:
                     case command.Reset():
                         _recover_if_needed(robot, in_error)

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -246,6 +246,11 @@ class Robot(pimm.ControlSystem):
                         target_pose_wxyz = np.asarray([*pose.translation, *pose.rotation.as_quat])
                         ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
                         robot.set_target_joints(ik_solution)
+                    case command.CartesianDelta(delta):
+                        target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
+                        target_pose_wxyz = np.asarray([*target.translation, *target.rotation.as_quat])
+                        ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
+                        robot.set_target_joints(ik_solution)
                     case command.JointPosition(positions):
                         robot.set_target_joints(positions)
                     case command.JointDelta(velocities=joint_delta):

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -100,6 +100,10 @@ class Robot(pimm.ControlSystem):
                         case command.CartesianPosition(pose):
                             qpos = self.solver.inverse(pose, robot_state.q)
                             joint_controller.set_target_qpos(qpos)
+                        case command.CartesianDelta(delta):
+                            target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
+                            qpos = self.solver.inverse(target, robot_state.q)
+                            joint_controller.set_target_qpos(qpos)
                         case command.JointPosition(positions):
                             qpos = np.array(positions, dtype=np.float32)
                             joint_controller.set_target_qpos(qpos)

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -87,13 +87,14 @@ class Robot(pimm.ControlSystem):
             joint_controller.compute_torque(q, dq, tau)
             current_command = np.zeros(api.actuator_count, dtype=np.float32)
 
-            player = command.TrajectoryPlayer()
+            player = command.TrajectoryPlayer(reduce=command.reduce)
 
             while not should_stop.value:
                 cmd_msg = self.commands.read()
                 if cmd_msg.updated:
                     player.set(cmd_msg.data)
-                for cmd in player.advance(clock.now_ns()):
+                cmd = player.advance(clock.now_ns())
+                if cmd is not None:
                     match cmd:
                         case command.Reset():
                             joint_controller.set_target_qpos(self.home_joints)

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -101,7 +101,7 @@ class Robot(pimm.ControlSystem):
                             qpos = self.solver.inverse(pose, robot_state.q)
                             joint_controller.set_target_qpos(qpos)
                         case command.CartesianDelta(delta):
-                            target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
+                            target = command.apply_cartesian_delta(self.solver.forward(joint_controller.q_s), delta)
                             qpos = self.solver.inverse(target, robot_state.q)
                             joint_controller.set_target_qpos(qpos)
                         case command.JointPosition(positions):

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -78,7 +78,7 @@ class Robot(pimm.ControlSystem):
         rate_limit = pimm.RateLimiter(hz=1000, clock=clock)
         state = SO101State()
 
-        player = roboarm_command.TrajectoryPlayer()
+        player = roboarm_command.TrajectoryPlayer(reduce=roboarm_command.reduce)
         grip_player = roboarm_command.TrajectoryPlayer()
 
         while not should_stop.value:
@@ -88,9 +88,11 @@ class Robot(pimm.ControlSystem):
             grip_msg = self.target_grip.read()
             if grip_msg.updated:
                 grip_player.set(grip_msg.data)
-            for grip in grip_player.advance(clock.now_ns()):
+            grip = grip_player.advance(clock.now_ns())
+            if grip is not None:
                 self._last_grip = grip
-            for cmd in player.advance(clock.now_ns()):
+            cmd = player.advance(clock.now_ns())
+            if cmd is not None:
                 match cmd:
                     case roboarm_command.Reset():
                         raise NotImplementedError('Reset not implemented')

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -98,6 +98,11 @@ class Robot(pimm.ControlSystem):
                         qpos = self._solve_ik(state, pose)
                         q_with_gripper = np.concatenate([qpos, [self._last_grip]])
                         self.motor_bus.set_target_position(q_with_gripper)
+                    case roboarm_command.CartesianDelta(delta):
+                        target = roboarm_command.apply_cartesian_delta(state.ee_pose, delta)
+                        qpos = self._solve_ik(state, target)
+                        q_with_gripper = np.concatenate([qpos, [self._last_grip]])
+                        self.motor_bus.set_target_position(q_with_gripper)
                     case roboarm_command.JointPosition(qpos):
                         q_norm = self.rad_to_norm(qpos)
                         q_with_gripper = np.concatenate([q_norm, [self._last_grip]])
@@ -115,10 +120,10 @@ class Robot(pimm.ControlSystem):
             self.grip.emit(gripper)
             yield rate_limit.wait()
 
-    def _solve_ik(self, state, command: roboarm_command.CartesianPosition) -> np.ndarray:
+    def _solve_ik(self, state, pose: geom.Transform3D) -> np.ndarray:
         q = np.array(state.q).tolist()
         q.append(0.0)  # ignore gripper in ik
-        q_rad_new = self.kinematic.inverse(q, command.pose, n_iter=10)
+        q_rad_new = self.kinematic.inverse(q, pose, n_iter=10)
         return self.rad_to_norm(q_rad_new)[:-1]
 
     def _forward_kinematics(self, motor_position) -> geom.Transform3D:

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -99,7 +99,8 @@ class Robot(pimm.ControlSystem):
                         q_with_gripper = np.concatenate([qpos, [self._last_grip]])
                         self.motor_bus.set_target_position(q_with_gripper)
                     case roboarm_command.CartesianDelta(delta):
-                        target = roboarm_command.apply_cartesian_delta(state.ee_pose, delta)
+                        ee_pose, _ = self._forward_kinematics(self.motor_bus.position)
+                        target = roboarm_command.apply_cartesian_delta(ee_pose, delta)
                         qpos = self._solve_ik(state, target)
                         q_with_gripper = np.concatenate([qpos, [self._last_grip]])
                         self.motor_bus.set_target_position(q_with_gripper)

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -149,7 +149,8 @@ class FakeRobot(pimm.ControlSystem):
             cmd_msg = self.commands.read()
             if cmd_msg.updated and cmd_msg.data is not None:
                 player.set(cmd_msg.data)
-            for cmd in player.advance(clock.now_ns()):
+            cmd = player.advance(clock.now_ns())
+            if cmd is not None:
                 self._apply(cmd)
             if self._error_pending:
                 self._status = RobotStatus.ERROR
@@ -172,7 +173,8 @@ class FakeGripper(pimm.ControlSystem):
             msg = self.target_grip.read()
             if msg.updated and msg.data is not None:
                 player.set(msg.data)
-            for grip in player.advance(clock.now_ns()):
+            grip = player.advance(clock.now_ns())
+            if grip is not None:
                 self._grip = float(grip)
             self.grip.emit(self._grip)
             yield pimm.Sleep(CONTROL_PERIOD_S)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -12,10 +12,14 @@ from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import (
     CartesianDelta,
     CartesianPosition,
+    JointDelta,
+    JointPosition,
     Recover,
     Reset,
+    TrajectoryPlayer,
     apply_cartesian_delta,
     from_wire,
+    reduce,
     to_wire,
 )
 from positronic.eval import Command, Embodiment, Observation, Task
@@ -1110,6 +1114,64 @@ def test_apply_cartesian_delta_composes_in_world_frame():
     np.testing.assert_allclose(target.translation, current.translation + delta.translation)
     np.testing.assert_allclose(target.rotation.as_quat, (delta.rotation * current.rotation).as_quat, atol=1e-12)
     assert not np.allclose(target.translation, (current * delta).translation)  # guards against body-frame compose
+
+
+def test_reduce_accumulates_due_cartesian_deltas():
+    # Rotations about different axes so the world-frame compose is non-commutative -- this pins the fold order
+    # (apply d0 then d1), not just that a fold happened.
+    d0 = Transform3D(np.array([0.01, 0.0, 0.0]), Rotation.from_rotvec(np.array([0.3, 0.0, 0.0])))
+    d1 = Transform3D(np.array([0.02, 0.01, 0.0]), Rotation.from_rotvec(np.array([0.0, 0.0, 0.2])))
+    out = reduce([(10, CartesianDelta(d0)), (20, CartesianDelta(d1))])
+    assert isinstance(out, CartesianDelta)
+    expected = apply_cartesian_delta(d0, d1)  # two due deltas catch up as their world-frame compose, not last-wins
+    np.testing.assert_allclose(out.delta.translation, expected.translation)
+    np.testing.assert_allclose(out.delta.rotation.as_quat, expected.rotation.as_quat, atol=1e-12)
+    assert not np.allclose(out.delta.rotation.as_quat, apply_cartesian_delta(d1, d0).rotation.as_quat)
+
+
+def test_reduce_sums_due_joint_deltas():
+    out = reduce([(10, JointDelta(np.array([0.1, -0.2, 0.3]))), (20, JointDelta(np.array([0.0, 0.2, -0.1])))])
+    assert isinstance(out, JointDelta)
+    np.testing.assert_allclose(out.velocities, [0.1, 0.0, 0.2])
+
+
+def test_reduce_absolute_run_keeps_last():
+    p0 = CartesianPosition(Transform3D(np.array([0.1, 0.0, 0.0]), Rotation.from_rotvec(np.zeros(3))))
+    p1 = JointPosition(np.array([0.2, 0.0, 0.0]))
+    assert reduce([(10, p0), (20, p1)]) is p1
+
+
+def test_reduce_raises_on_absolute_delta_mix():
+    cart_pos = CartesianPosition(Transform3D(np.zeros(3), Rotation.from_rotvec(np.zeros(3))))
+    cart_delta = CartesianDelta(Transform3D(np.array([0.01, 0.0, 0.0]), Rotation.from_rotvec(np.zeros(3))))
+    joint_pos = JointPosition(np.zeros(3))
+    joint_delta = JointDelta(np.array([0.1, 0.0, 0.0]))
+    with pytest.raises(ValueError):
+        reduce([(10, cart_pos), (20, cart_delta)])
+    with pytest.raises(ValueError):
+        reduce([(10, cart_delta), (20, cart_pos)])
+    with pytest.raises(ValueError):  # JointPosition then JointDelta: the delta has no faithful anchor to fold onto
+        reduce([(10, joint_pos), (20, joint_delta)])
+
+
+def test_reduce_raises_on_mixed_delta_spaces():
+    cart_delta = CartesianDelta(Transform3D(np.array([0.01, 0.0, 0.0]), Rotation.from_rotvec(np.zeros(3))))
+    joint_delta = JointDelta(np.array([0.1, 0.0, 0.0]))
+    with pytest.raises(ValueError):
+        reduce([(10, cart_delta), (20, joint_delta)])
+    with pytest.raises(ValueError):
+        reduce([(10, joint_delta), (20, cart_delta)])
+
+
+def test_trajectory_player_accumulates_missed_deltas():
+    d0 = Transform3D(np.array([0.01, 0.0, 0.0]), Rotation.from_rotvec(np.zeros(3)))
+    d1 = Transform3D(np.array([0.02, 0.0, 0.0]), Rotation.from_rotvec(np.zeros(3)))
+    player = TrajectoryPlayer(reduce=reduce)
+    player.set([(10, CartesianDelta(d0)), (20, CartesianDelta(d1))])
+    out = player.advance(20)  # both waypoints due in one tick -> summed, not dropped to the last
+    assert isinstance(out, CartesianDelta)
+    np.testing.assert_allclose(out.delta.translation, [0.03, 0.0, 0.0])
+    assert player.advance(30) is None
 
 
 @pytest.mark.parametrize('status, expected_error', [(RobotStatus.AVAILABLE, 0), (RobotStatus.ERROR, 1)])

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -9,7 +9,15 @@ from positronic.dataset.ds_writer_agent import DsWriterCommand, DsWriterCommandT
 from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import RobotStatus
-from positronic.drivers.roboarm.command import CartesianPosition, Recover, Reset, from_wire, to_wire
+from positronic.drivers.roboarm.command import (
+    CartesianDelta,
+    CartesianPosition,
+    Recover,
+    Reset,
+    apply_cartesian_delta,
+    from_wire,
+    to_wire,
+)
 from positronic.eval import Command, Embodiment, Observation, Task
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
@@ -1081,6 +1089,27 @@ def test_recover_command_wire_roundtrip():
     wire = to_wire(Recover())
     assert wire == {'type': 'recover'}
     assert isinstance(from_wire(wire), Recover)
+
+
+def test_cartesian_delta_wire_roundtrip():
+    delta = Transform3D(np.array([0.01, -0.02, 0.03]), Rotation.from_rotvec(np.array([0.0, 0.1, 0.0])))
+    wire = to_wire(CartesianDelta(delta=delta))
+    assert wire['type'] == 'cartesian_delta'
+    out = from_wire(wire)
+    assert isinstance(out, CartesianDelta)
+    np.testing.assert_allclose(out.delta.translation, delta.translation)
+    np.testing.assert_allclose(out.delta.rotation.as_quat, delta.rotation.as_quat, atol=1e-9)
+
+
+def test_apply_cartesian_delta_composes_in_world_frame():
+    current = Transform3D(np.array([0.5, 0.1, 0.3]), Rotation.from_rotvec(np.array([0.2, 0.1, 0.4])))
+    delta = Transform3D(np.array([0.02, -0.01, 0.05]), Rotation.from_rotvec(np.array([0.1, 0.0, 0.0])))
+    target = apply_cartesian_delta(current, delta)
+    # World frame: translation adds directly (not rotated by current, as Transform3D.__mul__ would) and the
+    # rotation left-multiplies.
+    np.testing.assert_allclose(target.translation, current.translation + delta.translation)
+    np.testing.assert_allclose(target.rotation.as_quat, (delta.rotation * current.rotation).as_quat, atol=1e-12)
+    assert not np.allclose(target.translation, (current * delta).translation)  # guards against body-frame compose
 
 
 @pytest.mark.parametrize('status, expected_error', [(RobotStatus.AVAILABLE, 0), (RobotStatus.ERROR, 1)])

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -8,9 +8,19 @@ benchmark ships one adapter (``vendors/``-style); the native ``MujocoSim`` fixtu
 """
 
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from typing import Any
 
 import pimm
+from positronic.drivers.roboarm import command as roboarm_command
+
+
+def fresh_command_players() -> defaultdict[str, roboarm_command.TrajectoryPlayer]:
+    """A trajectory player per command channel: ``robot_command`` accumulates the deltas due in one tick (a
+    missed tick catches up instead of dropping motion), every other channel keeps the last value due."""
+    players = defaultdict(roboarm_command.TrajectoryPlayer)
+    players['robot_command'] = roboarm_command.TrajectoryPlayer(reduce=roboarm_command.reduce)
+    return players
 
 
 class EnvAdapter(ABC):

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -8,7 +8,7 @@ serves. ``make_mujoco_env`` builds it; ``StackCubesAdapter`` + ``remote_stack_cu
 the client-side mapping + embodiment.
 """
 
-from collections import defaultdict, deque
+from collections import deque
 from contextlib import nullcontext
 from typing import Any
 
@@ -21,7 +21,7 @@ from positronic import geom
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Task
-from positronic.simulator.env_server.adapter import EnvAdapter
+from positronic.simulator.env_server.adapter import EnvAdapter, fresh_command_players
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
 from positronic.simulator.env_server.server import EnvProtocol
 from positronic.simulator.mujoco.sim import MujocoFrankaState, MujocoSim
@@ -164,13 +164,11 @@ class StackCubesAdapter(EnvAdapter):
 
     def __init__(self, camera_dict: dict[str, str]):
         self._camera_dict = camera_dict  # logical observation name -> the env's model camera name
-        self._players: defaultdict[str, roboarm_command.TrajectoryPlayer] = defaultdict(
-            roboarm_command.TrajectoryPlayer
-        )
+        self._players = fresh_command_players()
         self._held: dict[str, Any] = {}  # last sampled waypoint per channel — re-sent until it changes
 
     def reset_token(self, seed: int | None) -> Any:
-        self._players = defaultdict(roboarm_command.TrajectoryPlayer)
+        self._players = fresh_command_players()
         self._held = {}
         return seed
 
@@ -181,7 +179,8 @@ class StackCubesAdapter(EnvAdapter):
                 player.set(msg.data)
                 if not msg.data:  # an empty trajectory cancels: stop replaying the held waypoint
                     self._held.pop(name, None)
-            for value in player.advance(now_ns):
+            value = player.advance(now_ns)
+            if value is not None:
                 self._held[name] = value
         # Position setpoints are held and re-sent every control tick — absolute-mode by design. A CartesianDelta
         # is a one-shot relative motion, like Reset/Recover: emitted once, then dropped so it neither re-composes

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -120,7 +120,7 @@ class MujocoEnv(EnvProtocol):
 
     def step(self, action: dict[str, Any]) -> dict[str, Any]:
         assert self._gen is not None, 'step() called before reset()'  # real Gym envs reject step-before-reset
-        unknown = action.keys() - {'reset', 'recover', 'joints', 'pose', 'grip'}
+        unknown = action.keys() - {'reset', 'recover', 'joints', 'pose', 'pose_delta', 'grip'}
         if unknown:
             raise ValueError(f'MujocoEnv got unsupported action keys: {sorted(unknown)}')
         if 'reset' in action:
@@ -132,6 +132,10 @@ class MujocoEnv(EnvProtocol):
         elif 'pose' in action:
             self._cmd_emit.emit(
                 roboarm_command.CartesianPosition(geom.Transform3D.from_vector(action['pose'], _ROTMAT))
+            )
+        elif 'pose_delta' in action:
+            self._cmd_emit.emit(
+                roboarm_command.CartesianDelta(geom.Transform3D.from_vector(action['pose_delta'], _ROTMAT))
             )
         if 'grip' in action:
             self._grip_emit.emit(float(action['grip']))
@@ -179,9 +183,9 @@ class StackCubesAdapter(EnvAdapter):
                     self._held.pop(name, None)
             for value in player.advance(now_ns):
                 self._held[name] = value
-        # Position setpoints are held and re-sent every control tick — absolute-mode by design, so a
-        # relative delta would integrate repeatedly. Reset/Recover are one-shot events: emitted once,
-        # then dropped so they neither re-fire nor leave a stale setpoint holding behind them.
+        # Position setpoints are held and re-sent every control tick — absolute-mode by design. A CartesianDelta
+        # is a one-shot relative motion, like Reset/Recover: emitted once, then dropped so it neither re-composes
+        # against the moving eef nor leaves a stale setpoint holding behind it.
         action: dict[str, Any] = {}
         match self._held.get('robot_command'):
             case None:
@@ -190,6 +194,9 @@ class StackCubesAdapter(EnvAdapter):
                 action['joints'] = np.asarray(positions, dtype=np.float64)
             case roboarm_command.CartesianPosition(pose):
                 action['pose'] = pose.as_vector(_ROTMAT)
+            case roboarm_command.CartesianDelta(delta):
+                action['pose_delta'] = delta.as_vector(_ROTMAT)
+                self._held.pop('robot_command')
             case roboarm_command.Reset():
                 action['reset'] = True
                 self._held.pop('robot_command')

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -5,6 +5,7 @@ import pos3
 import pytest
 
 import pimm
+from positronic import geom
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.eval import Task
@@ -84,6 +85,43 @@ def test_transport_is_transparent(env_server):
         _assert_obs_equal(direct_step['obs'], socket_step['obs'])
         assert direct_step['done'] == socket_step['done']
         assert direct_step['control_dt'] == socket_step['control_dt']
+
+
+def _settle(env, action: dict, steps: int) -> np.ndarray:
+    """Apply ``action`` once, then idle ``steps`` ticks while the position actuators settle; return the final eef."""
+    env.step(action)
+    out = {'obs': None}
+    for _ in range(steps):
+        out = env.step({})
+    return np.asarray(out['obs']['ee_pos'])
+
+
+@pytest.mark.timeout(60.0)
+def test_cartesian_delta_matches_absolute_target():
+    """A CartesianDelta settles to the same eef as the absolute CartesianPosition for the composed target: it
+    confirms the world-frame compose and that the delta fires once — a delta re-applied every tick would overshoot.
+    Comparing the two paths cancels the actuators' shared steady-state offset, so the match is exact."""
+    rotmat = geom.Rotation.Representation.ROTATION_MATRIX
+    seed, settle = 11, 300
+    lift = np.array([0.0, 0.0, 0.04])
+
+    abs_env = make_mujoco_env(list(CAMERAS.values()))
+    reset = abs_env.reset(seed)
+    ee0 = np.asarray(reset['obs']['ee_pos'])
+    target = geom.Transform3D(ee0 + lift, geom.Rotation.from_quat(reset['obs']['ee_quat']))
+    ee_abs = _settle(abs_env, {'pose': target.as_vector(rotmat)}, settle)
+    abs_env.close()
+
+    delta_env = make_mujoco_env(list(CAMERAS.values()))
+    delta_env.reset(seed)
+    delta = geom.Transform3D(lift, geom.Rotation.identity)
+    ee_delta = _settle(delta_env, {'pose_delta': delta.as_vector(rotmat)}, settle)
+    ee_idle = _settle(delta_env, {}, 50)  # the delta already fired; idling must not re-compose it
+    delta_env.close()
+
+    assert ee_delta[2] > ee0[2] + 0.01, 'the delta did not lift the arm'
+    np.testing.assert_allclose(ee_delta, ee_abs, atol=1e-4)  # same composed target -> same settled eef
+    np.testing.assert_allclose(ee_idle, ee_delta, atol=1e-3)  # one-shot: idle ticks add no motion
 
 
 class _CountdownEnv(EnvProtocol):

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -29,6 +29,8 @@ def _wire_command(cmd: Any) -> dict[str, Any]:
             return {'type': 'joint_pos', 'q': positions}
         case roboarm_command.JointDelta(velocities):
             return {'type': 'joint_vel', 'dq': velocities}
+        case roboarm_command.CartesianDelta(delta):
+            return {'type': 'cartesian_delta', 'delta': delta.as_vector(geom.Rotation.Representation.ROTATION_MATRIX)}
         case None:
             return {'type': 'hold'}
         case other:
@@ -72,11 +74,15 @@ class LiberoAdapter(EnvAdapter):
             for value in player.advance(now_ns):
                 self._held[name] = value
         # The server maps the held command into the active controller's action. Reset/Recover have no robosuite
-        # action, so they forward as a hold.
+        # action, so they forward as a hold; a CartesianDelta is a one-shot relative motion, forwarded once then
+        # dropped so the held command never re-composes it against the moving eef.
         cmd = self._held.get('robot_command')
-        if isinstance(cmd, roboarm_command.Reset | roboarm_command.Recover):
-            self._held.pop('robot_command')
-            cmd = None
+        match cmd:
+            case roboarm_command.Reset() | roboarm_command.Recover():
+                self._held.pop('robot_command')
+                cmd = None
+            case roboarm_command.CartesianDelta():
+                self._held.pop('robot_command')
         if 'target_grip' in self._held:
             self._grip = float(self._held['target_grip'])
         return {'command': _wire_command(cmd), 'grip': self._grip}

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -8,7 +8,6 @@ action encoding — the OSC pose delta and its normalization, and the FK/IK that
 lives server-side in ``LiberoEnv`` where the MuJoCo model is; the adapter holds no model and stays geometry-only.
 """
 
-from collections import defaultdict
 from typing import Any
 
 import numpy as np
@@ -16,7 +15,7 @@ import numpy as np
 import pimm
 from positronic import geom
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.simulator.env_server.adapter import EnvAdapter
+from positronic.simulator.env_server.adapter import EnvAdapter, fresh_command_players
 from positronic.simulator.mujoco.sim import MujocoFrankaState
 
 
@@ -49,16 +48,14 @@ class LiberoAdapter(EnvAdapter):
             'camera_resolution': camera_resolution,
             'control_mode': control_mode,
         }
-        self._players: defaultdict[str, roboarm_command.TrajectoryPlayer] = defaultdict(
-            roboarm_command.TrajectoryPlayer
-        )
+        self._players = fresh_command_players()
         self._held: dict[str, Any] = {}  # last sampled waypoint per channel — re-sent until it changes
         # Last commanded gripper closure, held across a cancelled grip trajectory: grip is an absolute [0, 1]
         # value with no 'hold' command to fall back on (unlike the arm), so cancelling must freeze it, not reopen.
         self._grip = 0.0
 
     def reset_token(self, seed: int | None) -> Any:
-        self._players = defaultdict(roboarm_command.TrajectoryPlayer)
+        self._players = fresh_command_players()
         self._held = {}
         self._grip = 0.0
         # The task spec the server builds from + the seed it selects an init-state with (``None`` -> index 0).
@@ -71,7 +68,8 @@ class LiberoAdapter(EnvAdapter):
                 player.set(msg.data)
                 if not msg.data:  # an empty trajectory cancels: stop replaying the held waypoint
                     self._held.pop(name, None)
-            for value in player.advance(now_ns):
+            value = player.advance(now_ns)
+            if value is not None:
                 self._held[name] = value
         # The server maps the held command into the active controller's action. Reset/Recover have no robosuite
         # action, so they forward as a hold; a CartesianDelta is a one-shot relative motion, forwarded once then

--- a/positronic/simulator/libero/e2e.py
+++ b/positronic/simulator/libero/e2e.py
@@ -36,28 +36,47 @@ _SETTLE_STEPS = 10  # let objects fall and settle after the scene loads, matchin
 _OUTPUT_MAX = np.array([0.05, 0.05, 0.05, 0.5, 0.5, 0.5])
 
 
+def _physical_delta(delta: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Un-normalize an OSC ``delta`` ([-1, 1]) into the world-frame per-step pose delta ``(Δpos, Δrot matrix)``."""
+    physical = np.asarray(delta, dtype=float) * _OUTPUT_MAX
+    delta_rot = np.asarray(geom.Rotation.from_rotvec(physical[3:]).to(_ROTMAT)).reshape(3, 3)
+    return physical[:3], delta_rot
+
+
 def _compose_pose(obs: dict, delta: np.ndarray) -> np.ndarray:
     """The absolute pose the normalized OSC ``delta`` targets, anchored on the observed eef pose.
 
     Mirrors robosuite ``set_goal``: world-frame translation ``ee_pos + Δpos`` and orientation ``R(Δrot) @ ee_ori``
     (left-multiply), but reads ``ee_pos``/``ee_ori`` from the wire observation rather than the controller."""
-    physical = np.asarray(delta, dtype=float) * _OUTPUT_MAX
+    delta_pos, delta_rot = _physical_delta(delta)
     cur_rot = np.asarray(geom.Rotation.from_quat_xyzw(obs['eef_quat']).to(_ROTMAT)).reshape(3, 3)
-    delta_rot = np.asarray(geom.Rotation.from_rotvec(physical[3:]).to(_ROTMAT)).reshape(3, 3)
-    target_pos = np.asarray(obs['eef_pos']) + physical[:3]
-    return np.concatenate([target_pos, (delta_rot @ cur_rot).reshape(9)])
+    return np.concatenate([np.asarray(obs['eef_pos']) + delta_pos, (delta_rot @ cur_rot).reshape(9)])
 
 
-def _replay_episode(conn: EnvConnection, actions: np.ndarray, init_state: np.ndarray, scene: dict) -> bool:
+def _step_command(obs: dict, delta: np.ndarray, command_mode: str) -> dict:
+    """The per-step wire command for the active replay path: ``cartesian`` ships an absolute pose the env
+    re-derives a delta from; ``cartesian_delta`` ships the world-frame delta straight to the OSC controller."""
+    match command_mode:
+        case 'cartesian':
+            return {'type': 'cartesian', 'pose': _compose_pose(obs, delta)}
+        case 'cartesian_delta':
+            delta_pos, delta_rot = _physical_delta(delta)
+            return {'type': 'cartesian_delta', 'delta': np.concatenate([delta_pos, delta_rot.reshape(9)])}
+        case _:
+            raise ValueError(f'unknown command mode {command_mode!r}')
+
+
+def _replay_episode(
+    conn: EnvConnection, actions: np.ndarray, init_state: np.ndarray, scene: dict, *, command_mode: str
+) -> bool:
     # Exact-state reset: the token carries the task spec plus the demo's own recorded full state to restore.
     obs = conn.reset({**scene, 'state': init_state})['obs']
     for _ in range(_SETTLE_STEPS):
         obs = conn.step({'command': {'type': 'hold'}, 'grip': 0.0})['obs']
     success = False
     for action in actions:
-        pose = _compose_pose(obs, action[:6])
         grip = (float(action[6]) + 1.0) / 2.0  # robosuite gripper [-1, 1] -> positronic [0, 1]
-        out = conn.step({'command': {'type': 'cartesian', 'pose': pose}, 'grip': grip})
+        out = conn.step({'command': _step_command(obs, action[:6], command_mode), 'grip': grip})
         obs = out['obs']
         success = success or out['done']
     return success
@@ -71,7 +90,12 @@ def _load_fixture(path: str) -> list[tuple[np.ndarray, np.ndarray]]:
 
 
 def run_replay(
-    fixture_path: str, *, suite: str = 'libero_spatial', task_id: int = 0, camera_resolution: int = 128
+    fixture_path: str,
+    *,
+    suite: str = 'libero_spatial',
+    task_id: int = 0,
+    camera_resolution: int = 128,
+    command_mode: str = 'cartesian',
 ) -> float:
     """Replay every episode in ``fixture_path`` through the env server; return the success rate."""
     episodes = _load_fixture(fixture_path)
@@ -82,7 +106,7 @@ def run_replay(
         conn = EnvConnection(host, port)
         try:
             for i, (actions, init_state) in enumerate(episodes):
-                ok = _replay_episode(conn, actions, init_state, scene)
+                ok = _replay_episode(conn, actions, init_state, scene, command_mode=command_mode)
                 successes += int(ok)
                 print(f'  episode {i}: {"success" if ok else "FAIL"} ({len(actions)} steps)')
         finally:
@@ -96,10 +120,17 @@ def main() -> None:
     parser.add_argument('--suite', default='libero_spatial', help='LIBERO task suite the fixture was extracted from')
     parser.add_argument('--task-id', type=int, default=0)
     parser.add_argument('--camera-resolution', type=int, default=128)
+    parser.add_argument('--command-mode', choices=['cartesian', 'cartesian_delta'], default='cartesian')
     parser.add_argument('--min-success', type=float, default=0.8, help='replay success rate below this fails the run')
     args = parser.parse_args()
 
-    rate = run_replay(args.fixture, suite=args.suite, task_id=args.task_id, camera_resolution=args.camera_resolution)
+    rate = run_replay(
+        args.fixture,
+        suite=args.suite,
+        task_id=args.task_id,
+        camera_resolution=args.camera_resolution,
+        command_mode=args.command_mode,
+    )
     print(f'replay success rate: {rate:.2f}')
     assert rate >= args.min_success, f'success rate {rate:.2f} below {args.min_success} — env server likely broken'
     print('E2E REPLAY PASSED')

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -181,9 +181,8 @@ class LiberoEnv(EnvProtocol):
         match (self._control_mode, command['type']):
             case ('ee', 'cartesian'):  # OSC_POSE: world-frame pose error
                 physical = self._pose_error(*_unpack_pose(command['pose']))
-            case ('ee', 'cartesian_delta'):  # the world-frame delta is the per-step OSC error directly
-                delta_pos, delta_rot = _unpack_pose(command['delta'])
-                physical = np.concatenate([delta_pos, quat2axisangle(mat2quat(delta_rot))])
+            case ('ee', 'cartesian_delta'):  # OSC_POSE: the world-frame delta composed onto the live eef pose
+                physical = self._pose_error(*self._delta_target(command))
             case ('ee', 'joint_pos'):
                 physical = self._pose_error(*self._fk(command['q']))
             case ('ee', 'joint_vel'):
@@ -196,6 +195,8 @@ class LiberoEnv(EnvProtocol):
                 physical = command['dq']
             case ('joint', 'cartesian'):
                 physical = self._ik(*_unpack_pose(command['pose'])) - self._cur_q()
+            case ('joint', 'cartesian_delta'):
+                physical = self._ik(*self._delta_target(command)) - self._cur_q()
             case ('joint', 'hold'):
                 physical = np.zeros(len(self._qpos_idx))
             case ('joint_delta', 'joint_vel'):  # JOINT_VELOCITY: the per-step delta as a rate over the control period
@@ -204,6 +205,8 @@ class LiberoEnv(EnvProtocol):
                 physical = (command['q'] - self._cur_q()) / self._control_dt
             case ('joint_delta', 'cartesian'):
                 physical = (self._ik(*_unpack_pose(command['pose'])) - self._cur_q()) / self._control_dt
+            case ('joint_delta', 'cartesian_delta'):
+                physical = (self._ik(*self._delta_target(command)) - self._cur_q()) / self._control_dt
             case ('joint_delta', 'hold'):
                 physical = np.zeros(len(self._qpos_idx))
             case (mode, ctype):
@@ -226,6 +229,14 @@ class LiberoEnv(EnvProtocol):
         # world-frame axis-angle rotation error (``goal_pos = ee_pos + Δpos``; ``goal_ori = R(Δrot) @ ee_ori``).
         cur_pos, cur_rot = self._cur_pose()
         return np.concatenate([target_pos - cur_pos, quat2axisangle(mat2quat(target_rot @ cur_rot.T))])
+
+    def _delta_target(self, command: dict[str, Any]) -> tuple[np.ndarray, np.ndarray]:
+        # The absolute pose a world-frame ``cartesian_delta`` targets: translation adds and rotation left-multiplies
+        # onto the live eef pose (``goal_pos = ee_pos + Δpos``; ``goal_ori = R(Δrot) @ ee_ori``) — the same compose
+        # each control mode then bridges, as an OSC pose error or via IK to joints.
+        cur_pos, cur_rot = self._cur_pose()
+        delta_pos, delta_rot = _unpack_pose(command['delta'])
+        return cur_pos + delta_pos, delta_rot @ cur_rot
 
     def _cur_pose(self) -> tuple[np.ndarray, np.ndarray]:
         pos = np.array(self._sim.data.site_xpos[self._eef_site_id])

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -181,6 +181,9 @@ class LiberoEnv(EnvProtocol):
         match (self._control_mode, command['type']):
             case ('ee', 'cartesian'):  # OSC_POSE: world-frame pose error
                 physical = self._pose_error(*_unpack_pose(command['pose']))
+            case ('ee', 'cartesian_delta'):  # the world-frame delta is the per-step OSC error directly
+                delta_pos, delta_rot = _unpack_pose(command['delta'])
+                physical = np.concatenate([delta_pos, quat2axisangle(mat2quat(delta_rot))])
             case ('ee', 'joint_pos'):
                 physical = self._pose_error(*self._fk(command['q']))
             case ('ee', 'joint_vel'):

--- a/positronic/simulator/libero/tests/test_e2e.py
+++ b/positronic/simulator/libero/tests/test_e2e.py
@@ -29,6 +29,7 @@ _FIXTURE = os.path.join(os.path.dirname(__file__), 'libero_spatial_task0.npz')
     not os.path.exists(_FIXTURE), reason='e2e fixture missing — generate it on a LIBERO box with make_fixture.py'
 )
 @pytest.mark.timeout(900)  # the env server bootstraps its 3.10 deps on first run, which can take minutes
-def test_demo_replay_reaches_success():
-    rate = run_replay(_FIXTURE, suite='libero_spatial', task_id=0)
-    assert rate == 1.0, f'demo replay success rate {rate:.2f} — every prerecorded demo must replay to success'
+@pytest.mark.parametrize('command_mode', ['cartesian', 'cartesian_delta'])
+def test_demo_replay_reaches_success(command_mode):
+    rate = run_replay(_FIXTURE, suite='libero_spatial', task_id=0, command_mode=command_mode)
+    assert rate == 1.0, f'demo replay ({command_mode}) rate {rate:.2f} — every prerecorded demo must replay to success'

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -143,7 +143,7 @@ class MujocoSim(pimm.ControlSystem):
         self._home()
         self._error = False
         self._adapters: dict[str, pimm.shared_memory.NumpySMAdapter] | None = None
-        self._arm_player = roboarm_command.TrajectoryPlayer()
+        self._arm_player = roboarm_command.TrajectoryPlayer(reduce=roboarm_command.reduce)
         self._grip_player = roboarm_command.TrajectoryPlayer()
         self._last_grip = 0.0
         # Set by ``reset``; the run loop publishes frame-0 (instead of stepping) on its next turn and clears it.
@@ -181,12 +181,14 @@ class MujocoSim(pimm.ControlSystem):
             cmd_msg = self.commands.read()
             if cmd_msg.updated:
                 self._arm_player.set(cmd_msg.data)
-            for cmd in self._arm_player.advance(clock.now_ns()):
+            cmd = self._arm_player.advance(clock.now_ns())
+            if cmd is not None:
                 self._apply_command(cmd)
             grip_msg = self.target_grip.read()
             if grip_msg.updated:
                 self._grip_player.set(grip_msg.data)
-            for grip in self._grip_player.advance(clock.now_ns()):
+            grip = self._grip_player.advance(clock.now_ns())
+            if grip is not None:
                 self._last_grip = grip
             self._apply_grip(self._last_grip)
 

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -329,6 +329,14 @@ class MujocoSim(pimm.ControlSystem):
                 else:
                     logger.warning(f'IK failed for ee_pose: {pose}')
                     self._error = True
+            case roboarm_command.CartesianDelta(delta=delta):
+                target = roboarm_command.apply_cartesian_delta(self._ee_pose, delta)
+                q = self._recalculate_ik(target)
+                if q is not None:
+                    self._set_actuator_values(q)
+                else:
+                    logger.warning(f'IK failed for delta target: {target}')
+                    self._error = True
             case roboarm_command.JointPosition(positions=positions):
                 self._set_actuator_values(positions)
             case roboarm_command.JointDelta(velocities=delta):

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -55,6 +55,7 @@ _LEGACY_COMMAND_TYPES = frozenset({
     _roboarm_command.CartesianPosition.TYPE,
     _roboarm_command.JointPosition.TYPE,
     _roboarm_command.JointDelta.TYPE,
+    _roboarm_command.CartesianDelta.TYPE,
 })
 
 


### PR DESCRIPTION
## Summary
- Adds `CartesianDelta`, a one-shot **end-effector-space** pose delta (`geom.Transform3D`), distinct from the joint-space `JointDelta`.
- `apply_cartesian_delta` holds the single **world-frame** compose rule (translation adds, rotation left-multiplies — the robosuite OSC convention) shared by every IK-based driver. Deliberately **not** `Transform3D.__mul__`, which composes in the body frame and would rotate the translation.
- Supported by **all drivers**: franka, mujoco sim, kinova, so101, and the LIBERO env-server. The LIBERO `'ee'`/OSC mode applies the delta directly as the per-step pose error (joint control modes fall through to the existing loud `ValueError`).
- **One-shot** semantics throughout: `TrajectoryPlayer` drivers apply each waypoint exactly once; the two hold-and-resend adapters (`LiberoAdapter`, the test `StackCubesAdapter`) forward a delta once then drop it, so a held delta never re-composes against the moving eef.
- Fixes a latent so101 bug: `_solve_ik` was *called* with a bare pose but read `command.pose` off it (`AttributeError`); the parameter now takes the pose directly, fixing the existing `CartesianPosition` path too.

## Test plan
- `uv run --locked pytest --no-cov` — 600 passed, 7 skipped.
- New unit tests: wire round-trip, and `apply_cartesian_delta` world-frame compose (with an explicit guard that it is not the body-frame `__mul__`).
- New mujoco integration test: a `CartesianDelta` and the absolute `CartesianPosition` for the composed target settle to an identical eef (atol 1e-4) — proving the compose and that the delta fires once — plus an idle-steps-add-no-motion one-shot check.
- LIBERO demo-replay e2e parametrized over `['cartesian', 'cartesian_delta']` — **run locally, both modes reach 100% replay success** through the real env-server (the non-circular oracle); also runs in the dedicated `libero-e2e` CI lane.