### PR TITLE
Add motion-gated retention to TemporalStack

### DIFF
--- a/positronic/cfg/wrappers.py
+++ b/positronic/cfg/wrappers.py
@@ -32,7 +32,14 @@ def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[fl
 
 
 @cfn.config(keys=('image.wrist', 'image.exterior', 'robot_state.ee_pose', 'grip'), fps=15.0)
-def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ...], fps: float):
+def video_context_wrappers(
+    history_frames: int,
+    stride: int,
+    keys: tuple[str, ...],
+    fps: float,
+    motion_key: str | None = None,
+    motion_eps: float = 0.0,
+):
     """Eval ``wrap`` for video-conditioned policies: error recovery, strided temporal context, scheduling.
 
     The temporal stack sits outside the scheduler so it records the named ``keys`` every control tick and
@@ -43,6 +50,19 @@ def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ..
     ``('robot_state.ee_pose', 'grip')``) so each history step carries its own pose — the trajectory a
     model trained on real per-frame proprio expects. Drop the proprio keys for models whose codec
     consumes only the current proprio.
+
+    With ``motion_key`` set (one of ``keys``), the stack keeps only frames whose ``motion_key`` value
+    moved more than ``motion_eps`` since the last kept frame and samples the most recent kept frames at
+    ``stride`` — the client-side mirror of training's idle-frame filtering, so the window spans a fixed
+    amount of motion instead of wall-clock and idle inference stalls no longer fill it with frozen frames.
     """
-    stack = TemporalStack(keys=tuple(keys), offsets_sec=_frame_offsets_sec(history_frames, stride, fps))
+    offsets_sec = _frame_offsets_sec(history_frames, stride, fps)
+    stack = TemporalStack(
+        keys=tuple(keys),
+        offsets_sec=offsets_sec,
+        motion_key=motion_key,
+        motion_eps=motion_eps,
+        stride=stride,
+        n_samples=len(offsets_sec),
+    )
     return ErrorRecovery() | stack | ChunkedSchedule()

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -136,6 +136,40 @@ class _StackBuffer:
         return max(int(np.searchsorted(times, target, side='right')) - 1, 0)
 
 
+class _MotionStackBuffer:
+    """Motion-gated history: keeps a frame only when its ``motion_key`` value moved more than
+    ``motion_eps`` (L2) since the last kept frame, then samples the most recent ``n_samples`` kept
+    frames every ``stride``, repeating the oldest before enough motion accumulates. The window is a
+    fixed span of motion rather than wall-clock, so idle stalls between control steps never fill it
+    with frozen frames — the client-side mirror of training's idle-frame filtering.
+    """
+
+    def __init__(self, motion_key: str, motion_eps: float, stride: int, n_samples: int):
+        self._motion_key = motion_key
+        self._motion_eps = motion_eps
+        self._stride = stride
+        self._n_samples = n_samples
+        self._entries: deque[dict[str, np.ndarray]] = deque(maxlen=(n_samples - 1) * stride + 1)
+        self._last_motion: np.ndarray | None = None
+
+    def reset(self):
+        self._entries.clear()
+        self._last_motion = None
+
+    def append(self, now: float, values: dict[str, np.ndarray]):
+        motion = np.asarray(values[self._motion_key]).ravel()
+        if self._last_motion is not None and np.linalg.norm(motion - self._last_motion) <= self._motion_eps:
+            return
+        self._last_motion = motion
+        self._entries.append({k: np.array(v) for k, v in values.items()})
+
+    def sample(self, now: float) -> dict[str, np.ndarray]:
+        newest = len(self._entries) - 1
+        picked = [self._entries[max(newest - i * self._stride, 0)] for i in range(self._n_samples)]
+        picked.reverse()
+        return {k: np.stack([entry[k] for entry in picked]) for k in picked[0]}
+
+
 class TemporalStack(PolicyWrapper):
     """Replaces each named observation entry with a temporal stack of recent samples.
 
@@ -149,10 +183,23 @@ class TemporalStack(PolicyWrapper):
     """
 
     class _Session(DelegatingSession):
-        def __init__(self, inner: Session, keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+        def __init__(
+            self,
+            inner: Session,
+            keys: tuple[str, ...],
+            offsets_sec: tuple[float, ...],
+            motion_key: str | None,
+            motion_eps: float,
+            stride: int,
+            n_samples: int,
+        ):
             super().__init__(inner)
             self._keys = keys
-            self._buffer = _StackBuffer(offsets_sec)
+            self._buffer = (
+                _StackBuffer(offsets_sec)
+                if motion_key is None
+                else _MotionStackBuffer(motion_key, motion_eps, stride, n_samples)
+            )
 
         def __call__(self, obs):
             now = _obs_time(obs)
@@ -163,9 +210,23 @@ class TemporalStack(PolicyWrapper):
             self._buffer.reset()
             super().cancel()
 
-    def __init__(self, keys: tuple[str, ...], offsets_sec: tuple[float, ...]):
+    def __init__(
+        self,
+        keys: tuple[str, ...],
+        offsets_sec: tuple[float, ...],
+        motion_key: str | None = None,
+        motion_eps: float = 0.0,
+        stride: int = 1,
+        n_samples: int = 0,
+    ):
         self._keys = tuple(keys)
         self._offsets_sec = tuple(offsets_sec)
+        self._motion_key = motion_key
+        self._motion_eps = motion_eps
+        self._stride = stride
+        self._n_samples = n_samples
 
     def wrap_session(self, inner: Session, context, now: Now):
-        return TemporalStack._Session(inner, self._keys, self._offsets_sec)
+        return TemporalStack._Session(
+            inner, self._keys, self._offsets_sec, self._motion_key, self._motion_eps, self._stride, self._n_samples
+        )


### PR DESCRIPTION
`video_context_wrappers` gains optional `motion_key` / `motion_eps`. When `motion_key` is set, the temporal stack keeps only frames whose `motion_key` value moved more than `motion_eps` (L2) since the last kept frame, and samples the most recent kept frames at `stride` — so the window spans a fixed amount of **motion** instead of wall-clock. Idle stalls between control steps (e.g. slow remote inference) no longer fill the context with frozen frames; this is the client-side mirror of training that filters idle frames.

Default (`motion_key=None`) is unchanged: the existing wall-clock `_StackBuffer` (carry-over sampling) is used, so DreamZero and current configs are byte-identical.

Tests: `pytest positronic/policy/tests/test_wrappers.py` (16 pass); ruff clean.
