### PR TITLE
Add per-frame proprio context and JPEG-compress temporal image stacks

### DIFF
--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -70,6 +70,7 @@ def sample(origins: list[cfn.Config], weights: list[float] | None):
     secure=False,
     recording_dir=None,
     infer_timeout=DEFAULT_INFER_TIMEOUT,
+    compress_image_stacks=False,
 )
 def remote(
     host: str,
@@ -82,10 +83,18 @@ def remote(
     secure: bool = False,
     recording_dir: str | None = None,
     infer_timeout: float = DEFAULT_INFER_TIMEOUT,
+    compress_image_stacks: bool = False,
 ):
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
     policy = RemotePolicy(
-        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure, infer_timeout=infer_timeout
+        host,
+        port,
+        effective_resize,
+        model_id=model_id,
+        headers=headers,
+        secure=secure,
+        infer_timeout=infer_timeout,
+        compress_image_stacks=compress_image_stacks,
     )
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -70,7 +70,7 @@ def sample(origins: list[cfn.Config], weights: list[float] | None):
     secure=False,
     recording_dir=None,
     infer_timeout=DEFAULT_INFER_TIMEOUT,
-    compress_image_stacks=False,
+    compress_images=False,
 )
 def remote(
     host: str,
@@ -83,7 +83,7 @@ def remote(
     secure: bool = False,
     recording_dir: str | None = None,
     infer_timeout: float = DEFAULT_INFER_TIMEOUT,
-    compress_image_stacks: bool = False,
+    compress_images: bool = False,
 ):
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
     policy = RemotePolicy(
@@ -94,7 +94,7 @@ def remote(
         headers=headers,
         secure=secure,
         infer_timeout=infer_timeout,
-        compress_image_stacks=compress_image_stacks,
+        compress_images=compress_images,
     )
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -118,6 +118,7 @@ def remote(
     secure=False,
     recording_dir=None,
     infer_timeout=DEFAULT_INFER_TIMEOUT,
+    compress_images=False,
 )
 def weighted_remote(
     host: str | None,
@@ -131,13 +132,21 @@ def weighted_remote(
     secure: bool = False,
     recording_dir: str | None = None,
     infer_timeout: float = DEFAULT_INFER_TIMEOUT,
+    compress_images: bool = False,
 ):
     if not host:
         return None
 
     effective_resize = None if codec and codec.meta.get('image_sizes') else resize
     policy = RemotePolicy(
-        host, port, effective_resize, model_id=model_id, headers=headers, secure=secure, infer_timeout=infer_timeout
+        host,
+        port,
+        effective_resize,
+        model_id=model_id,
+        headers=headers,
+        secure=secure,
+        infer_timeout=infer_timeout,
+        compress_images=compress_images,
     )
     if horizon_sec is not None:
         codec = ActionHorizon(horizon_sec) | codec if codec else ActionHorizon(horizon_sec)

--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -31,15 +31,23 @@ def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[fl
     return tuple(-f / fps for f in reversed(frames))
 
 
-@cfn.config(image_keys=('image.wrist', 'image.exterior'), fps=15.0)
-def video_context_wrappers(history_frames: int, stride: int, image_keys: tuple[str, ...], fps: float):
+@cfn.config(image_keys=('image.wrist', 'image.exterior'), proprio_keys=(), fps=15.0)
+def video_context_wrappers(
+    history_frames: int, stride: int, image_keys: tuple[str, ...], proprio_keys: tuple[str, ...], fps: float
+):
     """Eval ``wrap`` for video-conditioned policies: error recovery, strided frame-stack context, scheduling.
 
-    The frame stack sits outside the scheduler so it records the named cameras every control tick and
+    The frame stack sits outside the scheduler so it records the named entries every control tick and
     substitutes a temporal stack sampled per ``history_frames``/``stride``; pair it with a codec whose
     ``horizon`` plays the full returned chunk so the re-query aligns with the frame-stack window.
+
+    ``proprio_keys`` additionally stacks per-frame proprio (e.g. ``('robot_state.ee_pose', 'grip')``) so
+    each history frame carries its own pose — the trajectory a model trained on real per-frame proprio
+    expects. Leave it empty (default) for models whose codec consumes only the current proprio.
     """
     frame_stack = TemporalFrameStack(
-        image_keys=tuple(image_keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps)
+        image_keys=tuple(image_keys),
+        offsets_sec=_frame_offsets_sec(history_frames, stride, fps),
+        proprio_keys=tuple(proprio_keys),
     )
     return ErrorRecovery() | frame_stack | ChunkedSchedule()

--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -1,15 +1,15 @@
 import configuronic as cfn
 
-from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery, TemporalFrameStack
+from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery, TemporalStack
 
 chunked_schedule = cfn.Config(ChunkedSchedule)
 error_recovery = cfn.Config(ErrorRecovery)
-temporal_frame_stack = cfn.Config(TemporalFrameStack)
+temporal_stack = cfn.Config(TemporalStack)
 
 
 @cfn.config()
 def default_wrappers():
-    """Eval ``wrap`` default: error recovery + chunked scheduling, no video frame stack."""
+    """Eval ``wrap`` default: error recovery + chunked scheduling, no temporal stack."""
     return ErrorRecovery() | ChunkedSchedule()
 
 
@@ -31,23 +31,18 @@ def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[fl
     return tuple(-f / fps for f in reversed(frames))
 
 
-@cfn.config(image_keys=('image.wrist', 'image.exterior'), proprio_keys=(), fps=15.0)
-def video_context_wrappers(
-    history_frames: int, stride: int, image_keys: tuple[str, ...], proprio_keys: tuple[str, ...], fps: float
-):
-    """Eval ``wrap`` for video-conditioned policies: error recovery, strided frame-stack context, scheduling.
+@cfn.config(keys=('image.wrist', 'image.exterior', 'robot_state.ee_pose', 'grip'), fps=15.0)
+def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ...], fps: float):
+    """Eval ``wrap`` for video-conditioned policies: error recovery, strided temporal context, scheduling.
 
-    The frame stack sits outside the scheduler so it records the named entries every control tick and
-    substitutes a temporal stack sampled per ``history_frames``/``stride``; pair it with a codec whose
-    ``horizon`` plays the full returned chunk so the re-query aligns with the frame-stack window.
+    The temporal stack sits outside the scheduler so it records the named ``keys`` every control tick and
+    substitutes a stack sampled per ``history_frames``/``stride``; pair it with a codec whose ``horizon``
+    plays the full returned chunk so the re-query aligns with the stack window.
 
-    ``proprio_keys`` additionally stacks per-frame proprio (e.g. ``('robot_state.ee_pose', 'grip')``) so
-    each history frame carries its own pose — the trajectory a model trained on real per-frame proprio
-    expects. Leave it empty (default) for models whose codec consumes only the current proprio.
+    ``keys`` are the entries to stack: the cameras plus any per-frame proprio (e.g.
+    ``('robot_state.ee_pose', 'grip')``) so each history step carries its own pose — the trajectory a
+    model trained on real per-frame proprio expects. Drop the proprio keys for models whose codec
+    consumes only the current proprio.
     """
-    frame_stack = TemporalFrameStack(
-        image_keys=tuple(image_keys),
-        offsets_sec=_frame_offsets_sec(history_frames, stride, fps),
-        proprio_keys=tuple(proprio_keys),
-    )
-    return ErrorRecovery() | frame_stack | ChunkedSchedule()
+    stack = TemporalStack(keys=tuple(keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps))
+    return ErrorRecovery() | stack | ChunkedSchedule()

--- a/positronic/offboard/tests/test_offboard.py
+++ b/positronic/offboard/tests/test_offboard.py
@@ -5,7 +5,7 @@ import numpy as np
 from positronic.drivers.roboarm.command import CartesianPosition, JointDelta, JointPosition, Recover, Reset
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceClient
-from positronic.utils.serialization import deserialise, serialise
+from positronic.utils.serialization import deserialise, encode_jpeg_stack, serialise
 
 
 def test_inference_client_connect_and_infer(inference_server, mock_policy):
@@ -86,6 +86,17 @@ def test_wire_serialisation_accepts_mappingproxy():
 
     # mappingproxy is normalized to a plain dict for the wire.
     assert round_trip == {'obs': {'a': 1, 'b': {'c': 2}}}
+
+
+def test_jpeg_stack_round_trips_to_array():
+    """An ``encode_jpeg_stack`` marker survives the wire and decodes back to the original shape and order."""
+    stack = np.stack([np.full((16, 24, 3), (t + 1) * 60, dtype=np.uint8) for t in range(3)])
+    restored = deserialise(serialise({'image.wrist': encode_jpeg_stack(stack)}))['image.wrist']
+    assert isinstance(restored, np.ndarray)
+    assert restored.shape == (3, 16, 24, 3)
+    assert restored.dtype == np.uint8
+    # q90 JPEG on solid colors is near-lossless; this also verifies per-frame order is preserved.
+    np.testing.assert_allclose(restored, stack, atol=4)
 
 
 class TestCommandRoundtrip:

--- a/positronic/offboard/tests/test_offboard.py
+++ b/positronic/offboard/tests/test_offboard.py
@@ -5,7 +5,7 @@ import numpy as np
 from positronic.drivers.roboarm.command import CartesianPosition, JointDelta, JointPosition, Recover, Reset
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceClient
-from positronic.utils.serialization import deserialise, encode_jpeg_stack, serialise
+from positronic.utils.serialization import deserialise, encode_jpeg, serialise
 
 
 def test_inference_client_connect_and_infer(inference_server, mock_policy):
@@ -88,15 +88,20 @@ def test_wire_serialisation_accepts_mappingproxy():
     assert round_trip == {'obs': {'a': 1, 'b': {'c': 2}}}
 
 
-def test_jpeg_stack_round_trips_to_array():
-    """An ``encode_jpeg_stack`` marker survives the wire and decodes back to the original shape and order."""
+def test_jpeg_round_trips_single_image_and_stack():
+    """An ``encode_jpeg`` marker survives the wire and decodes back to the original shape and order."""
+    single = np.full((16, 24, 3), 90, dtype=np.uint8)
+    restored_single = deserialise(serialise({'image.wrist': encode_jpeg(single)}))['image.wrist']
+    assert isinstance(restored_single, np.ndarray)
+    assert restored_single.shape == (16, 24, 3)
+    assert restored_single.dtype == np.uint8
+    np.testing.assert_allclose(restored_single, single, atol=4)
+
     stack = np.stack([np.full((16, 24, 3), (t + 1) * 60, dtype=np.uint8) for t in range(3)])
-    restored = deserialise(serialise({'image.wrist': encode_jpeg_stack(stack)}))['image.wrist']
-    assert isinstance(restored, np.ndarray)
-    assert restored.shape == (3, 16, 24, 3)
-    assert restored.dtype == np.uint8
+    restored_stack = deserialise(serialise({'image.wrist': encode_jpeg(stack)}))['image.wrist']
+    assert restored_stack.shape == (3, 16, 24, 3)
     # q90 JPEG on solid colors is near-lossless; this also verifies per-frame order is preserved.
-    np.testing.assert_allclose(restored, stack, atol=4)
+    np.testing.assert_allclose(restored_stack, stack, atol=4)
 
 
 class TestCommandRoundtrip:

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -381,7 +381,13 @@ class _RecordingTapSession(DelegatingSession):
         grip = _stack_numeric([a['target_grip'] for a in actions]) if all('target_grip' in a for a in actions) else None
         actual_pos = obs.get('robot_state.ee_pose') if isinstance(obs, Mapping) else None
         actual_grip = obs.get('grip') if isinstance(obs, Mapping) else None
-        actual_g = float(np.asarray(actual_grip).reshape(-1)[0]) if actual_grip is not None else None
+        # Under TemporalStack these arrive as (T, 7) / (T,) stacks; the overlay draws the current pose,
+        # which is the last frame (offsets end at 0 = now), mirroring the image collapse in `_as_image`.
+        if actual_pos is not None:
+            actual_pos = np.asarray(actual_pos)
+            if actual_pos.ndim == 2:
+                actual_pos = actual_pos[-1]
+        actual_g = float(np.asarray(actual_grip).reshape(-1)[-1]) if actual_grip is not None else None
         keys: list[str] = []
         for action in actions:
             for key in action:

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -75,7 +75,7 @@ def _squeeze_batch(arr: np.ndarray) -> np.ndarray:
 def _as_image(value: Any) -> np.ndarray | None:
     """Return a single RGB frame if *value* looks like an image, else None.
 
-    A temporal stack ``(T, H, W, 3)`` (e.g. from ``TemporalFrameStack``) records its most recent
+    A temporal stack ``(T, H, W, 3)`` (e.g. from ``TemporalStack``) records its most recent
     frame — the current observation — so the stack does not flood the recording as numeric series.
     """
     if not isinstance(value, np.ndarray):

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -1,4 +1,3 @@
-import io
 from typing import Any
 
 import numpy as np
@@ -6,21 +5,18 @@ from PIL import Image as PilImage
 
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
 from positronic.utils import flatten_dict
+from positronic.utils.serialization import encode_jpeg_stack
 
 from .base import Policy, Session
-
-# JPEG quality for temporal image stacks on the wire. A (T, H, W, 3) stack of HD frames is tens of MB
-# raw — over the ~2 MB websocket message cap of a Modal-fronted endpoint. Per-frame JPEG keeps a
-# 25-frame two-camera stack around 1-2 MB and cuts upload latency; q=90 is visually lossless here.
-_JPEG_STACK_QUALITY = 90
 
 
 class RemoteSession(Session):
     """Per-episode session that forwards observations to a remote inference server."""
 
-    def __init__(self, ws_session: InferenceSession, resize: int | None):
+    def __init__(self, ws_session: InferenceSession, resize: int | None, compress_image_stacks: bool = False):
         self._session = ws_session
         self._resize = resize
+        self._compress_image_stacks = compress_image_stacks
         self._image_sizes: dict[str, tuple[int, int]] = {}
         self._default_image_size: tuple[int, int] | None = None
 
@@ -43,22 +39,6 @@ class RemoteSession(Session):
         scale = min(1.0, tw / w, th / h)
         return RemoteSession._resize_to(image, int(w * scale), int(h * scale))
 
-    @staticmethod
-    def _encode_jpeg_stack(stack: np.ndarray) -> dict[bytes, Any]:
-        """JPEG-encode a ``(T, H, W, 3)`` stack to a compact wire marker the server decodes back.
-
-        Sends one JPEG per frame plus the original ``ndim`` so the server restores the exact shape.
-        """
-        frames = stack if stack.ndim == 4 else stack[None]
-        bufs = []
-        for frame in frames:
-            buf = io.BytesIO()
-            PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(
-                buf, format='JPEG', quality=_JPEG_STACK_QUALITY
-            )
-            bufs.append(buf.getvalue())
-        return {b'__jpeg_stack__': True, b'frames': bufs, b'ndim': int(stack.ndim)}
-
     def _prepare_obs(self, obs: dict[str, Any]) -> dict[str, Any]:
         result = {}
         for key, value in obs.items():
@@ -73,10 +53,11 @@ class RemoteSession(Session):
                         value = np.stack([self._fit(f, tw, th) for f in value])
                     else:
                         value = self._fit(value, tw, th)
-                # Compress temporal stacks: a raw HD stack is tens of MB and exceeds the ~2 MB
-                # websocket message cap of a Modal-fronted endpoint. Single frames stay raw (small).
-                if value.ndim == 4:
-                    value = self._encode_jpeg_stack(value)
+                # Optionally compress temporal stacks: a raw HD stack is tens of MB and can exceed the
+                # ~2 MB websocket message cap of a Modal-fronted endpoint. Off by default; single frames
+                # stay raw regardless (they're small).
+                if value.ndim == 4 and self._compress_image_stacks:
+                    value = encode_jpeg_stack(value)
             result[key] = value
         return result
 
@@ -122,11 +103,13 @@ class RemotePolicy(Policy):
         headers: dict[str, str] | None = None,
         secure: bool = False,
         infer_timeout: float = DEFAULT_INFER_TIMEOUT,
+        compress_image_stacks: bool = False,
     ):
         self._client = InferenceClient(host, port, headers=headers, secure=secure)
         self._resize = resize
         self._model_id = model_id
         self._infer_timeout = infer_timeout
+        self._compress_image_stacks = compress_image_stacks
         # Server metadata cached after the first session is created or `meta`
         # is read. Needed so consumers like ``SampledPolicy._get_keys`` see
         # ``server.checkpoint_path`` etc. before any session exists.
@@ -145,7 +128,7 @@ class RemotePolicy(Policy):
         ws_session = self._client.new_session(model_id=self._model_id, infer_timeout=self._infer_timeout)
         if self._server_meta is None:
             self._server_meta = dict(ws_session.metadata)
-        return RemoteSession(ws_session, self._resize)
+        return RemoteSession(ws_session, self._resize, compress_image_stacks=self._compress_image_stacks)
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -1,3 +1,4 @@
+import collections.abc as cabc
 from typing import Any
 
 import numpy as np
@@ -40,26 +41,32 @@ class RemoteSession(Session):
         return RemoteSession._resize_to(image, int(w * scale), int(h * scale))
 
     def _prepare_obs(self, obs: dict[str, Any]) -> dict[str, Any]:
-        result = {}
-        for key, value in obs.items():
-            # Resize single RGB frames and temporal stacks of them alike (TemporalStack emits a
-            # (T, H, W, 3) stack), so a stack of hd720 frames isn't shipped full-resolution.
-            if isinstance(value, np.ndarray) and value.ndim in (3, 4) and value.shape[-1] == 3:
-                target = self._image_sizes.get(key, self._default_image_size)
-                r = self._resize or 0
-                tw, th = target or (r, r)
-                if tw > 0 and th > 0:
-                    if value.ndim == 4:
-                        value = np.stack([self._fit(f, tw, th) for f in value])
-                    else:
-                        value = self._fit(value, tw, th)
-                # Optionally JPEG-compress images before sending: a raw HD frame — and especially a
-                # (T, H, W, 3) stack — can exceed the ~2 MB websocket message cap of a Modal-fronted
-                # endpoint. Off by default.
-                if self._compress_images:
-                    value = encode_jpeg(value)
-            result[key] = value
-        return result
+        return {key: self._prepare_value(key, value) for key, value in obs.items()}
+
+    def _prepare_value(self, key: str, value: Any) -> Any:
+        # Client-side codecs (e.g. GR00T) nest images inside dicts/lists, so recurse to reach every
+        # image array rather than scanning the top level alone.
+        if isinstance(value, np.ndarray) and value.ndim in (3, 4) and value.shape[-1] == 3:
+            return self._prepare_image(key, value)
+        if isinstance(value, cabc.Mapping):
+            return {k: self._prepare_value(k, v) for k, v in value.items()}
+        if isinstance(value, list | tuple):
+            return type(value)(self._prepare_value(key, v) for v in value)
+        return value
+
+    def _prepare_image(self, key: str, image: np.ndarray) -> np.ndarray | dict[bytes, Any]:
+        # Resize single RGB frames and temporal stacks of them alike (TemporalStack emits a
+        # (T, H, W, 3) stack), so a stack of hd720 frames isn't shipped full-resolution.
+        target = self._image_sizes.get(key, self._default_image_size)
+        r = self._resize or 0
+        tw, th = target or (r, r)
+        if tw > 0 and th > 0:
+            image = np.stack([self._fit(f, tw, th) for f in image]) if image.ndim == 4 else self._fit(image, tw, th)
+        # Optionally JPEG-compress before sending: a raw HD frame — and especially a (T, H, W, 3)
+        # stack — can exceed the ~2 MB websocket message cap of a Modal-fronted endpoint. Off by default.
+        if self._compress_images:
+            image = encode_jpeg(image)
+        return image
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
         """Forwards the observation to the remote server and returns the action trajectory.

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -1,3 +1,4 @@
+import io
 from typing import Any
 
 import numpy as np
@@ -7,6 +8,11 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, I
 from positronic.utils import flatten_dict
 
 from .base import Policy, Session
+
+# JPEG quality for temporal image stacks on the wire. A (T, H, W, 3) stack of HD frames is tens of MB
+# raw — over the ~2 MB websocket message cap of a Modal-fronted endpoint. Per-frame JPEG keeps a
+# 25-frame two-camera stack around 1-2 MB and cuts upload latency; q=90 is visually lossless here.
+_JPEG_STACK_QUALITY = 90
 
 
 class RemoteSession(Session):
@@ -37,6 +43,22 @@ class RemoteSession(Session):
         scale = min(1.0, tw / w, th / h)
         return RemoteSession._resize_to(image, int(w * scale), int(h * scale))
 
+    @staticmethod
+    def _encode_jpeg_stack(stack: np.ndarray) -> dict[bytes, Any]:
+        """JPEG-encode a ``(T, H, W, 3)`` stack to a compact wire marker the server decodes back.
+
+        Sends one JPEG per frame plus the original ``ndim`` so the server restores the exact shape.
+        """
+        frames = stack if stack.ndim == 4 else stack[None]
+        bufs = []
+        for frame in frames:
+            buf = io.BytesIO()
+            PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(
+                buf, format='JPEG', quality=_JPEG_STACK_QUALITY
+            )
+            bufs.append(buf.getvalue())
+        return {b'__jpeg_stack__': True, b'frames': bufs, b'ndim': int(stack.ndim)}
+
     def _prepare_obs(self, obs: dict[str, Any]) -> dict[str, Any]:
         result = {}
         for key, value in obs.items():
@@ -51,6 +73,10 @@ class RemoteSession(Session):
                         value = np.stack([self._fit(f, tw, th) for f in value])
                     else:
                         value = self._fit(value, tw, th)
+                # Compress temporal stacks: a raw HD stack is tens of MB and exceeds the ~2 MB
+                # websocket message cap of a Modal-fronted endpoint. Single frames stay raw (small).
+                if value.ndim == 4:
+                    value = self._encode_jpeg_stack(value)
             result[key] = value
         return result
 

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -62,7 +62,7 @@ class RemoteSession(Session):
     def _prepare_obs(self, obs: dict[str, Any]) -> dict[str, Any]:
         result = {}
         for key, value in obs.items():
-            # Resize single RGB frames and temporal stacks of them alike (TemporalFrameStack emits a
+            # Resize single RGB frames and temporal stacks of them alike (TemporalStack emits a
             # (T, H, W, 3) stack), so a stack of hd720 frames isn't shipped full-resolution.
             if isinstance(value, np.ndarray) and value.ndim in (3, 4) and value.shape[-1] == 3:
                 target = self._image_sizes.get(key, self._default_image_size)

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -5,7 +5,7 @@ from PIL import Image as PilImage
 
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
 from positronic.utils import flatten_dict
-from positronic.utils.serialization import encode_jpeg_stack
+from positronic.utils.serialization import encode_jpeg
 
 from .base import Policy, Session
 
@@ -13,10 +13,10 @@ from .base import Policy, Session
 class RemoteSession(Session):
     """Per-episode session that forwards observations to a remote inference server."""
 
-    def __init__(self, ws_session: InferenceSession, resize: int | None, compress_image_stacks: bool = False):
+    def __init__(self, ws_session: InferenceSession, resize: int | None, compress_images: bool = False):
         self._session = ws_session
         self._resize = resize
-        self._compress_image_stacks = compress_image_stacks
+        self._compress_images = compress_images
         self._image_sizes: dict[str, tuple[int, int]] = {}
         self._default_image_size: tuple[int, int] | None = None
 
@@ -53,11 +53,11 @@ class RemoteSession(Session):
                         value = np.stack([self._fit(f, tw, th) for f in value])
                     else:
                         value = self._fit(value, tw, th)
-                # Optionally compress temporal stacks: a raw HD stack is tens of MB and can exceed the
-                # ~2 MB websocket message cap of a Modal-fronted endpoint. Off by default; single frames
-                # stay raw regardless (they're small).
-                if value.ndim == 4 and self._compress_image_stacks:
-                    value = encode_jpeg_stack(value)
+                # Optionally JPEG-compress images before sending: a raw HD frame — and especially a
+                # (T, H, W, 3) stack — can exceed the ~2 MB websocket message cap of a Modal-fronted
+                # endpoint. Off by default.
+                if self._compress_images:
+                    value = encode_jpeg(value)
             result[key] = value
         return result
 
@@ -103,13 +103,13 @@ class RemotePolicy(Policy):
         headers: dict[str, str] | None = None,
         secure: bool = False,
         infer_timeout: float = DEFAULT_INFER_TIMEOUT,
-        compress_image_stacks: bool = False,
+        compress_images: bool = False,
     ):
         self._client = InferenceClient(host, port, headers=headers, secure=secure)
         self._resize = resize
         self._model_id = model_id
         self._infer_timeout = infer_timeout
-        self._compress_image_stacks = compress_image_stacks
+        self._compress_images = compress_images
         # Server metadata cached after the first session is created or `meta`
         # is read. Needed so consumers like ``SampledPolicy._get_keys`` see
         # ``server.checkpoint_path`` etc. before any session exists.
@@ -128,7 +128,7 @@ class RemotePolicy(Policy):
         ws_session = self._client.new_session(model_id=self._model_id, infer_timeout=self._infer_timeout)
         if self._server_meta is None:
             self._server_meta = dict(ws_session.metadata)
-        return RemoteSession(ws_session, self._resize, compress_image_stacks=self._compress_image_stacks)
+        return RemoteSession(ws_session, self._resize, compress_images=self._compress_images)
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -99,16 +99,15 @@ class ErrorRecovery(PolicyWrapper):
         return ErrorRecovery._Session(inner)
 
 
-class _FrameBuffer:
+class _StackBuffer:
     """Time-ordered history of ``(timestamp, values)`` entries, capped to the sampled window.
 
-    ``values`` is a dict of key → array (cameras, and optionally per-frame proprio); every entry holds
-    the same keys. ``append`` copies each new entry (cameras are views into a producer-reused buffer)
-    but skips one byte-identical to the previous entry — cameras tick slower than the control loop, and
-    carry-over sampling reuses the stored value — then drops entries before the oldest sampled offset,
-    keeping the one at or before it. ``sample`` returns, per key, a ``(len(offsets_sec), ...)`` stack
-    holding, for each offset, the latest value at or before that time — carry-over, never the future;
-    before enough history accumulates it repeats the oldest entry.
+    ``values`` is a dict of key → array; every entry holds the same keys. ``append`` copies each new
+    entry but skips one byte-identical to the previous — a source slower than the control loop repeats
+    its value, and carry-over sampling reuses the stored one — then drops entries before the oldest
+    sampled offset, keeping the one at or before it. ``sample`` returns, per key, a
+    ``(len(offsets_sec), ...)`` stack holding, for each offset, the latest value at or before that time
+    — carry-over, never the future; before enough history accumulates it repeats the oldest entry.
     """
 
     def __init__(self, offsets_sec: tuple[float, ...]):
@@ -118,10 +117,10 @@ class _FrameBuffer:
     def reset(self):
         self._entries.clear()
 
-    def append(self, now: float, frames: dict[str, np.ndarray]):
-        if self._entries and all(np.array_equal(self._entries[-1][1][k], v) for k, v in frames.items()):
+    def append(self, now: float, values: dict[str, np.ndarray]):
+        if self._entries and all(np.array_equal(self._entries[-1][1][k], v) for k, v in values.items()):
             return
-        self._entries.append((now, {k: np.array(v) for k, v in frames.items()}))
+        self._entries.append((now, {k: np.array(v) for k, v in values.items()}))
         cutoff = now + min(self._offsets_sec)
         while len(self._entries) >= 2 and self._entries[1][0] <= cutoff:
             self._entries.popleft()
@@ -129,48 +128,44 @@ class _FrameBuffer:
     def sample(self, now: float) -> dict[str, np.ndarray]:
         times = np.array([t for t, _ in self._entries])
         picked = [self._entries[self._at_or_before(times, now + off)][1] for off in self._offsets_sec]
-        return {k: np.stack([frames[k] for frames in picked]) for k in picked[0]}
+        return {k: np.stack([entry[k] for entry in picked]) for k in picked[0]}
 
     @staticmethod
     def _at_or_before(times: np.ndarray, target: float) -> int:
-        """Index of the latest frame at or before ``target``; clamps to the oldest when none precedes it."""
+        """Index of the latest entry at or before ``target``; clamps to the oldest when none precedes it."""
         return max(int(np.searchsorted(times, target, side='right')) - 1, 0)
 
 
-class TemporalFrameStack(PolicyWrapper):
+class TemporalStack(PolicyWrapper):
     """Replaces each named observation entry with a temporal stack of recent samples.
 
-    Servers whose model conditions on a short video (e.g. DreamZero) need several frames spanning the
-    just-executed chunk at the cadence seen in training, but the harness only forwards an observation
-    to the policy at re-query boundaries. This wrapper sits outside the scheduling wrapper so it sees
-    every control tick: it records the named entries and substitutes a ``(len(offsets_sec), ...)`` stack
-    sampled at ``offsets_sec`` (ascending negative seconds relative to now).
-
-    ``image_keys`` are the cameras (``(T, H, W, 3)``). ``proprio_keys`` are optional per-frame
-    proprioceptive signals (e.g. ``robot_state.ee_pose`` → ``(T, 7)``, ``grip`` → ``(T,)``) recorded
-    on the SAME buffer, so each stacked frame carries its own proprio — the trajectory a model trained
-    on real per-frame proprio expects, rather than the current pose repeated across history. Leave it
-    empty for models whose codec consumes only the current proprio (stacking would reshape it wrong).
+    A model that conditions on a short window of history (e.g. DreamZero's video context) needs several
+    samples spanning the just-executed chunk at the cadence seen in training, but the harness only
+    forwards an observation to the policy at re-query boundaries. This wrapper sits outside the
+    scheduling wrapper so it sees every control tick: it records the named ``keys`` and substitutes, for
+    each, a ``(len(offsets_sec), ...)`` stack sampled at ``offsets_sec`` (ascending negative seconds
+    relative to now), so every stacked step carries its own value at that time rather than the current
+    one repeated across history.
     """
 
     class _Session(DelegatingSession):
-        def __init__(self, inner: Session, stack_keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+        def __init__(self, inner: Session, keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
             super().__init__(inner)
-            self._stack_keys = stack_keys
-            self._buffer = _FrameBuffer(offsets_sec)
+            self._keys = keys
+            self._buffer = _StackBuffer(offsets_sec)
 
         def __call__(self, obs):
             now = _obs_time(obs)
-            self._buffer.append(now, {k: obs[k] for k in self._stack_keys})
+            self._buffer.append(now, {k: obs[k] for k in self._keys})
             return self._inner({**obs, **self._buffer.sample(now)})
 
         def cancel(self):
             self._buffer.reset()
             super().cancel()
 
-    def __init__(self, image_keys: tuple[str, ...], offsets_sec: tuple[float, ...], proprio_keys: tuple[str, ...] = ()):
-        self._stack_keys = (*image_keys, *proprio_keys)
+    def __init__(self, keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+        self._keys = tuple(keys)
         self._offsets_sec = tuple(offsets_sec)
 
     def wrap_session(self, inner: Session, context, now: Now):
-        return TemporalFrameStack._Session(inner, self._stack_keys, self._offsets_sec)
+        return TemporalStack._Session(inner, self._keys, self._offsets_sec)

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -100,15 +100,15 @@ class ErrorRecovery(PolicyWrapper):
 
 
 class _FrameBuffer:
-    """Time-ordered history of ``(timestamp, frames)`` entries, capped to the sampled window.
+    """Time-ordered history of ``(timestamp, values)`` entries, capped to the sampled window.
 
-    ``frames`` is a dict of camera-key → image; every entry holds the same keys. ``append`` copies each
-    new frame (cameras are views into a producer-reused buffer) but skips one byte-identical to the
-    previous entry — cameras tick slower than the control loop, and carry-over sampling reuses the
-    stored frame — then drops entries before the oldest sampled offset, keeping the one at or before it.
-    ``sample`` returns, per key, a ``(len(offsets_sec), H, W, 3)`` stack holding, for each offset, the
-    latest frame at or before that time — carry-over, never the future; before enough history
-    accumulates it repeats the oldest frame.
+    ``values`` is a dict of key → array (cameras, and optionally per-frame proprio); every entry holds
+    the same keys. ``append`` copies each new entry (cameras are views into a producer-reused buffer)
+    but skips one byte-identical to the previous entry — cameras tick slower than the control loop, and
+    carry-over sampling reuses the stored value — then drops entries before the oldest sampled offset,
+    keeping the one at or before it. ``sample`` returns, per key, a ``(len(offsets_sec), ...)`` stack
+    holding, for each offset, the latest value at or before that time — carry-over, never the future;
+    before enough history accumulates it repeats the oldest entry.
     """
 
     def __init__(self, offsets_sec: tuple[float, ...]):
@@ -138,33 +138,39 @@ class _FrameBuffer:
 
 
 class TemporalFrameStack(PolicyWrapper):
-    """Replaces each named image in the observation with a temporal stack of recent frames.
+    """Replaces each named observation entry with a temporal stack of recent samples.
 
     Servers whose model conditions on a short video (e.g. DreamZero) need several frames spanning the
     just-executed chunk at the cadence seen in training, but the harness only forwards an observation
     to the policy at re-query boundaries. This wrapper sits outside the scheduling wrapper so it sees
-    every control tick: it records each camera frame and substitutes a ``(len(offsets_sec), H, W, 3)``
-    stack sampled at ``offsets_sec`` (ascending negative seconds relative to now).
+    every control tick: it records the named entries and substitutes a ``(len(offsets_sec), ...)`` stack
+    sampled at ``offsets_sec`` (ascending negative seconds relative to now).
+
+    ``image_keys`` are the cameras (``(T, H, W, 3)``). ``proprio_keys`` are optional per-frame
+    proprioceptive signals (e.g. ``robot_state.ee_pose`` → ``(T, 7)``, ``grip`` → ``(T,)``) recorded
+    on the SAME buffer, so each stacked frame carries its own proprio — the trajectory a model trained
+    on real per-frame proprio expects, rather than the current pose repeated across history. Leave it
+    empty for models whose codec consumes only the current proprio (stacking would reshape it wrong).
     """
 
     class _Session(DelegatingSession):
-        def __init__(self, inner: Session, image_keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+        def __init__(self, inner: Session, stack_keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
             super().__init__(inner)
-            self._image_keys = image_keys
+            self._stack_keys = stack_keys
             self._buffer = _FrameBuffer(offsets_sec)
 
         def __call__(self, obs):
             now = _obs_time(obs)
-            self._buffer.append(now, {k: obs[k] for k in self._image_keys})
+            self._buffer.append(now, {k: obs[k] for k in self._stack_keys})
             return self._inner({**obs, **self._buffer.sample(now)})
 
         def cancel(self):
             self._buffer.reset()
             super().cancel()
 
-    def __init__(self, image_keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
-        self._image_keys = tuple(image_keys)
+    def __init__(self, image_keys: tuple[str, ...], offsets_sec: tuple[float, ...], proprio_keys: tuple[str, ...] = ()):
+        self._stack_keys = (*image_keys, *proprio_keys)
         self._offsets_sec = tuple(offsets_sec)
 
     def wrap_session(self, inner: Session, context, now: Now):
-        return TemporalFrameStack._Session(inner, self._image_keys, self._offsets_sec)
+        return TemporalFrameStack._Session(inner, self._stack_keys, self._offsets_sec)

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -42,9 +42,7 @@ def encode_jpeg(image: np.ndarray) -> dict[bytes, Any]:
         buf = io.BytesIO()
         PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(buf, format='JPEG', quality=_JPEG_QUALITY)
         bufs.append(buf.getvalue())
-    # TODO(rename-jpeg-marker): use `b'__jpeg__'` once Runway's deployed server decodes it. The marker
-    # says "stack" but also carries single frames; it stays this name only to match their live decoder.
-    return {b'__jpeg_stack__': True, b'frames': bufs, b'ndim': int(image.ndim)}
+    return {b'__jpeg__': True, b'frames': bufs, b'ndim': int(image.ndim)}
 
 
 def _decode_jpeg(marker: dict) -> np.ndarray:
@@ -94,7 +92,7 @@ def _unpack(obj):
         return np.ndarray(buffer=obj[b'data'], dtype=np.dtype(obj[b'dtype']), shape=obj[b'shape'])
     if b'__npgeneric__' in obj:
         return np.dtype(obj[b'dtype']).type(obj[b'data'])
-    if b'__jpeg_stack__' in obj:
+    if b'__jpeg__' in obj:
         return _decode_jpeg(obj)
     if b'__cmd__' in obj:
         inner = obj[b'__cmd__']

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -15,12 +15,42 @@ Supports:
 
 import collections.abc as cabc
 import functools
+import io
+from typing import Any
 
 import msgpack
 import numpy as np
+from PIL import Image as PilImage
 
 from positronic.drivers import roboarm as _roboarm
 from positronic.drivers.roboarm import command as _roboarm_command
+
+# JPEG quality for temporal image stacks on the wire. A (T, H, W, 3) stack of HD frames is tens of MB
+# raw — over the ~2 MB websocket message cap of a Modal-fronted endpoint. Per-frame JPEG keeps a
+# 25-frame two-camera stack around 1-2 MB and cuts upload latency; q=90 is visually lossless here.
+_JPEG_STACK_QUALITY = 90
+
+
+def encode_jpeg_stack(stack: np.ndarray) -> dict[bytes, Any]:
+    """JPEG-encode a ``(T, H, W, 3)`` (or single ``(H, W, 3)``) image stack to a compact wire marker.
+
+    Sends one JPEG per frame plus the original ``ndim`` so ``_unpack`` restores the exact shape.
+    """
+    frames = stack if stack.ndim == 4 else stack[None]
+    bufs = []
+    for frame in frames:
+        buf = io.BytesIO()
+        PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(
+            buf, format='JPEG', quality=_JPEG_STACK_QUALITY
+        )
+        bufs.append(buf.getvalue())
+    return {b'__jpeg_stack__': True, b'frames': bufs, b'ndim': int(stack.ndim)}
+
+
+def _decode_jpeg_stack(marker: dict) -> np.ndarray:
+    """Inverse of ``encode_jpeg_stack``: decode per-frame JPEGs and restore the original shape."""
+    stack = np.stack([np.asarray(PilImage.open(io.BytesIO(buf))) for buf in marker[b'frames']])
+    return stack if marker[b'ndim'] == 4 else stack[0]
 
 
 def _pack(obj):
@@ -64,6 +94,8 @@ def _unpack(obj):
         return np.ndarray(buffer=obj[b'data'], dtype=np.dtype(obj[b'dtype']), shape=obj[b'shape'])
     if b'__npgeneric__' in obj:
         return np.dtype(obj[b'dtype']).type(obj[b'data'])
+    if b'__jpeg_stack__' in obj:
+        return _decode_jpeg_stack(obj)
     if b'__cmd__' in obj:
         inner = obj[b'__cmd__']
         # The legacy shim below decodes the inner ``to_wire`` dict to a Command

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -25,32 +25,30 @@ from PIL import Image as PilImage
 from positronic.drivers import roboarm as _roboarm
 from positronic.drivers.roboarm import command as _roboarm_command
 
-# JPEG quality for temporal image stacks on the wire. A (T, H, W, 3) stack of HD frames is tens of MB
-# raw — over the ~2 MB websocket message cap of a Modal-fronted endpoint. Per-frame JPEG keeps a
+# JPEG quality for images on the wire. A single HD frame — and especially a (T, H, W, 3) stack — is many
+# MB raw, over the ~2 MB websocket message cap of a Modal-fronted endpoint. Per-frame JPEG keeps a
 # 25-frame two-camera stack around 1-2 MB and cuts upload latency; q=90 is visually lossless here.
-_JPEG_STACK_QUALITY = 90
+_JPEG_QUALITY = 90
 
 
-def encode_jpeg_stack(stack: np.ndarray) -> dict[bytes, Any]:
-    """JPEG-encode a ``(T, H, W, 3)`` (or single ``(H, W, 3)``) image stack to a compact wire marker.
+def encode_jpeg(image: np.ndarray) -> dict[bytes, Any]:
+    """JPEG-encode a single ``(H, W, 3)`` image or a ``(T, H, W, 3)`` stack to a compact wire marker.
 
     Sends one JPEG per frame plus the original ``ndim`` so ``_unpack`` restores the exact shape.
     """
-    frames = stack if stack.ndim == 4 else stack[None]
+    frames = image if image.ndim == 4 else image[None]
     bufs = []
     for frame in frames:
         buf = io.BytesIO()
-        PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(
-            buf, format='JPEG', quality=_JPEG_STACK_QUALITY
-        )
+        PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(buf, format='JPEG', quality=_JPEG_QUALITY)
         bufs.append(buf.getvalue())
-    return {b'__jpeg_stack__': True, b'frames': bufs, b'ndim': int(stack.ndim)}
+    return {b'__jpeg__': True, b'frames': bufs, b'ndim': int(image.ndim)}
 
 
-def _decode_jpeg_stack(marker: dict) -> np.ndarray:
-    """Inverse of ``encode_jpeg_stack``: decode per-frame JPEGs and restore the original shape."""
-    stack = np.stack([np.asarray(PilImage.open(io.BytesIO(buf))) for buf in marker[b'frames']])
-    return stack if marker[b'ndim'] == 4 else stack[0]
+def _decode_jpeg(marker: dict) -> np.ndarray:
+    """Inverse of ``encode_jpeg``: decode per-frame JPEGs and restore the original shape."""
+    frames = np.stack([np.asarray(PilImage.open(io.BytesIO(buf))) for buf in marker[b'frames']])
+    return frames if marker[b'ndim'] == 4 else frames[0]
 
 
 def _pack(obj):
@@ -94,8 +92,8 @@ def _unpack(obj):
         return np.ndarray(buffer=obj[b'data'], dtype=np.dtype(obj[b'dtype']), shape=obj[b'shape'])
     if b'__npgeneric__' in obj:
         return np.dtype(obj[b'dtype']).type(obj[b'data'])
-    if b'__jpeg_stack__' in obj:
-        return _decode_jpeg_stack(obj)
+    if b'__jpeg__' in obj:
+        return _decode_jpeg(obj)
     if b'__cmd__' in obj:
         inner = obj[b'__cmd__']
         # The legacy shim below decodes the inner ``to_wire`` dict to a Command

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -42,7 +42,9 @@ def encode_jpeg(image: np.ndarray) -> dict[bytes, Any]:
         buf = io.BytesIO()
         PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(buf, format='JPEG', quality=_JPEG_QUALITY)
         bufs.append(buf.getvalue())
-    return {b'__jpeg__': True, b'frames': bufs, b'ndim': int(image.ndim)}
+    # TODO(rename-jpeg-marker): use `b'__jpeg__'` once Runway's deployed server decodes it. The marker
+    # says "stack" but also carries single frames; it stays this name only to match their live decoder.
+    return {b'__jpeg_stack__': True, b'frames': bufs, b'ndim': int(image.ndim)}
 
 
 def _decode_jpeg(marker: dict) -> np.ndarray:
@@ -92,7 +94,7 @@ def _unpack(obj):
         return np.ndarray(buffer=obj[b'data'], dtype=np.dtype(obj[b'dtype']), shape=obj[b'shape'])
     if b'__npgeneric__' in obj:
         return np.dtype(obj[b'dtype']).type(obj[b'data'])
-    if b'__jpeg__' in obj:
+    if b'__jpeg_stack__' in obj:
         return _decode_jpeg(obj)
     if b'__cmd__' in obj:
         inner = obj[b'__cmd__']

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -49,7 +49,7 @@ uv run --locked positronic-inference sim \
 
 The server owns the codec, so you don't pass one client-side — it takes raw observations and returns
 decoded joint commands. The client-side piece that matters is `--wrap`: it supplies the model's
-autoregressive video context (`TemporalFrameStack`) and must run every control tick to record frames,
+autoregressive video context (`TemporalStack`) and must run every control tick to record frames,
 so omitting it strips the multi-frame history the model conditions on. (Server config and defaults:
 [`server.py`](./server.py); wrappers: [`codecs.py`](./codecs.py); remote-policy protocol:
 [Inference Guide](../../../docs/inference.md).)

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -248,4 +248,6 @@ joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 # DreamZero AR eval schedule: 24-step action horizon → 23-frame look-back (ACTION_HORIZON - 1), sampled
 # at stride 8 from the current frame with the oldest pinned to the window start → trained offsets
 # -23, -16, -8, 0 (test_client_AR.py RELATIVE_OFFSETS; -23 not -24 keeps the oldest inside the window).
-dreamzero_wrappers = wrappers.video_context_wrappers.override(history_frames=23, stride=8)
+dreamzero_wrappers = wrappers.video_context_wrappers.override(
+    history_frames=23, stride=8, keys=('image.wrist', 'image.exterior')
+)


### PR DESCRIPTION
## Summary

For policies that condition on a short window of history plus per-frame proprio:

- **`TemporalStack`** (`policy/wrappers.py`) — replaces each named observation entry in `keys` with a `(T, ...)` temporal stack sampled at strided offsets, so the model sees a history window at the training cadence even though the harness only forwards an observation at re-query boundaries. It's modality-agnostic: `keys` are the cameras plus any per-frame proprio (e.g. `robot_state.ee_pose`, `grip`), each stacked step carrying its own value at that time.
- **Opt-in JPEG compression of images** — with `--policy.compress_images` (default **off**), each image — a single `(H, W, 3)` frame or a `(T, H, W, 3)` stack — is JPEG-encoded per frame before send (q90) to stay under the ~2 MB websocket message cap of a Modal-fronted endpoint. Encode/decode live together in `utils/serialization.py`, and the marker decodes as a first-class wire type in `deserialise`, so every inference server restores the array transparently with no per-server change.
- **`video_context_wrappers`** default stacks images + proprio; DreamZero overrides to images-only.
- **Recorder** collapses a stacked proprio observation to its current (last) frame when drawing the actual-gripper overlay, so recording works with the proprio-context default.

## Test plan

Not yet verified end-to-end on hardware. Verified locally: the config instantiates, DreamZero resolves to images-only, the recorder handles stacked `(T, 7)` / `(T,)` proprio without the earlier broadcast crash, and the offboard test suite passes — including a round-trip test that a JPEG-compressed image (single frame and stack) survives `serialise`/`deserialise` back to the original array and frame order.
