### PR TITLE
Add between-episode jog teleop to the web eval console

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -35,6 +35,7 @@ class Driver:
     directives: pimm.SignalEmitter
     directive_wrapper: Callable
     control_systems: list[pimm.ControlSystem]
+    manual_commands: pimm.SignalEmitter | None = None
 
 
 def _seed_counter(policy, output_dir: Path):
@@ -121,6 +122,8 @@ def main(
                     world.connect(obs.source, gui.cameras[name])
         if driver is not None:
             world.connect(driver.directives, harness.directive, emitter_wrapper=driver.directive_wrapper)
+            if driver.manual_commands is not None:
+                world.connect(driver.manual_commands, harness.manual_command)
         if ds_agent is not None:
             world.connect(harness.ds_command, ds_agent.command)
 

--- a/positronic/gui/static/eval.css
+++ b/positronic/gui/static/eval.css
@@ -168,6 +168,12 @@ body {
   border-color: transparent;
 }
 
+.jog-slider {
+  width: 100%;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
 .jog.is-running {
   opacity: 0.5;
 }

--- a/positronic/gui/static/eval.css
+++ b/positronic/gui/static/eval.css
@@ -18,6 +18,13 @@ body {
   gap: 0.5rem;
 }
 
+.stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  gap: 0.5rem;
+}
+
 .camera {
   flex: 1 1 auto;
   min-height: 0;
@@ -66,4 +73,86 @@ body {
   background: var(--danger);
   color: var(--text-invert);
   box-shadow: 0 0 20px rgba(248, 113, 113, 0.55);
+}
+
+.jog {
+  flex: 0 0 auto;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+}
+
+.jog-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.jog-title {
+  margin: 0;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.jog-btn {
+  padding: 0.4rem 0.6rem;
+  font-size: 0.82rem;
+}
+
+.jog-cross {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 0.3rem;
+}
+
+.jog-up { grid-column: 2; grid-row: 1; }
+.jog-left { grid-column: 1; grid-row: 2; }
+.jog-right { grid-column: 3; grid-row: 2; }
+.jog-down { grid-column: 2; grid-row: 3; }
+
+.jog-z {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem;
+}
+
+.jog-rot-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.jog-label {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.jog-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem;
+}
+
+.jog-btn.is-active {
+  background: var(--accent);
+  color: var(--text-invert);
+  border-color: transparent;
+}
+
+.jog.is-running {
+  opacity: 0.5;
+}
+
+.jog.is-running .jog-btn {
+  cursor: not-allowed;
 }

--- a/positronic/gui/static/eval.css
+++ b/positronic/gui/static/eval.css
@@ -29,6 +29,7 @@ body {
   flex: 1 1 auto;
   min-height: 0;
   margin: 0;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -44,6 +45,24 @@ body {
   max-height: 100%;
   width: auto;
   height: auto;
+}
+
+.stream-status {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.6rem;
+  display: none;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--danger);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.stream-status.is-visible {
+  display: block;
 }
 
 .btn-primary {

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -64,6 +64,7 @@
               <button class="btn btn-ghost jog-btn" data-grip="0">Open</button>
               <button class="btn btn-ghost jog-btn" data-grip="1">Close</button>
             </div>
+            <input class="jog-slider" id="grip-slider" type="range" min="0" max="1" step="0.01" value="0" />
           </section>
         </aside>
       </div>
@@ -77,7 +78,7 @@
       const setRunning = (value) => {
         running = value;
         jog.classList.toggle('is-running', running);
-        for (const button of jog.querySelectorAll('button')) button.disabled = running;
+        for (const control of jog.querySelectorAll('button, input')) control.disabled = running;
       };
 
       for (const button of document.querySelectorAll('button[data-action]')) {
@@ -107,18 +108,36 @@
         });
       }
 
-      for (const button of document.querySelectorAll('[data-grip]')) {
+      const gripSlider = document.getElementById('grip-slider');
+      const gripButtons = document.querySelectorAll('[data-grip]');
+
+      const sendGrip = (value) => {
+        fetch('/grip', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value }),
+        });
+      };
+
+      const reflectGrip = (value) => {
+        for (const button of gripButtons) {
+          button.classList.toggle('is-active', Number(button.dataset.grip) === value);
+        }
+      };
+
+      for (const button of gripButtons) {
         button.addEventListener('click', () => {
-          fetch('/grip', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ value: Number(button.dataset.grip) }),
-          });
-          for (const other of document.querySelectorAll('[data-grip]')) {
-            other.classList.toggle('is-active', other === button);
-          }
+          const value = Number(button.dataset.grip);
+          gripSlider.value = value;
+          reflectGrip(value);
+          sendGrip(value);
         });
       }
