### PR TITLE
Add `web` operator console driver for remote evals

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -31,7 +31,7 @@ class Driver:
     the directory exists only after ``pos3.sync`` inside ``main``.
     """
 
-    gui: DearpyguiUi | None
+    gui: pimm.ControlSystem | None
     directives: pimm.SignalEmitter
     directive_wrapper: Callable
     control_systems: list[pimm.ControlSystem]

--- a/positronic/gui/static/eval.css
+++ b/positronic/gui/static/eval.css
@@ -1,37 +1,69 @@
 body {
-  overflow: auto;
+  margin: 0;
+  overflow: hidden;
+}
+
+.console {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  height: 100vh;
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+.controls-bar {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 0.5rem;
 }
 
 .camera {
+  flex: 1 1 auto;
+  min-height: 0;
   margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
-  background: var(--panel-bg);
-  box-shadow: var(--shadow-soft);
+  background: #000;
   overflow: hidden;
 }
 
 .camera video {
   display: block;
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
   height: auto;
-  background: #000;
 }
 
-.camera figcaption {
-  padding: 0.6rem 0.9rem;
-  font-size: 0.82rem;
-  letter-spacing: 0.04em;
-  color: var(--text-secondary);
+.btn-primary {
+  box-shadow: 0 0 14px rgba(177, 231, 79, 0.45);
+}
+
+.btn-primary:hover {
+  box-shadow: 0 0 20px rgba(177, 231, 79, 0.6);
+}
+
+.btn-ghost {
+  box-shadow: 0 0 14px rgba(148, 163, 184, 0.35);
+}
+
+.btn-ghost:hover {
+  box-shadow: 0 0 20px rgba(148, 163, 184, 0.5);
 }
 
 .btn-danger {
   background: var(--danger-soft);
   color: var(--danger);
   border-color: rgba(248, 113, 113, 0.4);
+  box-shadow: 0 0 14px rgba(248, 113, 113, 0.4);
 }
 
 .btn-danger:hover {
   background: var(--danger);
   color: var(--text-invert);
+  box-shadow: 0 0 20px rgba(248, 113, 113, 0.55);
 }

--- a/positronic/gui/static/eval.css
+++ b/positronic/gui/static/eval.css
@@ -2,12 +2,6 @@ body {
   overflow: auto;
 }
 
-.camera-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-  gap: 1.25rem;
-}
-
 .camera {
   margin: 0;
   border-radius: var(--radius-lg);
@@ -20,9 +14,8 @@ body {
 .camera video {
   display: block;
   width: 100%;
-  aspect-ratio: 16 / 9;
+  height: auto;
   background: #000;
-  object-fit: contain;
 }
 
 .camera figcaption {

--- a/positronic/gui/static/eval.css
+++ b/positronic/gui/static/eval.css
@@ -1,0 +1,44 @@
+body {
+  overflow: auto;
+}
+
+.camera-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 1.25rem;
+}
+
+.camera {
+  margin: 0;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.camera video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  object-fit: contain;
+}
+
+.camera figcaption {
+  padding: 0.6rem 0.9rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.btn-danger {
+  background: var(--danger-soft);
+  color: var(--danger);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.btn-danger:hover {
+  background: var(--danger);
+  color: var(--text-invert);
+}

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -22,14 +22,10 @@
           <button class="btn btn-danger" data-action="abort">Abort</button>
         </div>
 
-        <div class="camera-grid">
-          {% for name in cameras %}
-          <figure class="camera">
-            <video data-camera="{{ name }}" autoplay muted playsinline></video>
-            <figcaption>{{ name }}</figcaption>
-          </figure>
-          {% endfor %}
-        </div>
+        <figure class="camera">
+          <video id="feed" autoplay muted playsinline></video>
+          <figcaption>{{ cameras | join(' · ') }}</figcaption>
+        </figure>
       </main>
     </div>
 
@@ -38,17 +34,15 @@
         button.addEventListener('click', () => fetch('/directive/' + button.dataset.action, { method: 'POST' }));
       }
 
-      for (const video of document.querySelectorAll('video[data-camera]')) {
-        startStream(video, video.dataset.camera);
-      }
+      startStream(document.getElementById('feed'));
 
-      function startStream(video, name) {
+      function startStream(video) {
         if (!('MediaSource' in window)) {
           console.error('MediaSource Extensions not supported in this browser');
           return;
         }
         const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
-        const socket = new WebSocket(`${scheme}://${location.host}/video/${name}`);
+        const socket = new WebSocket(`${scheme}://${location.host}/video`);
         socket.binaryType = 'arraybuffer';
 
         let sourceBuffer = null;

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Positronic – Eval console</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="stylesheet" href="/assets/eval.css" />
+</head>
+<body>
+    <div id="app-shell">
+      <main class="main">
+        <header class="page-header">
+          <div class="page-kicker">Attended eval</div>
+          <h1>Eval console</h1>
+          <p>Live camera feeds from the robot. Start, finish, or abort the current episode.</p>
+        </header>
+
+        <div class="controls-bar">
+          <button class="btn btn-primary" data-action="start">Start</button>
+          <button class="btn btn-ghost" data-action="finish">Finish</button>
+          <button class="btn btn-danger" data-action="abort">Abort</button>
+        </div>
+
+        <div class="camera-grid">
+          {% for name in cameras %}
+          <figure class="camera">
+            <video data-camera="{{ name }}" autoplay muted playsinline></video>
+            <figcaption>{{ name }}</figcaption>
+          </figure>
+          {% endfor %}
+        </div>
+      </main>
+    </div>
+
+    <script>
+      for (const button of document.querySelectorAll('button[data-action]')) {
+        button.addEventListener('click', () => fetch('/directive/' + button.dataset.action, { method: 'POST' }));
+      }
+
+      for (const video of document.querySelectorAll('video[data-camera]')) {
+        startStream(video, video.dataset.camera);
+      }
+
+      function startStream(video, name) {
+        if (!('MediaSource' in window)) {
+          console.error('MediaSource Extensions not supported in this browser');
+          return;
+        }
+        const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+        const socket = new WebSocket(`${scheme}://${location.host}/video/${name}`);
+        socket.binaryType = 'arraybuffer';
+
+        let sourceBuffer = null;
+        const pending = [];
+        const pump = () => {
+          if (sourceBuffer && !sourceBuffer.updating && pending.length > 0) {
+            sourceBuffer.appendBuffer(pending.shift());
+          }
+        };
+
+        socket.addEventListener('message', (event) => {
+          if (typeof event.data === 'string') {
+            const codec = `video/mp4; codecs="${event.data}"`;
+            if (!MediaSource.isTypeSupported(codec)) {
+              console.error('Unsupported codec', codec);
+              socket.close();
+              return;
+            }
+            const mediaSource = new MediaSource();
+            video.src = URL.createObjectURL(mediaSource);
+            mediaSource.addEventListener('sourceopen', () => {
+              sourceBuffer = mediaSource.addSourceBuffer(codec);
+              sourceBuffer.addEventListener('updateend', pump);
+              pump();
+            });
+          } else {
+            pending.push(new Uint8Array(event.data));
+            pump();
+          }
+        });
+      }
+    </script>
+</body>
+</html>

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -65,6 +65,7 @@
             video.src = URL.createObjectURL(mediaSource);
             mediaSource.addEventListener('sourceopen', () => {
               sourceBuffer = mediaSource.addSourceBuffer(codec);
+              sourceBuffer.mode = 'sequence';
               sourceBuffer.addEventListener('updateend', pump);
               pump();
             });

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -3,30 +3,20 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Positronic – Eval console</title>
+    <title>Eval console</title>
     <link rel="stylesheet" href="/static/styles.css" />
     <link rel="stylesheet" href="/assets/eval.css" />
 </head>
 <body>
-    <div id="app-shell">
-      <main class="main">
-        <header class="page-header">
-          <div class="page-kicker">Attended eval</div>
-          <h1>Eval console</h1>
-          <p>Live camera feeds from the robot. Start, finish, or abort the current episode.</p>
-        </header>
-
-        <div class="controls-bar">
-          <button class="btn btn-primary" data-action="start">Start</button>
-          <button class="btn btn-ghost" data-action="finish">Finish</button>
-          <button class="btn btn-danger" data-action="abort">Abort</button>
-        </div>
-
-        <figure class="camera">
-          <video id="feed" autoplay muted playsinline></video>
-          <figcaption>{{ cameras | join(' · ') }}</figcaption>
-        </figure>
-      </main>
+    <div class="console">
+      <div class="controls-bar">
+        <button class="btn btn-primary" data-action="start">Start</button>
+        <button class="btn btn-ghost" data-action="finish">Finish</button>
+        <button class="btn btn-danger" data-action="abort">Abort</button>
+      </div>
+      <figure class="camera">
+        <video id="feed" autoplay muted playsinline></video>
+      </figure>
     </div>
 
     <script>
@@ -48,10 +38,18 @@
         const MAX_BUFFER_SECONDS = 10;
         let sourceBuffer = null;
         const pending = [];
+        const ensurePlaying = () => {
+          if (video.paused) video.play().catch(() => {});
+        };
         const pump = () => {
           if (!sourceBuffer || sourceBuffer.updating) return;
           const buffered = sourceBuffer.buffered;
           if (buffered.length > 0) {
+            // MSE does not autostart and playback drifts behind after a stall; keep it pinned near the live edge.
+            const liveEdge = buffered.end(buffered.length - 1);
+            if (liveEdge - video.currentTime > 1.5) {
+              video.currentTime = Math.max(buffered.start(0), liveEdge - 0.3);
+            }
             const dropTo = video.currentTime - MAX_BUFFER_SECONDS;
             if (dropTo > buffered.start(0) + 1) {
               sourceBuffer.remove(buffered.start(0), dropTo);
@@ -60,8 +58,10 @@
           }
           if (pending.length > 0) {
             sourceBuffer.appendBuffer(pending.shift());
+            ensurePlaying();
           }
         };
+        video.addEventListener('canplay', ensurePlaying);
 
         socket.addEventListener('message', (event) => {
           if (typeof event.data === 'string') {

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -45,10 +45,20 @@
         const socket = new WebSocket(`${scheme}://${location.host}/video`);
         socket.binaryType = 'arraybuffer';
 
+        const MAX_BUFFER_SECONDS = 10;
         let sourceBuffer = null;
         const pending = [];
         const pump = () => {
-          if (sourceBuffer && !sourceBuffer.updating && pending.length > 0) {
+          if (!sourceBuffer || sourceBuffer.updating) return;
+          const buffered = sourceBuffer.buffered;
+          if (buffered.length > 0) {
+            const dropTo = video.currentTime - MAX_BUFFER_SECONDS;
+            if (dropTo > buffered.start(0) + 1) {
+              sourceBuffer.remove(buffered.start(0), dropTo);
+              return;
+            }
+          }
+          if (pending.length > 0) {
             sourceBuffer.appendBuffer(pending.shift());
           }
         };

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -1,0 +1,115 @@
+import asyncio
+import threading
+from collections.abc import Iterator
+
+import turbojpeg
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse, StreamingResponse
+
+import pimm
+from positronic.policy.harness import Directive
+
+_LOG_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {'class': 'logging.FileHandler', 'formatter': 'default', 'filename': '/tmp/web_eval.log', 'mode': 'w'}
+    },
+    'loggers': {'': {'handlers': ['file'], 'level': 'INFO'}},
+    'formatters': {'default': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
+}
+
+
+class WebEvalUI(pimm.ControlSystem):
+    """Headless web operator surface for attended evals.
+
+    Streams the live eval cameras as MJPEG to a browser and turns Start/Finish/Abort presses into
+    harness directives. A drop-in directive source replacing the dearpygui/keyboard drivers, served
+    over an SSH tunnel.
+    """
+
+    def __init__(self, task=None, port=8080, fps=30, jpeg_quality=50):
+        self.task = task
+        self.port = port
+        self.fps = fps
+        self.jpeg_quality = jpeg_quality
+        self.cameras = pimm.ReceiverDict(self, default=None)
+        self.directive = pimm.ControlSystemEmitter(self)
+        self._frames: dict[str, bytes] = {}
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+        app = FastAPI()
+        jpeg_encoder = turbojpeg.TurboJPEG()
+
+        @app.get('/')
+        async def index():
+            feeds = ''.join(f'<img src="/stream/{name}" alt="{name}">' for name in self.cameras)
+            return HTMLResponse(
+                '<!doctype html><html><head><meta charset="utf-8"><title>Eval console</title></head><body>'
+                f'<div class="feeds">{feeds}</div>'
+                '<div class="controls">'
+                '<button data-action="start">Start</button>'
+                '<button data-action="finish">Finish</button>'
+                '<button data-action="abort">Abort</button>'
+                '</div>'
+                '<script>'
+                "for (const b of document.querySelectorAll('button')) "
+                "b.onclick = () => fetch('/directive/' + b.dataset.action, {method: 'POST'});"
+                '</script>'
+                '</body></html>'
+            )
+
+        @app.get('/stream/{name}')
+        async def stream(name: str):
+            if name not in self.cameras:
+                raise HTTPException(status_code=404)
+
+            async def frames():
+                last = None
+                while not should_stop.value:
+                    await asyncio.sleep(1 / self.fps)
+                    jpeg = self._frames.get(name)
+                    if jpeg is None or jpeg is last:
+                        continue
+                    last = jpeg
+                    yield b'--frame\r\nContent-Type: image/jpeg\r\n\r\n' + jpeg + b'\r\n'
+
+            return StreamingResponse(frames(), media_type='multipart/x-mixed-replace; boundary=frame')
+
+        @app.post('/directive/{action}')
+        async def directive(action: str):
+            match action:
+                case 'start':
+                    self.directive.emit(Directive.RUN(task=self.task), clock.now_ns())
+                case 'finish':
+                    self.directive.emit(Directive.FINISH(), clock.now_ns())
+                case 'abort':
+                    self.directive.emit(Directive.ABORT(), clock.now_ns())
+                case _:
+                    raise HTTPException(status_code=404)
+
+        config = uvicorn.Config(app, host='127.0.0.1', port=self.port, log_config=_LOG_CONFIG)
+        server = uvicorn.Server(config)
+        server_thread = threading.Thread(target=server.run, daemon=True)
+        server_thread.start()
+
+        banner = '=' * 80
+        print(banner)
+        print(
+            f' >>> WEB eval console: http://127.0.0.1:{self.port}/  '
+            f'(tunnel with: ssh -L {self.port}:localhost:{self.port} <robot-host>) <<<'
+        )
+        print(banner)
+
+        while not should_stop.value:
+            for cam_name, camera in self.cameras.items():
+                cam_msg = camera.read()
+                if cam_msg.data is not None and cam_msg.updated:
+                    self._frames[cam_name] = jpeg_encoder.encode(cam_msg.data.array, quality=self.jpeg_quality)
+            if not server_thread.is_alive():
+                raise RuntimeError('Web eval server thread died')
+            yield pimm.Sleep(1 / self.fps)
+
+        server.should_exit = True
+        server_thread.join()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -173,7 +173,8 @@ class WebEvalUI(pimm.ControlSystem):
     reachable over an SSH tunnel or directly on the host IP.
     """
 
