### PR TITLE
Serve openpi `pi05_libero` and match its LIBERO success rate

### DIFF
--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -11,7 +11,7 @@ from positronic.simulator.libero.launcher import serve_libero
 
 @cfn.config(
     camera_dict={'image.agentview': 'agentview_image', 'image.wrist': 'eye_in_hand_image'},
-    camera_resolution=256,  # openpi renders LIBERO at 256 then resizes to 224; render at 256 so the policy sees that
+    camera_resolution=256,
     control_mode='ee',
     timeout=20.0,
     seed=None,

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -11,7 +11,7 @@ from positronic.simulator.libero.launcher import serve_libero
 
 @cfn.config(
     camera_dict={'image.agentview': 'agentview_image', 'image.wrist': 'eye_in_hand_image'},
-    camera_resolution=224,
+    camera_resolution=256,  # openpi renders LIBERO at 256 then resizes to 224; render at 256 so the policy sees that
     control_mode='ee',
     timeout=20.0,
     seed=None,

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -2,6 +2,7 @@ import configuronic as cfn
 import pos3
 
 from positronic.cfg import codecs
+from positronic.offboard.client import DEFAULT_INFER_TIMEOUT
 from positronic.policy import ActionHorizon, Codec, Policy, Recorder, RemotePolicy
 from positronic.utils import get_latest_checkpoint
 
@@ -68,6 +69,7 @@ def sample(origins: list[cfn.Config], weights: list[float] | None):
     codec=None,
     secure=False,
     recording_dir=None,
+    infer_timeout=DEFAULT_INFER_TIMEOUT,
 )
 def remote(
     host: str,
@@ -79,9 +81,12 @@ def remote(
     headers: dict[str, str] | None = None,
     secure: bool = False,
     recording_dir: str | None = None,
+    infer_timeout: float = DEFAULT_INFER_TIMEOUT,
 ):
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
-    policy = RemotePolicy(host, port, effective_resize, model_id=model_id, headers=headers, secure=secure)
+    policy = RemotePolicy(
+        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure, infer_timeout=infer_timeout
+    )
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)
     if recording_dir is not None:
@@ -103,6 +108,7 @@ def remote(
     codec=None,
     secure=False,
     recording_dir=None,
+    infer_timeout=DEFAULT_INFER_TIMEOUT,
 )
 def weighted_remote(
     host: str | None,
@@ -115,12 +121,15 @@ def weighted_remote(
     headers: dict[str, str] | None = None,
     secure: bool = False,
     recording_dir: str | None = None,
+    infer_timeout: float = DEFAULT_INFER_TIMEOUT,
 ):
     if not host:
         return None
 
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
-    policy = RemotePolicy(host, port, effective_resize, model_id=model_id, headers=headers, secure=secure)
+    policy = RemotePolicy(
+        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure, infer_timeout=infer_timeout
+    )
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)
     if recording_dir is not None:

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -10,9 +10,14 @@ from positronic.utils.serialization import deserialise, serialise
 
 logger = logging.getLogger(__name__)
 
+# Only the checkpoint pinned at server startup is pre-warmed; a session that requests any other model loads it
+# cold, so its first ``infer`` can include the backend's JAX compilation. Bound each ``recv`` generously enough to
+# outlast that compile (still surfacing a truly stalled/half-open connection), and let callers override per use.
+DEFAULT_INFER_TIMEOUT = 180.0
+
 
 class InferenceSession:
-    def __init__(self, websocket: Connection, infer_timeout: float = 60.0):
+    def __init__(self, websocket: Connection, infer_timeout: float = DEFAULT_INFER_TIMEOUT):
         self._websocket = websocket
         self._infer_timeout = infer_timeout
         self._metadata = self._handshake()
@@ -100,7 +105,7 @@ class InferenceClient:
         model_id: str | None = None,
         open_timeout: float = 10.0,
         connect_deadline: float = 900.0,
-        infer_timeout: float = 60.0,
+        infer_timeout: float = DEFAULT_INFER_TIMEOUT,
     ) -> InferenceSession:
         """
         Creates a new inference session.

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -74,6 +74,10 @@ class InferenceSession:
         try:
             response = deserialise(self._websocket.recv(timeout=self._infer_timeout))
         except TimeoutError:
+            # The observation is in flight but unanswered; the server's late response would sit in the socket and
+            # the next ``recv`` would pair it with a future observation. Close so the desynced session can't be
+            # reused — a subsequent ``infer`` fails loudly on the closed socket instead.
+            self._websocket.close()
             raise TimeoutError(
                 f'No inference response within {self._infer_timeout}s — server stalled or connection half-open'
             ) from None

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class InferenceSession:
-    def __init__(self, websocket: Connection):
+    def __init__(self, websocket: Connection, infer_timeout: float = 60.0):
         self._websocket = websocket
+        self._infer_timeout = infer_timeout
         self._metadata = self._handshake()
 
     def _handshake(self, timeout_per_message: float = 30.0) -> dict[str, Any]:
@@ -65,7 +66,12 @@ class InferenceSession:
         logger.debug('Size of serialised obs: %1.f KiB', len(serialised) / 1024)
 
         self._websocket.send(serialised)
-        response = deserialise(self._websocket.recv())
+        try:
+            response = deserialise(self._websocket.recv(timeout=self._infer_timeout))
+        except TimeoutError:
+            raise TimeoutError(
+                f'No inference response within {self._infer_timeout}s — server stalled or connection half-open'
+            ) from None
         logger.debug('Size of deserialised response: %1.f KiB', len(response) / 1024)
 
         if isinstance(response, dict) and 'error' in response:
@@ -90,7 +96,11 @@ class InferenceClient:
         self.api_url = f'{http_scheme}://{netloc}/api/v1'
 
     def new_session(
-        self, model_id: str | None = None, open_timeout: float = 10.0, connect_deadline: float = 900.0
+        self,
+        model_id: str | None = None,
+        open_timeout: float = 10.0,
+        connect_deadline: float = 900.0,
+        infer_timeout: float = 60.0,
     ) -> InferenceSession:
         """
         Creates a new inference session.
@@ -120,7 +130,7 @@ class InferenceClient:
                 backoff = min(backoff * 2, 30.0)
             except OSError as e:
                 raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
-        return InferenceSession(ws)
+        return InferenceSession(ws, infer_timeout=infer_timeout)
 
     def list_models(self) -> list[str]:
         """List available models from the server."""

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from positronic.offboard.client import InferenceClient
+from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.remote import RemoteSession
@@ -117,7 +117,7 @@ class TestInferenceClientHeaders:
 
             mock_connect.assert_called_once()
             assert mock_connect.call_args.kwargs['additional_headers'] == headers
