### PR TITLE
Retry transient connection drops when opening a remote inference session

### DIFF
--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -133,6 +133,10 @@ class InferenceClient:
             try:
                 ws = connect(uri, **connect_kwargs)
                 break
+            # ``SSLCertVerificationError`` is an ``ssl.SSLError``, but a bad certificate is permanent
+            # misconfiguration, not a cold start — surface it immediately instead of retrying to the deadline.
+            except ssl.SSLCertVerificationError as e:
+                raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
             # A cold backend fails before a session exists in any of three ways: the connect times out, the edge
             # resets TLS (``SSLError``), or it closes the handshake (``ConnectionClosed``). All three mean "not
             # ready yet", so retry them within the deadline instead of letting one kill the run.

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -143,7 +143,7 @@ class InferenceClient:
             except (TimeoutError, ssl.SSLError, ConnectionClosed) as e:
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.host}:{self.port})') from e
-                logger.info('Server not ready (cold start?); retrying in %.0fs', backoff)
+                logger.info('Server not ready (cold start?): %s; retrying in %.0fs', e, backoff)
                 time.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
             except OSError as e:

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -1,8 +1,10 @@
 import logging
+import ssl
 import time
 from typing import Any
 
 import httpx
+from websockets.exceptions import ConnectionClosed
 from websockets.sync.client import connect
 from websockets.sync.connection import Connection
 
@@ -131,7 +133,10 @@ class InferenceClient:
             try:
                 ws = connect(uri, **connect_kwargs)
                 break