-    def __init__(self, port=8080, fps=20, width=640, keyframe_interval=15, bitrate=2_000_000):
+    def __init__(self, task: str | None = None, port=8080, fps=20, width=640, keyframe_interval=15, bitrate=2_000_000):
+        self.task = task
         self.port = port
         self.fps = fps
         self.width = width
@@ -222,7 +223,7 @@ class WebEvalUI(pimm.ControlSystem):
         async def directive(action: str):
             match action:
                 case 'start':
-                    self.directive.emit(Directive.RUN(), clock.now_ns())
+                    self.directive.emit(Directive.RUN(task=self.task), clock.now_ns())
                 case 'finish':
                     self.directive.emit(Directive.FINISH(), clock.now_ns())
                 case 'abort':

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -1,81 +1,205 @@
 import asyncio
+import queue
 import threading
 from collections.abc import Iterator
+from pathlib import Path
 
-import turbojpeg
+import av
 import uvicorn
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 import pimm
 from positronic.policy.harness import Directive
 
-_LOG_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'file': {'class': 'logging.FileHandler', 'formatter': 'default', 'filename': '/tmp/web_eval.log', 'mode': 'w'}
-    },
-    'loggers': {'': {'handlers': ['file'], 'level': 'INFO'}},
-    'formatters': {'default': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
-}
+
+def _pkg_path(*parts: str) -> str:
+    return str(Path(__file__).resolve().parent.joinpath(*parts))
+
+
+def _shared_static() -> str:
+    return str(Path(__file__).resolve().parent.parent / 'server' / 'static')
+
+
+def _next_fragment(subscriber: queue.Queue) -> bytes | None:
+    try:
+        return subscriber.get(timeout=1.0)
+    except queue.Empty:
+        return None
+
+
+def _codec_string(init: bytes) -> str:
+    """Build the MSE codec string (``avc1.PPCCLL``) from the avcC box of a fragmented-MP4 init segment."""
+    record = init[init.find(b'avcC') + 4 :]
+    return f'avc1.{record[1]:02X}{record[2]:02X}{record[3]:02X}'
+
+
+class _ChunkBuffer:
+    """Write-only sink that hands the muxer's output back to the producer one drain at a time."""
+
+    def __init__(self):
+        self._chunks: list[bytes] = []
+        self._pos = 0
+
+    def write(self, data) -> int:
+        self._chunks.append(bytes(data))
+        self._pos += len(data)
+        return len(data)
+
+    def drain(self) -> bytes:
+        data = b''.join(self._chunks)
+        self._chunks.clear()
+        return data
+
+    def tell(self) -> int:
+        return self._pos
+
+    def flush(self) -> None:
+        pass
+
+
+class _CameraStream:
+    """Encodes RGB frames to a fragmented-MP4 H.264 byte stream and fans the fragments out to subscribers.
+
+    The encoder runs in the producer thread; each completed fragment starts at a keyframe (``frag_keyframe``),
+    so it is independently decodable after the init segment and a late subscriber can join at any fragment.
+    """
+
+    def __init__(self, fps: int, keyframe_interval: int, bitrate: int):
+        self._fps = fps
+        self._keyframe_interval = keyframe_interval
+        self._bitrate = bitrate
+        self._buffer = _ChunkBuffer()
+        self._container = None
+        self._stream = None
+        self._init = b''
+        self._lock = threading.Lock()
+        self._subscribers: set[queue.Queue] = set()
+
+    def _open(self, height: int, width: int) -> None:
+        self._container = av.open(
+            self._buffer, mode='w', format='mp4', options={'movflags': 'frag_keyframe+empty_moov+default_base_moof'}
+        )
+        stream = self._container.add_stream(
+            'libx264',
+            rate=self._fps,
+            options={'preset': 'ultrafast', 'tune': 'zerolatency', 'profile': 'baseline', 'level': '3.1'},
+        )
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = 'yuv420p'
+        stream.gop_size = self._keyframe_interval
+        stream.bit_rate = self._bitrate
+        self._stream = stream
+
+    def push(self, rgb) -> None:
+        if self._container is None:
+            self._open(rgb.shape[0], rgb.shape[1])
+        frame = av.VideoFrame.from_ndarray(rgb, format='rgb24')
+        for packet in self._stream.encode(frame):
+            self._container.mux(packet)
+        self._dispatch(self._buffer.drain())
+
+    def _dispatch(self, data: bytes) -> None:
+        if not data:
+            return
+        with self._lock:
+            if not self._init:
+                marker = data.find(b'moof')
+                if marker < 4:
+                    self._init += data
+                    return
+                self._init = data[: marker - 4]
+                data = data[marker - 4 :]
+            subscribers = list(self._subscribers)
+        for subscriber in subscribers:
+            if subscriber.full():
+                try:
+                    subscriber.get_nowait()
+                except queue.Empty:
+                    pass
+            subscriber.put(data)
+
+    def subscribe(self) -> queue.Queue:
+        subscriber: queue.Queue = queue.Queue(maxsize=self._fps)
+        with self._lock:
+            self._subscribers.add(subscriber)
+        return subscriber
+
+    def unsubscribe(self, subscriber: queue.Queue) -> None:
+        with self._lock:
+            self._subscribers.discard(subscriber)
+
+    @property
+    def init_segment(self) -> bytes:
+        with self._lock:
+            return self._init
+
+    def close(self) -> None:
+        if self._container is None:
+            return
+        for packet in self._stream.encode(None):
+            self._container.mux(packet)
+        self._container.close()
 
 
 class WebEvalUI(pimm.ControlSystem):
     """Headless web operator surface for attended evals.
 
-    Streams the live eval cameras as MJPEG to a browser and turns Start/Finish/Abort presses into
-    harness directives. A drop-in directive source replacing the dearpygui/keyboard drivers, served
-    over an SSH tunnel.
+    Streams the live eval cameras as H.264 video to a browser and turns Start/Finish/Abort presses into
+    harness directives. A drop-in directive source replacing the dearpygui/keyboard drivers, served over
+    an SSH tunnel.
     """
 