-            mock_session_cls.assert_called_once_with(mock_connect.return_value, infer_timeout=60.0)
+            mock_session_cls.assert_called_once_with(mock_connect.return_value, infer_timeout=DEFAULT_INFER_TIMEOUT)
 
     def test_new_session_without_headers_omits_additional_headers(self):
         with (

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -117,7 +117,7 @@ class TestInferenceClientHeaders:
 
             mock_connect.assert_called_once()
             assert mock_connect.call_args.kwargs['additional_headers'] == headers
-            mock_session_cls.assert_called_once_with(mock_connect.return_value)
+            mock_session_cls.assert_called_once_with(mock_connect.return_value, infer_timeout=60.0)
 
     def test_new_session_without_headers_omits_additional_headers(self):
         with (

--- a/positronic/offboard/vendor_server.py
+++ b/positronic/offboard/vendor_server.py
@@ -139,6 +139,10 @@ class VendorServer(ABC):
         self.idle_timeout_min = idle_timeout_min
         self._active_sessions = 0
         self._last_activity = time.monotonic()
+        # Inference runs in a worker thread (so the event loop keeps servicing other connections and
+        # keepalives) but is serialized: vendor sessions may share one backend client/connection, which
+        # concurrent calls would corrupt.
+        self._infer_lock = asyncio.Lock()
 
         # The default checkpoint, resolved once at startup (see class docstring). Pinned
         # here so a request without an explicit checkpoint never re-resolves the latest.
@@ -229,7 +233,8 @@ class VendorServer(ABC):
                     self._last_activity = time.monotonic()
                     try:
                         raw_obs = deserialise(message)
-                        actions = session(raw_obs)
+                        async with self._infer_lock:
+                            actions = await asyncio.to_thread(session, raw_obs)
                         await websocket.send_bytes(serialise({'result': actions}))
                     except Exception as e:
                         logger.error(f'Error processing message: {e}', exc_info=True)

--- a/positronic/offboard/vendor_server.py
+++ b/positronic/offboard/vendor_server.py
@@ -139,9 +139,9 @@ class VendorServer(ABC):
         self.idle_timeout_min = idle_timeout_min
         self._active_sessions = 0
         self._last_activity = time.monotonic()
-        # Inference runs in a worker thread (so the event loop keeps servicing other connections and
-        # keepalives) but is serialized: vendor sessions may share one backend client/connection, which
-        # concurrent calls would corrupt.
+        # Backend-client calls — inference and the per-session reset in ``new_session`` — run in a worker thread
+        # (so the event loop keeps servicing other connections and keepalives) but are serialized under this lock:
+        # vendor sessions may share one backend client/connection, which concurrent calls would corrupt.
         self._infer_lock = asyncio.Lock()
 
         # The default checkpoint, resolved once at startup (see class docstring). Pinned
@@ -221,7 +221,10 @@ class VendorServer(ABC):
                     policy = rec.tap('inference').wrap(base_policy)
             else:
                 policy = self.codec.wrap(base_policy) if self.codec else base_policy
-            session = policy.new_session()
+            # ``new_session`` resets the backend client, which vendor sessions may share; hold the inference lock
+            # so the reset can't interleave with an in-flight ``session(raw_obs)`` running in another worker thread.
+            async with self._infer_lock:
+                session = await asyncio.to_thread(policy.new_session)
             # ``policy.meta`` is the static baseline; ``session.meta`` overlays
             # per-episode specifics and wins on conflict.
             meta = {**self.metadata, **extra_meta, **policy.meta, **session.meta}

--- a/positronic/offboard/vendor_server.py
+++ b/positronic/offboard/vendor_server.py
@@ -197,6 +197,19 @@ class VendorServer(ABC):
 
         return send_progress
 
+    async def _acquire_infer_lock(self, websocket: WebSocket):
+        """Acquire the inference lock, emitting ``waiting`` keepalives while queued behind another session.
+
+        A peer may hold the lock for a slow first-call compile or inference; a silent wait here would trip the
+        client handshake's 30s per-message timeout before ``ready`` is sent.
+        """
+        while True:
+            try:
+                await asyncio.wait_for(self._infer_lock.acquire(), timeout=10.0)
+                return
+            except TimeoutError:
+                await websocket.send_bytes(serialise({'status': 'waiting', 'message': 'Waiting for inference slot'}))
+
     async def websocket_endpoint(self, websocket: WebSocket, model_id: str | None = None):
         await websocket.accept()
         logger.info(f'Connected to {websocket.client} requesting {model_id or "default"}')
@@ -223,8 +236,12 @@ class VendorServer(ABC):
                 policy = self.codec.wrap(base_policy) if self.codec else base_policy
             # ``new_session`` resets the backend client, which vendor sessions may share; hold the inference lock
             # so the reset can't interleave with an in-flight ``session(raw_obs)`` running in another worker thread.
-            async with self._infer_lock:
+            # Acquire it with keepalives so queuing behind a peer's slow inference doesn't trip the handshake timeout.
+            await self._acquire_infer_lock(websocket)
+            try:
                 session = await asyncio.to_thread(policy.new_session)
+            finally:
+                self._infer_lock.release()
             # ``policy.meta`` is the static baseline; ``session.meta`` overlays
             # per-episode specifics and wins on conflict.
             meta = {**self.metadata, **extra_meta, **policy.meta, **session.meta}
@@ -236,6 +253,9 @@ class VendorServer(ABC):
                     self._last_activity = time.monotonic()
                     try:
                         raw_obs = deserialise(message)
+                        # Plain acquire, not ``_acquire_infer_lock``: past the handshake the client awaits a
+                        # ``result`` and would mis-parse a ``waiting`` keepalive; the wait is bounded client-side
+                        # by ``infer_timeout``.
                         async with self._infer_lock:
                             actions = await asyncio.to_thread(session, raw_obs)
                         await websocket.send_bytes(serialise({'result': actions}))

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -3,7 +3,7 @@ from typing import Any
 import numpy as np
 from PIL import Image as PilImage
 
-from positronic.offboard.client import InferenceClient, InferenceSession
+from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
 from positronic.utils import flatten_dict
 
 from .base import Policy, Session
@@ -95,10 +95,12 @@ class RemotePolicy(Policy):
         *,
         headers: dict[str, str] | None = None,
         secure: bool = False,
+        infer_timeout: float = DEFAULT_INFER_TIMEOUT,
     ):
         self._client = InferenceClient(host, port, headers=headers, secure=secure)
         self._resize = resize
         self._model_id = model_id
+        self._infer_timeout = infer_timeout
         # Server metadata cached after the first session is created or `meta`
         # is read. Needed so consumers like ``SampledPolicy._get_keys`` see
         # ``server.checkpoint_path`` etc. before any session exists.
@@ -106,7 +108,7 @@ class RemotePolicy(Policy):
 
     def _ensure_server_meta(self) -> dict[str, Any]:
         if self._server_meta is None:
-            ws_session = self._client.new_session(model_id=self._model_id)
+            ws_session = self._client.new_session(model_id=self._model_id, infer_timeout=self._infer_timeout)
             try:
                 self._server_meta = dict(ws_session.metadata)
             finally:
@@ -114,7 +116,7 @@ class RemotePolicy(Policy):
         return self._server_meta
 
     def new_session(self, context=None) -> RemoteSession:
-        ws_session = self._client.new_session(model_id=self._model_id)
+        ws_session = self._client.new_session(model_id=self._model_id, infer_timeout=self._infer_timeout)
         if self._server_meta is None:
             self._server_meta = dict(ws_session.metadata)
         return RemoteSession(ws_session, self._resize)

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -38,7 +38,14 @@ def _wire_command(cmd: Any) -> dict[str, Any]:
 
 class LiberoAdapter(EnvAdapter):
     def __init__(
-        self, camera_dict: dict[str, str], *, suite: str, task_id: int, camera_resolution: int, control_mode: str
+        self,
+        camera_dict: dict[str, str],
+        *,
+        suite: str,
+        task_id: int,
+        camera_resolution: int,
+        control_mode: str,
+        settle_steps: int = 10,
     ):
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
         # The task spec the server builds its env from — shipped in every reset token (the server caches by it).
@@ -48,6 +55,9 @@ class LiberoAdapter(EnvAdapter):
             'camera_resolution': camera_resolution,
             'control_mode': control_mode,
         }