-            except TimeoutError as e:
+            # A cold backend fails before a session exists in any of three ways: the connect times out, the edge
+            # resets TLS (``SSLError``), or it closes the handshake (``ConnectionClosed``). All three mean "not
+            # ready yet", so retry them within the deadline instead of letting one kill the run.
+            except (TimeoutError, ssl.SSLError, ConnectionClosed) as e:
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.host}:{self.port})') from e
                 logger.info('Server not ready (cold start?); retrying in %.0fs', backoff)

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -33,8 +33,7 @@ class InferenceSession:
         """
         try:
             while True:
-                self._websocket.socket.settimeout(timeout_per_message)
-                response = deserialise(self._websocket.recv())
+                response = deserialise(self._websocket.recv(timeout=timeout_per_message))
                 status = response.get('status')
 
                 if status == 'ready':
@@ -55,8 +54,6 @@ class InferenceSession:
                 f'Server did not send status update within {timeout_per_message}s. '
                 f'Server may have crashed or model loading is taking too long without progress updates.'
             ) from None
-        finally:
-            self._websocket.socket.settimeout(None)
 
     @property
     def metadata(self) -> dict[str, Any]:

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -130,17 +130,22 @@ class InferenceClient:
         deadline = time.monotonic() + connect_deadline
         backoff = 1.0
         while True:
+            ws = None
             try:
                 ws = connect(uri, **connect_kwargs)
-                break
+                return InferenceSession(ws, infer_timeout=infer_timeout)
             # ``SSLCertVerificationError`` is an ``ssl.SSLError``, but a bad certificate is permanent
             # misconfiguration, not a cold start — surface it immediately instead of retrying to the deadline.
             except ssl.SSLCertVerificationError as e:
                 raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
-            # A cold backend fails before a session exists in any of three ways: the connect times out, the edge
-            # resets TLS (``SSLError``), or it closes the handshake (``ConnectionClosed``). All three mean "not
-            # ready yet", so retry them within the deadline instead of letting one kill the run.
+            # A cold backend fails before the session is ready in several ways: the connect times out, the edge
+            # resets TLS (``SSLError``), it closes the WebSocket handshake, or it accepts the socket and then
+            # drops or stalls the status handshake inside ``InferenceSession`` (``ConnectionClosed``/
+            # ``TimeoutError``). All mean "not ready yet", so retry within the deadline instead of letting one
+            # kill the run.
             except (TimeoutError, ssl.SSLError, ConnectionClosed) as e:
+                if ws is not None:
+                    ws.close()
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.host}:{self.port})') from e
                 logger.info('Server not ready (cold start?): %s; retrying in %.0fs', e, backoff)
@@ -148,7 +153,6 @@ class InferenceClient:
                 backoff = min(backoff * 2, 30.0)
             except OSError as e:
                 raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
-        return InferenceSession(ws, infer_timeout=infer_timeout)
 
     def list_models(self) -> list[str]:
         """List available models from the server."""

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -4,7 +4,7 @@ import time
 from typing import Any
 
 import httpx
-from websockets.exceptions import ConnectionClosed, InvalidHandshake
+from websockets.exceptions import ConnectionClosed, InvalidHandshake, InvalidStatus
 from websockets.sync.client import connect
 from websockets.sync.connection import Connection
 
@@ -143,6 +143,12 @@ class InferenceClient:
             except (TimeoutError, ssl.SSLError, ConnectionClosed, InvalidHandshake) as e:
                 if ws is not None:
                     ws.close()
+                # A non-101 upgrade response only means "not ready" when it's a 5xx or 429; any other status
+                # (401/403/404, …) is permanent misconfiguration and surfaces immediately.
+                if isinstance(e, InvalidStatus) and not (
+                    e.response.status_code >= 500 or e.response.status_code == 429
+                ):
+                    raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.host}:{self.port})') from e
                 logger.info('Server not ready (cold start?): %s; retrying in %.0fs', e, backoff)

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -4,7 +4,7 @@ import time
 from typing import Any
 
 import httpx
-from websockets.exceptions import ConnectionClosed
+from websockets.exceptions import ConnectionClosed, InvalidHandshake
 from websockets.sync.client import connect
 from websockets.sync.connection import Connection
 
@@ -136,11 +136,11 @@ class InferenceClient:
             except ssl.SSLCertVerificationError as e:
                 raise type(e)(f'{e} (connecting to {self.host}:{self.port})') from e
             # A cold backend fails before the session is ready in several ways: the connect times out, the edge
-            # resets TLS (``SSLError``), it closes the WebSocket handshake, or it accepts the socket and then
-            # drops or stalls the status handshake inside ``InferenceSession`` (``ConnectionClosed``/
-            # ``TimeoutError``). All mean "not ready yet", so retry within the deadline instead of letting one
-            # kill the run.
-            except (TimeoutError, ssl.SSLError, ConnectionClosed) as e:
+            # resets TLS (``SSLError``), it rejects or drops the HTTP upgrade (``InvalidHandshake`` — e.g. a
+            # 502/503 while the backend boots), or it accepts the socket and then drops or stalls the status
+            # handshake inside ``InferenceSession`` (``ConnectionClosed``/``TimeoutError``). All mean "not ready
+            # yet", so retry within the deadline instead of letting one kill the run.
+            except (TimeoutError, ssl.SSLError, ConnectionClosed, InvalidHandshake) as e:
                 if ws is not None:
                     ws.close()
                 if time.monotonic() >= deadline:


### PR DESCRIPTION
## Summary

`InferenceClient.new_session` retried only `TimeoutError` on connect, but a cold backend (e.g. a Modal container that scaled down between rollouts) can reset TLS or close the WebSocket handshake instead of timing out — surfacing as `ssl.SSLError` / `websockets.ConnectionClosed`. Those slipped past the retry loop and propagated up through the harness, killing an otherwise-healthy multi-rollout run on the first cold reconnect.

This widens the retried set to those two transient failure modes, so they back off and retry within the existing `connect_deadline` (like a cold-start timeout) instead of crashing the run. Genuine connection failures (other `OSError`s) still surface immediately as before.

## Test plan

- Observed live: two remote-eval rollouts succeeded, the third `new_session` hit a cold Modal backend and died with `ssl.SSLError: [SSL] internal error` → `ConnectionClosedError`; starting over reconnected fine, confirming the server was healthy and only cold.
- `ruff check` / `ruff format --check` clean; module compiles.
- Not yet re-run end-to-end against a cold backend on hardware.