-    def __init__(self, task=None, port=8080, fps=30, jpeg_quality=50):
+    def __init__(self, task=None, port=8080, fps=30, keyframe_interval=15, bitrate=4_000_000):
         self.task = task
         self.port = port
         self.fps = fps
-        self.jpeg_quality = jpeg_quality
+        self.keyframe_interval = keyframe_interval
+        self.bitrate = bitrate
         self.cameras = pimm.ReceiverDict(self, default=None)
         self.directive = pimm.ControlSystemEmitter(self)
-        self._frames: dict[str, bytes] = {}
+        self._streams: dict[str, _CameraStream] = {}
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+        templates = Jinja2Templates(directory=_pkg_path('templates'))
+        self._streams = {name: _CameraStream(self.fps, self.keyframe_interval, self.bitrate) for name in self.cameras}
+
         app = FastAPI()
-        jpeg_encoder = turbojpeg.TurboJPEG()
+        app.mount('/static', StaticFiles(directory=_shared_static()), name='static')
+        app.mount('/assets', StaticFiles(directory=_pkg_path('static')), name='assets')
 
-        @app.get('/')
-        async def index():
-            feeds = ''.join(f'<img src="/stream/{name}" alt="{name}">' for name in self.cameras)
-            return HTMLResponse(
-                '<!doctype html><html><head><meta charset="utf-8"><title>Eval console</title></head><body>'
-                f'<div class="feeds">{feeds}</div>'
-                '<div class="controls">'
-                '<button data-action="start">Start</button>'
-                '<button data-action="finish">Finish</button>'
-                '<button data-action="abort">Abort</button>'
-                '</div>'
-                '<script>'
-                "for (const b of document.querySelectorAll('button')) "
-                "b.onclick = () => fetch('/directive/' + b.dataset.action, {method: 'POST'});"
-                '</script>'
-                '</body></html>'
-            )
+        @app.get('/', response_class=HTMLResponse)
+        async def index(request: Request):
+            return templates.TemplateResponse(request, 'eval_console.html', {'cameras': list(self._streams)})
 