+        # Hold-arm/open-gripper steps the server runs after a seeded reset to let dropped objects settle before the
+        # first observation (openpi's num_steps_wait dummy-action wait); a per-reset behavior, not a build param.
+        self._settle_steps = settle_steps
         self._players = fresh_command_players()
         self._held: dict[str, Any] = {}  # last sampled waypoint per channel — re-sent until it changes
         # Last commanded gripper closure, held across a cancelled grip trajectory: grip is an absolute [0, 1]
@@ -59,7 +69,7 @@ class LiberoAdapter(EnvAdapter):
         self._held = {}
         self._grip = 0.0
         # The task spec the server builds from + the seed it selects an init-state with (``None`` -> index 0).
-        return {**self._scene, 'seed': seed if seed is not None else 0}
+        return {**self._scene, 'seed': seed if seed is not None else 0, 'settle_steps': self._settle_steps}
 
     def action(self, commands: dict[str, pimm.Message], now_ns: int) -> dict[str, Any]:
         for name, msg in commands.items():

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -4,7 +4,7 @@
 #     "msgpack",
 #     "websockets",
 #     "robosuite==1.4.1",
-#     "mujoco",
+#     "mujoco==3.2.3",  # pin to openpi's LIBERO eval engine version, so our physics matches the policy's training/eval
 #     "numpy<2",
 #     # LIBERO is not listed here: it declares ``install_requires=[]`` and ships ``libero`` as a PEP 420 namespace
 #     # package, so no wheel carries it — the launcher puts a source checkout on ``PYTHONPATH``. These are the

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -4,7 +4,7 @@
 #     "msgpack",
 #     "websockets",
 #     "robosuite==1.4.1",
-#     "mujoco",
+#     "mujoco==3.2.3",  # pin to openpi's LIBERO eval engine version, so our physics matches the policy's training/eval
 #     "numpy<2",
 #     # LIBERO is not listed here: it declares ``install_requires=[]`` and ships ``libero`` as a PEP 420 namespace
 #     # package, so no wheel carries it — the launcher puts a source checkout on ``PYTHONPATH``. These are the
@@ -61,6 +61,8 @@ from libero.libero.envs import OffScreenRenderEnv  # noqa: E402
 _IK_ITERS = 100
 _IK_DAMPING = 0.05
 _IK_TOL = 1e-4
+_SETTLE_STEPS = 10  # hold-arm/open-gripper steps after a seeded reset to let dropped objects fall before the first
+# observation, matching openpi's num_steps_wait dummy-action wait (examples/libero/main.py)
 
 
 def _unpack_pose(vec: Any) -> tuple[np.ndarray, np.ndarray]:
@@ -158,6 +160,11 @@ class LiberoEnv(EnvProtocol):
             self._env.seed(seed)
             self._env.reset()
             raw = self._env.set_init_state(self._init_states[seed % len(self._init_states)])
+            # ``set_init_state`` only places objects kinematically (``sim.forward``, no dynamics), so they start
+            # mid-fall. Step a held arm with the gripper open so they settle before the first observation, the
+            # zero-pose-delta/open-gripper action openpi waits out as ``LIBERO_DUMMY_ACTION``.
+            for _ in range(_SETTLE_STEPS):
+                raw, _reward, _done, _info = self._env.step(np.zeros(len(self._controller.input_max)).tolist() + [-1.0])
         # ``robot_meta`` is empty: the 3.10 server can't import positronic to emit the Panda model, so the eval
         # supplies it via ``static_meta`` (``bundled_panda_model``). ``meta`` carries the scene/task identity.
         return {'obs': self._observe(raw), 'meta': self._meta, 'robot_meta': {}, 'control_dt': self._control_dt}

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -61,8 +61,6 @@ from libero.libero.envs import OffScreenRenderEnv  # noqa: E402
 _IK_ITERS = 100
 _IK_DAMPING = 0.05
 _IK_TOL = 1e-4
-_SETTLE_STEPS = 10  # hold-arm/open-gripper steps after a seeded reset to let dropped objects fall before the first
-# observation, matching openpi's num_steps_wait dummy-action wait (examples/libero/main.py)
 
 
 def _unpack_pose(vec: Any) -> tuple[np.ndarray, np.ndarray]:
@@ -163,7 +161,7 @@ class LiberoEnv(EnvProtocol):
             # ``set_init_state`` only places objects kinematically (``sim.forward``, no dynamics), so they start
             # mid-fall. Step a held arm with the gripper open so they settle before the first observation, the
             # zero-pose-delta/open-gripper action openpi waits out as ``LIBERO_DUMMY_ACTION``.
-            for _ in range(_SETTLE_STEPS):
+            for _ in range(token.get('settle_steps', 10)):
                 raw, _reward, _done, _info = self._env.step(np.zeros(len(self._controller.input_max)).tolist() + [-1.0])
         # ``robot_meta`` is empty: the 3.10 server can't import positronic to emit the Panda model, so the eval
         # supplies it via ``static_meta`` (``bundled_panda_model``). ``meta`` carries the scene/task identity.

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -4,7 +4,7 @@
 #     "msgpack",
 #     "websockets",
 #     "robosuite==1.4.1",
-#     "mujoco==3.2.3",  # pin to openpi's LIBERO eval engine version, so our physics matches the policy's training/eval
+#     "mujoco",
 #     "numpy<2",
 #     # LIBERO is not listed here: it declares ``install_requires=[]`` and ships ``libero`` as a PEP 420 namespace
 #     # package, so no wheel carries it — the launcher puts a source checkout on ``PYTHONPATH``. These are the

--- a/positronic/simulator/libero/validate.py
+++ b/positronic/simulator/libero/validate.py
@@ -46,12 +46,14 @@ import argparse
 
 import numpy as np
 from env import LiberoEnv
-from robosuite.utils.transform_utils import euler2mat, mat2quat, quat2axisangle, quat2mat
+from robosuite.utils.transform_utils import axisangle2quat, euler2mat, mat2quat, quat2axisangle, quat2mat
 
 _OSC_SAMPLES = 64
 _IK_SAMPLES = 16
-_ATOL = 1e-9  # joint cells and FK are float64-exact, so the algebra inverts to float error
+_ATOL = 1e-9  # pure joint-space algebra (q+dq, goal velocities) inverts to float64 error
 _OSC_ATOL = 1e-5  # robosuite mat2quat casts to float32, so the OSC orientation channel carries ~1e-6 error
+_FK_ATOL = 2e-4  # a fresh FK recompute vs the live stepped eef site agree only to float precision near the
+# settled, near-singular tool-down pose — far tighter than a real FK bug (O(1e-2)+), still not float64-exact
 
 
 def _token(args, control_mode: str) -> dict:
@@ -179,14 +181,17 @@ def _check_obs_encoding(env: LiberoEnv, token: dict) -> None:
             'grip->hand offset varies across poses'
         )
 
