### PR TITLE
Open Franka brakes and activate FCI via Desk around the driver session

### DIFF
--- a/pimm/world.py
+++ b/pimm/world.py
@@ -499,7 +499,9 @@ class World:
 
         logging.info(f'Waiting for {len(self.background_processes)} background processes to terminate...')
         for process in self.background_processes:
-            process.join(timeout=3)
+            # Control systems run teardown (with-blocks in run()) after the stop signal; hardware cleanup such as
+            # engaging robot brakes takes tens of seconds, so give it time before resorting to SIGTERM.
+            process.join(timeout=60)
             if process.is_alive():
                 logging.warning(f'Process {process.name} (pid {process.pid}) did not respond, terminating...')
                 process.terminate()

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -231,57 +231,62 @@ class Robot(pimm.ControlSystem):
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         with self._desk_session():
             robot = self._ensure_robot()
-            self._init_robot(robot)
-            self.robot_meta.emit(Robot._build_robot_meta(robot))
-            robot.recover_from_errors()
+            try:
+                self._init_robot(robot)
+                self.robot_meta.emit(Robot._build_robot_meta(robot))
+                robot.recover_from_errors()
 
-            robot_state = FrankaState()
-            rate_limiter = pimm.RateLimiter(clock, hz=2000)
+                robot_state = FrankaState()
+                rate_limiter = pimm.RateLimiter(clock, hz=2000)
 
-            self._reset(robot, robot_state)
+                self._reset(robot, robot_state)
 
-            in_error = False
-            player = command.TrajectoryPlayer(reduce=command.reduce)
+                in_error = False
+                player = command.TrajectoryPlayer(reduce=command.reduce)
 
-            while not should_stop.value:
-                st = robot.state()
-                robot_state.encode(st)
-                self.state.emit(robot_state)
+                while not should_stop.value:
+                    st = robot.state()
+                    robot_state.encode(st)
+                    self.state.emit(robot_state)
 
-                in_error, entered_error = _check_error(st.error != 0, in_error)
-                if entered_error:
-                    logging.warning(f'Robot error: {st.error_message}')
+                    in_error, entered_error = _check_error(st.error != 0, in_error)
+                    if entered_error:
+                        logging.warning(f'Robot error: {st.error_message}')
 
-                cmd_msg = self.commands.read()
-                if cmd_msg.updated:
-                    player.set(cmd_msg.data)
-                cmd = player.advance(clock.now_ns())
-                if cmd is not None:
-                    match cmd:
-                        case command.Reset():
-                            _recover_if_needed(robot, in_error)
-                            self._reset(robot, robot_state)
-                        case command.Recover():
-                            _recover_if_needed(robot, in_error)
-                        case _ if in_error:
-                            pass
-                        case command.CartesianPosition(pose):
-                            target_pose_wxyz = np.asarray([*pose.translation, *pose.rotation.as_quat])
-                            ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
-                            robot.set_target_joints(ik_solution)
-                        case command.CartesianDelta(delta):
-                            target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
-                            target_pose_wxyz = np.asarray([*target.translation, *target.rotation.as_quat])
-                            ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
-                            robot.set_target_joints(ik_solution)
-                        case command.JointPosition(positions):
-                            robot.set_target_joints(positions)
-                        case command.JointDelta(velocities=joint_delta):
-                            robot.set_target_joints(st.q + joint_delta)
-                        case _:
-                            raise NotImplementedError(f'Unsupported command {cmd}')
+                    cmd_msg = self.commands.read()
+                    if cmd_msg.updated:
+                        player.set(cmd_msg.data)
+                    cmd = player.advance(clock.now_ns())
+                    if cmd is not None:
+                        match cmd:
+                            case command.Reset():
+                                _recover_if_needed(robot, in_error)
+                                self._reset(robot, robot_state)
+                            case command.Recover():
+                                _recover_if_needed(robot, in_error)
+                            case _ if in_error:
+                                pass
+                            case command.CartesianPosition(pose):
+                                target_pose_wxyz = np.asarray([*pose.translation, *pose.rotation.as_quat])
+                                ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
+                                robot.set_target_joints(ik_solution)
+                            case command.CartesianDelta(delta):
+                                target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
+                                target_pose_wxyz = np.asarray([*target.translation, *target.rotation.as_quat])
+                                ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
+                                robot.set_target_joints(ik_solution)
+                            case command.JointPosition(positions):
+                                robot.set_target_joints(positions)
+                            case command.JointDelta(velocities=joint_delta):
+                                robot.set_target_joints(st.q + joint_delta)
+                            case _:
+                                raise NotImplementedError(f'Unsupported command {cmd}')
 