-        @app.get('/stream/{name}')
-        async def stream(name: str):
-            if name not in self.cameras:
-                raise HTTPException(status_code=404)
-
-            async def frames():
-                last = None
+        @app.websocket('/video/{name}')
+        async def video(websocket: WebSocket, name: str):
+            stream = self._streams.get(name)
+            if stream is None:
+                await websocket.close(code=1003)
+                return
+            await websocket.accept()
+            subscriber = stream.subscribe()
+            loop = asyncio.get_running_loop()
+            try:
+                while not stream.init_segment and not should_stop.value:
+                    await asyncio.sleep(0.05)
+                init = stream.init_segment
+                if not init:
+                    return
+                await websocket.send_text(_codec_string(init))
+                await websocket.send_bytes(init)
                 while not should_stop.value:
-                    await asyncio.sleep(1 / self.fps)
-                    jpeg = self._frames.get(name)
-                    if jpeg is None or jpeg is last:
-                        continue
-                    last = jpeg
-                    yield b'--frame\r\nContent-Type: image/jpeg\r\n\r\n' + jpeg + b'\r\n'
-
-            return StreamingResponse(frames(), media_type='multipart/x-mixed-replace; boundary=frame')
+                    fragment = await loop.run_in_executor(None, _next_fragment, subscriber)
+                    if fragment is not None:
+                        await websocket.send_bytes(fragment)
+            except WebSocketDisconnect:
+                pass
+            finally:
+                stream.unsubscribe(subscriber)
 
         @app.post('/directive/{action}')
         async def directive(action: str):
