### PR TITLE
Add `address-review` skill to repo

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -205,7 +205,8 @@ blocks until something actionable happens, then loop on how it exits:
 - exit **20** → truly converged: **CI green on the pushed commit AND** a reviewer sign-off
   (Codex 👍 newer than the push, or a human approval) → give the final report, **notify the
   user**, and **stop**;
-- exit **30** → nothing came back within the cap → tell the user it went quiet;
+- exit **30** → a quiet interval elapsed → **relaunch the watcher and keep waiting** (don't
+  stop); only after several consecutive quiet cycles ping the user that it's still watching;
 - exit **40** → **CI failed on the pushed commit** → run a CI-fix pass (below), which ends
   back here and relaunches the watcher.
 
@@ -215,10 +216,14 @@ CI **only for the commit you pushed** (`HEAD` sha), so stale runs from earlier c
 confuse it, and acts only once a check has *completed* with a failing conclusion.
 
 The watcher just polls `gh`, so it costs no tokens while it waits. It is **harness-tracked**:
-when it exits you are re-invoked automatically with its output — so launch it with
-`run_in_background` and **don't** also schedule a wakeup to poll for it. Its echoed
-`WATCH <code>` line names the next action, so the loop survives even if this skill text has
-fallen out of context (re-read this file if unsure).
+when it exits you are re-invoked automatically with its output — that notification is the
+primary wake signal, so launch it with `run_in_background` and **don't** add a short poll on top
+of it. Do, however, set one **long fallback heartbeat** when you launch the watcher
+(`ScheduleWakeup`, ~20–30 min) so a missed or dropped exit-notification can't strand the loop
+with feedback sitting unanswered — a safety net, not a poll; when it fires, re-check for
+unhandled comments and, if none, reschedule it. Its echoed `WATCH <code>` line names the next
+action, so the loop survives even if this skill text has fallen out of context (re-read this
+file if unsure).
 
 Launch the watcher (shipped alongside this skill) right after Step 5, in the background:
 
@@ -247,8 +252,11 @@ When the watcher exits and you are re-invoked:
   declines / defers / discussions are fine). Give the final report and **notify the user** (a
   push notification if available) that the review loop is done — they walked away expecting to
   be pinged.