+
+      gripSlider.addEventListener('input', () => reflectGrip(Number(gripSlider.value)));
+      gripSlider.addEventListener('change', () => sendGrip(Number(gripSlider.value)));
+
+      reflectGrip(Number(gripSlider.value));
 
       startStream(document.getElementById('feed'));
 

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -17,6 +17,7 @@
       <div class="stage">
         <figure class="camera">
           <video id="feed" autoplay muted playsinline></video>
+          <div id="stream-status" class="stream-status"></div>
         </figure>
         <aside class="jog" id="jog">
           <section class="jog-section">
@@ -126,16 +127,31 @@
           console.error('MediaSource Extensions not supported in this browser');
           return;
         }
-        const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
-        const socket = new WebSocket(`${scheme}://${location.host}/video`);
-        socket.binaryType = 'arraybuffer';
-
+        const status = document.getElementById('stream-status');
         const MAX_BUFFER_SECONDS = 10;
+        const STALL_MS = 5000;
+
+        let socket = null;
+        let mediaSource = null;
         let sourceBuffer = null;
-        const pending = [];
+        let pending = [];
+        let objectUrl = null;
+        let watchdog = null;
+        let reconnectTimer = null;
+        let backoff = 500;
+        let lastActivity = 0;
+
+        const setStatus = (text) => {
+          if (!status) return;
+          status.textContent = text;
+          status.classList.toggle('is-visible', Boolean(text));
+        };
+
         const ensurePlaying = () => {
           if (video.paused) video.play().catch(() => {});
         };
+        video.addEventListener('canplay', ensurePlaying);
+
         const pump = () => {
           if (!sourceBuffer || sourceBuffer.updating) return;
           const buffered = sourceBuffer.buffered;
@@ -156,29 +172,67 @@
             ensurePlaying();
           }
         };
-        video.addEventListener('canplay', ensurePlaying);
 
-        socket.addEventListener('message', (event) => {
-          if (typeof event.data === 'string') {
-            const codec = `video/mp4; codecs="${event.data}"`;
-            if (!MediaSource.isTypeSupported(codec)) {
-              console.error('Unsupported codec', codec);
-              socket.close();
-              return;
-            }
-            const mediaSource = new MediaSource();
-            video.src = URL.createObjectURL(mediaSource);
-            mediaSource.addEventListener('sourceopen', () => {
-              sourceBuffer = mediaSource.addSourceBuffer(codec);
-              sourceBuffer.mode = 'sequence';
-              sourceBuffer.addEventListener('updateend', pump);
-              pump();
-            });
-          } else {
-            pending.push(new Uint8Array(event.data));
-            pump();
+        // The socket dies on a server restart, tunnel blip, or silently on a half-open connection. Reconnect on
+        // close and, since a half-open socket fires no close, force one when no fragment has arrived for STALL_MS.
+        const scheduleReconnect = () => {
+          if (reconnectTimer) return;
+          if (watchdog) {
+            clearInterval(watchdog);
+            watchdog = null;
           }
-        });
+          setStatus('Reconnecting…');
+          reconnectTimer = setTimeout(() => {
+            reconnectTimer = null;
+            connect();
+          }, backoff);
+          backoff = Math.min(backoff * 2, 4000);
+        };
+
+        const connect = () => {
+          sourceBuffer = null;
+          pending = [];
+          lastActivity = Date.now();
+          const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+          socket = new WebSocket(`${scheme}://${location.host}/video`);
+          socket.binaryType = 'arraybuffer';
+
+          socket.addEventListener('message', (event) => {
+            lastActivity = Date.now();
+            if (typeof event.data === 'string') {
+              const codec = `video/mp4; codecs="${event.data}"`;
+              if (!MediaSource.isTypeSupported(codec)) {
+                console.error('Unsupported codec', codec);
+                socket.close();
+                return;
+              }
+              backoff = 500;
+              setStatus('');
+              mediaSource = new MediaSource();
+              if (objectUrl) URL.revokeObjectURL(objectUrl);
+              objectUrl = URL.createObjectURL(mediaSource);
+              video.src = objectUrl;
+              mediaSource.addEventListener('sourceopen', () => {
+                sourceBuffer = mediaSource.addSourceBuffer(codec);
+                sourceBuffer.mode = 'sequence';
+                sourceBuffer.addEventListener('updateend', pump);
+                pump();
+              });
+            } else {
+              pending.push(new Uint8Array(event.data));
+              pump();
+            }
+          });
+
+          socket.addEventListener('close', scheduleReconnect);
+          socket.addEventListener('error', () => socket.close());
+
+          watchdog = setInterval(() => {
+            if (Date.now() - lastActivity > STALL_MS) socket.close();
+          }, 1000);
+        };
+
+        connect();
       }
     </script>
 </body>

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -14,14 +14,109 @@
         <button class="btn btn-ghost" data-action="finish">Finish</button>
         <button class="btn btn-danger" data-action="abort">Abort</button>
       </div>