@@ -89,7 +213,7 @@ class WebEvalUI(pimm.ControlSystem):
                 case _:
                     raise HTTPException(status_code=404)
 
-        config = uvicorn.Config(app, host='127.0.0.1', port=self.port, log_config=_LOG_CONFIG)
+        config = uvicorn.Config(app, host='127.0.0.1', port=self.port)
         server = uvicorn.Server(config)
         server_thread = threading.Thread(target=server.run, daemon=True)
         server_thread.start()
@@ -102,14 +226,17 @@ class WebEvalUI(pimm.ControlSystem):
         )
         print(banner)
 
-        while not should_stop.value:
-            for cam_name, camera in self.cameras.items():
-                cam_msg = camera.read()
-                if cam_msg.data is not None and cam_msg.updated:
-                    self._frames[cam_name] = jpeg_encoder.encode(cam_msg.data.array, quality=self.jpeg_quality)
-            if not server_thread.is_alive():
-                raise RuntimeError('Web eval server thread died')
-            yield pimm.Sleep(1 / self.fps)
-
-        server.should_exit = True
-        server_thread.join()
+        try:
+            while not should_stop.value:
+                for name, camera in self.cameras.items():
+                    cam_msg = camera.read()
+                    if cam_msg.data is not None and cam_msg.updated:
+                        self._streams[name].push(cam_msg.data.array)
+                if not server_thread.is_alive():
+                    raise RuntimeError('Web eval server thread died')
+                yield pimm.Sleep(1 / self.fps)
+        finally:
+            for stream in self._streams.values():
+                stream.close()
+            server.should_exit = True
+            server_thread.join()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import av
+import numpy as np
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
@@ -12,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 import pimm
+from positronic import utils
 from positronic.policy.harness import Directive
 
 
@@ -34,6 +36,26 @@ def _codec_string(init: bytes) -> str:
     """Build the MSE codec string (``avc1.PPCCLL``) from the avcC box of a fragmented-MP4 init segment."""
     record = init[init.find(b'avcC') + 4 :]
     return f'avc1.{record[1]:02X}{record[2]:02X}{record[3]:02X}'
+
+
+def _even(value: int) -> int:
+    return max(2, value - value % 2)
+
+
+def _resize_to_height(rgb: np.ndarray, height: int) -> np.ndarray:
+    h, w = rgb.shape[:2]
+    width = _even(round(w * height / h))
+    if (h, w) == (height, width):
+        return rgb
+    return (
+        av.VideoFrame.from_ndarray(rgb, format='rgb24').reformat(width=width, height=height).to_ndarray(format='rgb24')
+    )
+
+
+def _tile(frames: list[np.ndarray]) -> np.ndarray:
+    """Lay frames out side by side at a common (even) height, so the row encodes as one H.264 stream."""
+    height = _even(min(frame.shape[0] for frame in frames))
+    return np.concatenate([_resize_to_height(frame, height) for frame in frames], axis=1)
 
 
 class _ChunkBuffer:
