### PR TITLE
Add `pad_start` to `TemporalStack` to send only observed history at session start

### DIFF
--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -31,8 +31,8 @@ def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[fl
     return tuple(-f / fps for f in reversed(frames))
 
 
-@cfn.config(keys=('image.wrist', 'image.exterior', 'robot_state.ee_pose', 'grip'), fps=15.0)
-def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ...], fps: float):
+@cfn.config(keys=('image.wrist', 'image.exterior', 'robot_state.ee_pose', 'grip'), fps=15.0, pad_start=True)
+def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ...], fps: float, pad_start: bool):
     """Eval ``wrap`` for video-conditioned policies: error recovery, strided temporal context, scheduling.
 
     The temporal stack sits outside the scheduler so it records the named ``keys`` every control tick and
@@ -43,6 +43,12 @@ def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ..
     ``('robot_state.ee_pose', 'grip')``) so each history step carries its own pose — the trajectory a
     model trained on real per-frame proprio expects. Drop the proprio keys for models whose codec
     consumes only the current proprio.
+
+    ``pad_start=False`` sends only observed history at episode start (a growing stack) instead of the
+    current frame repeated across the window; use it with servers that handle short history via a
+    cold-start path. Keep ``True`` for servers that require the trained fixed window length.
     """
-    stack = TemporalStack(keys=tuple(keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps))
+    stack = TemporalStack(
+        keys=tuple(keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps), pad_start=pad_start
+    )
     return ErrorRecovery() | stack | ChunkedSchedule()

--- a/positronic/policy/tests/test_wrappers.py
+++ b/positronic/policy/tests/test_wrappers.py
@@ -1,10 +1,12 @@
 """Unit tests for PolicyWrapper composition, ChunkedSchedule, and ErrorRecovery."""
 
+import numpy as np
+
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import Recover
 from positronic.policy.base import Policy, PolicyWrapper, Session
 from positronic.policy.codec import ActionTimestamp, Codec
-from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery
+from positronic.policy.wrappers import ChunkedSchedule, ErrorRecovery, TemporalStack
 
 
 class _FakeClock:
@@ -239,3 +241,68 @@ class TestPipelineComposition:
         result = session(_obs(now_sec=2.5, status=RobotStatus.AVAILABLE))
         assert result is not None
         assert inner._session.call_count == 2  # initial call + post-recovery call
+
+
+class _CaptureSession(Session):
+    def __init__(self):
+        self.seen = []
+
+    def __call__(self, obs):
+        self.seen.append(obs)
+        return []
+
+
+class _CapturePolicy(Policy):
+    def __init__(self):
+        self.session = _CaptureSession()
+
+    def new_session(self, context=None):
+        return self.session
+
+
+def _stack_obs(now_sec, value):
+    return {'obs_time_ns': int(now_sec * 1e9), 'v': np.array([value])}
+
+
+class TestTemporalStack:
+    OFFSETS = (-0.2, -0.1, 0.0)
+
+    def test_pad_start_repeats_oldest(self):
+        clock = _FakeClock(t=0.0)
+        inner = _CapturePolicy()
+        session = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS).wrap(inner, clock.now).new_session()
+        session(_stack_obs(0.0, 1.0))
+        stack = inner.session.seen[0]['v']
+        assert stack.shape == (3, 1)
+        assert (stack == 1.0).all()
+
+    def test_no_pad_start_grows_from_one(self):
+        clock = _FakeClock(t=0.0)
+        inner = _CapturePolicy()
+        wrapper = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS, pad_start=False)
+        session = wrapper.wrap(inner, clock.now).new_session()
+
+        session(_stack_obs(0.0, 1.0))
+        assert inner.session.seen[0]['v'].shape == (1, 1)
+
+        session(_stack_obs(0.1, 2.0))
+        assert inner.session.seen[1]['v'].shape == (2, 1)
+        assert inner.session.seen[1]['v'][:, 0].tolist() == [1.0, 2.0]
+
+        session(_stack_obs(0.2, 3.0))
+        assert inner.session.seen[2]['v'].shape == (3, 1)
+        assert inner.session.seen[2]['v'][:, 0].tolist() == [1.0, 2.0, 3.0]
+
+    def test_no_pad_start_full_window_matches_padded(self):
+        offsets = self.OFFSETS
+        stacks = {}
+        for pad_start in (True, False):
+            clock = _FakeClock(t=0.0)
+            inner = _CapturePolicy()
+            wrapper = TemporalStack(keys=('v',), offsets_sec=offsets, pad_start=pad_start)
+            session = wrapper.wrap(inner, clock.now).new_session()
+            for i in range(4):
+                session(_stack_obs(0.1 * i, float(i)))
+            stacks[pad_start] = inner.session.seen[-1]['v']
+        assert stacks[True].shape == stacks[False].shape == (3, 1)
+        assert (stacks[True] == stacks[False]).all()

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -105,13 +105,16 @@ class _StackBuffer:
     ``values`` is a dict of key → array; every entry holds the same keys. ``append`` copies each new
     entry but skips one byte-identical to the previous — a source slower than the control loop repeats
     its value, and carry-over sampling reuses the stored one — then drops entries before the oldest
