### PR TITLE
Sweep a full eval suite from one `eval run`

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -69,7 +69,7 @@ Use local when latency is critical (<50ms), robot has built-in GPU, or offline o
 
 Positronic provides two interactive drivers for managing inference episodes (see [`positronic/inference.py`](../positronic/inference.py)), plus an unattended mode:
 
-**Unattended (automatic):** The default for `sim` — runs `--trial_count=10` episodes back-to-back, each ending when the task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode); optionally `--show_gui=True` for DearPyGui visualization. Useful for batch evaluation without manual intervention.
+**Unattended (automatic):** The default for `sim` — runs `--eval.trial_count=10` episodes back-to-back, each ending when the task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode); optionally `--show_gui=True` for DearPyGui visualization. Useful for batch evaluation without manual intervention.
 
 **Keyboard driver (manual):** Control inference with keyboard. Press `s` to start episode, `p` to stop and save, `r` to home the robot, `q` to quit. The default for `real`; optionally pass `--driver.show_gui=True` for DearPyGui visualization. Useful for manual evaluation and debugging.
 

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -9,22 +9,18 @@ def placeholder():
     raise SystemExit('--eval is required, e.g. --eval=.sim.positronic.stack_cubes')
 
 
-def build_trials(seed: int | None, trial_count: int, task_ids: list[int] | None = None) -> list[dict]:
-    """The per-trial RUN contexts a self-driving eval sweeps: one per (task_id, seed) pair.
+def build_trials(seed: int | None, trial_count: int, scenes: list[dict] | None = None) -> list[dict]:
+    """The per-trial RUN contexts a self-driving eval sweeps: one per (scene, seed) pair.
 
-    ``task_ids`` ``None`` sweeps the seed alone (an eval with no task axis); a list sweeps each task_id over the
-    same seed set. ``seed`` ``None`` draws an independent random seed per trial; an int runs
-    ``seed .. seed + trial_count - 1`` for every task. Each context also carries its flat ``eval.trial_index``
-    and the total ``eval.trial_count``.
+    Each ``scenes`` entry is a scene-spec context base (e.g. ``{'eval.suite': ..., 'eval.task_id': ...}``)
+    swept over the seed set; ``None`` sweeps the seed alone (an eval with no scene axis). ``seed`` ``None``
+    draws an independent random seed per trial; an int runs ``seed .. seed + trial_count - 1`` for every
+    scene. Each context also carries its flat ``eval.trial_index`` and the total ``eval.trial_count``.
     """
-    axes = [None] if task_ids is None else task_ids
     trials = []
-    for task_id in axes:
+    for scene in scenes if scenes is not None else [{}]:
         for s in range(trial_count):
-            ctx = {'eval.seed': seed + s if seed is not None else random.randrange(2**31)}
-            if task_id is not None:
-                ctx['eval.task_id'] = task_id
-            trials.append(ctx)
+            trials.append({**scene, 'eval.seed': seed + s if seed is not None else random.randrange(2**31)})
     for i, ctx in enumerate(trials):
         ctx['eval.trial_index'] = i
         ctx['eval.trial_count'] = len(trials)

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -1,3 +1,5 @@
+import random
+
 import configuronic as cfn
 
 
@@ -5,3 +7,25 @@ import configuronic as cfn
 def placeholder():
     # Lets ``--eval=.sim.positronic.stack_cubes`` resolve relative to this package; never instantiated.
     raise SystemExit('--eval is required, e.g. --eval=.sim.positronic.stack_cubes')
+
+
+def build_trials(seed: int | None, trial_count: int, task_ids: list[int] | None = None) -> list[dict]:
+    """The per-trial RUN contexts a self-driving eval sweeps: one per (task_id, seed) pair.
+
+    ``task_ids`` ``None`` sweeps the seed alone (an eval with no task axis); a list sweeps each task_id over the
+    same seed set. ``seed`` ``None`` draws an independent random seed per trial; an int runs
+    ``seed .. seed + trial_count - 1`` for every task. Each context also carries its flat ``eval.trial_index``
+    and the total ``eval.trial_count``.
+    """
+    axes = [None] if task_ids is None else task_ids
+    trials = []
+    for task_id in axes:
+        for s in range(trial_count):
+            ctx = {'eval.seed': seed + s if seed is not None else random.randrange(2**31)}
+            if task_id is not None:
+                ctx['eval.task_id'] = task_id
+            trials.append(ctx)
+    for i, ctx in enumerate(trials):
+        ctx['eval.trial_index'] = i
+        ctx['eval.trial_count'] = len(trials)
+    return trials

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -1,20 +1,22 @@
 import configuronic as cfn
 
 from positronic.cfg.embodiment import droid
+from positronic.cfg.eval import build_trials
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
 from positronic.eval import Eval, Task
 
 
-@cfn.config(embodiment=droid, timeout=180)
-def _droid_pick_place(embodiment, instruction, timeout):
+@cfn.config(embodiment=droid, timeout=180, trial_count=1)
+def _droid_pick_place(embodiment, instruction, timeout, trial_count):
     """A real droid tote pick-and-place eval: the embodiment is the physical Franka, the task carries the instruction.
 
     Real has no scene to seed (``reset=None`` — reset is physical and human) and no privileged ground-truth source
     to record (``privileged={}`` — the droid exposes none), so the outcome is the operator's annotation rather than