@@ -92,7 +114,7 @@ class _CameraStream:
         stream.bit_rate = self._bitrate
         self._stream = stream
 
-    def push(self, rgb) -> None:
+    def push(self, rgb: np.ndarray) -> None:
         if self._container is None:
             self._open(rgb.shape[0], rgb.shape[1])
         frame = av.VideoFrame.from_ndarray(rgb, format='rgb24')
@@ -146,24 +168,24 @@ class _CameraStream:
 class WebEvalUI(pimm.ControlSystem):
     """Headless web operator surface for attended evals.
 
-    Streams the live eval cameras as H.264 video to a browser and turns Start/Finish/Abort presses into
-    harness directives. A drop-in directive source replacing the dearpygui/keyboard drivers, served over
-    an SSH tunnel.
+    Tiles the live eval cameras into a single H.264 stream served to a browser and turns Start/Finish/Abort
+    presses into harness directives. A drop-in directive source replacing the dearpygui/keyboard drivers,
+    reachable over an SSH tunnel or directly on the host IP.
     """
 
-    def __init__(self, task=None, port=8080, fps=30, keyframe_interval=15, bitrate=4_000_000):
-        self.task = task
+    def __init__(self, port=8080, fps=30, keyframe_interval=15, bitrate=8_000_000):
         self.port = port
         self.fps = fps
         self.keyframe_interval = keyframe_interval
         self.bitrate = bitrate
         self.cameras = pimm.ReceiverDict(self, default=None)
         self.directive = pimm.ControlSystemEmitter(self)
-        self._streams: dict[str, _CameraStream] = {}
+        self._stream = _CameraStream(fps, keyframe_interval, bitrate)
+        self._latest: dict[str, np.ndarray] = {}
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         templates = Jinja2Templates(directory=_pkg_path('templates'))
-        self._streams = {name: _CameraStream(self.fps, self.keyframe_interval, self.bitrate) for name in self.cameras}
+        names = list(self.cameras)
 
         app = FastAPI()
         app.mount('/static', StaticFiles(directory=_shared_static()), name='static')
@@ -171,21 +193,17 @@ class WebEvalUI(pimm.ControlSystem):
 
         @app.get('/', response_class=HTMLResponse)
         async def index(request: Request):
-            return templates.TemplateResponse(request, 'eval_console.html', {'cameras': list(self._streams)})
+            return templates.TemplateResponse(request, 'eval_console.html', {'cameras': names})
 
-        @app.websocket('/video/{name}')
-        async def video(websocket: WebSocket, name: str):
-            stream = self._streams.get(name)
-            if stream is None:
-                await websocket.close(code=1003)
-                return
+        @app.websocket('/video')
+        async def video(websocket: WebSocket):
             await websocket.accept()
-            subscriber = stream.subscribe()
+            subscriber = self._stream.subscribe()
             loop = asyncio.get_running_loop()
             try:
-                while not stream.init_segment and not should_stop.value:
+                while not self._stream.init_segment and not should_stop.value:
                     await asyncio.sleep(0.05)
-                init = stream.init_segment
+                init = self._stream.init_segment
                 if not init:
                     return
                 await websocket.send_text(_codec_string(init))
@@ -197,13 +215,13 @@ class WebEvalUI(pimm.ControlSystem):
             except WebSocketDisconnect:
                 pass
             finally:
-                stream.unsubscribe(subscriber)
+                self._stream.unsubscribe(subscriber)
 
         @app.post('/directive/{action}')
         async def directive(action: str):
             match action:
                 case 'start':
-                    self.directive.emit(Directive.RUN(task=self.task), clock.now_ns())
+                    self.directive.emit(Directive.RUN(), clock.now_ns())
                 case 'finish':
                     self.directive.emit(Directive.FINISH(), clock.now_ns())
                 case 'abort':
@@ -211,30 +229,31 @@ class WebEvalUI(pimm.ControlSystem):
                 case _:
                     raise HTTPException(status_code=404)
 
-        config = uvicorn.Config(app, host='127.0.0.1', port=self.port)
+        config = uvicorn.Config(app, host='0.0.0.0', port=self.port)
         server = uvicorn.Server(config)
         server_thread = threading.Thread(target=server.run, daemon=True)
         server_thread.start()
 
+        host = utils.resolve_host_ip()
         banner = '=' * 80
         print(banner)
-        print(
-            f' >>> WEB eval console: http://127.0.0.1:{self.port}/  '
-            f'(tunnel with: ssh -L {self.port}:localhost:{self.port} <robot-host>) <<<'
-        )
+        print(f' >>> WEB eval console available at: http://{host}:{self.port}/ <<<')
         print(banner)
 
         try:
             while not should_stop.value:
-                for name, camera in self.cameras.items():
-                    cam_msg = camera.read()
+                changed = False
+                for name in names:
+                    cam_msg = self.cameras[name].read()
                     if cam_msg.data is not None and cam_msg.updated:
-                        self._streams[name].push(cam_msg.data.array)
+                        self._latest[name] = cam_msg.data.array
+                        changed = True
+                if changed and len(self._latest) == len(names):
+                    self._stream.push(_tile([self._latest[name] for name in names]))
                 if not server_thread.is_alive():
                     raise RuntimeError('Web eval server thread died')
                 yield pimm.Sleep(1 / self.fps)
         finally:
-            for stream in self._streams.values():
-                stream.close()
+            self._stream.close()
             server.should_exit = True
             server_thread.join()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -180,12 +180,12 @@ class WebEvalUI(pimm.ControlSystem):
         self.bitrate = bitrate
         self.cameras = pimm.ReceiverDict(self, default=None)
         self.directive = pimm.ControlSystemEmitter(self)
