### PR TITLE
Unify gripper convention to 0 = open, 1 = closed

### DIFF
--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -102,7 +102,7 @@ The client sends the full raw robot state as a dict. Keys are flat strings (the 
 | `robot_state.ee_pose` | float32 | (7,) | End-effector pose: `x, y, z, qw, qx, qy, qz` (quaternion is **wxyz**, scalar first) |
 | `robot_state.q` | float32 | (7,) | Joint positions (radians) |
 | `robot_state.dq` | float32 | (7,) | Joint velocities (radians/s) |
-| `grip` | float32 | scalar | Gripper opening |
+| `grip` | float32 | scalar | Gripper closure in `[0, 1]`: 0 = open, 1 = closed |
 | `image.<name>` | uint8 | (H, W, 3) | Camera RGB. Stream names come from the run config — sim and PhAIL send `image.exterior` and `image.wrist` (sim also adds `image.agent_view`) |
 | `obs_time_ns` | int | scalar | Harness-clock timestamp of this observation (ns) |
 | `wall_time_ns` | int | scalar | Wall-clock timestamp (ns) |
@@ -117,8 +117,8 @@ The normal response is a list of action dicts — a short trajectory. (A single 
 
 ```python
 {"result": [
-    {"robot_command": {...}, "target_grip": 0.04, "timestamp": 0.0},
-    {"robot_command": {...}, "target_grip": 0.04, "timestamp": 0.066},
+    {"robot_command": {...}, "target_grip": 1.0, "timestamp": 0.0},
+    {"robot_command": {...}, "target_grip": 1.0, "timestamp": 0.066},
     ...
 ]}
 ```
@@ -126,7 +126,7 @@ The normal response is a list of action dicts — a short trajectory. (A single 
 | Field | Type | Description |
 |-------|------|-------------|
 | `robot_command` | dict | Control command (see below) |
-| `target_grip` | float | Target gripper opening |
+| `target_grip` | float | Target gripper closure in `[0, 1]`: 0 = open, 1 = closed |
 | `timestamp` | float | Execution time in seconds from the start of the returned trajectory (e.g. `i / action_fps` for the i-th action). The client runs each action at `now + timestamp`, where `now` is when the prediction arrived. A single action dict returned *outside* a list is auto-stamped `0.0`; give every action in a list its own `timestamp`, or they all collapse onto one instant and fire at once. |
 
 The `robot_command` field selects the control mode:
@@ -174,7 +174,7 @@ class MySession(Session):
         predicted_poses = self._model.predict(images, ee)
         # Return the actions to run: a list of wire-format dicts.
         return [
-            {'robot_command': {'type': 'cartesian_pos', 'pose': pose}, 'target_grip': 0.04}
+            {'robot_command': {'type': 'cartesian_pos', 'pose': pose}, 'target_grip': 0.0}
             for pose in predicted_poses
         ]
 

--- a/positronic/assets/mujoco/franka_table.xml
+++ b/positronic/assets/mujoco/franka_table.xml
@@ -46,7 +46,7 @@
 
   <custom>
     <text name="model_suffix" data="_ph"/>
-    <text name="initial_ctrl" data="0.3314,-0.4919,-0.5844,-2.0910,-0.2424,1.7946,0.6114,0.0000"/>
+    <text name="initial_ctrl" data="0.3314,-0.4919,-0.5844,-2.0910,-0.2424,1.7946,0.6114,0.0400"/>
     <text name="relative_assets_path" data="franka_table.assets.pkl"/>
   </custom>
 

--- a/positronic/assets/mujoco/panda.urdf
+++ b/positronic/assets/mujoco/panda.urdf
@@ -146,11 +146,13 @@
     </inertial>
     <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
   </link>
+  <!-- Fingers rest at the open pose at q=0 and slide together as q grows, so the recorded
+       ``grip`` signal (0 = open, 1 = closed) scales directly to q. -->
   <joint name="finger_joint1" type="prismatic">
-    <origin rpy="0 0 0" xyz="0 0 0.0584" />
+    <origin rpy="0 0 0" xyz="0 0.04 0.0584" />
     <parent link="hand" />
     <child link="left_finger" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 -1 0" />
     <limit effort="20" lower="0" upper="0.04" velocity="0.2" />
   </joint>
 
@@ -162,14 +164,14 @@
     </inertial>
     <visual><geometry><mesh filename="finger_0.obj" /></geometry></visual>
   </link>
-  <!-- HACK: the slide axis is given in the parent frame (0 -1 0), not the joint frame (0 1 0),
+  <!-- HACK: the slide axis is given in the parent frame (0 1 0), not the joint frame (0 -1 0),
        because rerun's prismatic compute_transform adds axis*q without rotating it by the joint
        origin. The 180-deg origin still mirrors the mesh. Mirrors franka_table.xml's right finger. -->
   <joint name="finger_joint2" type="prismatic">
-    <origin rpy="0 0 3.141592653589793" xyz="0 0 0.0584" />
+    <origin rpy="0 0 3.141592653589793" xyz="0 -0.04 0.0584" />
     <parent link="hand" />
     <child link="right_finger" />
-    <axis xyz="0 -1 0" />
+    <axis xyz="0 1 0" />
     <limit effort="20" lower="0" upper="0.04" velocity="0.2" />
   </joint>
 

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -512,7 +512,7 @@ def calculate_units(episode: Episode) -> int:
 
     threshold = (grip_vals.max() + grip_vals.min()) / 2
     units = 0
-    state = 'CLOSED' if grip_vals[0] < threshold else 'OPEN'
+    state = 'CLOSED' if grip_vals[0] > threshold else 'OPEN'
     min_z_holding = np.inf
     max_z_holding = -np.inf
     pick_x, pick_y = 0.0, 0.0
@@ -520,7 +520,7 @@ def calculate_units(episode: Episode) -> int:
     for i in range(1, len(grip_vals)):
         val = grip_vals[i]
         x, y, z = x_vals[i], y_vals[i], z_vals[i]
-        is_closed = val < threshold
+        is_closed = val > threshold
 
         if state == 'OPEN':
             if is_closed:

--- a/positronic/cfg/codecs.py
+++ b/positronic/cfg/codecs.py
@@ -43,17 +43,27 @@ eepose_joints_obs = eepose_grip_joints_obs.override(
 )
 
 
-@cfn.config(fps=15.0, horizon=None, binarize_grip=None)
-def compose(obs, action, fps: float, horizon: float | None, binarize_grip: tuple[str, ...] | None):
+@cfn.config(fps=15.0, horizon=None, binarize_grip=None, flip_grip=False)
+def compose(obs, action, fps: float, horizon: float | None, binarize_grip: tuple[str, ...] | None, flip_grip: bool):
     """Compose observation and action codecs with timing and optional grip binarization.
+
+    ``flip_grip`` serves checkpoints that speak the inverted grip convention (see ``FlipGrip``).
 
     Layout::
 
-        [ActionHorizon] | ActionTimestamp | [BinarizeGripTraining | BinarizeGripInference] | obs & action
+        [ActionHorizon] | ActionTimestamp | [BinarizeGripTraining | BinarizeGripInference] | [FlipGrip] | obs & action
     """
-    from positronic.policy.codec import ActionHorizon, ActionTimestamp, BinarizeGripInference, BinarizeGripTraining
+    from positronic.policy.codec import (
+        ActionHorizon,
+        ActionTimestamp,
+        BinarizeGripInference,
+        BinarizeGripTraining,
+        FlipGrip,
+    )
 
     result = obs & action
+    if flip_grip:
+        result = FlipGrip() | result
     if binarize_grip:
         result = BinarizeGripTraining(binarize_grip) | BinarizeGripInference() | result
     result = ActionTimestamp(fps=fps) | result

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -10,12 +10,13 @@ These datasets remain on the private s3://raw/ bucket and include:
 """
 
 import configuronic as cfn
+import numpy as np
 import pos3
 
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK
 from positronic.dataset.dataset import ConcatDataset, FilterDataset
 from positronic.dataset.local_dataset import load_all_datasets
-from positronic.dataset.transforms import TransformedDataset, agg_fraction_true, agg_max, agg_percentile
+from positronic.dataset.transforms import Elementwise, TransformedDataset, agg_fraction_true, agg_max, agg_percentile
 from positronic.dataset.transforms.episode import Concat, Derive, FromValue, Get, Group, Identity, Rename
 from positronic.dataset.transforms.quality import cmd_lag, cmd_velocity, idle_mask, jerk
 from positronic.drivers.roboarm.models import bundled_franka_model, bundled_panda_model
@@ -106,12 +107,19 @@ def droid(path, recovery_all, recovery_towels, duplicate_recovery):
     return TransformedDataset(ConcatDataset(*datasets), REAL_ROBOT_TRANSFORM)
 
 
+def _flip_grip(key: str):
+    """Legacy sim recordings store grip as 1 = open; flip to the canonical 1 = closed."""
+    return lambda episode: Elementwise(episode[key], lambda v: 1.0 - np.asarray(v))
+
+
 # Signal transformations for sim datasets
 old_to_new = Group(
     Derive(**{
         'robot_command.pose': Concat('target_robot_position_translation', 'target_robot_position_quaternion'),
         'robot_state.ee_pose': Concat('robot_position_translation', 'robot_position_quaternion'),
         'task': FromValue('Pick up the green cube and place it on the red cube.'),
+        'grip': _flip_grip('grip'),
+        'target_grip': _flip_grip('target_grip'),
     }),
     Rename(**{
         'robot_state.q': 'robot_joints',
@@ -119,7 +127,7 @@ old_to_new = Group(
         'image.wrist': 'image.handcam_left',
         'image.exterior': 'image.back_view',
     }),
-    Identity(select=['grip', 'target_grip', 'mjSTATE_FULLPHYSICS', 'mjSTATE_INTEGRATION', 'mjSTATE_WARMSTART']),
+    Identity(select=['mjSTATE_FULLPHYSICS', 'mjSTATE_INTEGRATION', 'mjSTATE_WARMSTART']),
 )
 
 sim_stack = transform.override(
@@ -130,7 +138,11 @@ sim_pnp = transform.override(
     base=local.override(path='s3://raw/sim_pnp/'),
     transforms=[
         Group(
-            Derive(task=FromValue('Pick up objects from the red tote and place them in the green tote.')),
+            Derive(
+                task=FromValue('Pick up objects from the red tote and place them in the green tote.'),
+                grip=_flip_grip('grip'),
+                target_grip=_flip_grip('target_grip'),
+            ),
             Rename(**{'image.exterior': 'image.back_view'}),
             Identity(),
         ),

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -164,6 +164,6 @@ def bundled_panda_model() -> dict:
         'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
         'joint_names': [f'joint{i}' for i in range(1, 8)],
         'control_frame': 'end_effector',
-        # ``grip`` is recorded in [0, 1] (closed→open); each finger slides 0..0.04 m along its axis.
+        # ``grip`` is recorded in [0, 1] (open→closed); each finger slides 0..0.04 m along its axis.
         'gripper': {'signal': 'grip', 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
     }

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -315,3 +315,31 @@ class BinarizeGripInference(Codec):
         if self._key in data:
             data[self._key] = 1.0 if data[self._key] > self._threshold else 0.0
         return data
+
+
+class FlipGrip(Codec):
+    """Serve a checkpoint that speaks the inverted grip convention (1 = open) on the canonical
+    1 = closed wire: flips ``grip`` entering the model and ``target_grip`` leaving it.
+
+    HACK: exists only to keep checkpoints trained on inverted-grip sim data alive.
+    TODO: Drop it (and its ``flip_grip`` compose hook) when no served checkpoint needs it.
+
+    Compose to the left of obs/action codecs::
+
+        timing | FlipGrip() | obs & action
+    """
+
+    def encode(self, data):
+        # Copy: the original dict is also the decode ``context`` and the raw recording tap's input.
+        if 'grip' in data:
+            data = {**data, 'grip': 1.0 - data['grip']}
+        return data
+
+    @property
+    def training_encoder(self) -> EpisodeTransform:
+        return Identity()
+
+    def _decode_single(self, data: dict, context: dict | None) -> dict:
+        if 'target_grip' in data:
+            data['target_grip'] = 1.0 - data['target_grip']
+        return data

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -15,6 +15,7 @@ from positronic.policy.codec import (
     BinarizeGripInference,
     BinarizeGripTraining,
     Codec,
+    FlipGrip,
 )
 from positronic.policy.observation import ObservationCodec
 
@@ -438,6 +439,35 @@ def test_binarize_grip_training_composed_with_action_codec():
     result = composed.training_encoder(ep)
     vec = list(result['action'])[0][0]
     assert vec[-1] == pytest.approx(1.0)
+
+
+def test_flip_grip():
+    flip = FlipGrip()
+
+    obs = {'grip': 0.2, 'other': 1.0}
+    assert flip.encode(obs) == {'grip': pytest.approx(0.8), 'other': 1.0}
+    assert obs['grip'] == 0.2  # the original obs dict doubles as decode context and must stay intact
+    assert flip.encode({'other': 1.0}) == {'other': 1.0}
+
+    assert flip._decode_single({'target_grip': 0.9}, None) == {'target_grip': pytest.approx(0.1)}
+    assert flip._decode_single({'pose': 1.0}, None) == {'pose': 1.0}
+    assert flip.decode([{'target_grip': 1.0}, {'target_grip': 0.25}]) == [
+        {'target_grip': pytest.approx(0.0)},
+        {'target_grip': pytest.approx(0.75)},
+    ]
+
+
+def test_flip_grip_composed_with_obs_and_action():
+    obs = ObservationCodec(state={'observation.state': ['grip']}, images={})
+    action = AbsolutePositionAction('robot_command.pose', 'target_grip', Rotation.Representation.QUAT)
+    composed = FlipGrip() | (obs & action)
+
+    encoded = composed.encode({'grip': 0.2})
+    np.testing.assert_allclose(encoded['observation.state'], [0.8])
+
+    vec = np.concatenate([[0.1, -0.2, 0.3], Rotation.identity.as_quat, [0.9]]).astype(np.float32)
+    decoded = composed.decode({'action': vec}, context={})
+    assert decoded['target_grip'] == pytest.approx(0.1)
 
 
 def test_parallel_codec_encode_merges_outputs():

--- a/positronic/simulator/mujoco/scene_builder.py
+++ b/positronic/simulator/mujoco/scene_builder.py
@@ -15,7 +15,7 @@ ASSET_DIR_MESSAGE = """
 !!! This spec should be loaded with asset dict.
 See simulator.mujoco.transforms.load_model_from_spec !!!
 """
-INITIAL_CTRL = [0.3314, -0.4919, -0.5844, -2.0910, -0.2424, 1.7946, 0.6114, 0.0000]
+INITIAL_CTRL = [0.3314, -0.4919, -0.5844, -2.0910, -0.2424, 1.7946, 0.6114, 0.0400]
 
 
 def random_range(value: RANGE_OR_VALUE) -> float:

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -374,14 +374,14 @@ class MujocoSim(pimm.ControlSystem):
             self.data.actuator(name).ctrl = value
 
     def _apply_grip(self, target: float):
-        """Convert [0, 1] target grip to the actuator control range."""
+        """Convert [0, 1] target grip (0 = open, 1 = closed) to the actuator control range."""
         min_grip, max_grip = self._grip_range
-        self.data.actuator(self._gripper_actuator).ctrl = min_grip + target * (max_grip - min_grip)
+        self.data.actuator(self._gripper_actuator).ctrl = max_grip - target * (max_grip - min_grip)
 
     def _current_grip(self) -> float:
-        """Convert the current grip joint position to the range of [0, 1]."""
+        """Convert the current grip joint position to [0, 1] (0 = open, 1 = closed)."""
         min_grip, max_grip = self._grip_range
-        return (self.data.joint(self._gripper_joint).qpos.item() - min_grip) / (max_grip - min_grip)
+        return 1.0 - (self.data.joint(self._gripper_joint).qpos.item() - min_grip) / (max_grip - min_grip)
 
     @property
     def _q(self) -> np.ndarray:

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -239,3 +239,34 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
 
     for name in ['robot_state.q', 'robot_state.dq', 'grip']:
         assert_strictly_increasing(ep[name])
+
+
+def test_mujoco_grip_one_is_closed():
+    sim = MujocoSim('positronic/assets/mujoco/franka_table.xml', loaders=())
+
+    def finger_qpos() -> float:
+        """Physical finger travel: 0 = fingers together (closed), 0.04 m = fully apart (open)."""
+        return sim.data.joint('finger_joint1_ph').qpos.item()
+
+    # The home pose leaves the gripper open.
+    assert finger_qpos() > 0.03
+
+    snapshots = {}
+    with pimm.World(virtual_time=True) as world:
+        target_grip = world.pair(sim.target_grip)
+        grip = world.pair(sim.grip)
+
+        driver = ManualDriver([
+            (lambda: target_grip.emit(1.0), 0.5),
+            (lambda: snapshots.update(closed=finger_qpos(), closed_grip=grip.read().data), 0.0),
+            (lambda: target_grip.emit(0.0), 0.5),
+            (lambda: snapshots.update(opened=finger_qpos(), opened_grip=grip.read().data), 0.0),
+        ])
+
+        scheduler = world.start([sim, driver])
+        drive_scheduler(scheduler, steps=2000)
+
+    assert snapshots['closed'] < 0.005
+    assert snapshots['closed_grip'] > 0.9
+    assert snapshots['opened'] > 0.035
+    assert snapshots['opened_grip'] < 0.1

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -427,9 +427,11 @@ phail = ee_rot6d_rel.override(
     checkpoints_dir='s3://checkpoints/phail_unified/groot/270226-ee_rot6d_rel/',
     recording_dir='s3://inference/phail_unified/server_recordings/groot/270226-ee_rot6d_rel/',
 )
+# The sim_stack checkpoint was trained on inverted-grip (1 = open) sim data, hence flip_grip.
 sim_stack = ee_rot6d.override(
     checkpoints_dir='s3://checkpoints/sim_stack/groot/ee_rot6d/230226/',
     recording_dir='s3://inference/sim_stack/server_recordings/groot/230226/',
+    codec=codecs.ee_rot6d.override(flip_grip=True),
 )
 
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -431,7 +431,7 @@ phail = ee_rot6d_rel.override(
 sim_stack = ee_rot6d.override(
     checkpoints_dir='s3://checkpoints/sim_stack/groot/ee_rot6d/230226/',
     recording_dir='s3://inference/sim_stack/server_recordings/groot/230226/',
-    codec=codecs.ee_rot6d.override(flip_grip=True),
+    **{'codec.flip_grip': True},
 )
 
 

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -135,15 +135,22 @@ phail = main.override(
     checkpoints_dir='s3://checkpoints/phail_unified/lerobot/270226-ee/',
     recording_dir='s3://inference/phail_unified/server_recordings/lerobot/270226-ee/',
 )
+# The sim_stack and demo checkpoints were trained on inverted-grip (1 = open) sim data, hence flip_grip.
 sim_stack = main.override(
     checkpoints_dir='s3://checkpoints/sim_stack/lerobot/230226-ee/',
     recording_dir='s3://inference/sim_stack/server_recordings/lerobot/230226-ee/',
+    codec=lerobot_codecs.ee.override(flip_grip=True),
 )
 _DEMO_CHECKPOINT = 's3://PUBLIC@positronic-public/checkpoints/sim_stack_cubes/act/'
 
 
 @cfn.config(
-    policy_factory=act, codec=lerobot_codecs.ee, checkpoint=None, port=8000, host='0.0.0.0', idle_timeout_min=None
+    policy_factory=act,
+    codec=lerobot_codecs.ee.override(flip_grip=True),
+    checkpoint=None,
+    port=8000,
+    host='0.0.0.0',
+    idle_timeout_min=None,
 )
 def demo(policy_factory, checkpoint, codec, port, host, idle_timeout_min):
     checkpoints_dir = str(pos3.download(_DEMO_CHECKPOINT))

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -139,7 +139,7 @@ phail = main.override(
 sim_stack = main.override(
     checkpoints_dir='s3://checkpoints/sim_stack/lerobot/230226-ee/',
     recording_dir='s3://inference/sim_stack/server_recordings/lerobot/230226-ee/',
-    codec=lerobot_codecs.ee.override(flip_grip=True),
+    **{'codec.flip_grip': True},
 )
 _DEMO_CHECKPOINT = 's3://PUBLIC@positronic-public/checkpoints/sim_stack_cubes/act/'
 

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -357,7 +357,7 @@ phail = server.override(
 sim_stack = server.override(
     checkpoints_dir='s3://checkpoints/sim_stack/openpi/ee/pi05_positronic_lowmem/230226/',
     recording_dir='s3://inference/sim_stack/server_recordings/openpi/230226/',
-    codec=codecs.ee.override(flip_grip=True),
+    **{'codec.flip_grip': True},
 )
 droid = server.override(
     codec=codecs.droid,

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -353,9 +353,11 @@ phail = server.override(
     checkpoints_dir='s3://checkpoints/phail_unified/openpi/pi05_positronic_lowmem/270226-ee/',
     recording_dir='s3://inference/phail_unified/server_recordings/openpi/270226-ee/',
 )
+# The sim_stack checkpoint was trained on inverted-grip (1 = open) sim data, hence flip_grip.
 sim_stack = server.override(
     checkpoints_dir='s3://checkpoints/sim_stack/openpi/ee/pi05_positronic_lowmem/230226/',
     recording_dir='s3://inference/sim_stack/server_recordings/openpi/230226/',
+    codec=codecs.ee.override(flip_grip=True),
 )
 droid = server.override(
     codec=codecs.droid,


### PR DESCRIPTION
Closes #456.

## Summary

Makes `0 = open, 1 = closed` (the real/DROID convention) the single grip convention; only the sim world moves. Nothing is retrained — existing sim checkpoints are served through a flip shim.

- **Simulator**: `MujocoSim._apply_grip`/`_current_grip` now map `1 → fingers closed`; `franka_table.xml` home pose and `scene_builder.INITIAL_CTRL` leave the gripper open.
- **Legacy sim recordings**: `old_to_new` and `sim_pnp` transforms in `cfg/ds/internal.py` flip `grip`/`target_grip` on the fly, so `sim_stack`, `sim_pnp`, and the mixed `full`/`full_recovery` datasets are self-consistent. The public `sim-stack-cubes`/`sim-pick-place` datasets were rewritten on S3 with the flip baked in.
- **Existing checkpoints**: new `FlipGrip` codec (marked HACK/TODO) flips `grip` entering the model and `target_grip` leaving it; enabled via `compose(flip_grip=True)` on the four sim presets (`lerobot_0_3_3` `sim_stack`/`demo`, `gr00t` `sim_stack`, `openpi` `sim_stack`). Real-robot presets untouched.
- **Viewer**: `panda.urdf` finger joints redefined so `q=0` = open — the 3D gripper animation now matches the canonical signal (this also fixes LIBERO episodes, which rendered backwards).
- **Analysis**: `calculate_units` pick/place heuristic reads `grip > threshold` as closed.
- **Docs**: wire-format table states the convention explicitly.

## Test plan

- New regression tests: `test_mujoco_grip_one_is_closed` (drives the sim and asserts physical finger qpos, non-circularly) and `test_flip_grip` / `test_flip_grip_composed_with_obs_and_action`.
- Full suite: 609 passed, 7 skipped.
- E2E A/B against the public demo ACT checkpoint served locally with `flip_grip=True`: 8/10 episodes achieve physical pickups (grip plateaus at 0.50 = cube aperture, cube lifted ~6 cm) with one clean stack; the same checkpoint without the flip achieves 0/10 pickups.
- Public dataset migration verified per-file against the originals: all 1062 grip/target_grip parquets confirmed flipped on S3 (byte-compared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)