-    a computed criterion. ``timeout`` is the per-trial wall-clock budget the Harness applies on the unattended path.
+    a computed criterion. ``timeout`` is the per-trial wall-clock budget the Harness applies on the unattended path;
+    ``trial_count`` is how many such trials it sweeps (real has no seed or task axis, so each is a bare timed trial).
     """
     task = Task(instruction=instruction, timeout=timeout)
-    return Eval(embodiment, task)
+    return Eval(embodiment, task, build_trials(None, trial_count))
 
 
 pick_place = _droid_pick_place.override(instruction=UNIFIED_TASK)

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -1,5 +1,6 @@
 import configuronic as cfn
 
+from positronic.cfg.eval import build_trials
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.models import bundled_panda_model
@@ -8,6 +9,10 @@ from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
 from positronic.simulator.libero.adapter import LiberoAdapter
 from positronic.simulator.libero.launcher import serve_libero
 
+# Task count per LIBERO suite — the config expands an unbound ``task_id`` over ``range(num_tasks)``. positronic
+# cannot import LIBERO (it lives in the 3.10 env server), so the counts are pinned here against the pinned commit.
+_SUITE_NUM_TASKS = {'libero_spatial': 10, 'libero_object': 10, 'libero_goal': 10, 'libero_10': 10, 'libero_90': 90}
+
 
 @cfn.config(
     camera_dict={'image.agentview': 'agentview_image', 'image.wrist': 'eye_in_hand_image'},
@@ -15,8 +20,10 @@ from positronic.simulator.libero.launcher import serve_libero
     control_mode='ee',
     timeout=20.0,
     seed=None,
+    task_id=None,
+    trial_count=1,
 )
-def _libero_eval(suite, task_id, timeout, camera_dict, camera_resolution, control_mode, seed):
+def _libero_eval(suite, task_id, trial_count, timeout, camera_dict, camera_resolution, control_mode, seed):
     """A LIBERO eval: the embodiment proxies a remote LIBERO env, the task carries the scenario.
 
     A LIBERO *suite* is a set of related manipulation tasks; ``task_id`` selects one within it — a fixed scene and