-        self._stream = _CameraStream(fps, keyframe_interval, bitrate)
-        self._latest: dict[str, np.ndarray] = {}
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         templates = Jinja2Templates(directory=_pkg_path('templates'))
         names = list(self.cameras)
+        stream = _CameraStream(self.fps, self.keyframe_interval, self.bitrate)
+        latest: dict[str, np.ndarray] = {}
 
         app = FastAPI()
         app.mount('/static', StaticFiles(directory=_shared_static()), name='static')
@@ -198,12 +198,12 @@ class WebEvalUI(pimm.ControlSystem):
         @app.websocket('/video')
         async def video(websocket: WebSocket):
             await websocket.accept()
-            subscriber = self._stream.subscribe()
+            subscriber = stream.subscribe()
             loop = asyncio.get_running_loop()
             try:
-                while not self._stream.init_segment and not should_stop.value:
+                while not stream.init_segment and not should_stop.value:
                     await asyncio.sleep(0.05)
-                init = self._stream.init_segment
+                init = stream.init_segment
                 if not init:
                     return
                 await websocket.send_text(_codec_string(init))
@@ -215,7 +215,7 @@ class WebEvalUI(pimm.ControlSystem):
             except WebSocketDisconnect:
                 pass
             finally:
-                self._stream.unsubscribe(subscriber)
+                stream.unsubscribe(subscriber)
 
         @app.post('/directive/{action}')
         async def directive(action: str):
@@ -246,14 +246,14 @@ class WebEvalUI(pimm.ControlSystem):
                 for name in names:
                     cam_msg = self.cameras[name].read()
                     if cam_msg.data is not None and cam_msg.updated:
-                        self._latest[name] = cam_msg.data.array
+                        latest[name] = cam_msg.data.array
                         changed = True
-                if changed and len(self._latest) == len(names):
-                    self._stream.push(_tile([self._latest[name] for name in names]))
+                if changed and len(latest) == len(names):
+                    stream.push(_tile([latest[name] for name in names]))
                 if not server_thread.is_alive():
                     raise RuntimeError('Web eval server thread died')
                 yield pimm.Sleep(1 / self.fps)
         finally:
-            self._stream.close()
+            stream.close()
             server.should_exit = True
             server_thread.join()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -42,9 +42,9 @@ def _even(value: int) -> int:
     return max(2, value - value % 2)
 
 
-def _resize_to_height(rgb: np.ndarray, height: int) -> np.ndarray:
+def _resize_to_width(rgb: np.ndarray, width: int) -> np.ndarray:
     h, w = rgb.shape[:2]
-    width = _even(round(w * height / h))
+    height = _even(round(h * width / w))
     if (h, w) == (height, width):
         return rgb
     return (
@@ -53,9 +53,9 @@ def _resize_to_height(rgb: np.ndarray, height: int) -> np.ndarray:
 
 
 def _tile(frames: list[np.ndarray]) -> np.ndarray:
-    """Lay frames out side by side at a common (even) height, so the row encodes as one H.264 stream."""
-    height = _even(min(frame.shape[0] for frame in frames))
-    return np.concatenate([_resize_to_height(frame, height) for frame in frames], axis=1)
+    """Stack frames vertically at a common (even) width, so the column encodes as one H.264 stream."""
+    width = _even(min(frame.shape[1] for frame in frames))
+    return np.concatenate([_resize_to_width(frame, width) for frame in frames], axis=0)
 
 
 class _ChunkBuffer:

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -195,7 +195,7 @@ class WebEvalUI(pimm.ControlSystem):
 
         @app.get('/', response_class=HTMLResponse)
         async def index(request: Request):
-            return templates.TemplateResponse(request, 'eval_console.html', {'cameras': names})
+            return templates.TemplateResponse(request, 'eval_console.html')
 
         @app.websocket('/video')
         async def video(websocket: WebSocket):
@@ -231,7 +231,10 @@ class WebEvalUI(pimm.ControlSystem):
                 case _:
                     raise HTTPException(status_code=404)
 
-        config = uvicorn.Config(app, host='0.0.0.0', port=self.port)
+        # The continuous fragment push is the connection's liveness signal. Uvicorn's keepalive ping
+        # runs in its own coroutine and would await a transport drain concurrently with the send loop,
+        # tripping an assertion in websockets and killing the feed; disable it.
+        config = uvicorn.Config(app, host='0.0.0.0', port=self.port, ws_ping_interval=None, ws_ping_timeout=None)
         server = uvicorn.Server(config)
         server_thread = threading.Thread(target=server.run, daemon=True)
         server_thread.start()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -83,9 +83,7 @@ class _CameraStream:
             self._buffer, mode='w', format='mp4', options={'movflags': 'frag_keyframe+empty_moov+default_base_moof'}
         )
         stream = self._container.add_stream(
-            'libx264',
-            rate=self._fps,
-            options={'preset': 'ultrafast', 'tune': 'zerolatency', 'profile': 'baseline', 'level': '3.1'},
+            'libx264', rate=self._fps, options={'preset': 'ultrafast', 'tune': 'zerolatency', 'profile': 'baseline'}
         )
         stream.width = width
         stream.height = height

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -52,9 +52,9 @@ def _resize_to_width(rgb: np.ndarray, width: int) -> np.ndarray:
     )
 
 
-def _tile(frames: list[np.ndarray]) -> np.ndarray:
+def _tile(frames: list[np.ndarray], width: int) -> np.ndarray:
     """Stack frames vertically at a common (even) width, so the column encodes as one H.264 stream."""