-- **exit 30** — went quiet. Don't loop blindly: tell the user, and relaunch the watcher only
-  if they want to keep waiting.
+- **exit 30** — a quiet interval elapsed with no CI failure, new round, or sign-off. The PR
+  isn't done, so **don't stop**: relaunch the watcher to keep waiting (reviewers and slow CI can
+  take far longer than one interval). Only after several consecutive quiet cycles — i.e. a long
+  genuine silence — ping the user that it's still watching, then keep watching unless they say to
+  stop. The point is to survive idle periods, not to hand the wait back at the first timeout.
 - **exit 40** — CI failed on the pushed commit. Re-enter the cycle treating the failing jobs
   as feedback, exactly like a review comment:
   1. **Identify** what failed: `gh pr checks $PR` for the overview, then read the failing

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -175,18 +175,19 @@ its **root** comment id — the thread's first comment; for a reply you answered
 then resolve:
 
 ```bash
-# Thread node id + isResolved + its ROOT comment's databaseId. Match a fixed comment to its
+# Each thread's node id + isResolved + its ROOT comment databaseId. Match a fixed comment to its
 # thread by that root id (a review-thread reply carries in_reply_to = the root), so thread length
 # never hides the match: `comments(first:1)` is the root regardless of how many replies follow.
-# `first:100` threads covers all but the largest PRs; if `hasNextPage` is true, page with
-# `after: <endCursor>` rather than silently dropping the overflow (a fixed thread not returned
-# stays unresolved).
+# The first output line is the page cursor: if it shows hasNextPage=true, re-run with
+# `-F after=<endCursor>` and resolve the later pages too, or a fixed thread there stays unresolved.
 gh api graphql -f query='
-query($owner:String!,$repo:String!,$num:Int!){
+query($owner:String!,$repo:String!,$num:Int!,$after:String){
   repository(owner:$owner,name:$repo){ pullRequest(number:$num){
-    reviewThreads(first:100){ pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:1){ nodes { databaseId } } } } } }
+    reviewThreads(first:100,after:$after){ pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:1){ nodes { databaseId } } } } } }
 }' -F owner=$OWNER -F repo=$NAME -F num=$PR \
-  -q '.data.repository.pullRequest.reviewThreads.nodes[] | [.id, (.isResolved|tostring), (.comments.nodes[0].databaseId|tostring)] | @tsv'
+  -q '.data.repository.pullRequest.reviewThreads as $t
+        | "hasNextPage=\($t.pageInfo.hasNextPage) endCursor=\($t.pageInfo.endCursor)",
+          ($t.nodes[] | [.id, (.isResolved|tostring), (.comments.nodes[0].databaseId|tostring)] | @tsv)'
 
 # Resolve a fixed thread by its node id
 gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread { isResolved } } }' -f id=<thread_node_id>

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -237,25 +237,29 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
   # --- new reviewer activity since the push, any of the three surfaces (Codex or a human) ---
-  # Only COMMENTED / CHANGES_REQUESTED reviews are actionable feedback; an APPROVED (or
-  # DISMISSED) review is a sign-off, left to the convergence block — counting it here would
-  # exit 10 instead of 20 and, with no new commit, re-count the same approval forever.
-  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate -q "[.[] | $reviewer | select(.submitted_at > \"$SINCE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length")
-  new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
-  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate -q "[.[] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
+  # Count with `--paginate --slurp | jq`, NOT `--paginate -q`: with -q, gh runs the filter once
+  # per page and prints one count per page, so the arithmetic below breaks on a multi-page PR.
+  # --slurp wraps all pages into a single array (`.[][]` flattens it). Only COMMENTED /
+  # CHANGES_REQUESTED reviews are actionable; an APPROVED (or DISMISSED) review is a sign-off,
+  # left to the convergence block — counting it here would exit 10 instead of 20 and, with no
+  # new commit, re-count the same approval forever.
+  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length")
+  new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
+  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
   if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
-  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off ---
-  # Codex signs off with a 👍 (+1) reaction created AFTER the push; a human signs off by
-  # approving the PR (reviewDecision APPROVED). 👀 (eyes) means "reviewing now" — ignore it.
+  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off that is
+  # newer than the push. Codex signs off with a 👍 (+1) reaction; a human signs off with an
+  # APPROVED review. Both are gated on `> $SINCE` — a stale approval predating the push does not
+  # certify the pushed changes. 👀 (eyes) means "reviewing now" — ignore it.
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
   plus1=$(gh api repos/$REPO/issues/$PR/reactions \
-    -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
-    -q "[.[] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
-  approved=$(gh pr view $PR --repo $REPO --json reviewDecision -q .reviewDecision 2>/dev/null || echo "")
-  if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" = "APPROVED" ]; }; then
+    -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
+    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
+  approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.submitted_at > \"$SINCE\")] | length")
+  if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
   fi
 done

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: address-review
+description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
+---
+
+# Address Review Comments
+
+One full cycle of responding to review feedback on the current branch's PR: read every
+unresolved comment, decide on the merits, fix what is worth fixing, then commit, push,
+reply, and resolve **only the threads you fixed**. Declines, defers, and discussion /
+question comments get a reasoned reply and stay **open** — closing them is the human's call.
+
+The `push-pr` skill delegates here when review comments arrive. After each push this skill
+watches **both CI (GitHub Actions on the pushed commit) and the reviewer's asynchronous
+re-review** in the background, and loops itself through another pass for each new comment
+round or CI failure (Step 7) — so the user can walk away instead of babysitting the cycle,
+and gets pinged only when it truly converges (CI green **and** the reviewer signs off) or
+needs their call. A red build is never "done", no matter what the reviewer says.
+
+## Principles
+
+- **Judge every comment on merit.** Agree or disagree; never auto-apply. A reviewer —
+  especially a bot — can be wrong, stale, or missing project context. Check intent before
+  deciding: `git show <sha>`, the surrounding code, and any design docs. The code may be
+  intentional.
+- **Fix → push → reply → resolve, in that order.** Reply text references the commit that
+  fixed it, so the fix must land first.
+- **Resolve only the threads you actually fixed.** A concrete code change that addresses
+  the comment → reply (referencing the commit), then resolve. **Declines, defers, and
+  discussion / question comments stay OPEN** — they get a reasoned reply, but resolving
+  them closes a conversation that is the human's to close (especially a reviewer's "why…?"
+  or "should we…?", which is an invitation to discuss, not a change request). Never resolve
+  a thread just to clear the queue. When in doubt, leave it open.
+- **Stay scoped** to the feedback. Don't sprawl into unrelated refactors.
+- **Follow the repo's commit conventions** (see the `push-pr` skill). CRITICAL: never add
+  `Co-Authored-By` or any AI / Claude / assistant attribution to commits, replies, or PRs.
+
+## Step 1: Find the PR and its comments
+
+```bash
+gh pr view --json number,url,headRefName,baseRefName \
+  -q '"PR #\(.number)  \(.url)  (\(.headRefName) -> \(.baseRefName))"' || { echo "No PR for this branch"; exit 1; }
+PR=$(gh pr view --json number -q .number)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}; NAME=${REPO#*/}
+```
+
+Fetch all three comment surfaces — any can carry feedback:
+
+```bash
+# Inline (line-level) review comments — the usual source
+gh api repos/$REPO/pulls/$PR/comments --paginate \
+  -q '.[] | {id, user:.user.login, path, line:(.line // .original_line), in_reply_to:.in_reply_to_id, body}'
+
+# Review summaries (top-level review bodies)
+gh api repos/$REPO/pulls/$PR/reviews --paginate -q '.[] | {user:.user.login, state, body}'
+
+# Conversation comments (issue-level)
+gh api repos/$REPO/issues/$PR/comments --paginate -q '.[] | {user:.user.login, body}'
+```
+
+Ignore comments that are already your own replies, and comments on already-resolved threads
+(the GraphQL query in Step 5 reports `isResolved` per thread).
+
+## Step 2: Triage (agree or disagree)
+
+For each open comment, decide and note severity if the bot tagged one (e.g. Codex P1/P2):
+
+- **Fix** — valid and in scope → change the code, then resolve.
+- **Partial / alternative** — valid concern, but a different fix than suggested → explain;
+  resolve only if you land a concrete change, else leave open.
+- **Decline** — wrong, not applicable, or contradicts a deliberate decision → reasoned
+  reply, **leave open**.
+- **Defer** — valid but out of scope for this PR → reply (note where it's tracked),
+  **leave open**.
+- **Discuss** — the reviewer is asking a question or opening a design discussion, not
+  requesting a change → answer it, **leave open** for them to respond.
+
+Present the triage as a short numbered list: comment → verdict → planned fix.
+
+**Autonomy:** invoking this skill authorizes the cycle. Act on clear-cut fixes and clear
+declines without prompting. Pause and confirm only when a fix is risky, large, or whether
+to agree is genuinely unclear. The user may drop or override any item.
+
+## Step 3: Fix
+
+Make the code changes for the Fix / Partial items. Group related changes into a coherent
+set.
+
+**Then judge the resulting whole, not the patch.** Review fixes are local edits into a
+structure that was reviewed as a whole, so they frequently spawn emergent smells: a
+unification that leaves two classes structurally identical, a moved value whose old
+parameter now has no reason to exist, a comment now describing pre-fix code. After the
+fixes, re-read each touched file in its entirety and run the design-integrity and
+comments checks from the `polish` skill (Steps 2 and 4 there) over it — explicitly
+including the structural-twins check. Fix what emerges before committing; fold those
+changes into the same commit and mention them in the relevant replies.
+
+## Step 4: Verify, commit, push
+
+Run the repo's checks before committing so pre-commit / CI find nothing new:
+
+```bash
+# only existing files — ruff fails on deleted paths (E902)
+uv run ruff check <existing files> && uv run ruff format <existing files>   # or the repo's own lint / test / format
+```
+
+Commit (concise, imperative, no AI attribution — see `push-pr` commit style) and push to the
+PR branch:
+
+```bash
+git add <files>
+git commit -m "<imperative summary of the review fixes>"
+git push origin HEAD
+SHA=$(git rev-parse --short HEAD)
+```
+
+## Step 5: Reply, then resolve
+
+**Reply** to each comment: state what changed and the commit (`Fixed in $SHA: ...`), or the
+reasoning for a decline/defer. Write the body to a file to dodge shell-quoting pitfalls
+(apostrophes, backticks):
+
+```bash
+gh api -X POST repos/$REPO/pulls/$PR/comments/<comment_id>/replies -F body=@reply.txt
+```
+
+**Resolve** only the threads you *fixed* (a concrete change landed). Resolution requires
+GraphQL (the REST API can't do it). Map each comment's `databaseId` to its thread node id,
+then resolve:
+
+```bash
+# Thread node id + isResolved + the comment databaseIds it contains
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){ pullRequest(number:$num){
+    reviewThreads(first:50){ nodes { id isResolved comments(first:10){ nodes { databaseId } } } } } }
+}' -F owner=$OWNER -F repo=$NAME -F num=$PR \
+  -q '.data.repository.pullRequest.reviewThreads.nodes[] | [.id, (.isResolved|tostring), ([.comments.nodes[].databaseId]|map(tostring)|join(","))] | @tsv'
+
+# Resolve a fixed thread by its node id
+gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread { isResolved } } }' -f id=<thread_node_id>
+```
+
+**Leave declined, deferred, and discussion threads OPEN** — each carries a reasoned reply,
+but closing the conversation is the human's call (resolving a "why…?"/"should we…?" thread
+preempts a discussion they opened on purpose). The reply records your reasoning either way,
+and the human resolves when satisfied.
+
+## Step 6: Report
+
+Summarize:
+- a table of comment → verdict → fix (with commit SHA),
+- what was pushed,
+- which threads you resolved (fixes only) vs left open (declines / defers / discussion),
+- any follow-ups the user should track.
+
+A bot will re-review on push and may add comments. **Don't hand the watch back to the
+user** — go to Step 7, which watches for that re-review in the background and loops you
+through another pass automatically until the reviewer converges.
+
+## Step 7: Watch for convergence in the background (so the user doesn't have to)
+
+Two signals decide whether a push actually lands the PR, and **both are asynchronous**: CI
+(GitHub Actions, minutes) and Codex's re-review (a few minutes later). The user should poll
+neither. After Step 5, launch one background watcher that blocks until something actionable
+happens, then loop on how it exits:
+
+- exit **10** → a new round of Codex comments landed → run another full pass (Steps 1–6),
+  which ends right back here and relaunches the watcher;
+- exit **20** → truly converged: **CI green on the pushed commit AND** Codex 👍 newer than
+  the push → give the final report, **notify the user**, and **stop**;
+- exit **30** → nothing came back within the cap → tell the user it went quiet;
+- exit **40** → **CI failed on the pushed commit** → run a CI-fix pass (below), which ends
+  back here and relaunches the watcher.
+
+CI failure is the **highest-priority** exit — a red build is never "converged" regardless of
+what Codex says, so the watcher checks it first and gates exit 20 on CI being green. It judges
+CI **only for the commit you pushed** (`HEAD` sha), so stale runs from earlier commits can't
+confuse it, and acts only once a check has *completed* with a failing conclusion.
+
+The watcher just polls `gh`, so it costs no tokens while it waits. It is **harness-tracked**:
+when it exits you are re-invoked automatically with its output — so launch it with
+`run_in_background` and **don't** also schedule a wakeup to poll for it. Its echoed
+`WATCH <code>` line names the next action, so the loop survives even if this skill text has
+fallen out of context (re-read this file if unsure).
+
+Launch this right after Step 5, in the background:
+
+```bash
+set -e
+PR=$(gh pr view --json number -q .number)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
+PUSH_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)               # ISO-8601 UTC sorts lexically
+codex='select(.user.login|test("codex"))'
+# Baseline counts captured right after your push; a NEW round increments one of them.
+base_reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
+base_comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $codex] | length")
+deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  sleep 90
+  # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
+  cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null || echo '{}')
+  fail=$(echo "$cr"    | jq '[.check_runs[]? | select(.conclusion=="failure" or .conclusion=="timed_out")] | length')
+  pending=$(echo "$cr" | jq '[.check_runs[]? | select(.status!="completed")] | length')
+  total=$(echo "$cr"   | jq '[.check_runs[]?] | length')
+  if [ "$fail" -gt 0 ]; then
+    echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
+  fi
+  # --- new Codex round ---
+  reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
+  comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $codex] | length")
+  if [ "$reviews" -gt "$base_reviews" ] || [ "$comments" -gt "$base_comments" ]; then
+    echo "WATCH 10: new Codex round — run another address-review pass (Steps 1-6)"; exit 10
+  fi
+  # --- convergence: CI green (all checks done, none failing) AND Codex 👍 newer than push ---
+  # 👍 (+1) created AFTER the push = signed off. 👀 (eyes) means "reviewing now" — ignore it.
+  ci_green=false
+  [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
+  plus1=$(gh api repos/$REPO/issues/$PR/reactions \
+    -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
+    -q "[.[] | $codex | select(.content==\"+1\") | select(.created_at > \"$PUSH_ISO\")] | length")
+  if [ "$plus1" -gt 0 ] && [ "$ci_green" = true ]; then
+    echo "WATCH 20: converged (CI green + Codex 👍 newer than push) — done"; exit 20
+  fi
+done
+echo "WATCH 30: no verdict after 25m — tell the user"; exit 30
+```
+
+When the watcher exits and you are re-invoked:
+
+- **exit 10** — run Steps 1–6 on the new comments, then relaunch the watcher.
+  **Stop-guard:** if the round only re-flags comments you already declined (Codex re-posts
+  declined items as fresh threads), that is **not** convergence — reply once more pointing at
+  your prior reasoning, then **stop and surface it for the user**; never loop into forcing a
+  fix you disagree with.
+- **exit 20** — converged: CI is green on the pushed commit, the 👍 is newer than your push,
+  and every comment carries your reply (open declines / defers / discussions are fine).
+  Give the final report and **notify the user** (a push notification if available) that the
+  review loop is done — they walked away expecting to be pinged.
+- **exit 30** — went quiet. Don't loop blindly: tell the user, and relaunch the watcher only
+  if they want to keep waiting.
+- **exit 40** — CI failed on the pushed commit. Re-enter the cycle treating the failing jobs
+  as feedback, exactly like a review comment:
+  1. **Identify** what failed: `gh pr checks $PR` for the overview, then read the failing
+     job's log — `gh run view --job <job-id> --log-failed` (the job id is in the check URL) —
+     for the actual error, not just the red X.
+  2. **Triage on merit**, the same Fix / flaky / decline split as a comment:
+     - *Real defect in this PR's changes* → fix it, verify locally if you can, push (the
+       watcher relaunches on the new commit).
+     - *Flaky / infra* (network blip, runner hiccup, transient) → `gh run rerun <run-id>
+       --failed` and relaunch the watcher; change no code.
+     - *Consequence of a deliberate design choice in the PR* (e.g. an interpreter version,
+       platform, or dependency the change knowingly can't satisfy at the pinned date) → this
+       is **not** a mechanical fix. **Stop and surface it to the user with options** (narrow
+       scope, pin/exclude, accept the gap); don't silently commit-thrash to force it green.
+  3. **Stop-guard:** never retry the same fix more than once or twice. If a CI failure
+     persists after your fix, stop and surface it rather than churning the PR with commits.
+
+For **human** reviewers the equivalent convergence signal is an approval —
+`gh pr view --json reviewDecision -q .reviewDecision` returning `APPROVED` (still gated on CI
+green: don't call a PR done with a red build).

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: address-review
 description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git rev-parse:*), Bash(git show:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh run:*), Bash(uv run:*)
 ---
 
 # Address Review Comments

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -144,11 +144,14 @@ reviewers. Resolution requires GraphQL (the REST API can't do it). Map each comm
 `databaseId` to its thread node id, then resolve:
 
 ```bash
-# Thread node id + isResolved + the comment databaseIds it contains
+# Thread node id + isResolved + the comment databaseIds it contains. `first:100` covers all
+# but the largest PRs; if `hasNextPage` is true, page with `after: <endCursor>` rather than
+# silently dropping the overflow threads (a fixed thread that isn't returned stays unresolved).
+# `comments(first:10)` is enough to match the original review comment, which is always first.
 gh api graphql -f query='
 query($owner:String!,$repo:String!,$num:Int!){
   repository(owner:$owner,name:$repo){ pullRequest(number:$num){
-    reviewThreads(first:50){ nodes { id isResolved comments(first:10){ nodes { databaseId } } } } } }
+    reviewThreads(first:100){ pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:10){ nodes { databaseId } } } } } }
 }' -F owner=$OWNER -F repo=$NAME -F num=$PR \
   -q '.data.repository.pullRequest.reviewThreads.nodes[] | [.id, (.isResolved|tostring), ([.comments.nodes[].databaseId]|map(tostring)|join(","))] | @tsv'
 
@@ -207,19 +210,18 @@ set -e
 PR=$(gh pr view --json number -q .number)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
-PUSH_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)               # ISO-8601 UTC sorts lexically
+# Anchor to the pushed commit's own timestamp, NOT to when this watcher launches: the
+# reply/resolve work in Step 5 takes a while and a reviewer can respond in that window, so a
+# launch-time anchor would fold those responses into the baseline and miss them. Counting
+# reviewer activity created after the commit time catches them no matter when the loop starts.
+# In UTC with a Z suffix so it sorts lexically against GitHub's UTC timestamps (a local-offset
+# %cI like +03:00 would mis-compare against their Z form).
+SINCE=$(TZ=UTC0 git show -s --date=format-local:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
 ME=$(gh api user -q .login)                            # the PR author — exclude your own replies
 # A tracked reviewer is the Codex bot OR any human; other bots (e.g. the repo's Claude review
 # workflow) are intentionally NOT gated on. So: login matches "codex", or is a non-bot that
 # isn't you.
 reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]\")|not) and (.user.login!=\"$ME\")))"
-# Baseline counts captured right after your push; a NEW round from any tracked reviewer
-# increments one of them. All three surfaces are polled — the next round can arrive as inline
-# comments, a review body, OR a combined issue-level comment (the surface Step 1/Step 5 handle),
-# so missing any one would strand actionable feedback and time out as "quiet".
-base_reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $reviewer] | length")
-base_comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer] | length")
-base_issue=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $reviewer] | length")
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
@@ -234,11 +236,11 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if [ "$fail" -gt 0 ]; then
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
-  # --- new reviewer round, any of the three surfaces (Codex or a human) ---
-  reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $reviewer] | length")
-  comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer] | length")
-  issuec=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $reviewer] | length")
-  if [ "$reviews" -gt "$base_reviews" ] || [ "$comments" -gt "$base_comments" ] || [ "$issuec" -gt "$base_issue" ]; then
+  # --- new reviewer activity since the push, any of the three surfaces (Codex or a human) ---
+  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate -q "[.[] | $reviewer | select(.submitted_at > \"$SINCE\")] | length")
+  new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
+  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate -q "[.[] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
+  if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
   # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off ---