-                yield rate_limiter.wait()
+                    yield rate_limiter.wait()
+            finally:
+                # Halt the driver's control thread before _desk_session deactivates FCI, or it dies mid-control
+                # with "TCP connection got interrupted".
+                robot.stop()
 
 
 if __name__ == '__main__':

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -1,4 +1,6 @@
+import contextlib
 import logging
+import os
 import time
 import xml.etree.ElementTree as ET
 from collections.abc import Iterator
@@ -9,6 +11,7 @@ import numpy as np
 
 try:
     import positronic_franka._franka as pf
+    from positronic_franka.desk import Desk
 except ImportError as e:
     raise ImportError(
         'Franka support is not installed. Install the hardware extra:\n'
@@ -102,6 +105,8 @@ class Robot(pimm.ControlSystem):
         home_joints_variation: list[float] | None = None,
         load: tuple | None = None,
         collision_coeff: float = 2.0,
+        desk_login: str | None = None,
+        desk_password: str | None = None,
     ) -> None:
         """
         :param ip: IP address of the robot.
@@ -110,6 +115,9 @@ class Robot(pimm.ControlSystem):
         :param home_joints_variation: Max random deviation per joint in radians. Set to [0]*7 to disable.
         :param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
             Default 2.0 (data collection). Use 6.0 for inference.
+        :param desk_login: Franka Desk login; defaults to the ``FRANKA_DESK_USER`` env var. When set with
+            ``desk_password``, the driver opens brakes and activates FCI via Desk on start and closes them on stop.
+        :param desk_password: Franka Desk password; defaults to the ``FRANKA_DESK_PASSWORD`` env var.
         """
         self._ip = ip
         self._relative_dynamics_factor = relative_dynamics_factor
@@ -123,6 +131,8 @@ class Robot(pimm.ControlSystem):
         self._load = load
         self._collision_coeff = collision_coeff
         self._robot: pf.Robot | None = None
+        self._desk_login = desk_login if desk_login is not None else os.environ.get('FRANKA_DESK_USER')
+        self._desk_password = desk_password if desk_password is not None else os.environ.get('FRANKA_DESK_PASSWORD')
 
     @staticmethod
     def _build_robot_meta(robot) -> dict:
@@ -207,59 +217,71 @@ class Robot(pimm.ControlSystem):
         robot_state._finish_reset()
         self.state.emit(robot_state)
 
+    @contextlib.contextmanager
+    def _desk_session(self):
+        """Bracket the run with a Franka Desk session that opens brakes and activates FCI, and always releases
+        control on exit. A no-op when Desk credentials are not configured (manual brake control, or simulation)."""
+        if not (self._desk_login and self._desk_password):
+            yield
+            return
+        with Desk(self._ip, self._desk_login, self._desk_password) as desk:
+            desk.prepare()
+            yield
+
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
-        robot = self._ensure_robot()
-        self._init_robot(robot)
-        self.robot_meta.emit(Robot._build_robot_meta(robot))
-        robot.recover_from_errors()
+        with self._desk_session():
+            robot = self._ensure_robot()
+            self._init_robot(robot)
+            self.robot_meta.emit(Robot._build_robot_meta(robot))
+            robot.recover_from_errors()
 
-        robot_state = FrankaState()
-        rate_limiter = pimm.RateLimiter(clock, hz=2000)
+            robot_state = FrankaState()
+            rate_limiter = pimm.RateLimiter(clock, hz=2000)
 
-        self._reset(robot, robot_state)
+            self._reset(robot, robot_state)
 
-        in_error = False
-        player = command.TrajectoryPlayer(reduce=command.reduce)
+            in_error = False
+            player = command.TrajectoryPlayer(reduce=command.reduce)
 