-    width = _even(min(frame.shape[1] for frame in frames))
+    width = _even(width)
     return np.concatenate([_resize_to_width(frame, width) for frame in frames], axis=0)
 
 
@@ -173,9 +173,10 @@ class WebEvalUI(pimm.ControlSystem):
     reachable over an SSH tunnel or directly on the host IP.
     """
 
-    def __init__(self, port=8080, fps=30, keyframe_interval=15, bitrate=8_000_000):
+    def __init__(self, port=8080, fps=20, width=640, keyframe_interval=15, bitrate=2_000_000):
         self.port = port
         self.fps = fps
+        self.width = width
         self.keyframe_interval = keyframe_interval
         self.bitrate = bitrate
         self.cameras = pimm.ReceiverDict(self, default=None)
@@ -249,7 +250,7 @@ class WebEvalUI(pimm.ControlSystem):
                         latest[name] = cam_msg.data.array
                         changed = True
                 if changed and len(latest) == len(names):
-                    stream.push(_tile([latest[name] for name in names]))
+                    stream.push(_tile([latest[name] for name in names], self.width))
                 if not server_thread.is_alive():
                     raise RuntimeError('Web eval server thread died')
                 yield pimm.Sleep(1 / self.fps)

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -61,10 +61,10 @@ def keyboard(show_gui, task):
     return make
 
 
-@cfn.config(port=8080)
-def web(port):
+@cfn.config(port=8080, fps=20, width=640, bitrate=2_000_000)
+def web(port, fps, width, bitrate):
     def make(output_dir: Path | None) -> Driver:
-        ui = WebEvalUI(port=port)
+        ui = WebEvalUI(port=port, fps=fps, width=width, bitrate=bitrate)
         return Driver(ui, ui.directive, pimm.utils.identity, [])
 
     return make

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -62,9 +62,9 @@ def keyboard(show_gui, task):
 
 
 @cfn.config(port=8080, fps=20, width=640, bitrate=2_000_000)
-def web(port, fps, width, bitrate):
+def web(port, fps, width, bitrate, task):
     def make(output_dir: Path | None) -> Driver:
-        ui = WebEvalUI(port=port, fps=fps, width=width, bitrate=bitrate)
+        ui = WebEvalUI(task=task, port=port, fps=fps, width=width, bitrate=bitrate)
         return Driver(ui, ui.directive, pimm.utils.identity, [])
 
     return make

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -16,6 +16,7 @@ from positronic.dataset.local_dataset import load_all_datasets
 from positronic.gui.dpg import DearpyguiUi
 from positronic.gui.eval import EvalUI
 from positronic.gui.keyboard import KeyboardControl
+from positronic.gui.web import WebEvalUI
 from positronic.policy.harness import Directive
 from positronic.utils.logging import init_logging
 
@@ -60,6 +61,15 @@ def keyboard(show_gui, task):
     return make
 
 
+@cfn.config(port=8080)
+def web(port, task):
+    def make(output_dir: Path | None) -> Driver:
+        ui = WebEvalUI(task=task, port=port)
+        return Driver(ui, ui.directive, pimm.utils.identity, [])
+
+    return make
+
+
 run_cfg = cfn.Config(
     main,
     embodiment=positronic.cfg.embodiment.droid,
@@ -77,6 +87,7 @@ def _internal_main():
         'run': run_cfg,
         'real': run_cfg,  # `real` is the documented name for the hardware path
         'sim': run.override(eval=stack_cubes),
+        'web': run_cfg.override(driver=web),
         'phail': run_cfg.override(
             policy=policy_cfg.phail_multiple,
             driver=eval_ui,

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -62,9 +62,9 @@ def keyboard(show_gui, task):
 
 
 @cfn.config(port=8080)
-def web(port, task):
+def web(port):
     def make(output_dir: Path | None) -> Driver:
-        ui = WebEvalUI(task=task, port=port)
+        ui = WebEvalUI(port=port)
         return Driver(ui, ui.directive, pimm.utils.identity, [])
 
     return make

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,8 @@ positronic = [
   "assets/**",
   "drivers/**/*.xml",
   "drivers/**/*.urdf",
+  "gui/static/**",
+  "gui/templates/**",
   "server/static/**",
   "server/templates/**",
 ]


### PR DESCRIPTION
## Summary
- Add `WebEvalUI`, a headless web operator console that streams the live eval cameras as MJPEG to a browser and turns Start/Finish/Abort button presses into harness directives — a drop-in directive source replacing the `eval_ui`/`keyboard` drivers, for running attended evals remotely over an SSH tunnel.
- Register it as the `web` eval driver: `positronic-inference web`.
- Broaden `Driver.gui` from `DearpyguiUi | None` to `pimm.ControlSystem | None` (the slot already holds `EvalUI`).

It reuses the existing server pattern from `drivers/webxr.py` (uvicorn in a daemon thread, turbojpeg encoding). Frames are JPEG-encoded in the control-system run loop so only immutable bytes cross to the server thread. No harness changes — remote teleop is a planned follow-up.

Binds `127.0.0.1` only; reach it from a laptop with `ssh -L 8080:localhost:8080 <robot-host>` then open `http://localhost:8080`.

## Test plan
- `ruff check` and `ruff format --check` pass on the three files.
- Import/registration smoke passes: `python -c "import positronic.gui.web; import positronic.inference; import positronic.cli.eval.run"` — the `web` driver config resolves without error.
- Not yet exercised live: end-to-end MJPEG streaming and the directive flow require a real robot run (`positronic-inference web`) with cameras, which has not been run.