@@ -248,7 +250,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
   plus1=$(gh api repos/$REPO/issues/$PR/reactions \
     -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
-    -q "[.[] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$PUSH_ISO\")] | length")
+    -q "[.[] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
   approved=$(gh pr view $PR --repo $REPO --json reviewDecision -q .reviewDecision 2>/dev/null || echo "")
   if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" = "APPROVED" ]; }; then
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -48,6 +48,7 @@ gh pr view --json number,url,headRefName,baseRefName \
 PR=$(gh pr view --json number -q .number)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 OWNER=${REPO%/*}; NAME=${REPO#*/}
+HEAD_REF=$(gh pr view --json headRefName -q .headRefName)   # the PR's head branch — push to this
 ```
 
 Fetch all three comment surfaces — any can carry feedback:
@@ -128,7 +129,7 @@ if git diff --cached --quiet; then
   SHA=$(git rev-parse --short HEAD)        # nothing staged — keep HEAD, go reply
 else
   git commit -m "<imperative summary of the review fixes>"
-  git push origin HEAD
+  git push origin HEAD:"$HEAD_REF"   # explicit refspec — local branch may not match the PR head
   SHA=$(git rev-parse --short HEAD)
 fi
 ```

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -126,8 +126,11 @@ reasoning for a decline/defer. Write the body to a file to dodge shell-quoting p
 (apostrophes, backticks). The endpoint depends on which surface the comment came from:
 
 ```bash
-# Inline (line-level) review comment — reply into its thread:
-gh api -X POST repos/$REPO/pulls/$PR/comments/<comment_id>/replies -F body=@reply.txt
+# Inline (line-level) review comment — reply into its thread. The id must be the thread's
+# TOP-LEVEL comment; GitHub rejects a reply addressed to a reply. If the comment you're
+# answering is itself a follow-up, Step 1 shows its `in_reply_to` (the thread root) — use that
+# id here instead of the follow-up's own id.
+gh api -X POST repos/$REPO/pulls/$PR/comments/<root_comment_id>/replies -F body=@reply.txt
 
 # Review summary (top-level review body) or issue-level conversation comment — these have no
 # inline thread, so post a normal PR comment that quotes/links what you are answering:

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -119,11 +119,20 @@ SHA=$(git rev-parse --short HEAD)
 
 **Reply** to each comment: state what changed and the commit (`Fixed in $SHA: ...`), or the
 reasoning for a decline/defer. Write the body to a file to dodge shell-quoting pitfalls
-(apostrophes, backticks):
+(apostrophes, backticks). The endpoint depends on which surface the comment came from:
 
 ```bash
+# Inline (line-level) review comment — reply into its thread:
 gh api -X POST repos/$REPO/pulls/$PR/comments/<comment_id>/replies -F body=@reply.txt
+
+# Review summary (top-level review body) or issue-level conversation comment — these have no
+# inline thread, so post a normal PR comment that quotes/links what you are answering:
+gh api -X POST repos/$REPO/issues/$PR/comments -F body=@reply.txt
 ```
+
+A combined review (e.g. one Codex body carrying several findings) arrives as a single
+conversation comment, not per-finding threads — answer it with one issue-level reply that
+addresses each finding; there is nothing to resolve in Step 5 for that surface.
 
 **Resolve** only the threads you *fixed* (a concrete change landed). Resolution requires
 GraphQL (the REST API can't do it). Map each comment's `databaseId` to its thread node id,
@@ -193,6 +202,8 @@ PR=$(gh pr view --json number -q .number)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
 PUSH_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)               # ISO-8601 UTC sorts lexically
+# Tracked reviewers are Codex and humans; the repo's Claude review workflow is intentionally
+# not gated on, so the predicate matches only the Codex bot.
 codex='select(.user.login|test("codex"))'
 # Baseline counts captured right after your push; a NEW round increments one of them.
 base_reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
@@ -202,7 +213,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
   # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
   cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null || echo '{}')
-  fail=$(echo "$cr"    | jq '[.check_runs[]? | select(.conclusion=="failure" or .conclusion=="timed_out")] | length')
+  # Any completed check whose conclusion is outside the passing set counts as failed — this
+  # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a
+  # non-passing-but-not-"failure" check can never be mistaken for green.
+  fail=$(echo "$cr"    | jq '[.check_runs[]? | select(.status=="completed") | select((.conclusion // "") as $c | (["success","neutral","skipped"] | index($c)) == null)] | length')
   pending=$(echo "$cr" | jq '[.check_runs[]? | select(.status!="completed")] | length')
   total=$(echo "$cr"   | jq '[.check_runs[]?] | length')
   if [ "$fail" -gt 0 ]; then

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: address-review
 description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
-allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*)
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(awk:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*)
 ---
 
 # Address Review Comments
@@ -53,7 +53,9 @@ OWNER=${REPO%/*}; NAME=${REPO#*/}
 # the PR — never hard-code a remote.
 HEAD_REF=$(gh pr view --json headRefName -q .headRefName)
 HEAD_REPO=$(gh pr view --json headRepositoryOwner,headRepository -q '.headRepositoryOwner.login + "/" + .headRepository.name')
-git remote -v     # HEAD_REMOTE = the entry whose URL is $HEAD_REPO (origin = your fork in the standard setup)
+# the local remote whose URL hosts $HEAD_REPO — origin in the standard fork setup; empty only if
+# no remote points at the head repo, in which case the Step 4 push fails loudly (add the remote)
+HEAD_REMOTE=$(git remote -v | awk -v r="$HEAD_REPO" '$2 ~ "[:/]" r "(\\.git)?$" {print $1; exit}')
 ```
 
 `REPO` (base) is where every `gh api repos/$REPO/...` read below goes; `HEAD_REMOTE` + `HEAD_REF`

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -262,10 +262,16 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   # Inline (the surface Codex/humans use most): race-free and timestamp-free — count UNRESOLVED
   # threads whose latest comment is a reviewer's (not you). A thread you handled has your reply
   # as its last comment (fixed ones are also resolved), so neither handled nor declined threads
-  # re-trigger; only an unanswered reviewer comment does.
-  new=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' \
-    -F o=$OWNER -F r=$NAME -F n=$PR \
-    --jq "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | (.comments.nodes[-1].author.login // \"\") | select(test(\"codex\") or ((endswith(\"[bot]\")|not) and (. != \"$ME\")))] | length")
+  # re-trigger; only an unanswered reviewer comment does. Paginate by cursor: threads come back
+  # oldest-first, so on a PR with >100 threads a fresh unanswered round sits on the LAST page.
+  new=0; after=""; more=true
+  while [ "$more" = "true" ]; do
+    targs=(-F o=$OWNER -F r=$NAME -F n=$PR); [ -n "$after" ] && targs+=(-F after="$after")
+    page=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!,$after:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' "${targs[@]}")
+    new=$(( new + $(echo "$page" | jq "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | (.comments.nodes[-1].author.login // \"\") | select(test(\"codex\") or ((endswith(\"[bot]\")|not) and (. != \"$ME\")))] | length") ))
+    more=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+    after=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+  done
   # Review summaries + issue comments have no per-item state, so they're time-anchored on
   # SINCE_DONE with `--paginate --slurp | jq` (NOT `--paginate -q`, which prints one count per
   # page and breaks the arithmetic). COMMENTED/CHANGES_REQUESTED only — an APPROVED/DISMISSED

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -237,7 +237,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
   # --- new reviewer activity since the push, any of the three surfaces (Codex or a human) ---
-  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate -q "[.[] | $reviewer | select(.submitted_at > \"$SINCE\")] | length")
+  # Only COMMENTED / CHANGES_REQUESTED reviews are actionable feedback; an APPROVED (or
+  # DISMISSED) review is a sign-off, left to the convergence block — counting it here would
+  # exit 10 instead of 20 and, with no new commit, re-count the same approval forever.
+  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate -q "[.[] | $reviewer | select(.submitted_at > \"$SINCE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length")
   new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
   new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate -q "[.[] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
   if [ "$new" -gt 0 ]; then

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -169,20 +169,24 @@ addresses each finding; there is nothing to resolve in Step 5 for that surface.
 
 **Resolve** every thread you *fixed* (a concrete change landed) — this is mandatory, not
 optional: a fixed Codex thread you leave open keeps the PR looking unaddressed to human