@@ -28,19 +35,19 @@ def _libero_eval(suite, task_id, timeout, camera_dict, camera_resolution, contro
       - ``libero_10`` (libero_10 / LIBERO-LONG, 10 tasks) — long-horizon, entangled tasks across diverse scenes
       - ``libero_90`` (libero_90, 90 tasks) — the large short-horizon pool; with libero_10 it forms LIBERO-100
 
-    ``_libero_eval`` leaves ``suite`` and ``task_id`` unbound; each suite below is a named ``.override`` binding
-    only ``suite``, so a trial is picked with ``--task_id`` on the CLI. The instruction is never pinned: the task
-    reads its language live from the env, which reports it (with ``suite`` and ``task_id``) in every reset's meta.
+    ``_libero_eval`` leaves ``suite`` unbound and ``task_id`` ``None``; each suite below is a named ``.override``
+    binding only ``suite``. An unbound ``task_id`` sweeps every task in the suite; ``--eval.task_id`` pins one.
+    The instruction is never pinned: the task reads its language live from the env, which reports it (with
+    ``suite`` and ``task_id``) in every reset's meta.
 
-    positronic launches the env server in its own 3.10 interpreter for ``(suite, task_id)``; the proxy
-    drives it over the socket. The per-trial seed selects a saved init-state and re-randomizes the scene.
+    positronic launches a single task-agnostic env server in its own 3.10 interpreter; the proxy drives it over
+    the socket and ``task_id`` rides each reset token. The per-trial seed selects a saved init-state and re-randomizes
+    the scene.
     LIBERO's full physics state is the privileged ground truth (recorded, never fed to the policy), so
     success is recomputable downstream; the live ``done`` flag also rides the trial's terminal.
     """
     proxy = RemoteEnvControlSystem(
-        LiberoAdapter(
-            camera_dict, suite=suite, task_id=task_id, camera_resolution=camera_resolution, control_mode=control_mode
-        ),
+        LiberoAdapter(camera_dict, suite=suite, camera_resolution=camera_resolution, control_mode=control_mode),
         serve_libero(),
     )
     observations = {
@@ -69,15 +76,17 @@ def _libero_eval(suite, task_id, timeout, camera_dict, camera_resolution, contro
         instruction=lambda: proxy.meta['task'],
         timeout=timeout,
         privileged=privileged,
-        seed=seed,
         reset=proxy.reset,
         done=proxy.done,
     )
-    return Eval(embodiment, task)
+    # An unbound ``task_id`` sweeps the whole suite; a pinned one runs just that task. Either way it rides each
+    # reset token, so the single task-agnostic env server serves every trial.
+    task_ids = [task_id] if task_id is not None else list(range(_SUITE_NUM_TASKS[suite]))
+    return Eval(embodiment, task, build_trials(seed, trial_count, task_ids))
 
 
-# Each suite binds only its LIBERO ``suite``; ``--task_id`` selects the trial. The instruction is not pinned —
-# the task reads it live from the env's reset meta. The task count per suite is in ``_libero_eval``'s docstring.
+# Each suite binds only its LIBERO ``suite``; an unbound ``task_id`` sweeps the whole suite, ``--eval.task_id``
+# pins one. The instruction is not pinned — the task reads it live from the env's reset meta.
 
 # libero_spatial — 10 tasks
 spatial = _libero_eval.override(suite='libero_spatial')

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -22,8 +22,11 @@ _SUITE_NUM_TASKS = {'libero_spatial': 10, 'libero_object': 10, 'libero_goal': 10
     seed=None,
     task_id=None,
     trial_count=1,
+    settle_steps=10,
 )
-def _libero_eval(suite, task_id, trial_count, timeout, camera_dict, camera_resolution, control_mode, seed):
+def _libero_eval(
+    suite, task_id, trial_count, timeout, camera_dict, camera_resolution, control_mode, seed, settle_steps
+):
     """A LIBERO eval: the embodiment proxies a remote LIBERO env, the task carries the scenario.
 
     A LIBERO *suite* is a set of related manipulation tasks; ``task_id`` selects one within it — a fixed scene and
@@ -35,21 +38,19 @@ def _libero_eval(suite, task_id, trial_count, timeout, camera_dict, camera_resol
       - ``libero_10`` (libero_10 / LIBERO-LONG, 10 tasks) — long-horizon, entangled tasks across diverse scenes
       - ``libero_90`` (libero_90, 90 tasks) — the large short-horizon pool; with libero_10 it forms LIBERO-100
 
-    ``_libero_eval`` leaves ``suite`` unbound and ``task_id`` ``None``; each suite below is a named ``.override``
-    binding only ``suite``. An unbound ``task_id`` sweeps every task in the suite; ``--eval.task_id`` pins one.
-    The instruction is never pinned: the task reads its language live from the env, which reports it (with
-    ``suite`` and ``task_id``) in every reset's meta.
+    ``_libero_eval`` leaves ``suite`` unbound; each named config below is a ``.override`` binding it — to one
+    suite, or to a list (``all``) swept in one run. An unbound ``task_id`` sweeps every task of each bound suite;
+    ``--eval.task_id`` pins one. The instruction is never pinned: the task reads its language live from the env,
+    which reports it (with ``suite`` and ``task_id``) in every reset's meta.
 
     positronic launches a single task-agnostic env server in its own 3.10 interpreter; the proxy drives it over
-    the socket and ``task_id`` rides each reset token. The per-trial seed selects a saved init-state and re-randomizes
-    the scene.
+    the socket and the whole scene spec — suite, task_id, camera_resolution, control_mode, settle_steps — rides
+    each trial's reset token, so one embodiment serves any mix of suites and tasks. The per-trial seed selects a
+    saved init-state and re-randomizes the scene.
     LIBERO's full physics state is the privileged ground truth (recorded, never fed to the policy), so
     success is recomputable downstream; the live ``done`` flag also rides the trial's terminal.
     """
-    proxy = RemoteEnvControlSystem(
-        LiberoAdapter(camera_dict, suite=suite, camera_resolution=camera_resolution, control_mode=control_mode),
-        serve_libero(),
-    )
+    proxy = RemoteEnvControlSystem(LiberoAdapter(camera_dict), serve_libero())
     observations = {
         'robot_state': Observation(proxy.observations['robot_state'], Serializers.robot_state),
         'grip': Observation(proxy.observations['grip'], None),
@@ -79,10 +80,21 @@ def _libero_eval(suite, task_id, trial_count, timeout, camera_dict, camera_resol
         reset=proxy.reset,
         done=proxy.done,
     )
-    # An unbound ``task_id`` sweeps the whole suite; a pinned one runs just that task. Either way it rides each
-    # reset token, so the single task-agnostic env server serves every trial.
-    task_ids = [task_id] if task_id is not None else list(range(_SUITE_NUM_TASKS[suite]))
-    return Eval(embodiment, task, build_trials(seed, trial_count, task_ids))
+    # One scene per (suite, task) pair: an unbound ``task_id`` sweeps each suite, a pinned one runs that task
+    # in every bound suite. The scene spec rides each trial's reset token, so the single task-agnostic env
+    # server serves every trial.
+    scenes = [
+        {
+            'eval.suite': s,
+            'eval.task_id': t,
+            'eval.camera_resolution': camera_resolution,
+            'eval.control_mode': control_mode,
+            'eval.settle_steps': settle_steps,
+        }
+        for s in ([suite] if isinstance(suite, str) else suite)
+        for t in ([task_id] if task_id is not None else range(_SUITE_NUM_TASKS[s]))
+    ]
+    return Eval(embodiment, task, build_trials(seed, trial_count, scenes))
 
 
 # Each suite binds only its LIBERO ``suite``; an unbound ``task_id`` sweeps the whole suite, ``--eval.task_id``
@@ -102,3 +114,7 @@ libero_10 = _libero_eval.override(suite='libero_10')
 
 # libero_90 — 90 tasks
 libero_90 = _libero_eval.override(suite='libero_90')
+
+# The four-suite LIBERO benchmark (40 tasks) in one run — the set papers report as "LIBERO average".
+# libero_90 stays out: it is the LIBERO-100 pretraining pool, not a standard eval target.
+all = _libero_eval.override(suite=['libero_spatial', 'libero_object', 'libero_goal', 'libero_10'])

--- a/positronic/cfg/eval/sim/positronic.py
+++ b/positronic/cfg/eval/sim/positronic.py
@@ -2,6 +2,7 @@ import configuronic as cfn
 
 import positronic.cfg.simulator
 from positronic.cfg.embodiment import mujoco_franka
+from positronic.cfg.eval import build_trials
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.utils import package_assets_path
@@ -14,22 +15,29 @@ from positronic.utils import package_assets_path
     camera_dict={'image.wrist': 'handcam_left_ph', 'image.exterior': 'back_view_ph', 'image.agent_view': 'agentview'},
     timeout=15,
     seed=None,
+    trial_count=1,
 )
-def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, instruction, timeout, seed):
+def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, instruction, timeout, seed, trial_count):
     """A Mujoco Franka sim eval: the eval holds the sim, the embodiment is pure robot.
 
     The task carries the instruction, the per-trial ``timeout``, the privileged sim-state
     ground truth (built from the eval's sim, recorded but never fed to the policy), and the
     sim's seeded scene reset. The scene (``loaders``) is embodiment-specific and wired here,
     not a generic Task field; the loaders carry no seeds of their own — the per-trial seed
-    handed to ``sim.reset`` drives the whole scene draw.
+    handed to ``sim.reset`` drives the whole scene draw. ``trial_count`` seeds (from ``seed``)
+    make the trial sweep; this eval has no task axis, so each is a fresh scene draw.
     """
     sim = MujocoSim(mujoco_model_path, loaders, camera_fps=camera_fps)
     embodiment = mujoco_franka(sim, camera_dict)
     # Full sim state is the privileged ground truth; scoring is computed downstream.
     privileged = {'sim_state': Observation(sim.sim_state, None)}
-    task = Task(instruction=instruction, timeout=timeout, privileged=privileged, seed=seed, reset=sim.reset)
-    return Eval(embodiment, task)
+    task = Task(
+        instruction=instruction,
+        timeout=timeout,
+        privileged=privileged,
+        reset=lambda ctx: sim.reset(ctx.get('eval.seed')),
+    )
+    return Eval(embodiment, task, build_trials(seed, trial_count))
 
 
 stack_cubes = _mujoco_franka_eval.override(instruction='Pick up the green cube and place it on the red cube.')

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -1,8 +1,7 @@
 import logging
-import random
 from collections.abc import Callable
 from contextlib import nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import configuronic as cfn
@@ -61,47 +60,24 @@ def _completion_sink(policy):
     return policy.counter.record if isinstance(policy, SampledPolicy) else None
 
 
-def main(
-    embodiment: Embodiment,
+def _run_world(
     policy,
-    driver: Callable[[Path | None], Driver] | None = None,
-    output_dir: str | Path | None = None,
-    task: Task | None = None,
-    trials: list[dict] | None = None,
-    show_gui: bool = False,
+    embodiment: Embodiment,
+    task: Task | None,
+    trials: list[dict] | None,
+    driver: Driver | None,
+    output_dir: Path | None,
+    show_gui: bool,
+    on_complete,
     *,
     wrap,
 ):
-    """Run inference for an embodiment, real or simulated.
+    """Wire one embodiment under a fresh Harness + World and run it to completion.
 
-    ``task`` (when given) supplies the policy-facing instruction, the per-trial ``timeout``
-    bounding self-driven trials, the privileged ground-truth signals to record, and the seeded
-    scene reset run at each trial start; without it the instruction rides the driver. Exactly
-    one of ``driver`` (attended: a factory producing the operator surface that emits the
-    directives) or ``trials`` (unattended: the harness runs the plan itself) must be given;
-    ``show_gui`` applies to the unattended path (attended surfaces bring their own).
+    ``driver`` (attended) and ``trials`` (unattended self-driving) are the two lifecycle sources, mutually
+    exclusive per the caller. The shared ``policy`` is wrapped here per run, but its lifetime stays with ``main``.
     """
-    assert (driver is None) != (trials is None), 'Provide exactly one of driver or trials'
-
-    # Drive the policy's remote endpoints through their cold start before hardware and the operator
-    # surface come up: opening a session blocks on the server handshake, which returns only once the
-    # model is loaded, and a SampledPolicy reaches every sub-policy. The first episode then begins
-    # warm instead of stalling on an on-request endpoint's model load while the robot waits.
-    # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
-    # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
-    logger.info('Warming up policy endpoints')
-    policy.new_session().close()
-
-    harness = Harness(
-        policy, embodiment, task=task, trials=trials, wrap=wrap, on_episode_complete=_completion_sink(policy)
-    )
-
-    if output_dir is not None:
-        output_dir = pos3.sync(output_dir, sync_on_error=True)
-        utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])
-        _seed_counter(policy, output_dir)
-
-    driver = driver(output_dir) if driver is not None else None
+    harness = Harness(policy, embodiment, task=task, trials=trials, wrap=wrap, on_episode_complete=on_complete)
     gui = driver.gui if driver is not None else (DearpyguiUi() if show_gui else None)
 
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
@@ -140,30 +116,59 @@ def main(
             world.run([harness, *foreground], [*producers, ds_agent, gui])
 
 
-@cfn.config(
-    eval=placeholder, policy=policy_cfg.placeholder, trial_count=1, show_gui=False, wrap=wrappers_cfg.default_wrappers
-)
-def run(eval: Eval, policy, trial_count, show_gui, output_dir=None, inference_latency=False, *, wrap):
-    """Run a selected eval (embodiment + task) through the shared inference harness."""
-    # The trial plan: one RUN context per trial, consumed by the self-driving Harness. Per-trial seeds
-    # are known upfront — ``--eval.seed`` + trial index, or an independent random draw per trial when
-    # unset — and ride the RUN context, so the seed used always lands in episode meta.
-    base = eval.task.seed
-    trials = [
-        {
-            'inference_latency': inference_latency,
-            'eval.seed': base + i if base is not None else random.randrange(2**31),
-            'eval.trial_index': i,
-            'eval.trial_count': trial_count,
-        }
-        for i in range(trial_count)
-    ]
-    main(
-        embodiment=eval.embodiment,
-        task=eval.task,
-        policy=policy,
-        trials=trials,
-        show_gui=show_gui,
-        output_dir=output_dir,
-        wrap=wrap,
-    )
+def main(
+    policy,
+    *,
+    wrap,
+    evals: list[Eval] | None = None,
+    embodiment: Embodiment | None = None,
+    driver: Callable[[Path | None], Driver] | None = None,
+    output_dir: str | Path | None = None,
+    show_gui: bool = False,
+):
+    """Run inference for an embodiment, real or simulated.
+
+    Exactly one of ``driver`` (attended: a factory producing the operator surface that emits the directives
+    over a single ``embodiment``) or ``evals`` (unattended: the harness self-drives each eval's trial plan,
+    rebuilding the World per eval) must be given; ``show_gui`` applies to the unattended path (attended surfaces
+    bring their own). ``main`` owns the policy lifetime: it warms the policy once up front and closes it once
+    after the last World, so a multi-eval sweep reuses one live policy across the rebuilds.
+    """
+    assert (driver is None) != (evals is None), 'Provide exactly one of driver or evals'
+
+    # Drive the policy's remote endpoints through their cold start before hardware and the operator
+    # surface come up: opening a session blocks on the server handshake, which returns only once the
+    # model is loaded, and a SampledPolicy reaches every sub-policy. The first episode then begins
+    # warm instead of stalling on an on-request endpoint's model load while the robot waits.
+    # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
+    # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
+    logger.info('Warming up policy endpoints')
+    policy.new_session().close()
+
+    if output_dir is not None:
+        output_dir = pos3.sync(output_dir, sync_on_error=True)
+        utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])
+        _seed_counter(policy, output_dir)
+
+    # One completion sink — so one ``SampledPolicy`` counter — across every eval, keeping sampling balanced
+    # over the whole sweep.
+    on_complete = _completion_sink(policy)
+    try:
+        if driver is not None:
+            _run_world(policy, embodiment, None, None, driver(output_dir), output_dir, show_gui, on_complete, wrap=wrap)
+        else:
+            for ev in evals:
+                _run_world(
+                    policy, ev.embodiment, ev.task, ev.trials, None, output_dir, show_gui, on_complete, wrap=wrap
+                )
+    finally:
+        policy.close()
+
+
+@cfn.config(eval=placeholder, policy=policy_cfg.placeholder, show_gui=False, wrap=wrappers_cfg.default_wrappers)
+def run(eval: Eval, policy, show_gui, output_dir=None, inference_latency=False, *, wrap):
+    """Run a selected eval (embodiment + task + its trial sweep) through the shared inference harness."""
+    # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob
+    # (sim inference-cost simulation). Overlay it onto every trial context, then self-drive the eval.
+    eval = replace(eval, trials=[{**trial, 'inference_latency': inference_latency} for trial in eval.trials])
+    main(policy=policy, evals=[eval], show_gui=show_gui, output_dir=output_dir, wrap=wrap)

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import pimm
@@ -77,9 +77,8 @@ class Task:
     ground-truth source to capture (the sim's full ``save_state``, a real scale) — recorded but never fed to
     the policy.
 
-    ``seed`` is the base seed for reproducible runs (``None`` → fully random); the
-    runner derives per-trial seeds from it into the trial plan. ``reset`` re-randomizes
-    the scene for a new trial from a per-trial seed; ``None`` on real embodiments,
+    ``reset`` re-randomizes the scene for a new trial from the per-trial run context, reading the keys it
+    needs (e.g. ``eval.seed``, and ``eval.task_id`` for a multi-task suite); ``None`` on real embodiments,
     where reset is physical/human.
 
     ``done`` is the optional terminating signal: a source that delivers a dict payload when the
@@ -92,14 +91,12 @@ class Task:
         instruction: str | Callable[[], str],
         timeout: float,
         privileged: dict[str, Observation] | None = None,
-        seed: int | None = None,
-        reset: Callable[[int | None], None] | None = None,
+        reset: Callable[[dict[str, Any]], None] | None = None,
         done: pimm.SignalEmitter | None = None,
     ):
         self._instruction = (lambda: instruction) if isinstance(instruction, str) else instruction
         self.timeout = timeout
         self.privileged = privileged or {}
