### PR TITLE
Key viewer RRD cache by episode uid

### DIFF
--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -75,7 +75,9 @@ def _get_rrd_cache_path(episode_id: int) -> str:
     ds_id = str(Path(str(app_state['root'])).resolve()).replace(os.sep, '_').replace(':', '')
     episode_cache_dir = os.path.join(cache_root, ds_id)
     os.makedirs(episode_cache_dir, exist_ok=True)
-    return os.path.join(episode_cache_dir, f'episode_{episode_id}.rrd')
+    # Key the cache by episode uid, not position: position is view-dependent, and datasets without a
+    # resolvable root (e.g. concatenated ones) all share the 'unknown_dataset' namespace.
+    return os.path.join(episode_cache_dir, f'{ds[episode_id].meta["uid"]}.rrd')
 
 
 @asynccontextmanager


### PR DESCRIPTION
## Summary

The positronic-server RRD cache keyed episode files by position (`episode_{id}.rrd`) inside a namespace derived from the dataset root. `get_dataset_root()` returns `None` for concatenated datasets — which is what serving a directory of multiple runs produces — so every such session shares the literal `unknown_dataset` namespace, and a cached `episode_0.rrd` from one dataset is silently served for episode 0 of any other. Hit in practice: an eval-run session served a LIBERO episode's RRD.

The fix keys the cache file by the episode's `meta['uid']` — per the dataset library's identity contract, position is access, uid is identity. Uids are globally unique, so the shared namespace becomes harmless. One line plus a comment; the episode lookup is free since `CachedDataset` memoizes episodes per index.

## Test plan

Verified locally against a 20-episode concatenated dataset: episodes 0 and 10 generate uid-named cache files (`9a385e3b….rrd`, `757f8b36….rrd`), and a repeat request serves the 4.9 MB RRD from cache in 0.4 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)