-reviewers. Resolution requires GraphQL (the REST API can't do it). Map each comment's
-`databaseId` to its thread node id, then resolve:
+reviewers. Resolution requires GraphQL (the REST API can't do it). Identify each fixed thread by
+its **root** comment id — the thread's first comment; for a reply you answered that's its
+`in_reply_to` (Step 1 shows it), otherwise the comment's own id. Match that root id to the thread,
+then resolve:
 
 ```bash
-# Thread node id + isResolved + the comment databaseIds it contains. `first:100` covers all
-# but the largest PRs; if `hasNextPage` is true, page with `after: <endCursor>` rather than
-# silently dropping the overflow threads (a fixed thread that isn't returned stays unresolved).
-# `comments(first:10)` is enough to match the original review comment, which is always first.
+# Thread node id + isResolved + its ROOT comment's databaseId. Match a fixed comment to its
+# thread by that root id (a review-thread reply carries in_reply_to = the root), so thread length
+# never hides the match: `comments(first:1)` is the root regardless of how many replies follow.
+# `first:100` threads covers all but the largest PRs; if `hasNextPage` is true, page with
+# `after: <endCursor>` rather than silently dropping the overflow (a fixed thread not returned
+# stays unresolved).
 gh api graphql -f query='
 query($owner:String!,$repo:String!,$num:Int!){
   repository(owner:$owner,name:$repo){ pullRequest(number:$num){
-    reviewThreads(first:100){ pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:10){ nodes { databaseId } } } } } }
+    reviewThreads(first:100){ pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:1){ nodes { databaseId } } } } } }
 }' -F owner=$OWNER -F repo=$NAME -F num=$PR \
-  -q '.data.repository.pullRequest.reviewThreads.nodes[] | [.id, (.isResolved|tostring), ([.comments.nodes[].databaseId]|map(tostring)|join(","))] | @tsv'
+  -q '.data.repository.pullRequest.reviewThreads.nodes[] | [.id, (.isResolved|tostring), (.comments.nodes[0].databaseId|tostring)] | @tsv'
 
 # Resolve a fixed thread by its node id
 gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread { isResolved } } }' -f id=<thread_node_id>

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: address-review
 description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
-allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(awk:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*)
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(awk:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*), Edit, Write
 ---
 
 # Address Review Comments

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -208,7 +208,9 @@ blocks until something actionable happens, then loop on how it exits:
 - exit **30** → a quiet interval elapsed → **relaunch the watcher and keep waiting** (don't
   stop); only after several consecutive quiet cycles ping the user that it's still watching;
 - exit **40** → **CI failed on the pushed commit** → run a CI-fix pass (below), which ends
-  back here and relaunches the watcher.
+  back here and relaunches the watcher;
+- exit **50** → **CI couldn't be read** (the check-runs API kept failing) → stop and tell the
+  user; it's a token/permission or outage problem, not something to loop on.
 
 CI failure is the **highest-priority** exit — a red build is never "converged" regardless of
 what the reviewer says, so the watcher checks it first and gates exit 20 on CI being green. It judges
@@ -274,3 +276,7 @@ When the watcher exits and you are re-invoked:
        scope, pin/exclude, accept the gap); don't silently commit-thrash to force it green.
   3. **Stop-guard:** never retry the same fix more than once or twice. If a CI failure
      persists after your fix, stop and surface it rather than churning the PR with commits.
+- **exit 50** — the watcher couldn't read check runs for the pushed commit even after retries.
+  This is an environment problem (most often the token lacks the checks-read scope, or a GitHub
+  outage), not reviewer feedback. **Stop and tell the user** the SHA and the likely cause —
+  don't relaunch, which would just hit the same wall.

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -284,16 +284,19 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
-  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off that is
-  # newer than the push. Codex signs off with a 👍 (+1) reaction; a human signs off with an
-  # APPROVED review. Both are gated on `> $SINCE` — a stale approval predating the push does not
-  # certify the pushed changes. 👀 (eyes) means "reviewing now" — ignore it.
+  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off for THIS
+  # pushed commit. Codex signs off with a 👍 (+1) reaction; a human with an APPROVED review.
+  # The approval is pinned to the exact SHA (commit_id == $SHA) so a sign-off for an earlier PR
+  # state — e.g. one that landed between the local commit and a delayed/retried push — can't be
+  # mistaken for certifying these changes. The 👍 path needs no SHA pin: only Codex 👍 counts,
+  # and Codex reacts only after the push triggers its re-review, so its 👍 is always post-push;
+  # `> $SINCE` just rules out a 👍 left for a prior commit. 👀 (eyes) = "reviewing now" — ignore.
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
   plus1=$(gh api repos/$REPO/issues/$PR/reactions \
     -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
     | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
-  approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.submitted_at > \"$SINCE\")] | length")
+  approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
   if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
   fi

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -46,8 +46,9 @@ needs their call. A red build is never "done", no matter what the reviewer says.
 gh pr view --json number,url,headRefName,baseRefName \
   -q '"PR #\(.number)  \(.url)  (\(.headRefName) -> \(.baseRefName))"' || { echo "No PR for this branch"; exit 1; }
 PR=$(gh pr view --json number -q .number)
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)        # BASE repo — the PR and its comments live here
-OWNER=${REPO%/*}; NAME=${REPO#*/}
+REPO=$(gh pr view --json url -q .url | awk -F/ '{print $4"/"$5}')  # BASE repo from the PR URL — the PR and
+OWNER=${REPO%/*}; NAME=${REPO#*/}                                  # its comments live here; gh repo view can
+                                                                  # return the fork in a fork checkout
 # The PR's head branch + the repo that hosts it. In a cross-repo (fork) PR the head repo is NOT
 # $REPO: the PR lives on the base, its commits belong on the fork. Derive the push target from
 # the PR — never hard-code a remote.

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -102,6 +102,12 @@ changes into the same commit and mention them in the relevant replies.
 
 ## Step 4: Verify, commit, push
 
+Re-run the Step 1 fetch right before committing and triage anything new. A comment that lands
+while you were fixing — after your first fetch but before this commit — is in a blind spot:
+the Step 7 watcher only counts activity created after the commit it anchors on, so without this
+re-fetch that feedback is in neither the triage list nor the watcher and gets silently skipped.
+Fold late arrivals into this same pass.
+
 Run the repo's checks before committing so pre-commit / CI find nothing new:
 
 ```bash

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -176,20 +176,21 @@ through another pass automatically until the reviewer converges.
 ## Step 7: Watch for convergence in the background (so the user doesn't have to)
 
 Two signals decide whether a push actually lands the PR, and **both are asynchronous**: CI
-(GitHub Actions, minutes) and Codex's re-review (a few minutes later). The user should poll
-neither. After Step 5, launch one background watcher that blocks until something actionable
-happens, then loop on how it exits:
+(GitHub Actions, minutes) and the reviewer's re-review (Codex within minutes, a human whenever
+they get to it). The user should poll neither. After Step 5, launch one background watcher that
+blocks until something actionable happens, then loop on how it exits:
 
-- exit **10** → a new round of Codex comments landed → run another full pass (Steps 1–6),
-  which ends right back here and relaunches the watcher;
-- exit **20** → truly converged: **CI green on the pushed commit AND** Codex 👍 newer than
-  the push → give the final report, **notify the user**, and **stop**;
+- exit **10** → a new round of reviewer comments landed (Codex or a human) → run another full
+  pass (Steps 1–6), which ends right back here and relaunches the watcher;
+- exit **20** → truly converged: **CI green on the pushed commit AND** a reviewer sign-off
+  (Codex 👍 newer than the push, or a human approval) → give the final report, **notify the
+  user**, and **stop**;
 - exit **30** → nothing came back within the cap → tell the user it went quiet;
 - exit **40** → **CI failed on the pushed commit** → run a CI-fix pass (below), which ends
   back here and relaunches the watcher.
 
 CI failure is the **highest-priority** exit — a red build is never "converged" regardless of
-what Codex says, so the watcher checks it first and gates exit 20 on CI being green. It judges
+what the reviewer says, so the watcher checks it first and gates exit 20 on CI being green. It judges
 CI **only for the commit you pushed** (`HEAD` sha), so stale runs from earlier commits can't
 confuse it, and acts only once a check has *completed* with a failing conclusion.
 
@@ -207,16 +208,18 @@ PR=$(gh pr view --json number -q .number)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
 PUSH_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)               # ISO-8601 UTC sorts lexically
-# Tracked reviewers are Codex and humans; the repo's Claude review workflow is intentionally
-# not gated on, so the predicate matches only the Codex bot.
-codex='select(.user.login|test("codex"))'
-# Baseline counts captured right after your push; a NEW round increments one of them. All
-# three surfaces are polled — Codex may post the next round as inline comments, a review body,
-# OR a combined issue-level comment (the surface Step 1/Step 5 handle), so missing any one
-# would strand actionable feedback and time out as "quiet".
-base_reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
-base_comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $codex] | length")
-base_issue=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $codex] | length")
+ME=$(gh api user -q .login)                            # the PR author — exclude your own replies
+# A tracked reviewer is the Codex bot OR any human; other bots (e.g. the repo's Claude review
+# workflow) are intentionally NOT gated on. So: login matches "codex", or is a non-bot that
+# isn't you.
+reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]\")|not) and (.user.login!=\"$ME\")))"
+# Baseline counts captured right after your push; a NEW round from any tracked reviewer
+# increments one of them. All three surfaces are polled — the next round can arrive as inline
+# comments, a review body, OR a combined issue-level comment (the surface Step 1/Step 5 handle),
+# so missing any one would strand actionable feedback and time out as "quiet".
+base_reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $reviewer] | length")
+base_comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer] | length")
+base_issue=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $reviewer] | length")
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
@@ -231,22 +234,24 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if [ "$fail" -gt 0 ]; then
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
-  # --- new Codex round (any of the three surfaces) ---
-  reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
-  comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $codex] | length")
-  issuec=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $codex] | length")
+  # --- new reviewer round, any of the three surfaces (Codex or a human) ---
+  reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $reviewer] | length")
+  comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $reviewer] | length")
+  issuec=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $reviewer] | length")
   if [ "$reviews" -gt "$base_reviews" ] || [ "$comments" -gt "$base_comments" ] || [ "$issuec" -gt "$base_issue" ]; then
-    echo "WATCH 10: new Codex round — run another address-review pass (Steps 1-6)"; exit 10
+    echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
-  # --- convergence: CI green (all checks done, none failing) AND Codex 👍 newer than push ---
-  # 👍 (+1) created AFTER the push = signed off. 👀 (eyes) means "reviewing now" — ignore it.
+  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off ---
+  # Codex signs off with a 👍 (+1) reaction created AFTER the push; a human signs off by
+  # approving the PR (reviewDecision APPROVED). 👀 (eyes) means "reviewing now" — ignore it.
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
   plus1=$(gh api repos/$REPO/issues/$PR/reactions \
     -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
-    -q "[.[] | $codex | select(.content==\"+1\") | select(.created_at > \"$PUSH_ISO\")] | length")
-  if [ "$plus1" -gt 0 ] && [ "$ci_green" = true ]; then
-    echo "WATCH 20: converged (CI green + Codex 👍 newer than push) — done"; exit 20
+    -q "[.[] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$PUSH_ISO\")] | length")
+  approved=$(gh pr view $PR --repo $REPO --json reviewDecision -q .reviewDecision 2>/dev/null || echo "")
+  if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" = "APPROVED" ]; }; then
+    echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
   fi
 done
 echo "WATCH 30: no verdict after 25m — tell the user"; exit 30
@@ -259,10 +264,11 @@ When the watcher exits and you are re-invoked:
   declined items as fresh threads), that is **not** convergence — reply once more pointing at
   your prior reasoning, then **stop and surface it for the user**; never loop into forcing a
   fix you disagree with.
-- **exit 20** — converged: CI is green on the pushed commit, the 👍 is newer than your push,
-  and every comment carries your reply (open declines / defers / discussions are fine).
-  Give the final report and **notify the user** (a push notification if available) that the
-  review loop is done — they walked away expecting to be pinged.
+- **exit 20** — converged: CI is green on the pushed commit, a reviewer signed off (Codex 👍
+  newer than your push, or a human approval), and every comment carries your reply (open
+  declines / defers / discussions are fine). Give the final report and **notify the user** (a
+  push notification if available) that the review loop is done — they walked away expecting to
+  be pinged.
 - **exit 30** — went quiet. Don't loop blindly: tell the user, and relaunch the watcher only
   if they want to keep waiting.
 - **exit 40** — CI failed on the pushed commit. Re-enter the cycle treating the failing jobs
@@ -281,7 +287,3 @@ When the watcher exits and you are re-invoked:
        scope, pin/exclude, accept the gap); don't silently commit-thrash to force it green.
   3. **Stop-guard:** never retry the same fix more than once or twice. If a CI failure
      persists after your fix, stop and surface it rather than churning the PR with commits.
-
-For **human** reviewers the equivalent convergence signal is an approval —
-`gh pr view --json reviewDecision -q .reviewDecision` returning `APPROVED` (still gated on CI
-green: don't call a PR done with a red build).

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -218,6 +218,7 @@ Launch this right after Step 5, in the background:
 set -e
 PR=$(gh pr view --json number -q .number)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}; NAME=${REPO#*/}                      # for the GraphQL thread query below
 SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
 # Anchor to the pushed commit's own timestamp, NOT to when this watcher launches: the
 # reply/resolve work in Step 5 takes a while and a reviewer can respond in that window, so a
@@ -231,14 +232,15 @@ ME=$(gh api user -q .login)                            # the PR author — exclu
 # workflow) are intentionally NOT gated on. So: login matches "codex", or is a non-bot that
 # isn't you.
 reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]\")|not) and (.user.login!=\"$ME\")))"