-        self.seed = seed
         self.reset = reset
         self.done = done
 
@@ -110,11 +107,14 @@ class Task:
 
 @dataclass
 class Eval:
-    """An eval = embodiment + task, produced by a single config.
+    """An eval = embodiment + task + the trial sweep, produced by a single config.
 
     For a sim eval that config holds the shared ``MujocoSim`` both are built from, so the
-    embodiment stays pure robot while the task carries the scene's privileged signals.
+    embodiment stays pure robot while the task carries the scene's privileged signals. ``trials`` is the
+    sequence of RUN contexts the self-driving Harness runs — one per (task variant, seed) the config sweeps;
+    empty for an attended/real eval, driven by an operator rather than a trial plan.
     """
 
     embodiment: Embodiment
     task: Task
+    trials: list[dict[str, Any]] = field(default_factory=list)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -52,8 +52,8 @@ class Harness(pimm.ControlSystem):
     policy/session layer — the harness just calls the session, demuxes the action dicts into
     per-channel trajectories, and emits.
 
-    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation) and ``eval.seed``
-    (handed to the task's scene reset) in its context.
+    ``RUN`` may carry ``inference_latency`` (sim-only inference-cost simulation) in its context; the whole
+    context is handed to the task's scene reset, which reads the per-trial keys it needs (e.g. ``eval.seed``).
     A ``trials`` plan (a sequence of RUN contexts) makes the harness self-driving: whenever it is
     idle it starts the next trial itself and exits once the plan is exhausted, so the unattended
     path needs no driver at all. A task's ``timeout`` bounds every trial it is given to — self-driven
@@ -217,7 +217,7 @@ class Harness(pimm.ControlSystem):
         # (a remote env reports it then), so the session context — and the task-grouped sampling/counting it
         # drives — must read the instruction here, once it is known.
         if self._task is not None and self._task.reset is not None:
-            self._task.reset(self.context.get('eval.seed'))
+            self._task.reset(self.context)
         if self._task is not None:
             self.context = {**self.context, 'task': self._task.instruction}
         self._session = self.policy.new_session(self.context)
@@ -402,4 +402,5 @@ class Harness(pimm.ControlSystem):
             self._finalize_recording()
         if self._session:
             self._session.close()
-        self.policy.close()
+        # The harness wraps the policy per run but does not own its lifetime: the caller may run several
+        # harnesses over one policy (a multi-eval sweep), so it closes the policy once, after the last run.

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -602,7 +602,7 @@ class _FrameIndexDevice(pimm.ControlSystem):
         self._frame = 0
         self._reset_pending = False
 
-    def reset(self, seed):
+    def reset(self, _context):
         self._frame = 0
         self._reset_pending = True
 
@@ -728,8 +728,8 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
     seeds = []
     trials = [{'eval.seed': 7 + i} for i in range(2)]
 
-    def reset(seed):
-        seeds.append(seed)
+    def reset(context):
+        seeds.append(context.get('eval.seed'))
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
     task = Task(instruction='stack', timeout=0.05, reset=reset)
@@ -871,7 +871,7 @@ def test_task_instruction_reaches_session_context_after_reset(world):
     policy = StubPolicy()
     scene = {}
 
-    def reset(_seed):
+    def reset(_context):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
     task = Task(instruction=lambda: scene['task'], timeout=0.05, reset=reset)

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -27,10 +27,11 @@ class EnvAdapter(ABC):
     """The mappings between the canonical embodiment contract and an env's raw wire payloads."""
 
     @abstractmethod