-        while not should_stop.value:
-            st = robot.state()
-            robot_state.encode(st)
-            self.state.emit(robot_state)
+            while not should_stop.value:
+                st = robot.state()
+                robot_state.encode(st)
+                self.state.emit(robot_state)
 
-            in_error, entered_error = _check_error(st.error != 0, in_error)
-            if entered_error:
-                logging.warning(f'Robot error: {st.error_message}')
+                in_error, entered_error = _check_error(st.error != 0, in_error)
+                if entered_error:
+                    logging.warning(f'Robot error: {st.error_message}')
 
-            cmd_msg = self.commands.read()
-            if cmd_msg.updated:
-                player.set(cmd_msg.data)
-            cmd = player.advance(clock.now_ns())
-            if cmd is not None:
-                match cmd:
-                    case command.Reset():
-                        _recover_if_needed(robot, in_error)
-                        self._reset(robot, robot_state)
-                    case command.Recover():
-                        _recover_if_needed(robot, in_error)
-                    case _ if in_error:
-                        pass
-                    case command.CartesianPosition(pose):
-                        target_pose_wxyz = np.asarray([*pose.translation, *pose.rotation.as_quat])
-                        ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
-                        robot.set_target_joints(ik_solution)
-                    case command.CartesianDelta(delta):
-                        target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
-                        target_pose_wxyz = np.asarray([*target.translation, *target.rotation.as_quat])
-                        ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
-                        robot.set_target_joints(ik_solution)
-                    case command.JointPosition(positions):
-                        robot.set_target_joints(positions)
-                    case command.JointDelta(velocities=joint_delta):
-                        robot.set_target_joints(st.q + joint_delta)
-                    case _:
-                        raise NotImplementedError(f'Unsupported command {cmd}')
+                cmd_msg = self.commands.read()
+                if cmd_msg.updated:
+                    player.set(cmd_msg.data)
+                cmd = player.advance(clock.now_ns())
+                if cmd is not None:
+                    match cmd:
+                        case command.Reset():
+                            _recover_if_needed(robot, in_error)
+                            self._reset(robot, robot_state)
+                        case command.Recover():
+                            _recover_if_needed(robot, in_error)
+                        case _ if in_error:
+                            pass
+                        case command.CartesianPosition(pose):
+                            target_pose_wxyz = np.asarray([*pose.translation, *pose.rotation.as_quat])
+                            ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
+                            robot.set_target_joints(ik_solution)
+                        case command.CartesianDelta(delta):
+                            target = command.apply_cartesian_delta(robot_state.ee_pose, delta)
+                            target_pose_wxyz = np.asarray([*target.translation, *target.rotation.as_quat])
+                            ik_solution = robot.inverse_kinematics_with_limits(target_pose_wxyz)
+                            robot.set_target_joints(ik_solution)
+                        case command.JointPosition(positions):
+                            robot.set_target_joints(positions)
+                        case command.JointDelta(velocities=joint_delta):
+                            robot.set_target_joints(st.q + joint_delta)
+                        case _:
+                            raise NotImplementedError(f'Unsupported command {cmd}')
 
-            yield rate_limiter.wait()
+                yield rate_limiter.wait()
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ pyzed = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl", marker = "python_full_version >= '3.13'" },
 ]
 openpi-client = { git = "https://github.com/Positronic-Robotics/openpi.git", rev = "main-positronic", subdirectory = "packages/openpi-client" }
+# Local checkout of the Franka driver so its in-progress `positronic_franka.desk` module is importable here.
+positronic-franka = { path = "../positronic-franka", editable = true }
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ openpi = [
 ]
 hardware = [
     "feetech-servo-sdk", # for feetech motors
-    "positronic-franka>=0.3.0; sys_platform == 'linux'",
+    "positronic-franka>=0.5.0; sys_platform == 'linux'",
     # "kortex_api; sys_platform == 'linux'",  # Kinova: disabled, artifactory.kinovaapps.com is unreliable
     "linuxpy",  # For Linux video capture
     "placo",
@@ -147,8 +147,6 @@ pyzed = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp313-cp313-linux_x86_64.whl", marker = "python_full_version >= '3.13'" },
 ]
 openpi-client = { git = "https://github.com/Positronic-Robotics/openpi.git", rev = "main-positronic", subdirectory = "packages/openpi-client" }