-# Re-entry needs a second anchor. SINCE (commit time) is right for sign-off — a 👍/approval any
-# time after the push counts — but wrong for new feedback: a decline-only pass makes no commit,
-# so SINCE wouldn't advance and the just-handled comment would re-trigger exit 10 forever. You
-# reply to every comment you handle, so your own latest reply post-dates anything already
-# processed; anchor re-entry at the later of SINCE and that reply (lexical max — all UTC Z).
-me_inline=$(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+# Re-entry can't key off SINCE alone: a decline-only pass makes no commit (SINCE wouldn't
+# advance, so the handled comment would re-trigger forever), and your own reply can post-date a
+# reviewer comment that arrived mid-pass (burying it under a later anchor). Inline feedback is
+# therefore detected structurally below — an unresolved thread whose last comment is a
+# reviewer's, no timestamps. The review-summary and issue-comment surfaces have no per-item
+# resolved state, so they fall back to a timestamp: SINCE_DONE = the later of the commit and
+# your latest issue-level reply, which clears anything you have already answered there.
 me_issue=$(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
-SINCE_DONE=$(printf '%s\n%s\n%s\n' "$SINCE" "$me_inline" "$me_issue" | sort | tail -1)
+SINCE_DONE=$(printf '%s\n%s\n' "$SINCE" "$me_issue" | sort | tail -1)
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
@@ -256,14 +258,21 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if [ "$fail" -gt 0 ]; then
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
-  # --- new reviewer activity since you finished (SINCE_DONE), any of the three surfaces ---
-  # Count with `--paginate --slurp | jq`, NOT `--paginate -q`: with -q, gh runs the filter once
-  # per page and prints one count per page, so the arithmetic below breaks on a multi-page PR.
-  # --slurp wraps all pages into a single array (`.[][]` flattens it). Only COMMENTED /
-  # CHANGES_REQUESTED reviews are actionable; an APPROVED (or DISMISSED) review is a sign-off,
-  # left to the convergence block.
-  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length")
-  new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
+  # --- new reviewer feedback to re-enter on ---
+  # Inline (the surface Codex/humans use most): race-free and timestamp-free — count UNRESOLVED
+  # threads whose latest comment is a reviewer's (not you). A thread you handled has your reply
+  # as its last comment (fixed ones are also resolved), so neither handled nor declined threads
+  # re-trigger; only an unanswered reviewer comment does.
+  new=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' \
+    -F o=$OWNER -F r=$NAME -F n=$PR \
+    --jq "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | (.comments.nodes[-1].author.login // \"\") | select(test(\"codex\") or ((endswith(\"[bot]\")|not) and (. != \"$ME\")))] | length")
+  # Review summaries + issue comments have no per-item state, so they're time-anchored on
+  # SINCE_DONE with `--paginate --slurp | jq` (NOT `--paginate -q`, which prints one count per
+  # page and breaks the arithmetic). COMMENTED/CHANGES_REQUESTED only — an APPROVED/DISMISSED
+  # review is a sign-off for the convergence block. This timestamp path is best-effort, but a
+  # round that also carries inline comments is caught race-free above, so the gap is only a
+  # body-only review/comment landing in your reply window — rare, and it surfaces on next trigger.
+  new=$(( new + $(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length") ))
   new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
   if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: address-review
 description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
-allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git rev-parse:*), Bash(git show:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh run:*), Bash(uv run:*)
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*)
 ---
 
 # Address Review Comments
@@ -117,13 +117,20 @@ uv run --locked ruff check <existing files> && uv run --locked ruff format <exis
 ```
 
 Commit (concise, imperative, no AI attribution — see `push-pr` commit style) and push to the
-PR branch:
+PR branch — but only if this pass actually changed files. A decline/defer/discuss-only round
+or a flaky-CI rerun stages nothing, and an empty `git commit` exits non-zero and would abort
+the pass before you reply; in that case skip the commit/push and reply against the current
+`HEAD`:
 
 ```bash
 git add <files>
-git commit -m "<imperative summary of the review fixes>"
-git push origin HEAD
-SHA=$(git rev-parse --short HEAD)
+if git diff --cached --quiet; then
+  SHA=$(git rev-parse --short HEAD)        # nothing staged — keep HEAD, go reply
+else
+  git commit -m "<imperative summary of the review fixes>"
+  git push origin HEAD
+  SHA=$(git rev-parse --short HEAD)
+fi
 ```
 
 ## Step 5: Reply, then resolve
@@ -213,96 +220,20 @@ when it exits you are re-invoked automatically with its output — so launch it 
 `WATCH <code>` line names the next action, so the loop survives even if this skill text has
 fallen out of context (re-read this file if unsure).
 
-Launch this right after Step 5, in the background:
+Launch the watcher (shipped alongside this skill) right after Step 5, in the background:
 
 ```bash
-set -e
-PR=$(gh pr view --json number -q .number)
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-OWNER=${REPO%/*}; NAME=${REPO#*/}                      # for the GraphQL thread query below
-SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
-# Anchor to the pushed commit's own timestamp, NOT to when this watcher launches: the
-# reply/resolve work in Step 5 takes a while and a reviewer can respond in that window, so a
-# launch-time anchor would fold those responses into the baseline and miss them. Counting
-# reviewer activity created after the commit time catches them no matter when the loop starts.
-# In UTC with a Z suffix so it sorts lexically against GitHub's UTC timestamps (a local-offset
-# %cI like +03:00 would mis-compare against their Z form).
-SINCE=$(TZ=UTC0 git show -s --date=format-local:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
-ME=$(gh api user -q .login)                            # the PR author — exclude your own replies
-# A tracked reviewer is the Codex bot OR any human; other bots (e.g. the repo's Claude review
-# workflow) are intentionally NOT gated on. So: login matches "codex", or is a non-bot that
-# isn't you.
-reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]\")|not) and (.user.login!=\"$ME\")))"
-# Re-entry can't key off SINCE alone: a decline-only pass makes no commit (SINCE wouldn't
-# advance, so the handled comment would re-trigger forever), and your own reply can post-date a
-# reviewer comment that arrived mid-pass (burying it under a later anchor). Inline feedback is
-# therefore detected structurally below — an unresolved thread whose last comment is a
-# reviewer's, no timestamps. The review-summary and issue-comment surfaces have no per-item
-# resolved state, so they fall back to a timestamp: SINCE_DONE = the later of the commit and
-# your latest issue-level reply, which clears anything you have already answered there.
-me_issue=$(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
-SINCE_DONE=$(printf '%s\n%s\n' "$SINCE" "$me_issue" | sort | tail -1)
-deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
-while [ "$(date +%s)" -lt "$deadline" ]; do
-  sleep 90
-  # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
-  # --paginate --slurp so a commit with >100 check runs isn't judged on its first page alone —
-  # a failing or pending job on a later page must not be missed. Slurp yields an array of page
-  # objects, so the runs are at `.[].check_runs[]`.
-  cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp 2>/dev/null || echo '[]')
-  # Any completed check whose conclusion is outside the passing set counts as failed — this
-  # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a
-  # non-passing-but-not-"failure" check can never be mistaken for green.
-  fail=$(echo "$cr"    | jq '[.[].check_runs[]? | select(.status=="completed") | select((.conclusion // "") as $c | (["success","neutral","skipped"] | index($c)) == null)] | length')
-  pending=$(echo "$cr" | jq '[.[].check_runs[]? | select(.status!="completed")] | length')
-  total=$(echo "$cr"   | jq '[.[].check_runs[]?] | length')
-  if [ "$fail" -gt 0 ]; then
-    echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
-  fi
-  # --- new reviewer feedback to re-enter on ---
-  # Inline (the surface Codex/humans use most): race-free and timestamp-free — count UNRESOLVED
-  # threads whose latest comment is a reviewer's (not you). A thread you handled has your reply
-  # as its last comment (fixed ones are also resolved), so neither handled nor declined threads
-  # re-trigger; only an unanswered reviewer comment does. Paginate by cursor: threads come back
-  # oldest-first, so on a PR with >100 threads a fresh unanswered round sits on the LAST page.
-  new=0; after=""; more=true
-  while [ "$more" = "true" ]; do
-    targs=(-F o=$OWNER -F r=$NAME -F n=$PR); [ -n "$after" ] && targs+=(-F after="$after")
-    page=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!,$after:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' "${targs[@]}")
-    new=$(( new + $(echo "$page" | jq "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | (.comments.nodes[-1].author.login // \"\") | select(test(\"codex\") or ((endswith(\"[bot]\")|not) and (. != \"$ME\")))] | length") ))
-    more=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
-    after=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
-  done
-  # Review summaries + issue comments have no per-item state, so they're time-anchored on
-  # SINCE_DONE with `--paginate --slurp | jq` (NOT `--paginate -q`, which prints one count per
-  # page and breaks the arithmetic). COMMENTED/CHANGES_REQUESTED only — an APPROVED/DISMISSED
-  # review is a sign-off for the convergence block. This timestamp path is best-effort, but a
-  # round that also carries inline comments is caught race-free above, so the gap is only a
-  # body-only review/comment landing in your reply window — rare, and it surfaces on next trigger.
-  new=$(( new + $(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length") ))
-  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
-  if [ "$new" -gt 0 ]; then
-    echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
-  fi
-  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off for THIS
-  # pushed commit. Codex signs off with a 👍 (+1) reaction; a human with an APPROVED review.
-  # The approval is pinned to the exact SHA (commit_id == $SHA) so a sign-off for an earlier PR
-  # state — e.g. one that landed between the local commit and a delayed/retried push — can't be
-  # mistaken for certifying these changes. The 👍 path needs no SHA pin: only Codex 👍 counts,
-  # and Codex reacts only after the push triggers its re-review, so its 👍 is always post-push;
-  # `> $SINCE` just rules out a 👍 left for a prior commit. 👀 (eyes) = "reviewing now" — ignore.
-  ci_green=false
-  [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
-  plus1=$(gh api repos/$REPO/issues/$PR/reactions \
-    -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
-    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
-  approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
-  if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
-    echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
-  fi
-done
-echo "WATCH 30: no verdict after 25m — tell the user"; exit 30
+bash .claude/skills/address-review/watch.sh
 ```
+
+`watch.sh` is self-contained — it reads the PR, repo, pushed SHA, and reviewer set from the
+current checkout, polls `gh` every 90s for up to 25 minutes, and echoes a `WATCH <code>` line
+then exits with that code (each handled below). It lives in its own file rather than inline so a
+single allow rule, `Bash(bash .claude/skills/address-review/watch.sh:*)`, pre-approves the whole
+loop: Claude Code does not re-parse a script file's internal commands for permission, whereas an
+inline compound command would have every subcommand (`jq`, `date`, `sleep`, `[`, …) checked
+independently and could stop for a prompt mid-run while the user has walked away. The decision
+logic and its rationale live in the script's comments — read `watch.sh` before changing it.
 
 When the watcher exits and you are re-invoked:
 

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -55,8 +55,10 @@ OWNER=${REPO%/*}; NAME=${REPO#*/}                                  # its comment
 HEAD_REF=$(gh pr view --json headRefName -q .headRefName)
 HEAD_REPO=$(gh pr view --json headRepositoryOwner,headRepository -q '.headRepositoryOwner.login + "/" + .headRepository.name')
 # the local remote whose URL hosts $HEAD_REPO — origin in the standard fork setup; empty only if
-# no remote points at the head repo, in which case the Step 4 push fails loudly (add the remote)
-HEAD_REMOTE=$(git remote -v | awk -v r="$HEAD_REPO" '$2 ~ "[:/]" r "(\\.git)?$" {print $1; exit}')
+# no remote points at the head repo, in which case the Step 4 push fails loudly (add the remote).
+# Compare owner/repo literally — normalize `:`→`/`, drop `.git`, take the last two path segments —
+# rather than regex-matching $HEAD_REPO, whose `.` would otherwise match the wrong remote.
+HEAD_REMOTE=$(git remote -v | awk -v r="$HEAD_REPO" '{u=$2; sub(/\.git$/,"",u); gsub(/:/,"/",u); n=split(u,p,"/"); if (n>=2 && p[n-1]"/"p[n]==r){print $1; exit}}')
 ```
 
 `REPO` (base) is where every `gh api repos/$REPO/...` read below goes; `HEAD_REMOTE` + `HEAD_REF`

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: address-review
 description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
-allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*)
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*)
 ---
 
 # Address Review Comments
@@ -46,10 +46,19 @@ needs their call. A red build is never "done", no matter what the reviewer says.
 gh pr view --json number,url,headRefName,baseRefName \
   -q '"PR #\(.number)  \(.url)  (\(.headRefName) -> \(.baseRefName))"' || { echo "No PR for this branch"; exit 1; }
 PR=$(gh pr view --json number -q .number)
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)        # BASE repo — the PR and its comments live here
 OWNER=${REPO%/*}; NAME=${REPO#*/}
-HEAD_REF=$(gh pr view --json headRefName -q .headRefName)   # the PR's head branch — push to this
+# The PR's head branch + the repo that hosts it. In a cross-repo (fork) PR the head repo is NOT
+# $REPO: the PR lives on the base, its commits belong on the fork. Derive the push target from
+# the PR — never hard-code a remote.
+HEAD_REF=$(gh pr view --json headRefName -q .headRefName)
+HEAD_REPO=$(gh pr view --json headRepositoryOwner,headRepository -q '.headRepositoryOwner.login + "/" + .headRepository.name')
+git remote -v     # HEAD_REMOTE = the entry whose URL is $HEAD_REPO (origin = your fork in the standard setup)
 ```
+
+`REPO` (base) is where every `gh api repos/$REPO/...` read below goes; `HEAD_REMOTE` + `HEAD_REF`
+(head) is where Step 4 pushes. For a same-repo PR they coincide; for a fork PR they differ —
+keep them distinct.
 
 Fetch all three comment surfaces — any can carry feedback:
 
@@ -129,7 +138,7 @@ if git diff --cached --quiet; then
   SHA=$(git rev-parse --short HEAD)        # nothing staged — keep HEAD, go reply
 else
   git commit -m "<imperative summary of the review fixes>"
-  git push origin HEAD:"$HEAD_REF"   # explicit refspec — local branch may not match the PR head
+  git push "$HEAD_REMOTE" HEAD:"$HEAD_REF"   # head repo's remote (Step 1) — not necessarily origin; explicit refspec
   SHA=$(git rev-parse --short HEAD)
 fi
 ```

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -25,12 +25,16 @@ needs their call. A red build is never "done", no matter what the reviewer says.
   intentional.
 - **Fix → push → reply → resolve, in that order.** Reply text references the commit that
   fixed it, so the fix must land first.
-- **Resolve only the threads you actually fixed.** A concrete code change that addresses
-  the comment → reply (referencing the commit), then resolve. **Declines, defers, and
-  discussion / question comments stay OPEN** — they get a reasoned reply, but resolving
-  them closes a conversation that is the human's to close (especially a reviewer's "why…?"
-  or "should we…?", which is an invitation to discuss, not a change request). Never resolve
-  a thread just to clear the queue. When in doubt, leave it open.
+- **Every thread you fixed MUST be resolved — and only those.** Once a bot comment's fix is
+  pushed and you have replied referencing the commit, resolve its thread: a fixed Codex
+  thread left open reads as still-broken to anyone scanning the PR and leaves the conversation
+  cluttered with items already handled. The two directions are symmetric and both mandatory:
+  **fixed → resolve**, and **declines,
+  defers, and discussion / question comments stay OPEN** — those get a reasoned reply, but
+  resolving them closes a conversation that is the human's to close (especially a reviewer's
+  "why…?" or "should we…?", which is an invitation to discuss, not a change request). Never
+  resolve a thread just to clear the queue, and never leave a thread you fixed unresolved.
+  When a comment is genuinely on the fence, leave it open.
 - **Stay scoped** to the feedback. Don't sprawl into unrelated refactors.
 - **Follow the repo's commit conventions** (see the `push-pr` skill). CRITICAL: never add
   `Co-Authored-By` or any AI / Claude / assistant attribution to commits, replies, or PRs.
@@ -102,7 +106,7 @@ Run the repo's checks before committing so pre-commit / CI find nothing new:
 
 ```bash
 # only existing files — ruff fails on deleted paths (E902)
-uv run ruff check <existing files> && uv run ruff format <existing files>   # or the repo's own lint / test / format
+uv run --locked ruff check <existing files> && uv run --locked ruff format <existing files>   # or the repo's own lint / test / format
 ```
 
 Commit (concise, imperative, no AI attribution — see `push-pr` commit style) and push to the
@@ -134,9 +138,10 @@ A combined review (e.g. one Codex body carrying several findings) arrives as a s
 conversation comment, not per-finding threads — answer it with one issue-level reply that
 addresses each finding; there is nothing to resolve in Step 5 for that surface.
 
-**Resolve** only the threads you *fixed* (a concrete change landed). Resolution requires
-GraphQL (the REST API can't do it). Map each comment's `databaseId` to its thread node id,
-then resolve:
+**Resolve** every thread you *fixed* (a concrete change landed) — this is mandatory, not
+optional: a fixed Codex thread you leave open keeps the PR looking unaddressed to human
+reviewers. Resolution requires GraphQL (the REST API can't do it). Map each comment's
+`databaseId` to its thread node id, then resolve:
 
 ```bash
 # Thread node id + isResolved + the comment databaseIds it contains
@@ -205,9 +210,13 @@ PUSH_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)               # ISO-8601 UTC sorts lexic
 # Tracked reviewers are Codex and humans; the repo's Claude review workflow is intentionally
 # not gated on, so the predicate matches only the Codex bot.
 codex='select(.user.login|test("codex"))'
-# Baseline counts captured right after your push; a NEW round increments one of them.
+# Baseline counts captured right after your push; a NEW round increments one of them. All
+# three surfaces are polled — Codex may post the next round as inline comments, a review body,
+# OR a combined issue-level comment (the surface Step 1/Step 5 handle), so missing any one
+# would strand actionable feedback and time out as "quiet".
 base_reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
 base_comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $codex] | length")
+base_issue=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $codex] | length")
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
@@ -222,10 +231,11 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if [ "$fail" -gt 0 ]; then
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
-  # --- new Codex round ---
+  # --- new Codex round (any of the three surfaces) ---
   reviews=$(gh api repos/$REPO/pulls/$PR/reviews  --paginate -q "[.[] | $codex] | length")
   comments=$(gh api repos/$REPO/pulls/$PR/comments --paginate -q "[.[] | $codex] | length")
-  if [ "$reviews" -gt "$base_reviews" ] || [ "$comments" -gt "$base_comments" ]; then
+  issuec=$(gh api repos/$REPO/issues/$PR/comments  --paginate -q "[.[] | $codex] | length")
+  if [ "$reviews" -gt "$base_reviews" ] || [ "$comments" -gt "$base_comments" ] || [ "$issuec" -gt "$base_issue" ]; then
     echo "WATCH 10: new Codex round — run another address-review pass (Steps 1-6)"; exit 10
   fi
   # --- convergence: CI green (all checks done, none failing) AND Codex 👍 newer than push ---

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -218,10 +218,11 @@ confuse it, and acts only once a check has *completed* with a failing conclusion
 The watcher just polls `gh`, so it costs no tokens while it waits. It is **harness-tracked**:
 when it exits you are re-invoked automatically with its output — that notification is the
 primary wake signal, so launch it with `run_in_background` and **don't** add a short poll on top
-of it. Do, however, set one **long fallback heartbeat** when you launch the watcher
-(`ScheduleWakeup`, ~20–30 min) so a missed or dropped exit-notification can't strand the loop
-with feedback sitting unanswered — a safety net, not a poll; when it fires, re-check for
-unhandled comments and, if none, reschedule it. Its echoed `WATCH <code>` line names the next
+of it. If your runtime exposes a scheduled-wake primitive (e.g. `ScheduleWakeup` under `/loop`),
+also set one **long fallback heartbeat** (~20–30 min) as a safety net against a missed or dropped
+exit-notification — not a poll; when it fires, re-check for unhandled comments and, if none,
+reschedule it. Otherwise the primary notification plus the watcher relaunching on every exit
+(see exit 30) are the wake mechanism. Its echoed `WATCH <code>` line names the next
 action, so the loop survives even if this skill text has fallen out of context (re-read this
 file if unsure).
 

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -231,30 +231,40 @@ ME=$(gh api user -q .login)                            # the PR author — exclu
 # workflow) are intentionally NOT gated on. So: login matches "codex", or is a non-bot that
 # isn't you.
 reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]\")|not) and (.user.login!=\"$ME\")))"
+# Re-entry needs a second anchor. SINCE (commit time) is right for sign-off — a 👍/approval any
+# time after the push counts — but wrong for new feedback: a decline-only pass makes no commit,
+# so SINCE wouldn't advance and the just-handled comment would re-trigger exit 10 forever. You
+# reply to every comment you handle, so your own latest reply post-dates anything already
+# processed; anchor re-entry at the later of SINCE and that reply (lexical max — all UTC Z).
+me_inline=$(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+me_issue=$(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+SINCE_DONE=$(printf '%s\n%s\n%s\n' "$SINCE" "$me_inline" "$me_issue" | sort | tail -1)
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
   # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
-  cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null || echo '{}')
+  # --paginate --slurp so a commit with >100 check runs isn't judged on its first page alone —
+  # a failing or pending job on a later page must not be missed. Slurp yields an array of page
+  # objects, so the runs are at `.[].check_runs[]`.
+  cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp 2>/dev/null || echo '[]')
   # Any completed check whose conclusion is outside the passing set counts as failed — this
   # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a
   # non-passing-but-not-"failure" check can never be mistaken for green.
-  fail=$(echo "$cr"    | jq '[.check_runs[]? | select(.status=="completed") | select((.conclusion // "") as $c | (["success","neutral","skipped"] | index($c)) == null)] | length')
-  pending=$(echo "$cr" | jq '[.check_runs[]? | select(.status!="completed")] | length')
-  total=$(echo "$cr"   | jq '[.check_runs[]?] | length')
+  fail=$(echo "$cr"    | jq '[.[].check_runs[]? | select(.status=="completed") | select((.conclusion // "") as $c | (["success","neutral","skipped"] | index($c)) == null)] | length')
+  pending=$(echo "$cr" | jq '[.[].check_runs[]? | select(.status!="completed")] | length')
+  total=$(echo "$cr"   | jq '[.[].check_runs[]?] | length')
   if [ "$fail" -gt 0 ]; then
     echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
   fi
-  # --- new reviewer activity since the push, any of the three surfaces (Codex or a human) ---
+  # --- new reviewer activity since you finished (SINCE_DONE), any of the three surfaces ---
   # Count with `--paginate --slurp | jq`, NOT `--paginate -q`: with -q, gh runs the filter once
   # per page and prints one count per page, so the arithmetic below breaks on a multi-page PR.
   # --slurp wraps all pages into a single array (`.[][]` flattens it). Only COMMENTED /
   # CHANGES_REQUESTED reviews are actionable; an APPROVED (or DISMISSED) review is a sign-off,
-  # left to the convergence block — counting it here would exit 10 instead of 20 and, with no
-  # new commit, re-count the same approval forever.
-  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length")
-  new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
-  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE\")] | length") ))
+  # left to the convergence block.
+  new=$(gh api repos/$REPO/pulls/$PR/reviews   --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length")
+  new=$(( new + $(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
+  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
   if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -88,18 +88,20 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
   # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off. A human
-  # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA), so an approval of
-  # an earlier state can't certify this one. Codex signs off with a 👍 (+1) reaction, which carries
-  # no commit id and so can't be SHA-pinned the way a review can. Anchor it as tightly as the API
-  # allows: created_at > $SINCE_DONE (the later of the pushed commit and your latest reply ≈ push
-  # time), which drops a 👍 left before this round's reply. A residual race is unavoidable — a
-  # delayed Codex 👍 for an earlier clean state landing after this reply would still count, since a
-  # reaction is not tied to a SHA. 👀 (eyes) = "reviewing now" — ignore.
+  # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA). Codex signs off
+  # with a 👍 (+1) reaction, which carries no commit id and so can't be SHA-pinned like a review.
+  # Anchor it on the PUSH, not the commit or your reply: pushed_at = the earliest check-run
+  # started_at on this SHA (CI fires when GitHub receives the push). That counts a genuine post-push
+  # 👍 even if it lands before your Step 5 reply (a reply anchor would miss it) and drops a 👍 left
+  # before the push. Residual: a reaction still isn't tied to a SHA, so a delayed 👍 for an earlier
+  # state landing after this push would count — unfixable without a SHA-stamped sign-off. 👀 (eyes)
+  # = "reviewing now" — ignore. (At convergence pending==0, so every run has a started_at.)
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
+  pushed_at=$(echo "$cr" | jq -r '[.[].check_runs[]? | .started_at | select(. != null)] | min // ""')
   plus1=$(gh api repos/$REPO/issues/$PR/reactions \
     -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
-    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE_DONE\")] | length")
+    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$pushed_at\")] | length")
   approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
   if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/env bash
 # Background convergence watcher for the address-review skill. Launched in the background after a
-# pass; blocks until something actionable happens, then echoes a `WATCH <code>` line and exits
-# with that code (10 new round, 20 converged, 30 quiet, 40 CI failed). Self-contained — it reads
-# the PR/repo from the current checkout. Lives in its own file so a single allow rule
-# (`Bash(bash .claude/skills/address-review/watch.sh:*)`) pre-approves the whole loop: Claude
-# Code does not re-parse a script file's internal commands for permission, whereas an inline
-# compound command would have every subcommand (jq, date, sleep, `[`, …) checked independently.
+# pass; blocks until something actionable happens, then echoes a `WATCH <code>` line and exits with
+# that code (10 new round, 20 converged, 30 quiet, 40 CI failed, 50 API unreadable). Self-contained
+# — it reads the PR/repo from the current checkout. Lives in its own file so a single allow rule
+# (`Bash(bash .claude/skills/address-review/watch.sh:*)`) pre-approves the whole loop: Claude Code
+# does not re-parse a script file's internal commands for permission, whereas an inline compound
+# command would have every subcommand (jq, date, sleep, `[`, …) checked independently.
 set -e
+
+# Every GitHub read goes through ghr: 3 tries, then a non-zero RETURN — never `exit`, because ghr
+# runs inside `$(...)` where exit would only kill the subshell and be silently swallowed. A plain
+# `gh | jq` pipeline hides a failed read: jq sees empty input, emits an empty/zero count, and the
+# pipeline still exits 0 on jq's success — so a rate-limited or unreadable API reads as "no new
+# feedback" and the loop quietly stalls instead of surfacing the problem. Keeping the gh read and
+# the jq parse in separate steps lets a real failure be caught: `data=$(ghr ...) || fail50 ...`,
+# then `echo "$data" | jq ...`. fail50 runs at top level (not in `$(...)`), so it can exit.
+ghr() {
+  local out
+  for t in 1 2 3; do out=$(gh "$@" 2>/dev/null) && { printf '%s' "$out"; return 0; }; sleep 5; done
+  return 1
+}
+fail50() { echo "WATCH 50: $1 — token scope or a GitHub outage; surface to the user"; exit 50; }
+
 PR=$(gh pr view --json number -q .number)
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+# The repo that hosts the PR — its comments, reviews, reactions — is the PR's BASE repo, taken from
+# the PR URL, NOT from `gh repo view`: that returns the checkout's default repo, which in a fork
+# checkout can be the head (fork) repo, sending every read below to a repo where this PR number
+# doesn't exist. The URL path is always <host>/<owner>/<repo>/pull/<n>, so fields 4 and 5 are it.
+REPO=$(gh pr view --json url -q .url | awk -F/ '{print $4"/"$5}')
 OWNER=${REPO%/*}; NAME=${REPO#*/}                      # for the GraphQL thread query below
 SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
 # Anchor to the pushed commit's own timestamp, NOT to when this watcher launches: the
@@ -32,27 +51,22 @@ reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]
 # your latest reply on ANY surface. Include inline replies, not just issue-level ones — when you
 # answer a Codex round inline (e.g. a decline, no commit), its COMMENTED review row is still
 # `> SINCE` and would re-trigger forever unless your inline reply also advances the floor.
-me_issue=$(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
-me_inline=$(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+mi=$(ghr api repos/$REPO/issues/$PR/comments --paginate --slurp) || fail50 "cannot read issue comments for PR $PR"
+me_issue=$(echo "$mi" | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+ml=$(ghr api repos/$REPO/pulls/$PR/comments --paginate --slurp) || fail50 "cannot read inline comments for PR $PR"
+me_inline=$(echo "$ml" | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
 SINCE_DONE=$(printf '%s\n%s\n%s\n' "$SINCE" "$me_issue" "$me_inline" | sort | tail -1)
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90
   # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
-  # --paginate --slurp so a commit with >100 check runs isn't judged on its first page alone —
-  # a failing or pending job on a later page must not be missed. Slurp yields an array of page
-  # objects, so the runs are at `.[].check_runs[]`. Do NOT fabricate an empty list on API failure:
-  # that would hide a token/permission or outage problem behind a fake "no checks" reading
-  # (total=0 blocks both exit 40 and ci_green, so the persisting loop would spin forever). Retry a
-  # few times for a transient blip; if it stays unreadable, surface it and stop (exit 50).
-  cr=""
-  for try in 1 2 3; do
-    cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp 2>/dev/null) && break
-    cr=""; sleep 5
-  done
-  if [ -z "$cr" ]; then
-    echo "WATCH 50: cannot read check runs for $SHA after 3 tries — token checks-read scope or a GitHub outage; surface to the user"; exit 50
-  fi
+  # --paginate --slurp so a commit with >100 check runs isn't judged on its first page alone — a
+  # failing or pending job on a later page must not be missed. Slurp yields an array of page
+  # objects, so the runs are at `.[].check_runs[]`. ghr surfaces an unreadable API as exit 50
+  # rather than a fake "no checks" reading (total=0 would block both exit 40 and ci_green, so the
+  # persisting loop would spin forever); a readable-but-empty response is still valid JSON, so a
+  # commit with genuinely no checks yet stays in the loop.
+  cr=$(ghr api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp) || fail50 "cannot read check runs for $SHA"
   # Any completed check whose conclusion is outside the passing set counts as failed — this
   # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a
   # non-passing-but-not-"failure" check can never be mistaken for green.
@@ -71,19 +85,22 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   new=0; after=""; more=true
   while [ "$more" = "true" ]; do
     targs=(-F o=$OWNER -F r=$NAME -F n=$PR); [ -n "$after" ] && targs+=(-F after="$after")
-    page=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!,$after:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' "${targs[@]}")
+    page=$(ghr api graphql -f query='query($o:String!,$r:String!,$n:Int!,$after:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' "${targs[@]}") || fail50 "cannot read review threads for PR $PR"
     new=$(( new + $(echo "$page" | jq "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | (.comments.nodes[-1].author.login // \"\") | select(test(\"codex\") or ((endswith(\"[bot]\")|not) and (. != \"$ME\")))] | length") ))
     more=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
     after=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
   done
   # Review summaries + issue comments have no per-item state, so they're time-anchored on
-  # SINCE_DONE with `--paginate --slurp | jq` (NOT `--paginate -q`, which prints one count per
+  # SINCE_DONE with `--paginate --slurp` then jq (NOT `--paginate -q`, which prints one count per
   # page and breaks the arithmetic). COMMENTED/CHANGES_REQUESTED only — an APPROVED/DISMISSED
   # review is a sign-off for the convergence block. This timestamp path is best-effort, but a
   # round that also carries inline comments is caught race-free above, so the gap is only a
   # body-only review/comment landing in your reply window — rare, and it surfaces on next trigger.
-  new=$(( new + $(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length") ))
-  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
+  # The reviews list is fetched once here and reused for the APPROVED sign-off check below.
+  rv=$(ghr api repos/$REPO/pulls/$PR/reviews --paginate --slurp) || fail50 "cannot read reviews for PR $PR"
+  new=$(( new + $(echo "$rv" | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length") ))
+  ic=$(ghr api repos/$REPO/issues/$PR/comments --paginate --slurp) || fail50 "cannot read issue comments for PR $PR"
+  new=$(( new + $(echo "$ic" | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
   if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
@@ -99,10 +116,9 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
   pushed_at=$(echo "$cr" | jq -r '[.[].check_runs[]? | .started_at | select(. != null)] | min // ""')
-  plus1=$(gh api repos/$REPO/issues/$PR/reactions \
-    -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
-    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$pushed_at\")] | length")
-  approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
+  rx=$(ghr api repos/$REPO/issues/$PR/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp) || fail50 "cannot read reactions for PR $PR"
+  plus1=$(echo "$rx" | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$pushed_at\")] | length")
+  approved=$(echo "$rv" | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
   if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
   fi

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -29,9 +29,12 @@ reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]
 # therefore detected structurally below — an unresolved thread whose last comment is a
 # reviewer's, no timestamps. The review-summary and issue-comment surfaces have no per-item
 # resolved state, so they fall back to a timestamp: SINCE_DONE = the later of the commit and
-# your latest issue-level reply, which clears anything you have already answered there.
+# your latest reply on ANY surface. Include inline replies, not just issue-level ones — when you
+# answer a Codex round inline (e.g. a decline, no commit), its COMMENTED review row is still
+# `> SINCE` and would re-trigger forever unless your inline reply also advances the floor.
 me_issue=$(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
-SINCE_DONE=$(printf '%s\n%s\n' "$SINCE" "$me_issue" | sort | tail -1)
+me_inline=$(gh api repos/$REPO/pulls/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+SINCE_DONE=$(printf '%s\n%s\n%s\n' "$SINCE" "$me_issue" "$me_inline" | sort | tail -1)
 deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
 while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 90

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Background convergence watcher for the address-review skill. Launched in the background after a
+# pass; blocks until something actionable happens, then echoes a `WATCH <code>` line and exits
+# with that code (10 new round, 20 converged, 30 quiet, 40 CI failed). Self-contained — it reads
+# the PR/repo from the current checkout. Lives in its own file so a single allow rule
+# (`Bash(bash .claude/skills/address-review/watch.sh:*)`) pre-approves the whole loop: Claude
+# Code does not re-parse a script file's internal commands for permission, whereas an inline
+# compound command would have every subcommand (jq, date, sleep, `[`, …) checked independently.
+set -e
+PR=$(gh pr view --json number -q .number)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}; NAME=${REPO#*/}                      # for the GraphQL thread query below
+SHA=$(git rev-parse HEAD)                              # judge CI only for the commit we pushed
+# Anchor to the pushed commit's own timestamp, NOT to when this watcher launches: the
+# reply/resolve work in Step 5 takes a while and a reviewer can respond in that window, so a
+# launch-time anchor would fold those responses into the baseline and miss them. Counting
+# reviewer activity created after the commit time catches them no matter when the loop starts.
+# In UTC with a Z suffix so it sorts lexically against GitHub's UTC timestamps (a local-offset
+# %cI like +03:00 would mis-compare against their Z form).
+SINCE=$(TZ=UTC0 git show -s --date=format-local:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
+ME=$(gh api user -q .login)                            # the PR author — exclude your own replies
+# A tracked reviewer is the Codex bot OR any human; other bots (e.g. the repo's Claude review
+# workflow) are intentionally NOT gated on. So: login matches "codex", or is a non-bot that
+# isn't you.
+reviewer="select((.user.login|test(\"codex\")) or ((.user.login|endswith(\"[bot]\")|not) and (.user.login!=\"$ME\")))"
+# Re-entry can't key off SINCE alone: a decline-only pass makes no commit (SINCE wouldn't
+# advance, so the handled comment would re-trigger forever), and your own reply can post-date a
+# reviewer comment that arrived mid-pass (burying it under a later anchor). Inline feedback is
+# therefore detected structurally below — an unresolved thread whose last comment is a
+# reviewer's, no timestamps. The review-summary and issue-comment surfaces have no per-item
+# resolved state, so they fall back to a timestamp: SINCE_DONE = the later of the commit and
+# your latest issue-level reply, which clears anything you have already answered there.
+me_issue=$(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq -r "[.[][] | select(.user.login==\"$ME\") | .created_at] | max // \"\"")
+SINCE_DONE=$(printf '%s\n%s\n' "$SINCE" "$me_issue" | sort | tail -1)
+deadline=$(( $(date +%s) + 1500 ))                    # 25-minute cap
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  sleep 90
+  # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
+  # --paginate --slurp so a commit with >100 check runs isn't judged on its first page alone —
+  # a failing or pending job on a later page must not be missed. Slurp yields an array of page
+  # objects, so the runs are at `.[].check_runs[]`.
+  cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp 2>/dev/null || echo '[]')
+  # Any completed check whose conclusion is outside the passing set counts as failed — this
+  # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a
+  # non-passing-but-not-"failure" check can never be mistaken for green.
+  fail=$(echo "$cr"    | jq '[.[].check_runs[]? | select(.status=="completed") | select((.conclusion // "") as $c | (["success","neutral","skipped"] | index($c)) == null)] | length')
+  pending=$(echo "$cr" | jq '[.[].check_runs[]? | select(.status!="completed")] | length')
+  total=$(echo "$cr"   | jq '[.[].check_runs[]?] | length')
+  if [ "$fail" -gt 0 ]; then
+    echo "WATCH 40: CI failed on $SHA ($fail failing check(s)) — run a CI-fix pass"; exit 40
+  fi
+  # --- new reviewer feedback to re-enter on ---
+  # Inline (the surface Codex/humans use most): race-free and timestamp-free — count UNRESOLVED
+  # threads whose latest comment is a reviewer's (not you). A thread you handled has your reply
+  # as its last comment (fixed ones are also resolved), so neither handled nor declined threads
+  # re-trigger; only an unanswered reviewer comment does. Paginate by cursor: threads come back
+  # oldest-first, so on a PR with >100 threads a fresh unanswered round sits on the LAST page.
+  new=0; after=""; more=true
+  while [ "$more" = "true" ]; do
+    targs=(-F o=$OWNER -F r=$NAME -F n=$PR); [ -n "$after" ] && targs+=(-F after="$after")
+    page=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!,$after:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved comments(last:1){nodes{author{login}}}}}}}}' "${targs[@]}")
+    new=$(( new + $(echo "$page" | jq "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | (.comments.nodes[-1].author.login // \"\") | select(test(\"codex\") or ((endswith(\"[bot]\")|not) and (. != \"$ME\")))] | length") ))
+    more=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+    after=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+  done
+  # Review summaries + issue comments have no per-item state, so they're time-anchored on
+  # SINCE_DONE with `--paginate --slurp | jq` (NOT `--paginate -q`, which prints one count per
+  # page and breaks the arithmetic). COMMENTED/CHANGES_REQUESTED only — an APPROVED/DISMISSED
+  # review is a sign-off for the convergence block. This timestamp path is best-effort, but a
+  # round that also carries inline comments is caught race-free above, so the gap is only a
+  # body-only review/comment landing in your reply window — rare, and it surfaces on next trigger.
+  new=$(( new + $(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.submitted_at > \"$SINCE_DONE\") | select(.state==\"COMMENTED\" or .state==\"CHANGES_REQUESTED\")] | length") ))
+  new=$(( new + $(gh api repos/$REPO/issues/$PR/comments --paginate --slurp | jq "[.[][] | $reviewer | select(.created_at > \"$SINCE_DONE\")] | length") ))
+  if [ "$new" -gt 0 ]; then
+    echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
+  fi
+  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off for THIS
+  # pushed commit. Codex signs off with a 👍 (+1) reaction; a human with an APPROVED review.
+  # The approval is pinned to the exact SHA (commit_id == $SHA) so a sign-off for an earlier PR
+  # state — e.g. one that landed between the local commit and a delayed/retried push — can't be
+  # mistaken for certifying these changes. The 👍 path needs no SHA pin: only Codex 👍 counts,
+  # and Codex reacts only after the push triggers its re-review, so its 👍 is always post-push;
+  # `> $SINCE` just rules out a 👍 left for a prior commit. 👀 (eyes) = "reviewing now" — ignore.
+  ci_green=false
+  [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
+  plus1=$(gh api repos/$REPO/issues/$PR/reactions \
+    -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
+    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
+  approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
+  if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
+    echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
+  fi
+done
+echo "WATCH 30: no verdict after 25m — tell the user"; exit 30

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -41,8 +41,18 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   # --- CI on the pushed commit (highest priority; a failing check is actionable at once) ---
   # --paginate --slurp so a commit with >100 check runs isn't judged on its first page alone —
   # a failing or pending job on a later page must not be missed. Slurp yields an array of page
-  # objects, so the runs are at `.[].check_runs[]`.
-  cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp 2>/dev/null || echo '[]')
+  # objects, so the runs are at `.[].check_runs[]`. Do NOT fabricate an empty list on API failure:
+  # that would hide a token/permission or outage problem behind a fake "no checks" reading
+  # (total=0 blocks both exit 40 and ci_green, so the persisting loop would spin forever). Retry a
+  # few times for a transient blip; if it stays unreadable, surface it and stop (exit 50).
+  cr=""
+  for try in 1 2 3; do
+    cr=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp 2>/dev/null) && break
+    cr=""; sleep 5
+  done
+  if [ -z "$cr" ]; then
+    echo "WATCH 50: cannot read check runs for $SHA after 3 tries — token checks-read scope or a GitHub outage; surface to the user"; exit 50
+  fi
   # Any completed check whose conclusion is outside the passing set counts as failed — this
   # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a
   # non-passing-but-not-"failure" check can never be mistaken for green.
@@ -94,4 +104,4 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20
   fi
 done
-echo "WATCH 30: no verdict after 25m — tell the user"; exit 30
+echo "WATCH 30: quiet interval elapsed — relaunch and keep waiting (ping the user only after several quiet cycles)"; exit 30

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -107,15 +107,18 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off. A human
   # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA). Codex signs off
   # with a 👍 (+1) reaction, which carries no commit id and so can't be SHA-pinned like a review.
-  # Anchor it on the PUSH, not the commit or your reply: pushed_at = the earliest check-run
-  # started_at on this SHA (CI fires when GitHub receives the push). That counts a genuine post-push
-  # 👍 even if it lands before your Step 5 reply (a reply anchor would miss it) and drops a 👍 left
-  # before the push. Residual: a reaction still isn't tied to a SHA, so a delayed 👍 for an earlier
-  # state landing after this push would count — unfixable without a SHA-stamped sign-off. 👀 (eyes)
-  # = "reviewing now" — ignore. (At convergence pending==0, so every run has a started_at.)
+  # Anchor it on the PUSH: pushed_at = the earliest check-SUITE created_at on this SHA. GitHub
+  # creates the suite the moment it receives the push, before any runner queues — so this tracks
+  # push time, unlike a check-RUN's started_at, which trails the push by the runner-queue delay and
+  # would wrongly drop a 👍 that lands after the push but before the first run starts. A genuine
+  # post-push 👍 counts even if it precedes your Step 5 reply; a 👍 left before the push is dropped.
+  # Residual: a reaction still isn't tied to a SHA, so a delayed 👍 for an earlier state landing
+  # after this push would count — unfixable without a SHA-stamped sign-off. 👀 (eyes) = "reviewing
+  # now" — ignore. (At convergence pending==0, so the suite exists and pushed_at is set.)
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
-  pushed_at=$(echo "$cr" | jq -r '[.[].check_runs[]? | .started_at | select(. != null)] | min // ""')
+  cs=$(ghr api "repos/$REPO/commits/$SHA/check-suites?per_page=100" --paginate --slurp) || fail50 "cannot read check suites for $SHA"
+  pushed_at=$(echo "$cs" | jq -r '[.[].check_suites[]? | .created_at | select(. != null)] | min // ""')
   rx=$(ghr api repos/$REPO/issues/$PR/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp) || fail50 "cannot read reactions for PR $PR"
   plus1=$(echo "$rx" | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$pushed_at\")] | length")
   approved=$(echo "$rv" | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -87,18 +87,19 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if [ "$new" -gt 0 ]; then
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
-  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off for THIS
-  # pushed commit. Codex signs off with a 👍 (+1) reaction; a human with an APPROVED review.
-  # The approval is pinned to the exact SHA (commit_id == $SHA) so a sign-off for an earlier PR
-  # state — e.g. one that landed between the local commit and a delayed/retried push — can't be
-  # mistaken for certifying these changes. The 👍 path needs no SHA pin: only Codex 👍 counts,
-  # and Codex reacts only after the push triggers its re-review, so its 👍 is always post-push;
-  # `> $SINCE` just rules out a 👍 left for a prior commit. 👀 (eyes) = "reviewing now" — ignore.
+  # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off. A human
+  # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA), so an approval of
+  # an earlier state can't certify this one. Codex signs off with a 👍 (+1) reaction, which carries
+  # no commit id and so can't be SHA-pinned the way a review can. Anchor it as tightly as the API
+  # allows: created_at > $SINCE_DONE (the later of the pushed commit and your latest reply ≈ push
+  # time), which drops a 👍 left before this round's reply. A residual race is unavoidable — a
+  # delayed Codex 👍 for an earlier clean state landing after this reply would still count, since a
+  # reaction is not tied to a SHA. 👀 (eyes) = "reviewing now" — ignore.
   ci_green=false
   [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && [ "$fail" -eq 0 ] && ci_green=true
   plus1=$(gh api repos/$REPO/issues/$PR/reactions \
     -H "Accept: application/vnd.github.squirrel-girl-preview+json" --paginate --slurp \
-    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE\")] | length")
+    | jq "[.[][] | select(.user.login|test(\"codex\")) | select(.content==\"+1\") | select(.created_at > \"$SINCE_DONE\")] | length")
   approved=$(gh api repos/$REPO/pulls/$PR/reviews --paginate --slurp | jq "[.[][] | $reviewer | select(.state==\"APPROVED\") | select(.commit_id == \"$SHA\")] | length")
   if [ "$ci_green" = true ] && { [ "$plus1" -gt 0 ] || [ "$approved" -gt 0 ]; }; then
     echo "WATCH 20: converged (CI green + reviewer sign-off) — done"; exit 20


### PR DESCRIPTION
## Summary
- Add the `address-review` skill at `.claude/skills/address-review/SKILL.md` so it is version-controlled with the repo alongside the existing `polish` and `remote-training` skills, rather than living only in a contributor's global `~/.claude`.
- This is the action counterpart invoked by `push-pr` to triage and address PR review comments.

## Test plan
Documentation/skill addition only — no code changes. Verified the file is a valid skill (`SKILL.md` with frontmatter) and matches the repo's `.claude/skills/<name>/SKILL.md` layout.