-      <figure class="camera">
-        <video id="feed" autoplay muted playsinline></video>
-      </figure>
+      <div class="stage">
+        <figure class="camera">
+          <video id="feed" autoplay muted playsinline></video>
+        </figure>
+        <aside class="jog" id="jog">
+          <section class="jog-section">
+            <h2 class="jog-title">Translation</h2>
+            <div class="jog-cross">
+              <button class="btn btn-ghost jog-btn jog-up" data-jog data-axis="x" data-sign="1">+X</button>
+              <button class="btn btn-ghost jog-btn jog-left" data-jog data-axis="y" data-sign="1">+Y</button>
+              <button class="btn btn-ghost jog-btn jog-right" data-jog data-axis="y" data-sign="-1">-Y</button>
+              <button class="btn btn-ghost jog-btn jog-down" data-jog data-axis="x" data-sign="-1">-X</button>
+            </div>
+            <div class="jog-z">
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="z" data-sign="1">+Z</button>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="z" data-sign="-1">-Z</button>
+            </div>
+          </section>
+          <section class="jog-section">
+            <h2 class="jog-title">Rotation</h2>
+            <div class="jog-rot-row">
+              <span class="jog-label">Roll</span>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="rx" data-sign="-1">-</button>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="rx" data-sign="1">+</button>
+            </div>
+            <div class="jog-rot-row">
+              <span class="jog-label">Pitch</span>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="ry" data-sign="-1">-</button>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="ry" data-sign="1">+</button>
+            </div>
+            <div class="jog-rot-row">
+              <span class="jog-label">Yaw</span>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="rz" data-sign="-1">-</button>
+              <button class="btn btn-ghost jog-btn" data-jog data-axis="rz" data-sign="1">+</button>
+            </div>
+          </section>
+          <section class="jog-section">
+            <h2 class="jog-title">Scale</h2>
+            <div class="jog-toggle" id="scale">
+              <button class="btn btn-ghost jog-btn is-active" data-scale="fine">Fine</button>
+              <button class="btn btn-ghost jog-btn" data-scale="coarse">Coarse</button>
+            </div>
+          </section>
+          <section class="jog-section">
+            <h2 class="jog-title">Gripper</h2>
+            <div class="jog-toggle" id="grip">
+              <button class="btn btn-ghost jog-btn" data-grip="0">Open</button>
+              <button class="btn btn-ghost jog-btn" data-grip="1">Close</button>
+            </div>
+          </section>
+        </aside>
+      </div>
     </div>
 
     <script>
+      const jog = document.getElementById('jog');
+      let scale = 'fine';
+      let running = false;
+
+      const setRunning = (value) => {
+        running = value;
+        jog.classList.toggle('is-running', running);
+        for (const button of jog.querySelectorAll('button')) button.disabled = running;
+      };
+
       for (const button of document.querySelectorAll('button[data-action]')) {
-        button.addEventListener('click', () => fetch('/directive/' + button.dataset.action, { method: 'POST' }));
+        button.addEventListener('click', () => {
+          fetch('/directive/' + button.dataset.action, { method: 'POST' });
+          if (button.dataset.action === 'start') setRunning(true);
+          else setRunning(false);
+        });
+      }
+
+      for (const button of document.querySelectorAll('[data-scale]')) {
+        button.addEventListener('click', () => {
+          scale = button.dataset.scale;
+          for (const other of document.querySelectorAll('[data-scale]')) {
+            other.classList.toggle('is-active', other === button);
+          }
+        });
+      }
+
+      for (const button of document.querySelectorAll('[data-jog]')) {
+        button.addEventListener('click', () => {
+          fetch('/jog', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ axis: button.dataset.axis, sign: Number(button.dataset.sign), scale }),
+          });
+        });
+      }
+
+      for (const button of document.querySelectorAll('[data-grip]')) {
+        button.addEventListener('click', () => {
+          fetch('/grip', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: Number(button.dataset.grip) }),
+          });
+          for (const other of document.querySelectorAll('[data-grip]')) {
+            other.classList.toggle('is-active', other === button);
+          }
+        });
       }
 
       startStream(document.getElementById('feed'));