-# Local checkout of the Franka driver so its in-progress `positronic_franka.desk` module is importable here.
-positronic-franka = { path = "../positronic-franka", editable = true }
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/uv.lock
+++ b/uv.lock
@@ -4293,7 +4293,7 @@ requires-dist = [
     { name = "placo", marker = "extra == 'hardware'" },
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pos3", specifier = ">=0.3.1" },
-    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", editable = "../positronic-franka" },
+    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.5.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "protobuf", marker = "extra == 'molmoact2'" },
     { name = "pyarrow" },
@@ -4335,17 +4335,12 @@ provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2"
 [[package]]
 name = "positronic-franka"
 version = "0.5.0"
-source = { editable = "../positronic-franka" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "requests", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "numpy", specifier = ">=1.22" },
-    { name = "requests", specifier = ">=2.28" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/97/c7/ea8132fd80a7e064b462df39b87ec6b750874b54885bfe45162cc32af3b8/positronic_franka-0.5.0.tar.gz", hash = "sha256:0937c3654b6d026d6a87a2892094c20459980683d14ce19604f8a8b41d1d5e40", size = 1796271, upload-time = "2026-07-14T21:32:24.866Z" }
 
 [[package]]
 name = "pre-commit"

--- a/uv.lock
+++ b/uv.lock
@@ -4293,7 +4293,7 @@ requires-dist = [
     { name = "placo", marker = "extra == 'hardware'" },
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pos3", specifier = ">=0.3.1" },
-    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.3.0" },
+    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", editable = "../positronic-franka" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "protobuf", marker = "extra == 'molmoact2'" },
     { name = "pyarrow" },
@@ -4334,12 +4334,18 @@ provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2"
 
 [[package]]
 name = "positronic-franka"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.5.0"
+source = { editable = "../positronic-franka" }
 dependencies = [
     { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
+    { name = "requests", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b6/ce86bfa8526c4ca9ca848333499ebe71ad3548677c21e62ae8a719515e8e/positronic_franka-0.4.0.tar.gz", hash = "sha256:276a6c42b054f3b9dcfade2d47387d7bca70dc1b3ef6ed05db8d734e76b5d56f", size = 1792844, upload-time = "2026-03-17T19:05:18.249Z" }
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=1.22" },
+    { name = "requests", specifier = ">=2.28" },
+]
 
 [[package]]
 name = "pre-commit"


### PR DESCRIPTION
## Summary
Wires `positronic_franka.desk.Desk` (released in `positronic-franka` 0.5.0) into the Franka driver so a session never needs the Desk web UI. When Desk credentials are configured (`FRANKA_DESK_USER`/`FRANKA_DESK_PASSWORD`), `run()` wraps the libfranka session in a Desk session: take robot control, run the TD2 safety self-test if due or overdue, open the brakes, activate FCI — and on stop, halt the control thread, deactivate FCI, close the brakes, and release control. A no-op without credentials (manual brakes, or simulation). Credentials come from the environment, so they never land in argv / `run_metadata`.

Also:
- `robot.stop()` (new in 0.5.0) halts the driver's control thread before FCI deactivation, so shutdown no longer prints `Joint control thread error: libfranka: TCP connection got interrupted`.
- `pimm.World` now gives background processes 60s (was 3s) to finish teardown before SIGTERM — engaging the brakes takes tens of seconds.
- `positronic-franka` dependency bumped to the released `>=0.5.0` on PyPI.

## Test plan
Verified live on the FR3, end to end:
- Full session: take control → open brakes → activate FCI (polled until actually up) → libfranka run → clean teardown (control thread stop → FCI deactivate → brakes close → control release), with no shutdown errors.
- Overdue-TD2 path: with the self-test overdue (robot in Recovery, Desk refusing all actions), `prepare()` acknowledges the safety error, runs the self-test (~34s), then proceeds to brakes + FCI.
- Control held elsewhere: startup refuses with a clear message instead of silently queuing a pending token; the pending request is withdrawn.
- No-credentials branch is a clean no-op.