-    # The policy consumes the axis-angle 3-vector, not the matrix: assert the exact value the codec emits matches
-    # robosuite's quat2axisangle(robot0_eef_quat). robosuite's quat is MuJoCo's body_xquat, FK-continuous from the
-    # tool-down home pose and thus in the w<=0 hemisphere (angle >= pi); the codec canonicalizes to w<=0 to match,
-    # so the exact branch coincides — `mat2quat` gives the w>=0 form, negate it to replicate the codec.
+    # The policy consumes the axis-angle 3-vector the codec emits, so verify it encodes robosuite's orientation.
+    # The tool-down home pose sits at angle ~pi, where the axis-angle map is singular (w ~ 0, so a tiny quat
+    # perturbation flips the 3-vector's sign for the same rotation); convert the codec's axis-angle back to a quat
+    # and compare to robosuite's, double-cover and all. A genuine branch/sign bug away from pi yields a different
+    # rotation and still fails, so this stays a real check.
     for w, robo in samples:
         aa_codec = quat2axisangle(-mat2quat(quat2mat(w['eef_quat']) @ r_off))  # negate w>=0 form to the codec's w<=0
-        aa_ref = quat2axisangle(robo['robot0_eef_quat'])
-        assert np.allclose(aa_codec, aa_ref, atol=_OSC_ATOL), f'axis-angle branch mismatch: {aa_codec} vs {aa_ref}'
+        q_codec, q_ref = axisangle2quat(aa_codec), robo['robot0_eef_quat']
+        assert np.allclose(q_codec, q_ref, atol=_OSC_ATOL) or np.allclose(q_codec, -q_ref, atol=_OSC_ATOL), (
+            f'axis-angle encodes the wrong rotation: {aa_codec} -> {q_codec} vs {q_ref}'
+        )
     print(f'    grip->hand offset + axis-angle branch match robosuite across {len(samples)} poses')
 
 
@@ -208,9 +213,11 @@ def _check_fk_identity(env: LiberoEnv, token: dict) -> None:
     env.reset(token)
     pos_fk, rot_fk = env._fk(env._cur_q())
     pos_live, rot_live = env._cur_pose()
-    assert np.allclose(pos_fk, pos_live, atol=_ATOL), f'fk pos {pos_fk} vs live {pos_live}'
-    assert np.allclose(rot_fk, rot_live, atol=_ATOL), f'fk rot {rot_fk} vs live {rot_live}'
-    print(f'  fk identity: OK (matches eef-site read, atol {_ATOL})')
+    # After the seeded reset's settle the arm carries residual motion near the singular tool-down pose, so the
+    # scratch ``mj_forward`` recompute and the live stepped site agree only to float precision, not float64.
+    assert np.allclose(pos_fk, pos_live, atol=_FK_ATOL), f'fk pos {pos_fk} vs live {pos_live}'
+    assert np.allclose(rot_fk, rot_live, atol=_FK_ATOL), f'fk rot {rot_fk} vs live {rot_live}'
+    print(f'  fk identity: OK (matches eef-site read, atol {_FK_ATOL})')
 
 
 def _check_ik_roundtrip(env: LiberoEnv, token: dict) -> None:

--- a/positronic/simulator/libero/validate.py
+++ b/positronic/simulator/libero/validate.py
@@ -4,7 +4,7 @@
 #     "msgpack",
 #     "websockets",
 #     "robosuite==1.4.1",
-#     "mujoco",
+#     "mujoco==3.2.3",  # pin to openpi's LIBERO eval engine version, so our physics matches the policy's training/eval
 #     "numpy<2",
 #     # LIBERO is not listed here: it ships ``libero`` as a namespace package with no installable wheel, so the
 #     # caller puts a source checkout on ``PYTHONPATH`` (see ``launcher._ensure_libero_src``). These are the
@@ -191,11 +191,11 @@ def _check_obs_encoding(env: LiberoEnv, token: dict) -> None:
 
 
 def _check_osc_delta_scale(env: LiberoEnv, token: dict) -> None:
-    """Pin the OSC scaling and control rate the libero codec bakes: ``CumulativePoseDeltaAction.OUTPUT_MAX``
+    """Pin the OSC scaling and control rate the libero codec bakes: ``PoseDeltaAction.OUTPUT_MAX``
     must equal the controller's per-step output range, and the codec stamps the chunk at the env's control rate."""
     env.reset(token)
     c = env._controller
-    output_max = np.array([0.05, 0.05, 0.05, 0.5, 0.5, 0.5])  # mirrors CumulativePoseDeltaAction.OUTPUT_MAX
+    output_max = np.array([0.05, 0.05, 0.05, 0.5, 0.5, 0.5])  # mirrors PoseDeltaAction.OUTPUT_MAX
     assert np.allclose(c.output_max, output_max) and np.allclose(c.output_min, -output_max), (
         f'OSC output range [{c.output_min}, {c.output_max}] != +/-{output_max.tolist()}'
     )

--- a/positronic/simulator/libero/validate.py
+++ b/positronic/simulator/libero/validate.py
@@ -130,7 +130,7 @@ def _nudge_pose(env: LiberoEnv) -> np.ndarray:
 
 
 def _check_obs_encoding(env: LiberoEnv, token: dict) -> None:
-    """Measure and verify the constants ``OpenpiLiberoObservationCodec`` needs for the 8-dim state.
+    """Measure and verify the constants ``LiberoObservationCodec`` needs for the 8-dim state.
 
     openpi's LIBERO state is ``[robot0_eef_pos(3), quat2axisangle(robot0_eef_quat)(3), robot0_gripper_qpos(2)]``
     (openpi ``examples/libero/main.py``). The env reports the eef pose in the grip-site frame and the gripper as a

--- a/positronic/simulator/libero/validate.py
+++ b/positronic/simulator/libero/validate.py
@@ -46,7 +46,7 @@ import argparse
 
 import numpy as np
 from env import LiberoEnv
-from robosuite.utils.transform_utils import mat2quat, quat2axisangle
+from robosuite.utils.transform_utils import euler2mat, mat2quat, quat2axisangle, quat2mat
 
 _OSC_SAMPLES = 64
 _IK_SAMPLES = 16
@@ -114,6 +114,96 @@ def _check_action_inverse(env: LiberoEnv, token: dict, ctype: str, key: str, goa
     print(f'  {ctype} inverse: OK ({_OSC_SAMPLES} random actions, atol {atol})')
 
 
+def _robosuite_obs(env: LiberoEnv) -> dict:
+    """robosuite's own observation dict — the source openpi's LIBERO eval reads its state from."""
+    return env._env.env._get_observations(force_update=True)
+
+
+def _nudge_pose(env: LiberoEnv) -> np.ndarray:
+    """A small random Cartesian goal (pos + orientation) off the current pose, in the adapter's wire format."""
+    pos, rot = env._cur_pose()
+    target_pos = pos + np.random.uniform(-0.02, 0.02, 3)
+    target_rot = euler2mat(np.random.uniform(-0.1, 0.1, 3)) @ rot
+    return np.concatenate([target_pos, target_rot.reshape(9)])
+
+
+def _check_obs_encoding(env: LiberoEnv, token: dict) -> None:
+    """Measure and verify the constants ``OpenpiLiberoObservationCodec`` needs for the 8-dim state.
+
+    openpi's LIBERO state is ``[robot0_eef_pos(3), quat2axisangle(robot0_eef_quat)(3), robot0_gripper_qpos(2)]``
+    (openpi ``examples/libero/main.py``). The env reports the eef pose in the grip-site frame and the gripper as a
+    single closure scalar, so the codec must (a) rotate the grip-site orientation into robosuite's hand-body frame
+    by a fixed offset and (b) reconstruct the two finger qpos from the closure scalar. This drives the arm and
+    gripper across their range, proves both are pose-invariant, and prints the values to bake into the codec.
+    """
+    wire = env.reset(token)['obs']
+    samples = []
+    for _ in range(8):
+        samples.append((wire, _robosuite_obs(env)))
+        wire = env.step({'command': {'type': 'cartesian', 'pose': _nudge_pose(env)}, 'grip': 0.0})['obs']
+
+    # Orientation: a fixed grip-site -> hand-body rotation. Measure on the first sample (xyzw, w>=0 from mat2quat).
+    r_off = quat2mat(samples[0][0]['eef_quat']).T @ quat2mat(samples[0][1]['robot0_eef_quat'])
+    q = mat2quat(r_off)
+
+    # Gripper: drive to both stops to read the finger qpos endpoints, then the codec's linear reconstruction
+    # CLOSED + (1 - grip) * (OPEN - CLOSED) recovers the true qpos from the closure scalar (q_open/q_closed are
+    # the load-bearing, non-circular measurement; the sweep checks the linear model holds).
+    env.reset(token)
+    for _ in range(40):
+        wire = env.step({'command': {'type': 'hold'}, 'grip': 0.0})['obs']
+    q_open = np.asarray(_robosuite_obs(env)['robot0_gripper_qpos'])
+    for _ in range(40):
+        wire = env.step({'command': {'type': 'hold'}, 'grip': 1.0})['obs']
+    q_closed = np.asarray(_robosuite_obs(env)['robot0_gripper_qpos'])
+    recon_err = 0.0
+    env.reset(token)
+    for g in np.linspace(0.0, 1.0, 6):
+        for _ in range(20):
+            wire = env.step({'command': {'type': 'hold'}, 'grip': float(g)})['obs']
+        true_qpos = np.asarray(_robosuite_obs(env)['robot0_gripper_qpos'])
+        recon = q_closed + (1.0 - wire['grip']) * (q_open - q_closed)
+        recon_err = max(recon_err, float(np.max(np.abs(recon - true_qpos))))
+
+    # Print the bake values first so they surface even if a check below fails.
+    print('  obs encoding:')
+    print(f'    bake _GRIP_SITE_TO_HAND = geom.Rotation.from_quat([{q[3]:.9f}, {q[0]:.9f}, {q[1]:.9f}, {q[2]:.9f}])')
+    print(f'    bake _GRIPPER_QPOS_OPEN = np.array({np.round(q_open, 6).tolist()})')
+    print(f'    bake _GRIPPER_QPOS_CLOSED = np.array({np.round(q_closed, 6).tolist()})')
+    print(f'    gripper reconstruction max err over sweep: {recon_err:.5f}')
+
+    # Position matches robosuite's grip-site pos directly; the grip->hand offset is a fixed rotation.
+    for w, robo in samples:
+        assert np.allclose(w['eef_pos'], robo['robot0_eef_pos'], atol=_OSC_ATOL), 'eef_pos != robot0_eef_pos'
+        assert np.allclose(quat2mat(w['eef_quat']) @ r_off, quat2mat(robo['robot0_eef_quat']), atol=_OSC_ATOL), (
+            'grip->hand offset varies across poses'
+        )
+
+    # The policy consumes the axis-angle 3-vector, not the matrix: assert the exact value the codec emits matches
+    # robosuite's quat2axisangle(robot0_eef_quat). robosuite's quat is MuJoCo's body_xquat, FK-continuous from the
+    # tool-down home pose and thus in the w<=0 hemisphere (angle >= pi); the codec canonicalizes to w<=0 to match,
+    # so the exact branch coincides — `mat2quat` gives the w>=0 form, negate it to replicate the codec.
+    for w, robo in samples:
+        aa_codec = quat2axisangle(-mat2quat(quat2mat(w['eef_quat']) @ r_off))  # negate w>=0 form to the codec's w<=0
+        aa_ref = quat2axisangle(robo['robot0_eef_quat'])
+        assert np.allclose(aa_codec, aa_ref, atol=_OSC_ATOL), f'axis-angle branch mismatch: {aa_codec} vs {aa_ref}'
+    print(f'    grip->hand offset + axis-angle branch match robosuite across {len(samples)} poses')
+
+
+def _check_osc_delta_scale(env: LiberoEnv, token: dict) -> None:
+    """Pin the OSC scaling and control rate the libero codec bakes: ``CumulativePoseDeltaAction.OUTPUT_MAX``
+    must equal the controller's per-step output range, and the codec stamps the chunk at the env's control rate."""
+    env.reset(token)
+    c = env._controller
+    output_max = np.array([0.05, 0.05, 0.05, 0.5, 0.5, 0.5])  # mirrors CumulativePoseDeltaAction.OUTPUT_MAX
+    assert np.allclose(c.output_max, output_max) and np.allclose(c.output_min, -output_max), (
+        f'OSC output range [{c.output_min}, {c.output_max}] != +/-{output_max.tolist()}'
+    )
+    freq = env._env.env.control_freq
+    assert freq == 20, f'control_freq {freq} Hz != 20 (the libero codec stamps the chunk at fps=20)'
+    print(f'  osc delta scale: output_max == {output_max.tolist()} OK; control_freq {freq} Hz == libero codec fps')
+
+
 def _check_fk_identity(env: LiberoEnv, token: dict) -> None:
     env.reset(token)
     pos_fk, rot_fk = env._fk(env._cur_q())
@@ -149,6 +239,8 @@ def main() -> None:
     _check_serve(ee, ee_token)
     _check_grip(ee, ee_token)
     _check_action_inverse(ee, ee_token, 'cartesian', 'pose', _osc_goal, atol=_OSC_ATOL)
+    _check_obs_encoding(ee, ee_token)
+    _check_osc_delta_scale(ee, ee_token)
     _check_fk_identity(ee, ee_token)
     _check_ik_roundtrip(ee, ee_token)
     ee.close()

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -8,7 +8,7 @@ OpenPI has different key format expectations for training vs inference:
 - **Inference (OpenPI format)**: Slash-separated keys like `observation/state`, `observation/image`.
   This is what OpenPI's policy classes (e.g., `positronic_policy.py`) expect at inference time.
 
-The `OpenpiObservationCodec` class handles both cases:
+The `ObservationCodec` class handles both cases:
 - `encode()` (inference): Produces OpenPI-compatible format with slash-separated keys
 - `training_encoder` (training): Produces LeRobot-compatible format with dot-separated keys
 
@@ -30,10 +30,10 @@ from positronic.dataset.transforms import image
 from positronic.dataset.transforms.episode import Derive, Get
 from positronic.drivers.roboarm import command
 from positronic.policy.codec import Codec, lerobot_image, lerobot_state
-from positronic.policy.observation import ObservationCodec
+from positronic.policy.observation import ObservationCodec as GenericObservationCodec
 
 
-class OpenpiObservationCodec(Codec):
+class ObservationCodec(Codec):
     """Observation encoder that outputs LeRobot keys for training, OpenPI keys for inference."""
 
     def __init__(
@@ -128,7 +128,7 @@ class OpenpiObservationCodec(Codec):
 )
 def observation(state_features: dict[str, int], exterior_camera: str, wrist_camera: str, image_size: tuple[int, int]):
     """General OpenPI observation encoder with configurable state features."""