--- a/positronic/gui/templates/eval_console.html
+++ b/positronic/gui/templates/eval_console.html
@@ -84,6 +84,9 @@
       for (const button of document.querySelectorAll('button[data-action]')) {
         button.addEventListener('click', () => {
           fetch('/directive/' + button.dataset.action, { method: 'POST' });
+          // TODO: this re-enables the jog controls on the Finish/Abort click, but the harness stays busy until
+          // it finalizes the episode and the arm finishes homing. Gate the controls on a real idle signal
+          // pushed from the harness instead of the button press.
           if (button.dataset.action === 'start') setRunning(true);
           else setRunning(false);
         });

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -26,7 +26,7 @@ class _JogBody(BaseModel):
 
 
 class _GripBody(BaseModel):
-    value: int
+    value: float
 
 
 _TRANSLATION_AXES = {'x': 0, 'y': 1, 'z': 2}
@@ -282,7 +282,7 @@ class WebEvalUI(pimm.ControlSystem):
 
         @app.post('/grip')
         async def grip(body: _GripBody):
-            self.manual_command.emit({'target_grip': float(body.value)}, clock.now_ns())
+            self.manual_command.emit({'target_grip': body.value}, clock.now_ns())
 
         # The continuous fragment push is the connection's liveness signal. Uvicorn's keepalive ping
         # runs in its own coroutine and would await a transport drain concurrently with the send loop,

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -284,10 +284,10 @@ class WebEvalUI(pimm.ControlSystem):
         async def grip(body: _GripBody):
             self.manual_command.emit({'target_grip': body.value}, clock.now_ns())
 
-        # The continuous fragment push is the connection's liveness signal. Uvicorn's keepalive ping
-        # runs in its own coroutine and would await a transport drain concurrently with the send loop,
-        # tripping an assertion in websockets and killing the feed; disable it.
-        config = uvicorn.Config(app, host='0.0.0.0', port=self.port, ws_ping_interval=None, ws_ping_timeout=None)
+        # The legacy asyncio `websockets` backend drains the transport from its reader and keepalive
+        # coroutines concurrently with our send loop, tripping an assertion that kills the feed. The
+        # sans-io backend serializes every write through the event-loop transport instead.
+        config = uvicorn.Config(app, host='0.0.0.0', port=self.port, ws='websockets-sansio')
         server = uvicorn.Server(config)
         server_thread = threading.Thread(target=server.run, daemon=True)
         server_thread.start()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -3,6 +3,7 @@ import queue
 import threading
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Literal
 
 import av
 import numpy as np
@@ -11,7 +12,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import pimm
 from positronic import geom, utils
@@ -20,13 +21,13 @@ from positronic.policy.harness import Directive
 
 
 class _JogBody(BaseModel):
-    axis: str
-    sign: int
-    scale: str
+    axis: Literal['x', 'y', 'z', 'rx', 'ry', 'rz']
+    sign: Literal[-1, 1]
+    scale: Literal['fine', 'coarse']
 
 
 class _GripBody(BaseModel):
-    value: float
+    value: float = Field(ge=0.0, le=1.0)
 
 
 _TRANSLATION_AXES = {'x': 0, 'y': 1, 'z': 2}
@@ -276,8 +277,6 @@ class WebEvalUI(pimm.ControlSystem):
                 rotvec = np.zeros(3)
                 rotvec[_ROTATION_AXES[body.axis]] = np.deg2rad(body.sign * angle)
                 delta = geom.Transform3D(rotation=geom.Rotation.from_rotvec(rotvec))
-            else:
-                raise HTTPException(status_code=404)
             self.manual_command.emit({'robot_command': command.CartesianDelta(delta)}, clock.now_ns())
 
         @app.post('/grip')

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -11,10 +11,26 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
 
 import pimm
-from positronic import utils
+from positronic import geom, utils
+from positronic.drivers.roboarm import command
 from positronic.policy.harness import Directive
+
+
+class _JogBody(BaseModel):
+    axis: str
+    sign: int
+    scale: str
+
+
+class _GripBody(BaseModel):
+    value: int
+
+
+_TRANSLATION_AXES = {'x': 0, 'y': 1, 'z': 2}
+_ROTATION_AXES = {'rx': 0, 'ry': 1, 'rz': 2}
 
 
 def _pkg_path(*parts: str) -> str:
@@ -173,15 +189,32 @@ class WebEvalUI(pimm.ControlSystem):
     reachable over an SSH tunnel or directly on the host IP.
     """
 
-    def __init__(self, task: str | None = None, port=8080, fps=20, width=640, keyframe_interval=15, bitrate=2_000_000):
+    def __init__(
+        self,
+        task: str | None = None,
+        port=8080,
+        fps=20,
+        width=640,
+        keyframe_interval=15,
+        bitrate=2_000_000,
+        translation_fine=0.01,
+        translation_coarse=0.05,
+        rotation_fine=2.0,
+        rotation_coarse=10.0,
+    ):
         self.task = task
         self.port = port
         self.fps = fps
         self.width = width
         self.keyframe_interval = keyframe_interval
         self.bitrate = bitrate
+        self.translation_fine = translation_fine
+        self.translation_coarse = translation_coarse
+        self.rotation_fine = rotation_fine
+        self.rotation_coarse = rotation_coarse
         self.cameras = pimm.ReceiverDict(self, default=None)
         self.directive = pimm.ControlSystemEmitter(self)
+        self.manual_command = pimm.ControlSystemEmitter(self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         templates = Jinja2Templates(directory=_pkg_path('templates'))
@@ -230,6 +263,26 @@ class WebEvalUI(pimm.ControlSystem):
                     self.directive.emit(Directive.ABORT(), clock.now_ns())
                 case _:
                     raise HTTPException(status_code=404)
+
+        @app.post('/jog')
+        async def jog(body: _JogBody):
+            if body.axis in _TRANSLATION_AXES:
+                step = self.translation_fine if body.scale == 'fine' else self.translation_coarse
+                translation = np.zeros(3)
+                translation[_TRANSLATION_AXES[body.axis]] = body.sign * step
+                delta = geom.Transform3D(translation=translation)
+            elif body.axis in _ROTATION_AXES:
+                angle = self.rotation_fine if body.scale == 'fine' else self.rotation_coarse
+                rotvec = np.zeros(3)
+                rotvec[_ROTATION_AXES[body.axis]] = np.deg2rad(body.sign * angle)
+                delta = geom.Transform3D(rotation=geom.Rotation.from_rotvec(rotvec))
+            else:
+                raise HTTPException(status_code=404)
+            self.manual_command.emit({'robot_command': command.CartesianDelta(delta)}, clock.now_ns())
+
+        @app.post('/grip')
+        async def grip(body: _GripBody):
+            self.manual_command.emit({'target_grip': float(body.value)}, clock.now_ns())
 
         # The continuous fragment push is the connection's liveness signal. Uvicorn's keepalive ping
         # runs in its own coroutine and would await a transport drain concurrently with the send loop,

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -61,11 +61,30 @@ def keyboard(show_gui, task):
     return make
 
 
-@cfn.config(port=8080, fps=20, width=640, bitrate=2_000_000)
-def web(port, fps, width, bitrate, task):
+@cfn.config(
+    port=8080,
+    fps=20,
+    width=640,
+    bitrate=2_000_000,
+    translation_fine=0.01,
+    translation_coarse=0.05,
+    rotation_fine=2.0,
+    rotation_coarse=10.0,
+)
+def web(port, fps, width, bitrate, translation_fine, translation_coarse, rotation_fine, rotation_coarse, task):
     def make(output_dir: Path | None) -> Driver:
-        ui = WebEvalUI(task=task, port=port, fps=fps, width=width, bitrate=bitrate)
-        return Driver(ui, ui.directive, pimm.utils.identity, [])
+        ui = WebEvalUI(
+            task=task,
+            port=port,
+            fps=fps,
+            width=width,
+            bitrate=bitrate,
+            translation_fine=translation_fine,
+            translation_coarse=translation_coarse,
+            rotation_fine=rotation_fine,
+            rotation_coarse=rotation_coarse,
+        )
+        return Driver(ui, ui.directive, pimm.utils.identity, [], manual_commands=ui.manual_command)
 
     return make
 

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -125,6 +125,8 @@ class Harness(pimm.ControlSystem):
             self.commands[name]
 
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
+        # Operator jog commands honored only between episodes; last-value-wins, may be left unconnected.
+        self.manual_command = pimm.ControlSystemReceiver(self, default=None)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})
         # Privileged stop-signal: a truthy value within a trial's time budget ends it,
@@ -154,6 +156,11 @@ class Harness(pimm.ControlSystem):
     def _home(self, clock):
         now = clock.now_ns()
         for name, value in self._embodiment.home.items():
+            self.commands[name].emit([(now, value)])
+
+    def _apply_manual(self, action: dict[str, Any], clock: pimm.Clock) -> None:
+        now = clock.now_ns()
+        for name, value in action.items():
             self.commands[name].emit([(now, value)])
 
     def _pace(self) -> pimm.Command:
@@ -380,10 +387,15 @@ class Harness(pimm.ControlSystem):
             # waits for the producer's post-reset frame-0, which the recorder logs once its open-turn drain
             # has cleared the channels of the pre-reset frame.
             directive_msg = self.directive.read()
+            # Read every round so the updated flag clears even mid-episode; a press arriving during a
+            # trial is consumed here and never replayed once idle.
+            manual_msg = self.manual_command.read()
             if directive_msg.updated:
                 yield from self._handle_directive(directive_msg.data, clock)
             elif not self._running:
-                if self._trials is not None:
+                if manual_msg.updated and manual_msg.data is not None:
+                    self._apply_manual(manual_msg.data, clock)
+                elif self._trials is not None:
                     trial = next(self._trials, None)
                     if trial is None:  # plan exhausted — let the recorder commit the final episode, then exit
                         yield pimm.Sleep(0.5)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -125,7 +125,6 @@ class Harness(pimm.ControlSystem):
             self.commands[name]
 
         self.directive = pimm.ControlSystemReceiver[Directive](self, default=None, maxsize=3)
-        # Operator jog commands honored only between episodes; last-value-wins, may be left unconnected.
         self.manual_command = pimm.ControlSystemReceiver(self, default=None)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         self.robot_meta_in = pimm.ControlSystemReceiver(self, default={})


### PR DESCRIPTION
## Summary
- Lets the operator jog the real robot **between episodes** from the web eval console to restore the scene, over an SSH tunnel.
- **Harness:** new optional `manual_command` receiver. The run loop reads it every round (so a mid-episode press is consumed and never replayed) and forwards it to the device command channels via the existing `_home` pattern **only while idle** (`not _running`). Unconnected for drivers that don't jog, so it no-ops like `done`.
- **Web console:** spatial jog pad beside the camera — base-frame `CartesianDelta` for X/Y/Z translation and roll/pitch/yaw rotation, a Fine/Coarse scale selector, and gripper control: Open/Close buttons that highlight the current state plus a precise `[0,1]` slider (open=0 / close=1, matching the driver convention). Disabled while an episode runs.
- **Video connection:** the browser reconnects the stream on drop or stall (capped backoff + a stall watchdog for half-open sockets), and the console is served over uvicorn's sans-io websocket backend so a client close or keepalive can no longer race the send loop into the concurrent-drain assertion that killed the feed.
- **Wiring:** new optional `Driver.manual_commands` channel, connected in `main()` only when present. Step sizes (`translation_fine/coarse`, `rotation_fine/coarse`) are CLI-overridable on the `web` config.

Jog is `CartesianDelta` in the **robot base frame** (translation added in base frame, rotation left-multiplied about base axes), so each press is a stateless one-shot relative step.

## Test plan
- `python -m py_compile`, `ruff check`/`format`, and a pickle round-trip of `WebEvalUI` (spawn-safety) — pass.
- `pytest positronic/policy/tests` — 127/127 (run with `--extra dev`).
- JS syntax check of the console page; the sans-io ws backend resolves and a local WebSocket probe streams frames and tears down cleanly on client close with zero error logs.
- **Verified on the real DROID:** live browser jog of the arm and the gripper controls both work. One known rough edge: the jog controls re-enable on the Finish/Abort click, slightly before the harness has finalized the episode and the arm has finished homing (see Known limitation; flagged with an in-code TODO).

## Known limitation
The browser's running-state is optimistic (toggled by Start/Finish/Abort clicks, not a server signal), so a page refresh mid-episode or a timed task auto-ending can desync the panel's enabled state, and the jog controls re-enable before the harness has finished homing after Finish/Abort. The harness gates jogs correctly regardless (mid-episode presses are dropped), so it is never unsafe — surfacing real harness idle state to the client is the intended follow-up (in-code TODO in `eval_console.html`).