-    sampled offset, keeping the one at or before it. ``sample`` returns, per key, a
-    ``(len(offsets_sec), ...)`` stack holding, for each offset, the latest value at or before that time
-    — carry-over, never the future; before enough history accumulates it repeats the oldest entry.
+    sampled offset, keeping the one at or before it. ``sample`` returns, per key, a stack holding, for
+    each offset, the latest value at or before that time — carry-over, never the future. Offsets that
+    precede the first entry either repeat the oldest entry (``pad_start=True``, a fixed
+    ``len(offsets_sec)``-long stack) or are dropped (``pad_start=False``, the stack grows from 1 to
+    ``len(offsets_sec)`` as history accumulates).
     """
 
-    def __init__(self, offsets_sec: tuple[float, ...]):
+    def __init__(self, offsets_sec: tuple[float, ...], pad_start: bool = True):
         self._offsets_sec = offsets_sec
+        self._pad_start = pad_start
         self._entries: deque[tuple[float, dict[str, np.ndarray]]] = deque()
 
     def reset(self):
@@ -127,7 +130,10 @@ class _StackBuffer:
 
     def sample(self, now: float) -> dict[str, np.ndarray]:
         times = np.array([t for t, _ in self._entries])
-        picked = [self._entries[self._at_or_before(times, now + off)][1] for off in self._offsets_sec]
+        targets = [now + off for off in self._offsets_sec]
+        if not self._pad_start:
+            targets = [t for t in targets if t >= times[0]]
+        picked = [self._entries[self._at_or_before(times, t)][1] for t in targets]
         return {k: np.stack([entry[k] for entry in picked]) for k in picked[0]}
 
     @staticmethod
@@ -146,13 +152,21 @@ class TemporalStack(PolicyWrapper):
     each, a ``(len(offsets_sec), ...)`` stack sampled at ``offsets_sec`` (ascending negative seconds
     relative to now), so every stacked step carries its own value at that time rather than the current
     one repeated across history.
+
+    ``pad_start`` controls the stack before a full window of history exists (the first
+    ``-min(offsets_sec)`` seconds of a session). ``True`` repeats the oldest sample so the stack always
+    has ``len(offsets_sec)`` steps — for servers that require the trained window length. ``False``
+    sends only observed samples (the stack grows from 1 to ``len(offsets_sec)``), so the server sees a
+    genuine episode start instead of a fabricated static history — a model conditioned on "nothing has
+    moved for the whole window" predicts near-zero motion, and servers with a cold-start path (e.g. a
+    chunk-0 empty prefix) never engage it on a padded full-length stack.
     """
 
     class _Session(DelegatingSession):
-        def __init__(self, inner: Session, keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+        def __init__(self, inner: Session, keys: tuple[str, ...], offsets_sec: tuple[float, ...], pad_start: bool):
             super().__init__(inner)
             self._keys = keys
-            self._buffer = _StackBuffer(offsets_sec)
+            self._buffer = _StackBuffer(offsets_sec, pad_start=pad_start)
 
         def __call__(self, obs):
             now = _obs_time(obs)
@@ -163,9 +177,10 @@ class TemporalStack(PolicyWrapper):
             self._buffer.reset()
             super().cancel()
 
-    def __init__(self, keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+    def __init__(self, keys: tuple[str, ...], offsets_sec: tuple[float, ...], pad_start: bool = True):
         self._keys = tuple(keys)
         self._offsets_sec = tuple(offsets_sec)
+        self._pad_start = pad_start
 
     def wrap_session(self, inner: Session, context, now: Now):
-        return TemporalStack._Session(inner, self._keys, self._offsets_sec)
+        return TemporalStack._Session(inner, self._keys, self._offsets_sec, self._pad_start)

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -181,6 +181,10 @@ class TemporalStack(PolicyWrapper):
         self._keys = tuple(keys)
         self._offsets_sec = tuple(offsets_sec)
         self._pad_start = pad_start
+        assert pad_start or 0.0 in self._offsets_sec, (
+            'pad_start=False requires 0.0 in offsets_sec: with only past offsets the first observation has no '
+            'in-range targets and the stack would be empty'
+        )
 
     def wrap_session(self, inner: Session, context, now: Now):
         return TemporalStack._Session(inner, self._keys, self._offsets_sec, self._pad_start)


### PR DESCRIPTION
`_StackBuffer.sample` clamps every offset to the oldest entry, so the first query of a session sends the current frame repeated across the whole window — a fabricated static history. A model conditioned on "nothing has moved for the full window" predicts near-zero motion, and servers with a cold-start path for short history never engage it on a padded full-length stack.

With `pad_start=False` the stack contains only observed samples: offsets that precede the first entry are dropped, so the stack grows from 1 to `len(offsets_sec)` during warm-up and matches the padded behavior once a full window exists. Default stays `True` for servers that require the trained fixed window length (e.g. DreamZero). Exposed on `video_context_wrappers` as `--wrap.pad_start`.