-    def reset_token(self, seed: int | None) -> Any:
-        """A per-trial seed -> the env's opaque reset token (an int for most, a blob for exact replay).
+    def reset_token(self, context: dict[str, Any]) -> Any:
+        """The per-trial RUN context -> the env's opaque reset token (an int for most, a blob for exact replay).
 
-        Called at each trial start, so it is also where the adapter clears any per-trial command state.
+        Reads the context keys it needs (e.g. ``eval.seed``, ``eval.task_id``). Called at each trial start, so
+        it is also where the adapter clears any per-trial command state.
         """
 
     @abstractmethod

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -58,8 +58,8 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
         assert self._meta is not None, 'meta read before the first reset'
         return self._meta
 
-    def reset(self, seed: int | None = None) -> None:
-        """Re-randomize the env from ``seed`` and arm frame-0 publication for the next turn (the ``RUN`` hook).
+    def reset(self, context: dict[str, Any]) -> None:
+        """Re-randomize the env from the trial context and arm frame-0 publication for the next turn (the ``RUN`` hook).
 
         Resets the remote env (acquiring the fresh frame and its ``control_dt``), then flags the run loop
         to publish the scene meta, a full observation payload (frame-0) and a non-terminal ``done`` on its
@@ -75,7 +75,7 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
             self._cleanup.callback(self._conn.close)
         for _, receiver in self.commands.items():
             receiver.read()
-        self._frame = self._conn.reset(self._adapter.reset_token(seed))
+        self._frame = self._conn.reset(self._adapter.reset_token(context))
         self._meta = self._frame['meta']
         self._robot_meta = self._frame['robot_meta']
         self._reset_pending = True

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -167,10 +167,10 @@ class StackCubesAdapter(EnvAdapter):
         self._players = fresh_command_players()
         self._held: dict[str, Any] = {}  # last sampled waypoint per channel — re-sent until it changes
 
-    def reset_token(self, seed: int | None) -> Any:
+    def reset_token(self, context: dict[str, Any]) -> Any:
         self._players = fresh_command_players()
         self._held = {}
-        return seed
+        return context.get('eval.seed')
 
     def action(self, commands: dict[str, pimm.Message], now_ns: int) -> dict[str, Any]:
         for name, msg in commands.items():
@@ -261,7 +261,6 @@ def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str]
         instruction='Pick up the green cube and place it on the red cube.',
         timeout=15.0,
         privileged=privileged,
-        seed=None,
         reset=proxy.reset,
         done=proxy.done,
     )

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from dataclasses import replace
 
 import numpy as np
 import pos3
@@ -154,8 +155,8 @@ class _CountdownEnv(EnvProtocol):
 
 
 class _CountdownAdapter(EnvAdapter):
-    def reset_token(self, seed):
-        return seed
+    def reset_token(self, context):
+        return context.get('eval.seed')
 
     def action(self, commands, now_ns):
         return {}
@@ -183,7 +184,7 @@ def test_proxy_publishes_frame0_then_free_runs():
         scheduler = world.start([proxy])
         drive_scheduler(scheduler, steps=2)  # inactive: the proxy paces time without an env
 
-        proxy.reset(0)  # arm frame-0; the run loop publishes it on its next turn
+        proxy.reset({'eval.seed': 0})  # arm frame-0; the run loop publishes it on its next turn
         drive_scheduler(scheduler, steps=1)
         np.testing.assert_array_equal(obs_rx.read().data, np.zeros(7))
         assert done_rx.read().data == {}
@@ -202,7 +203,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
         task = Task(instruction=lambda: proxy.meta['task'], timeout=1.0, reset=proxy.reset)
         scheduler = world.start([proxy])
 
-        proxy.reset(0)
+        proxy.reset({'eval.seed': 0})
         assert task.instruction == 'countdown'  # resolved live off the cached reset meta
         drive_scheduler(scheduler, steps=4)  # the env steps, each ``step`` omitting meta ...
         assert task.instruction == 'countdown'  # ... yet the reset-scoped cache holds
@@ -218,10 +219,8 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
         ev.task.timeout = 0.1
         policy = StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0)
         main(
-            embodiment=ev.embodiment,
-            task=ev.task,
             policy=policy,
-            trials=[{'eval.trial_index': 0, 'eval.seed': 100}],
+            evals=[replace(ev, trials=[{'eval.trial_index': 0, 'eval.seed': 100}])],
             output_dir=str(tmp_path),
             wrap=ErrorRecovery() | ChunkedSchedule(),
         )

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -42,19 +42,14 @@ class LiberoAdapter(EnvAdapter):
         camera_dict: dict[str, str],
         *,
         suite: str,
-        task_id: int,
         camera_resolution: int,
         control_mode: str,
         settle_steps: int = 10,
     ):
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
-        # The task spec the server builds its env from — shipped in every reset token (the server caches by it).
-        self._scene = {
-            'suite': suite,
-            'task_id': task_id,
-            'camera_resolution': camera_resolution,
-            'control_mode': control_mode,
-        }
+        # The scene spec the server builds its env from, minus the per-trial ``task_id`` that rides each reset
+        # token — the server caches its env by ``(suite, task_id, ...)``, so one server serves the whole suite.
+        self._scene = {'suite': suite, 'camera_resolution': camera_resolution, 'control_mode': control_mode}
         # Hold-arm/open-gripper steps the server runs after a seeded reset to let dropped objects settle before the
         # first observation (openpi's num_steps_wait dummy-action wait); a per-reset behavior, not a build param.
         self._settle_steps = settle_steps
@@ -64,12 +59,19 @@ class LiberoAdapter(EnvAdapter):
         # value with no 'hold' command to fall back on (unlike the arm), so cancelling must freeze it, not reopen.
         self._grip = 0.0
 
-    def reset_token(self, seed: int | None) -> Any:
+    def reset_token(self, context: dict[str, Any]) -> Any:
         self._players = fresh_command_players()
         self._held = {}
         self._grip = 0.0
-        # The task spec the server builds from + the seed it selects an init-state with (``None`` -> index 0).
-        return {**self._scene, 'seed': seed if seed is not None else 0, 'settle_steps': self._settle_steps}
+        seed = context.get('eval.seed')
+        # The scene spec + the per-trial task_id the server builds from and the seed it selects an init-state
+        # with (``None`` -> index 0).
+        return {
+            **self._scene,
+            'task_id': context['eval.task_id'],
+            'seed': seed if seed is not None else 0,
+            'settle_steps': self._settle_steps,
+        }
 
     def action(self, commands: dict[str, pimm.Message], now_ns: int) -> dict[str, Any]:
         for name, msg in commands.items():

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -49,18 +49,17 @@ class LiberoAdapter(EnvAdapter):
         self._players = fresh_command_players()
         self._held = {}
         self._grip = 0.0
-        seed = context.get('eval.seed')
         # The whole scene spec rides the trial context: the server caches its env by ``(suite, task_id,
         # camera_resolution, control_mode)``, so one adapter + one server serve any mix of suites and tasks.
-        # ``seed`` selects a saved init-state (``None`` -> index 0); ``settle_steps`` is the hold-arm/open-gripper
-        # wait the server runs after a seeded reset so dropped objects settle before the first observation
-        # (openpi's num_steps_wait dummy-action wait).
+        # ``seed`` selects a saved init-state (``None`` -> the server draws one at random); ``settle_steps`` is
+        # the hold-arm/open-gripper wait the server runs after a seeded reset so dropped objects settle before
+        # the first observation (openpi's num_steps_wait dummy-action wait).
         return {
             'suite': context['eval.suite'],
             'task_id': context['eval.task_id'],
             'camera_resolution': context['eval.camera_resolution'],
             'control_mode': context['eval.control_mode'],
-            'seed': seed if seed is not None else 0,
+            'seed': context.get('eval.seed'),
             'settle_steps': context['eval.settle_steps'],
         }
 

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -37,22 +37,8 @@ def _wire_command(cmd: Any) -> dict[str, Any]:
 
 
 class LiberoAdapter(EnvAdapter):
-    def __init__(
-        self,
-        camera_dict: dict[str, str],
-        *,
-        suite: str,
-        camera_resolution: int,
-        control_mode: str,
-        settle_steps: int = 10,
-    ):
+    def __init__(self, camera_dict: dict[str, str]):
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
-        # The scene spec the server builds its env from, minus the per-trial ``task_id`` that rides each reset
-        # token — the server caches its env by ``(suite, task_id, ...)``, so one server serves the whole suite.
-        self._scene = {'suite': suite, 'camera_resolution': camera_resolution, 'control_mode': control_mode}
-        # Hold-arm/open-gripper steps the server runs after a seeded reset to let dropped objects settle before the
-        # first observation (openpi's num_steps_wait dummy-action wait); a per-reset behavior, not a build param.
-        self._settle_steps = settle_steps
         self._players = fresh_command_players()
         self._held: dict[str, Any] = {}  # last sampled waypoint per channel — re-sent until it changes
         # Last commanded gripper closure, held across a cancelled grip trajectory: grip is an absolute [0, 1]
@@ -64,13 +50,18 @@ class LiberoAdapter(EnvAdapter):
         self._held = {}
         self._grip = 0.0
         seed = context.get('eval.seed')
-        # The scene spec + the per-trial task_id the server builds from and the seed it selects an init-state
-        # with (``None`` -> index 0).
+        # The whole scene spec rides the trial context: the server caches its env by ``(suite, task_id,
+        # camera_resolution, control_mode)``, so one adapter + one server serve any mix of suites and tasks.
+        # ``seed`` selects a saved init-state (``None`` -> index 0); ``settle_steps`` is the hold-arm/open-gripper
+        # wait the server runs after a seeded reset so dropped objects settle before the first observation
+        # (openpi's num_steps_wait dummy-action wait).
         return {
-            **self._scene,
+            'suite': context['eval.suite'],
             'task_id': context['eval.task_id'],
+            'camera_resolution': context['eval.camera_resolution'],
+            'control_mode': context['eval.control_mode'],
             'seed': seed if seed is not None else 0,
-            'settle_steps': self._settle_steps,
+            'settle_steps': context['eval.settle_steps'],
         }
 
     def action(self, commands: dict[str, pimm.Message], now_ns: int) -> dict[str, Any]:

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -37,12 +37,13 @@ goal is solved to joints with damped-least-squares IK and a joint goal is turned
 forward kinematics, both on the MuJoCo site Jacobian OSC itself computes. The reset token carries the task spec
 (suite, task_id, camera resolution, control mode) plus the per-trial seed; the env builds that task on the first
 reset and caches it, rebuilding only when the spec changes. The seed selects a saved init-state and re-randomizes
-object positions.
+object positions; a ``None`` seed draws one at random.
 """
 
 import argparse
 import builtins
 import pathlib