-    return OpenpiObservationCodec(
+    return ObservationCodec(
         state_features=state_features, exterior_camera=exterior_camera, wrist_camera=wrist_camera, image_size=image_size
     )
 
@@ -140,7 +140,7 @@ ee_joints_obs = observation.override(state_features={'robot_state.ee_pose': 7, '
 # Pretrained DROID models read joints and gripper as separate observation keys and the language
 # prompt under `prompt` (see openpi `droid_policy.DroidInputs`).
 droid_obs = cfn.Config(
-    ObservationCodec,
+    GenericObservationCodec,
     state={'observation/joint_position': {'robot_state.q': 7}, 'observation/gripper_position': {'grip': 1}},
     images={
         'observation/wrist_image_left': ('image.wrist', (224, 224)),
@@ -205,7 +205,7 @@ _GRIPPER_QPOS_OPEN = np.array([0.039683, -0.039682])
 _GRIPPER_QPOS_CLOSED = np.array([0.0005, -0.0005])
 
 
-class OpenpiLiberoObservationCodec(Codec):
+class LiberoObservationCodec(Codec):
     """pi05_libero observation: 8-dim ``[eef_pos(3), eef_axisangle(3), gripper_qpos(2)]`` + 180°-rotated images.
 
     Reproduces openpi's LIBERO training preprocessing (openpi ``examples/libero/main.py``): the state packs the
@@ -269,7 +269,7 @@ class OpenpiLiberoObservationCodec(Codec):
         return {'image_sizes': self._image_size}
 
 
-libero_obs = cfn.Config(OpenpiLiberoObservationCodec)
+libero_obs = cfn.Config(LiberoObservationCodec)
 libero_action = cfn.Config(PoseDeltaAction)
 
 # pi05_libero emits a 10-step chunk, but openpi's official LIBERO eval (`replan_steps=5`) executes only the

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -172,40 +172,26 @@ joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 droid = codecs.compose.override(obs=droid_obs, action=codecs.joint_delta_action, horizon=8 / 15)
 
 
-class CumulativePoseDeltaAction(Codec):
-    """Decodes pi05_libero's OSC pose-delta action chunk into absolute Cartesian waypoints (inference only).
+class PoseDeltaAction(Codec):
+    """Decodes pi05_libero's OSC pose-delta chunk into per-step end-effector ``CartesianDelta`` (inference only).
 
-    The policy emits a chunk of per-step actions ``[Δpos(3), Δrotvec(3), grip(1)]`` normalized to ``[-1, 1]``
-    in robosuite OSC_POSE space. Each step's pose delta is scaled by the controller's per-step output range
-    (``OUTPUT_MAX``) and integrated cumulatively onto the previous waypoint, anchored once on the observed
-    end-effector pose, so the chunk plays open-loop as a trajectory of absolute poses — the LIBERO env
-    recovers each per-step OSC delta from its own controller pose. The rotation delta left-multiplies the
-    running orientation and the position delta adds in the world frame, matching robosuite ``set_goal``. The
-    open-loop chunk assumes OSC tracking error stays within one step's output range; the short replan horizon
-    bounds the accumulated divergence from the per-step control law.
+    The policy emits a chunk of per-step actions ``[Δpos(3), Δrotvec(3), grip(1)]`` normalized to ``[-1, 1]`` in
+    robosuite OSC_POSE space. Each step's pose delta is scaled by the controller's per-step output range
+    (``OUTPUT_MAX``) and forwarded as a world-frame ``CartesianDelta`` the driver composes onto its live measured
+    pose, reproducing robosuite's feed-forward OSC control (``goal = live_eef ∘ Δ`` every step). Integrating the
+    chunk into absolute waypoints instead chases the open-loop trajectory and folds the OSC tracking residual back
+    into each command — dynamics the policy was never trained against. The grip channel maps to the absolute
+    ``[0, 1]`` closure the gripper command uses.
     """
 
     OUTPUT_MAX = np.array([0.05, 0.05, 0.05, 0.5, 0.5, 0.5])
 
-    def __init__(self, robot_pose_key: str = 'robot_state.ee_pose'):
-        self.robot_pose_key = robot_pose_key
-
-    def decode(self, data, *, context=None):
-        if not isinstance(data, list):
-            raise ValueError('CumulativePoseDeltaAction decodes whole action chunks, not single actions')
-        anchor = np.asarray(context[self.robot_pose_key], dtype=float)
-        pos = anchor[:3].copy()
-        rot = geom.Rotation.from_quat(anchor[3:7])
-        decoded = []
-        for step in data:
-            action = np.asarray(step['action']).clip(-1.0, 1.0)  # robosuite clips both pose and gripper to [-1, 1]
-            physical = action[:6] * self.OUTPUT_MAX
-            pos = pos + physical[:3]
-            rot = geom.Rotation.from_rotvec(physical[3:6]) * rot
-            grip = (float(action[6]) + 1.0) / 2.0
-            pose = geom.Transform3D(translation=pos, rotation=rot)
-            decoded.append({'robot_command': command.CartesianPosition(pose=pose), 'target_grip': grip})
-        return decoded
+    def _decode_single(self, data, context=None):
+        action = np.asarray(data['action']).clip(-1.0, 1.0)  # robosuite clips both pose and gripper to [-1, 1]
+        physical = action[:6] * self.OUTPUT_MAX
+        delta = geom.Transform3D(translation=physical[:3], rotation=geom.Rotation.from_rotvec(physical[3:6]))
+        grip = (float(action[6]) + 1.0) / 2.0
+        return {'robot_command': command.CartesianDelta(delta=delta), 'target_grip': grip}
 
 
 # Constants pi05_libero's training distribution requires that the env's wire observation does not carry
@@ -284,7 +270,7 @@ class OpenpiLiberoObservationCodec(Codec):
 
 
 libero_obs = cfn.Config(OpenpiLiberoObservationCodec)
-libero_action = cfn.Config(CumulativePoseDeltaAction)
+libero_action = cfn.Config(PoseDeltaAction)
 
 # pi05_libero emits a 10-step chunk, but openpi's official LIBERO eval (`replan_steps=5`) executes only the
 # first 5 before re-querying; truncate to match. LIBERO's OSC runs at 20 Hz, so the chunk is stamped at

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -272,7 +272,10 @@ class LiberoObservationCodec(Codec):
 libero_obs = cfn.Config(LiberoObservationCodec)
 libero_action = cfn.Config(PoseDeltaAction)
 
-# pi05_libero emits a 10-step chunk, but openpi's official LIBERO eval (`replan_steps=5`) executes only the
-# first 5 before re-querying; truncate to match. LIBERO's OSC runs at 20 Hz, so the chunk is stamped at
-# 20 fps and the horizon keeps the first 5 steps (timestamps < 0.25 s).
-libero = codecs.compose.override(obs=libero_obs, action=libero_action, fps=20.0, horizon=0.25)
+# pi05_libero emits a 10-step chunk; openpi's official LIBERO eval (`replan_steps=5`) executes the first 5 before
+# re-querying. LIBERO's OSC runs at 20 Hz, so the chunk is stamped at 20 fps (one step per 0.05 s). The sim
+# schedules the harness before the producer, so the replan at the trajectory end pre-empts the producer's waypoint
+# at that same instant — keeping only timestamps < 0.25 s would drop the 5th step and execute four. Keep six
+# (timestamps < 0.30 s): the first five run and the 6th (0.25 s) is the guard whose drop pushes the replan past
+# step five.
+libero = codecs.compose.override(obs=libero_obs, action=libero_action, fps=20.0, horizon=0.30)

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -22,11 +22,13 @@ import configuronic as cfn
 import numpy as np
 from PIL import Image as PilImage
 
+from positronic import geom
 from positronic.cfg import codecs
 from positronic.dataset import Signal, transforms
 from positronic.dataset.episode import Episode
 from positronic.dataset.transforms import image
 from positronic.dataset.transforms.episode import Derive, Get
+from positronic.drivers.roboarm import command
 from positronic.policy.codec import Codec, lerobot_image, lerobot_state
 from positronic.policy.observation import ObservationCodec
 
@@ -168,3 +170,123 @@ joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 # DROID re-queries after its 8-step open-loop horizon; truncate the served chunk to match (8/15 s
 # at 15 fps) so the client re-queries every 8 steps instead of playing the full chunk open-loop.
 droid = codecs.compose.override(obs=droid_obs, action=codecs.joint_delta_action, horizon=8 / 15)
+
+
+class CumulativePoseDeltaAction(Codec):
+    """Decodes pi05_libero's OSC pose-delta action chunk into absolute Cartesian waypoints (inference only).
+
+    The policy emits a chunk of per-step actions ``[Δpos(3), Δrotvec(3), grip(1)]`` normalized to ``[-1, 1]``
+    in robosuite OSC_POSE space. Each step's pose delta is scaled by the controller's per-step output range
+    (``OUTPUT_MAX``) and integrated cumulatively onto the previous waypoint, anchored once on the observed
+    end-effector pose, so the chunk plays open-loop as a trajectory of absolute poses — the LIBERO env
+    recovers each per-step OSC delta from its own controller pose. The rotation delta left-multiplies the
+    running orientation and the position delta adds in the world frame, matching robosuite ``set_goal``. The
+    open-loop chunk assumes OSC tracking error stays within one step's output range; the short replan horizon
+    bounds the accumulated divergence from the per-step control law.
+    """
+
+    OUTPUT_MAX = np.array([0.05, 0.05, 0.05, 0.5, 0.5, 0.5])
+
+    def __init__(self, robot_pose_key: str = 'robot_state.ee_pose'):
+        self.robot_pose_key = robot_pose_key
+
+    def decode(self, data, *, context=None):
+        if not isinstance(data, list):
+            raise ValueError('CumulativePoseDeltaAction decodes whole action chunks, not single actions')
+        anchor = np.asarray(context[self.robot_pose_key], dtype=float)
+        pos = anchor[:3].copy()
+        rot = geom.Rotation.from_quat(anchor[3:7])
+        decoded = []
+        for step in data:
+            action = np.asarray(step['action']).clip(-1.0, 1.0)  # robosuite clips both pose and gripper to [-1, 1]
+            physical = action[:6] * self.OUTPUT_MAX
+            pos = pos + physical[:3]
+            rot = geom.Rotation.from_rotvec(physical[3:6]) * rot
+            grip = (float(action[6]) + 1.0) / 2.0
+            pose = geom.Transform3D(translation=pos, rotation=rot)
+            decoded.append({'robot_command': command.CartesianPosition(pose=pose), 'target_grip': grip})
+        return decoded
+
+
+# Constants pi05_libero's training distribution requires that the env's wire observation does not carry
+# directly, measured once on a LIBERO box (`validate.py` drives the arm/gripper and prints these to bake):
+#   - the env reports the eef orientation in the grip-site frame; openpi trained on robosuite's hand-body
+#     `robot0_eef_quat`, a fixed 90°-about-z rotation away;
+#   - the env collapses the two Panda finger qpos to a single closure scalar, reconstructed by interpolating
+#     between the open (grip=0) and closed (grip=1) finger endpoints.
+_GRIP_SITE_TO_HAND = geom.Rotation.from_quat([0.7071068, 0.0, 0.0, 0.7071068])
+_GRIPPER_QPOS_OPEN = np.array([0.039683, -0.039682])
+_GRIPPER_QPOS_CLOSED = np.array([0.0005, -0.0005])
+
+
+class OpenpiLiberoObservationCodec(Codec):
+    """pi05_libero observation: 8-dim ``[eef_pos(3), eef_axisangle(3), gripper_qpos(2)]`` + 180°-rotated images.
+
+    Reproduces openpi's LIBERO training preprocessing (openpi ``examples/libero/main.py``): the state packs the
+    end-effector position, its orientation as an axis-angle vector in robosuite's hand-body frame, and the two
+    Panda finger positions; both cameras are rotated 180°. The env reports the orientation in the grip-site frame
+    and the gripper as a single closure scalar, so the codec rotates into the hand frame (``_GRIP_SITE_TO_HAND``)
+    and reconstructs the finger positions. The adapter already flips images vertically, so the codec adds the
+    horizontal flip to complete the 180° rotation. Inference only.
+    """
+
+    def __init__(
+        self,
+        exterior_camera: str = 'image.agentview',
+        wrist_camera: str = 'image.wrist',
+        image_size: tuple[int, int] = (224, 224),
+    ):
+        self._exterior_camera = exterior_camera
+        self._wrist_camera = wrist_camera
+        self._image_size = image_size
+
+    def encode(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        obs = {
+            'observation/state': self._libero_state(inputs),
+            'observation/wrist_image': self._encode_image(self._wrist_camera, inputs),
+            'observation/image': self._encode_image(self._exterior_camera, inputs),
+        }
+        if 'task' in inputs:
+            obs['prompt'] = inputs['task']
+        return obs
+
+    def _libero_state(self, inputs: dict[str, Any]) -> np.ndarray:
+        ee_pose = np.asarray(inputs['robot_state.ee_pose'], dtype=float)
+        hand_rot = geom.Rotation.from_quat(ee_pose[3:7]) * _GRIP_SITE_TO_HAND
+        # Reproduce robosuite's axis-angle branch. Its `robot0_eef_quat` is MuJoCo's `body_xquat`, FK-continuous
+        # from the tool-down home pose and thus consistently in the w<=0 hemisphere (angle >= pi) across the
+        # manipulation workspace — not the canonical w>=0 a fresh `mat2quat` would pick. Canonicalize to w<=0 to
+        # match (`validate.py` asserts the per-pose axis-angle equals robosuite's; rerun it per suite to confirm).
+        quat = np.asarray(hand_rot.to(geom.Rotation.Representation.QUAT))
+        canonical = geom.Rotation.from_quat(quat if quat[0] <= 0 else -quat)
+        axisangle = np.asarray(canonical.to(geom.Rotation.Representation.ROTVEC)).reshape(3)
+        closure = 1.0 - float(inputs['grip'])
+        gripper_qpos = _GRIPPER_QPOS_CLOSED + closure * (_GRIPPER_QPOS_OPEN - _GRIPPER_QPOS_CLOSED)
+        return np.concatenate([ee_pose[:3], axisangle, gripper_qpos]).astype(np.float32)
+
+    def _encode_image(self, input_key: str, inputs: dict[str, Any]) -> np.ndarray:
+        frame = np.ascontiguousarray(np.asarray(inputs[input_key])[:, ::-1])
+        w, h = self._image_size
+        return image.resize_with_pad_per_frame(w, h, PilImage.Resampling.BILINEAR, frame)
+
+    def dummy_encoded(self, data: dict | None = None) -> dict[str, Any]:
+        w, h = self._image_size
+        return {
+            'observation/state': np.zeros(8, dtype=np.float32),
+            'observation/wrist_image': np.zeros((h, w, 3), dtype=np.uint8),
+            'observation/image': np.zeros((h, w, 3), dtype=np.uint8),
+            'prompt': 'warmup',
+        }
+
+    @property
+    def meta(self) -> dict[str, Any]:
+        return {'image_sizes': self._image_size}
+
+
+libero_obs = cfn.Config(OpenpiLiberoObservationCodec)
+libero_action = cfn.Config(CumulativePoseDeltaAction)
+
+# pi05_libero emits a 10-step chunk, but openpi's official LIBERO eval (`replan_steps=5`) executes only the
+# first 5 before re-querying; truncate to match. LIBERO's OSC runs at 20 Hz, so the chunk is stamped at
+# 20 fps and the horizon keeps the first 5 steps (timestamps < 0.25 s).
+libero = codecs.compose.override(obs=libero_obs, action=libero_action, fps=20.0, horizon=0.25)

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -219,7 +219,15 @@ class InferenceServer(VendorServer):
         self._subprocesses: dict[str, OpenpiSubprocess] = {}
         self._subprocess_lock = asyncio.Lock()
 
+    @property
+    def _passthrough(self) -> bool:
+        # gs:// is a published openpi checkpoint that openpi fetches itself via fsspec[gcs]: pos3 handles only
+        # s3://, and there are no numeric-step subdirs to resolve — the dir is the single checkpoint.
+        return self.checkpoints_dir.startswith('gs://')
+
     def _resolve_checkpoint_id(self, checkpoint_id: str | None) -> str:
+        if self._passthrough:
+            return self.checkpoints_dir.rsplit('/', 1)[-1]
         if checkpoint_id:
             available = list_checkpoints(self.checkpoints_dir)
             if checkpoint_id.isdigit():
@@ -240,12 +248,15 @@ class InferenceServer(VendorServer):
 
         async with self._subprocess_lock:
             if resolved_id not in self._subprocesses:
-                checkpoint_path = f'{self.checkpoints_dir}/{resolved_id}'
-                download_task = asyncio.create_task(asyncio.to_thread(pos3.download, checkpoint_path))
-                await monitor_async_task(
-                    download_task, description=f'Downloading checkpoint {resolved_id}', on_progress=send_progress
-                )
-                checkpoint_dir = download_task.result()
+                if self._passthrough:
+                    checkpoint_dir = self.checkpoints_dir  # openpi's subprocess downloads it via fsspec
+                else:
+                    checkpoint_path = f'{self.checkpoints_dir}/{resolved_id}'
+                    download_task = asyncio.create_task(asyncio.to_thread(pos3.download, checkpoint_path))
+                    await monitor_async_task(
+                        download_task, description=f'Downloading checkpoint {resolved_id}', on_progress=send_progress
+                    )
+                    checkpoint_dir = download_task.result()
 
                 logger.info(f'Starting OpenPI subprocess for checkpoint {resolved_id}')
                 subprocess_obj = OpenpiSubprocess(
@@ -260,6 +271,8 @@ class InferenceServer(VendorServer):
         return OpenpiPolicy(model_handle.client)
 
     async def get_models(self) -> dict:
+        if self._passthrough:
+            return {'models': [self._resolve_checkpoint_id(None)]}
         try:
             checkpoints = list_checkpoints(self.checkpoints_dir)
             normalized = [int(cp) for cp in checkpoints if cp.isdigit()]
@@ -344,10 +357,13 @@ droid = server.override(
     config_name='pi05_droid',
     checkpoints_dir='s3://PUBLIC@positronic-public/checkpoints/openpi/pi05_droid/',
 )
+libero = server.override(
+    codec=codecs.libero, config_name='pi05_libero', checkpoints_dir='gs://openpi-assets/checkpoints/pi05_libero'
+)
 
 
 if __name__ == '__main__':
     init_logging()
     ensure_paligemma_tokenizer()
     with pos3.mirror():
-        cfn.cli({'serve': server, 'phail': phail, 'sim_stack': sim_stack, 'droid': droid})
+        cfn.cli({'serve': server, 'phail': phail, 'sim_stack': sim_stack, 'droid': droid, 'libero': libero})

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -227,7 +227,12 @@ class InferenceServer(VendorServer):
 
     def _resolve_checkpoint_id(self, checkpoint_id: str | None) -> str:
         if self._passthrough:
-            return self.checkpoints_dir.rsplit('/', 1)[-1]
+            served = self.checkpoints_dir.rsplit('/', 1)[-1]
+            if checkpoint_id and checkpoint_id != served:
+                raise ValueError(
+                    f'Checkpoint not found or invalid ID: {checkpoint_id}. This server serves only {served}.'
+                )
+            return served
         if checkpoint_id:
             available = list_checkpoints(self.checkpoints_dir)
             if checkpoint_id.isdigit():


### PR DESCRIPTION
## Summary
Serve openpi's published `pi05_libero` against our LIBERO env-server and reproduce its rollout success rate.

- **Serving** — dedicated obs codec (8-dim state + 180°-rotated images) and a `gs://` pass-through mode so the single published checkpoint loads without a pos3 mirror (sibling of the `droid` command).
- **Action interpretation** — decode the policy's OSC pose-delta chunk as per-step feed-forward `CartesianDelta` (the env composes Δ onto its live measured pose, `goal = live_eef ∘ Δ`), rather than integrating it into absolute waypoints anchored once. The integrated scheme folded the OSC tracking residual back into every command and was the primary rollout success-rate gap vs openpi.
- **Scene fidelity** — settle the scene after a seeded reset (objects start mid-fall from `set_init_state`) and render at openpi's 256 resolution; pin `mujoco==3.2.3` to openpi's eval engine.
- **Offboard hardening** — client `recv` timeout so a stalled server raises instead of hanging; serialize server-side inference and the per-session client reset under one lock in a worker thread, so the event loop stays responsive and concurrent sessions can't corrupt a shared backend client.

## Test plan
- `uv run --locked pytest positronic/offboard/tests` — 44 passed (covers the inference hardening).
- `validate.py` env-transform oracles (software rendering, `mujoco==3.2.3`) — all pass: obs encoding, OSC delta scale, FK identity, IK round-trip, joint/cartesian action inverses.
- LIBERO rollout sweep, 50 trials × 10 tasks × 4 suites (2000 episodes, 0 failures), served from the published `pi05_libero`. Per-suite success vs openpi's published numbers:

| suite | ours | openpi (pi05) |
|---|---|---|
| spatial | 99.0% | 97.1% |
| object | 98.0% | 98.4% |
| goal | 97.8% | 96.2% |
| libero_10 | 88.6% | 91.5% |
| **overall** | **95.9%** | **~95.8%** |

Overall parity with openpi's published pi05_libero; we exceed on spatial/goal, match object, and come in ~3 pts under on the long-horizon `libero_10`.