+import random
 from typing import Any
 
 import mujoco
@@ -73,8 +74,8 @@ class LiberoEnv(EnvProtocol):
     """A LIBERO task behind the gym-style ``reset``/``step``/``close`` the env server serves.
 
     Built from the reset token's task spec (suite, task_id, resolution, control mode) and cached; ``reset``
-    rebuilds when the spec changes, then re-seeds and selects a saved init-state, or restores an exact recorded
-    full state when the token carries one (demo replay).
+    rebuilds when the spec changes, then re-seeds and selects a saved init-state (drawing the seed when the token
+    carries ``None``), or restores an exact recorded full state when the token carries one (demo replay).
     ``step`` maps the forwarded command into the active controller's action (FK/IK bridging pose<->joint) and
     returns LIBERO's raw obs plus the full physics state — the privileged ground truth, so success is
     recomputable downstream — and ``done``.
@@ -154,7 +155,8 @@ class LiberoEnv(EnvProtocol):
             self._env.reset()
             raw = self._env.set_init_state(np.asarray(state))
         else:
-            seed = int(token['seed'])
+            # An absent seed draws a fresh scene, matching ``MujocoSim.reset(seed=None)``.
+            seed = int(token['seed']) if token['seed'] is not None else random.randrange(2**31)
             self._env.seed(seed)
             self._env.reset()
             raw = self._env.set_init_state(self._init_states[seed % len(self._init_states)])

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from dataclasses import replace
 
 import mujoco as mj
 import numpy as np
@@ -74,10 +75,8 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
             timeout=0.4,
         )
         main(
-            embodiment=ev.embodiment,
-            task=ev.task,
             policy=policy,
-            trials=[{'eval.trial_index': i, 'eval.seed': 100 + i} for i in range(2)],
+            evals=[replace(ev, trials=[{'eval.trial_index': i, 'eval.seed': 100 + i} for i in range(2)])],
             output_dir=str(tmp_path),
             wrap=ErrorRecovery() | ChunkedSchedule(),
         )
@@ -167,7 +166,7 @@ class _CountdownProducer(pimm.ControlSystem):
         self.robot_meta = pimm.ControlSystemEmitter(self)
         self.done = pimm.ControlSystemEmitter(self)
 
-    def reset(self, seed: int | None = None) -> None:
+    def reset(self, _context: dict | None = None) -> None:
         self._steps = 0
         self._reset_pending = True
         self._active = True
@@ -205,9 +204,7 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float) -> Eval:
         control_systems=(producer,),
         simulated=True,
     )
-    task = Task(
-        instruction='count', timeout=timeout, privileged={}, seed=None, reset=producer.reset, done=producer.done
-    )
+    task = Task(instruction='count', timeout=timeout, privileged={}, reset=producer.reset, done=producer.done)
     return Eval(embodiment, task)
 
 
@@ -221,10 +218,8 @@ def test_countdown_records_frame0_every_trial(tmp_path):
     ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35)
     with pos3.mirror():
         main(
-            embodiment=ev.embodiment,
-            task=ev.task,
             policy=StubPolicy(command=ev.embodiment.commands['robot_command'].home, target_grip=0.0),
-            trials=[{'eval.trial_index': i, 'eval.seed': i} for i in range(2)],
+            evals=[replace(ev, trials=[{'eval.trial_index': i, 'eval.seed': i} for i in range(2)])],
             output_dir=str(tmp_path),
             wrap=None,  # the degenerate obs is not Franka-shaped; ErrorRecovery hard-codes robot_state.error
         )
@@ -243,10 +238,8 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     ev = _countdown_eval(_CountdownProducer(done_after=4), timeout=15.0)
     with pos3.mirror():
         main(
-            embodiment=ev.embodiment,
-            task=ev.task,
             policy=StubPolicy(command=ev.embodiment.commands['robot_command'].home, target_grip=0.0),
-            trials=[{'eval.trial_index': 0, 'eval.seed': 100}],
+            evals=[replace(ev, trials=[{'eval.trial_index': 0, 'eval.seed': 100}])],
             output_dir=str(tmp_path),
             wrap=None,
         )

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -44,7 +44,7 @@ CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports
 uv run --locked positronic-inference sim \
   --policy=.remote --policy.host=<h100-host> --policy.port=8000 \
   --wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers \
-  --trial_count=2 --show_gui=True
+  --eval.trial_count=2 --show_gui=True
 ```
 
 The server owns the codec, so you don't pass one client-side — it takes raw observations and returns
@@ -149,7 +149,7 @@ Sanity-check once warm: `curl http://<h100-host>:8000/api/v1/models` → `{"mode
 uv run --locked positronic-inference sim \
   --policy=.remote --policy.host=<h100-host> --policy.port=8000 \
   --wrap=@positronic.vendors.dreamzero.codecs.dreamzero_wrappers \
-  --trial_count=<N> --output_dir=<dir-or-s3-path>
+  --eval.trial_count=<N> --output_dir=<dir-or-s3-path>
 ```
 
 Sim runs locally on your machine; only inference is remote. Each episode records 3 camera views +


### PR DESCRIPTION
## Summary
One `positronic eval run` now sweeps a whole eval's trial space — no external bash loop. Builds on #459 (the LIBERO env-server, now in main).

- **`task_id` rides the reset token.** `Task.reset` takes the per-trial run context; the Harness hands it the whole context; `EnvAdapter.reset_token(context)` / `proxy.reset(context)`; `LiberoAdapter` drops `task_id` from `__init__`. `MujocoSim.reset(seed)` is left unchanged (it doubles as the env-server token decoder), so the native config adapts via a lambda. **Env-server transport unchanged** — the server already caches per `(suite, task_id, …)`.
- **Eval configs own the trial sweep.** `build_trials(seed, trial_count, task_ids)` builds the per-trial RUN contexts (task range × seed); `Eval` gains a `trials` field; `Task.seed` is removed. Sim, LIBERO, and real configs all build their trials.
- **`main(evals)`** loops evals (a World + self-driving Harness per eval) and owns the policy lifetime: warmup / `pos3.sync` / seed-counter run once, the sampler counter is shared across evals, and `policy.close()` runs once. The Harness no longer closes the policy (that nulled `RemotePolicy._client` and would kill a multi-eval sweep after the first). `run` overlays the CLI-owned `inference_latency`.

Usage: `--eval=.sim.libero.spatial` sweeps all 10 spatial tasks; `--eval.task_id=3 --eval.trial_count=5` pins task 3 over 5 seeds.

## Test plan
- `uv run --locked pytest --no-cov` over the affected suites — harness (42), policy dir (127), sim-integration + env-server (12) — all pass; repo-wide collection (610) imports clean.
- `ruff check` + `ruff format` clean.
- A live LIBERO full-suite sweep needs the 3.10 env-server subprocess + a served policy and was **not** run here.