### PR TITLE
Add `positronic-launcher` web console for preset-based inference sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 
 # Environment variables
 .env*
+
+# Operator-local launcher presets (endpoints are customer-specific)
+/presets*.toml

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -767,22 +767,35 @@ class World:
         self,
         main_process: ControlSystem | list[ControlSystem | None],
         background: ControlSystem | list[ControlSystem | None] | None = None,
+        *,
+        pace_to_wall: bool = False,
     ) -> None:
         """Drive the cooperative scheduler to completion.
 
         On a wall-clock world, honour each yielded ``Sleep`` so loops keep their real
         rate. On a virtual-time world the clock is advanced inside ``interleave``, so
-        there is nothing to wait for — just pump as fast as the machine allows.
+        there is nothing to wait for — pump as fast as the machine allows, unless
+        ``pace_to_wall`` asks to keep virtual time in step with wall time (a live
+        operator interacting with a simulation): then only step while virtual time
+        trails the wall clock, sleeping off any surplus.
 
         Runs until the scheduler is exhausted: when one loop finishes and sets
         ``should_stop``, the others still run once more to observe it and finalize
         (flush the episode, close the policy) before the iterator ends.
         """
-        real_time = not isinstance(self._clock, VirtualClock)
-        for command in self.start(main_process, background):
-            if real_time:
+        if not isinstance(self._clock, VirtualClock):
+            for command in self.start(main_process, background):
                 # Sleep its duration; a Yield() becomes sleep(0) — an OS yield, not a busy-spin.
                 time.sleep(command.seconds if isinstance(command, Sleep) else 0)
+        elif pace_to_wall:
+            wall = SystemClock()
+            wall_start, virtual_start = wall.now_ns(), self._clock.now_ns()
+            for _ in self.start(main_process, background):
+                while self._clock.now_ns() - virtual_start > wall.now_ns() - wall_start:
+                    time.sleep(0.001)
+        else:
+            for _ in self.start(main_process, background):
+                pass
 
     def start_in_subprocess(self, *background_loops: ControlLoop):
         """Starts background control loops. Can be called multiple times for different control loops.

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -789,8 +789,11 @@ class World:
                 time.sleep(command.seconds if isinstance(command, Sleep) else 0)
         elif pace_to_wall:
             wall = SystemClock()
+            # Baselines come after start(): binding and background spawns must not count as elapsed wall time,
+            # or the sim free-runs to "catch up" by that delay instead of pacing from the first tick.
+            commands = self.start(main_process, background)
             wall_start, virtual_start = wall.now_ns(), self._clock.now_ns()
-            for _ in self.start(main_process, background):
+            for _ in commands:
                 while self._clock.now_ns() - virtual_start > wall.now_ns() - wall_start:
                     time.sleep(0.001)
         else:

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -4,9 +4,12 @@ import numpy as np
 import positronic.cfg.hardware.camera
 import positronic.cfg.hardware.gripper
 import positronic.cfg.hardware.roboarm
+import positronic.cfg.simulator
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation
+from positronic.simulator.mujoco.sim import MujocoSim
+from positronic.utils import package_assets_path
 
 
 @cfn.config(
@@ -71,3 +74,19 @@ def mujoco_franka(sim, camera_dict):
         control_systems=(sim,),
         simulated=True,
     )
+
+
+@cfn.config(
+    mujoco_model_path=package_assets_path('assets/mujoco/franka_table.xml'),
+    loaders=positronic.cfg.simulator.stack_cubes_loaders,
+    camera_fps=15,
+    camera_dict={'image.wrist': 'handcam_left_ph', 'image.exterior': 'back_view_ph', 'image.agent_view': 'agentview'},
+)
+def mujoco_franka_table(mujoco_model_path, loaders, camera_fps, camera_dict):
+    """Attended Mujoco Franka on the table scene: the sim without an eval/trials wrapper.
+
+    The scene draws once at construction and episodes inherit the world state, like the real
+    robot; seeded per-trial re-draws stay the eval configs' concern.
+    """
+    sim = MujocoSim(mujoco_model_path, loaders, camera_fps=camera_fps)
+    return mujoco_franka(sim, camera_dict)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -114,7 +114,8 @@ def _run_world(
         producers = [cs for cs in embodiment.control_systems if cs is not None]
         foreground = driver.control_systems if driver is not None else []
         if embodiment.simulated:
-            world.run([*foreground, harness, ds_agent, *producers], gui)
+            # An attended sim serves a live operator, so it runs at wall pace; unattended evals free-run.
+            world.run([*foreground, harness, ds_agent, *producers], gui, pace_to_wall=driver is not None)
         else:
             world.run([harness, *foreground], [*producers, ds_agent, gui])
 

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import nullcontext
 from enum import Enum
@@ -311,22 +310,8 @@ def main_sim(
         ds_agent = wire.wire(world, data_collection, dataset_writer, cameras, sim, sim, gui, TimeMode.MESSAGE)
         _wire(world, ds_agent, data_collection, webxr, sim, sound)
 
-        sim_iter = world.start([sim, data_collection], [webxr, gui, ds_agent, sound])
-        sim_iter = iter(sim_iter)
-
-        # VR teleop is live, so pace virtual time to wall time: only step the sim when it has fallen behind.
-        start_time = pimm.world.SystemClock().now_ns()
-        sim_start_time = world.clock.now_ns()
-
-        while not world.should_stop:
-            try:
-                time_since_start = pimm.world.SystemClock().now_ns() - start_time
-                if world.clock.now_ns() < sim_start_time + time_since_start:
-                    next(sim_iter)
-                else:
-                    time.sleep(0.001)
-            except StopIteration:
-                break
+        # VR teleop is live, so pace virtual time to wall time.
+        world.run([sim, data_collection], [webxr, gui, ds_agent, sound], pace_to_wall=True)
 
 
 main_cfg = cfn.Config(

--- a/positronic/server/launcher.py
+++ b/positronic/server/launcher.py
@@ -37,6 +37,7 @@ _ANSI_RE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 _LOG_BUFFER_LINES = 20000
 _CONSOLE_CACHE_SECONDS = 2.0
 _CONSOLE_PROBE_TIMEOUT = 0.3
+_SHUTDOWN_WAIT_SECONDS = 120.0
 
 
 def _pkg_path(*parts: str) -> str:
@@ -240,7 +241,15 @@ class Launcher:
         if proc is None:
             return
         os.killpg(os.getpgid(proc.pid), signal.SIGINT)
-        proc.wait()
+        try:
+            proc.wait(timeout=_SHUTDOWN_WAIT_SECONDS)
+        except subprocess.TimeoutExpired:
+            # No SIGKILL escalation: the child may be attached to a robot, and force-killing that is the
+            # operator's explicit call (the console's Force button), never an automatic side effect.
+            logging.warning(
+                f'Child process group {proc.pid} still running {_SHUTDOWN_WAIT_SECONDS:.0f}s after SIGINT; '
+                f'leaving it alive (kill -9 -- -{proc.pid} to force)'
+            )
 
 
 launcher: Launcher | None = None

--- a/positronic/server/launcher.py
+++ b/positronic/server/launcher.py
@@ -75,10 +75,14 @@ def _load_presets(path: str) -> dict:
     except tomllib.TOMLDecodeError as e:
         return {**defaults, 'error': f'Failed to parse {p}: {e}'}
 
+    presets_tbl = data.get('presets', {})
+    if not isinstance(presets_tbl, dict) or not all(isinstance(e, dict) for e in presets_tbl.values()):
+        return {**defaults, 'error': f'{p}: each preset must be a [presets.<name>] table with an `args` value'}
+
     common_raw = _collapse(str(data.get('common', '')))
     common_args = _split_args(common_raw)
     presets = {}
-    for name, entry in data.get('presets', {}).items():
+    for name, entry in presets_tbl.items():
         raw = _collapse(str(entry.get('args', '')))
         presets[name] = {'raw': raw, 'args': _split_args(raw)}
     return {

--- a/positronic/server/launcher.py
+++ b/positronic/server/launcher.py
@@ -124,6 +124,11 @@ class Launcher:
         with self._lock:
             if self._proc is not None:
                 return 409, {'error': 'A run is already in progress'}
+            if self._tcp_probe():
+                return 409, {
+                    'error': f'Port {self.console_port} is already in use — '
+                    'stop whatever serves it before launching, or the console cannot come up'
+                }
             command = self._build_command(parsed, preset, task, extra_args)
             proc = subprocess.Popen(
                 ['bash', '-c', command],

--- a/positronic/server/launcher.py
+++ b/positronic/server/launcher.py
@@ -140,6 +140,7 @@ class Launcher:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                errors='replace',
                 bufsize=1,
                 start_new_session=True,
             )

--- a/positronic/server/launcher.py
+++ b/positronic/server/launcher.py
@@ -1,0 +1,310 @@
+"""FastAPI server that manages named presets of policy-inference commands.
+
+Presets live in a TOML file the operator edits by hand. Each preset is the full policy contract
+(remote endpoint plus how observations are shaped for it). Starting a run pastes the preset through
+``bash -c`` so ``$(date ...)`` and ``$ENV_VARS`` expand at launch, exactly as they do in tmux today.
+The launched process serves its own robot console; the launcher only detects that console's readiness,
+streams the process logs, and stops it with SIGINT (Ctrl-C) or SIGKILL.
+"""
+
+import logging
+import os
+import re
+import shlex
+import signal
+import socket
+import subprocess
+import threading
+import time
+import tomllib
+from collections import deque
+from datetime import datetime
+from pathlib import Path
+
+import configuronic as cfn
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from positronic.utils.logging import init_logging
+
+_DATE_RE = re.compile(r'\$\(date \+([^)]+)\)')
+_ARG_SPLIT_RE = re.compile(r'\s+(?=--)')
+_ANSI_RE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+_LOG_BUFFER_LINES = 20000
+_CONSOLE_CACHE_SECONDS = 2.0
+_CONSOLE_PROBE_TIMEOUT = 0.3
+
+
+def _pkg_path(*parts: str) -> str:
+    return str(Path(__file__).resolve().parent.joinpath(*parts))
+
+
+def _collapse(text: str) -> str:
+    return ' '.join(text.split())
+
+
+def _split_args(raw: str) -> list[str]:
+    if not raw:
+        return []
+    return _ARG_SPLIT_RE.split(raw)
+
+
+def _resolve_dates(text: str) -> str:
+    return _DATE_RE.sub(lambda m: datetime.now().strftime(m.group(1)), text)
+
+
+def _load_presets(path: str) -> dict:
+    """Parse the presets TOML into the /api/presets response shape, re-reading the file on every call."""
+    defaults = {
+        'error': None,
+        'runner': '',
+        'default_task': '',
+        'common': {'raw': '', 'args': []},
+        'common_resolved': [],
+        'presets': {},
+    }
+    p = Path(path)
+    if not p.exists():
+        return {**defaults, 'error': f'Presets file not found: {p}'}
+    try:
+        data = tomllib.loads(p.read_text())
+    except tomllib.TOMLDecodeError as e:
+        return {**defaults, 'error': f'Failed to parse {p}: {e}'}
+
+    common_raw = _collapse(str(data.get('common', '')))
+    common_args = _split_args(common_raw)
+    presets = {}
+    for name, entry in data.get('presets', {}).items():
+        raw = _collapse(str(entry.get('args', '')))
+        presets[name] = {'raw': raw, 'args': _split_args(raw)}
+    return {
+        'error': None,
+        'runner': str(data.get('runner', '')),
+        'default_task': str(data.get('default_task', '')),
+        'common': {'raw': common_raw, 'args': common_args},
+        'common_resolved': [_resolve_dates(a) for a in common_args],
+        'presets': presets,
+    }
+
+
+class Launcher:
+    """Single-slot manager for the running inference subprocess and its logs."""
+
+    def __init__(self, presets_path: str, console_port: int):
+        self.presets_path = presets_path
+        self.console_port = console_port
+        self._lock = threading.Lock()
+        self._proc: subprocess.Popen | None = None
+        self._status = 'idle'
+        self._run: dict | None = None
+        self._last_run: dict | None = None
+        self._log: deque[str] = deque(maxlen=_LOG_BUFFER_LINES)
+        self._log_count = 0
+        self._console_ready = False
+        self._console_checked_at = 0.0
+
+    def _build_command(self, parsed: dict, preset: str, task: str, extra_args: str) -> str:
+        parts = [parsed['runner'], parsed['presets'][preset]['raw'], parsed['common']['raw']]
+        if task:
+            parts.append(f'--driver.task={shlex.quote(task)}')
+        if extra_args:
+            parts.append(extra_args)
+        return ' '.join(p for p in parts if p)
+
+    def start(self, preset: str, task: str, extra_args: str) -> tuple[int, dict]:
+        parsed = _load_presets(self.presets_path)
+        if parsed['error'] is not None:
+            return 400, {'error': parsed['error']}
+        if preset not in parsed['presets']:
+            return 400, {'error': f'Unknown preset: {preset}'}
+        with self._lock:
+            if self._proc is not None:
+                return 409, {'error': 'A run is already in progress'}
+            command = self._build_command(parsed, preset, task, extra_args)
+            proc = subprocess.Popen(
+                ['bash', '-c', command],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                start_new_session=True,
+            )
+            self._proc = proc
+            self._status = 'running'
+            self._run = {
+                'preset': preset,
+                'task': task,
+                'command': command,
+                'started_at': time.time(),
+                'stop_requested_at': None,
+            }
+            self._log.clear()
+            self._log_count = 0
+            self._console_ready = False
+            self._console_checked_at = 0.0
+            threading.Thread(target=self._reader, args=(proc,), daemon=True).start()
+        return 200, {'ok': True}
+
+    def stop(self, force: bool) -> tuple[int, dict]:
+        with self._lock:
+            proc = self._proc
+            if proc is None:
+                return 409, {'error': 'Nothing is running'}
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL if force else signal.SIGINT)
+            self._status = 'stopping'
+            if self._run['stop_requested_at'] is None:
+                self._run['stop_requested_at'] = time.time()
+        return 200, {'ok': True}
+
+    def _reader(self, proc: subprocess.Popen) -> None:
+        for line in iter(proc.stdout.readline, ''):
+            clean = _ANSI_RE.sub('', line).rstrip('\n')
+            with self._lock:
+                self._log.append(clean)
+                self._log_count += 1
+        exit_code = proc.wait()
+        with self._lock:
+            if self._proc is proc:
+                run = self._run
+                self._last_run = {
+                    'preset': run['preset'],
+                    'exit_code': exit_code,
+                    'started_at': run['started_at'],
+                    'ended_at': time.time(),
+                    'stopped': run['stop_requested_at'] is not None,
+                }
+                self._run = None
+                self._proc = None
+                self._status = 'idle'
+
+    def _tcp_probe(self) -> bool:
+        try:
+            with socket.create_connection(('127.0.0.1', self.console_port), timeout=_CONSOLE_PROBE_TIMEOUT):
+                return True
+        except OSError:
+            return False
+
+    def _console_ready_cached(self) -> bool:
+        now = time.time()
+        with self._lock:
+            if now - self._console_checked_at < _CONSOLE_CACHE_SECONDS:
+                return self._console_ready
+        ready = self._tcp_probe()
+        with self._lock:
+            self._console_checked_at = time.time()
+            self._console_ready = ready
+        return ready
+
+    def state(self) -> dict:
+        with self._lock:
+            run = dict(self._run) if self._run is not None else None
+            last_run = dict(self._last_run) if self._last_run is not None else None
+            status = self._status
+            log_length = self._log_count
+        if run is not None:
+            run['console_ready'] = self._console_ready_cached()
+        return {
+            'status': status,
+            'run': run,
+            'last_run': last_run,
+            'console_port': self.console_port,
+            'log_length': log_length,
+        }
+
+    def get_logs(self, offset: int) -> dict:
+        with self._lock:
+            count = self._log_count
+            buf = list(self._log)
+        base = count - len(buf)
+        if offset < base:
+            return {'next': count, 'lines': buf, 'truncated': True}
+        start = min(offset, count) - base
+        return {'next': count, 'lines': buf[start:], 'truncated': False}
+
+    def shutdown(self) -> None:
+        with self._lock:
+            proc = self._proc
+        if proc is None:
+            return
+        os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+        proc.wait()
+
+
+launcher: Launcher | None = None
+
+app = FastAPI()
+app.mount('/static', StaticFiles(directory=_pkg_path('static')), name='static')
+
+
+class StartRequest(BaseModel):
+    preset: str
+    task: str = ''
+    extra_args: str = ''
+
+
+class StopRequest(BaseModel):
+    force: bool = False
+
+
+@app.get('/')
+async def index():
+    return FileResponse(_pkg_path('templates', 'launcher.html'))
+
+
+@app.get('/api/state')
+async def api_state():
+    return launcher.state()
+
+
+@app.get('/api/presets')
+async def api_presets():
+    return _load_presets(launcher.presets_path)
+
+
+@app.post('/api/start')
+async def api_start(req: StartRequest):
+    code, body = launcher.start(req.preset, req.task, req.extra_args)
+    return body if code == 200 else JSONResponse(status_code=code, content=body)
+
+
+@app.post('/api/stop')
+async def api_stop(req: StopRequest):
+    code, body = launcher.stop(req.force)
+    return body if code == 200 else JSONResponse(status_code=code, content=body)
+
+
+@app.get('/api/logs')
+async def api_logs(offset: int = 0):
+    return launcher.get_logs(offset)
+
+
+@cfn.config()
+def main(presets: str = 'presets.toml', port: int = 8000, console_port: int = 8080, host: str = '0.0.0.0'):
+    """Serve the launcher web app.
+
+    Args:
+        presets: Path to the presets TOML, resolved against the current working directory.
+        port: Port the launcher listens on.
+        console_port: Port where the launched process serves its own robot console.
+        host: Interface the launcher binds to.
+    """
+    global launcher
+    launcher = Launcher(presets_path=presets, console_port=console_port)
+    logging.info(f'Starting launcher on http://{host}:{port} (child console on port {console_port})')
+    try:
+        uvicorn.run(app, host=host, port=port)
+    finally:
+        launcher.shutdown()
+
+
+def _internal_main():
+    init_logging()
+    cfn.cli(main)
+
+
+if __name__ == '__main__':
+    _internal_main()

--- a/positronic/server/static/launcher.css
+++ b/positronic/server/static/launcher.css
@@ -1,31 +1,33 @@
-/* Positronic launch console — a robotics flight-deck at dusk. */
+/* Positronic launch console — navy deck lit by a single lime accent. */
 
 :root {
-  --bg: #12161d;
-  --panel: #1a2029;
-  --panel-hi: #1e2530;
-  --line: #2a3240;
-  --line-soft: #222a36;
-  --text: #d7dde6;
-  --muted: #8b95a4;
-  --muted-dim: #6b7686;
+  --bg: #0a0f1e;
+  --panel: #0f172a;
+  --panel-hi: #16213a;
+  --line: rgba(148, 163, 184, 0.18);
+  --line-soft: rgba(148, 163, 184, 0.10);
+  --text: #e8ebf5;
+  --muted: #9ca3af;
+  --muted-dim: #6b7280;
 
-  --amber: #ffb454;
-  --amber-soft: #ffd9a0;
-  --green: #4fd08c;
-  --danger: #ff5d5d;
+  --accent: #b1e74f;
+  --accent-soft: #cdf08a;
+  --accent-ink: #0a0f1e;
+  --green: #4ade80;
+  --warn: #fbbf24;
+  --danger: #f97373;
 
   /* command-strip provenance */
   --seg-runner: #7b8698;
-  --seg-session: #6f8aa6;
-  --seg-preset: var(--amber);
+  --seg-session: #7e97b5;
+  --seg-preset: var(--accent);
   --seg-task: var(--green);
-  --seg-extra: var(--amber-soft);
+  --seg-extra: var(--accent-soft);
 
-  --mono: ui-monospace, 'JetBrains Mono', 'Cascadia Code', Menlo, Consolas, monospace;
-  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, 'SF Mono', 'JetBrains Mono', 'Cascadia Code', Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 
-  --radius: 10px;
+  --radius: 12px;
   --maxw: 1200px;
 }
 
@@ -44,7 +46,8 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   background:
-    radial-gradient(130% 62% at 50% -12%, rgba(64, 84, 116, 0.38), rgba(18, 22, 29, 0) 62%),
+    radial-gradient(circle at 100% 0%, rgba(177, 231, 79, 0.06), rgba(0, 0, 0, 0) 55%),
+    radial-gradient(circle at 0% 100%, rgb(15, 20, 31), rgb(10, 15, 26) 65%),
     var(--bg);
   background-attachment: fixed;
 }
@@ -65,7 +68,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .eyebrow-sub {
   margin-left: 0.5em;
   letter-spacing: 0.04em;
-  color: var(--amber);
+  color: var(--accent);
   text-transform: none;
 }
 
@@ -81,8 +84,8 @@ code, textarea, input, .mono { font-family: var(--mono); }
   font-size: 13.5px;
   font-weight: 600;
   border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 9px 16px;
+  border-radius: 999px;
+  padding: 9px 18px;
   cursor: pointer;
   color: var(--text);
   background: transparent;
@@ -92,54 +95,58 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
 .btn-launch {
-  background: var(--amber);
-  color: #14181f;
+  background: var(--accent);
+  color: var(--accent-ink);
   font-weight: 700;
   letter-spacing: 0.01em;
-  padding: 11px 30px;
-  box-shadow: 0 0 0 1px rgba(255, 180, 84, 0.35), 0 8px 28px -12px rgba(255, 180, 84, 0.7);
+  padding: 11px 32px;
+  box-shadow: 0 0 0 1px rgba(17, 24, 39, 0.9), 0 10px 24px rgba(177, 231, 79, 0.35);
 }
 .btn-launch:not(:disabled):hover {
-  background: #ffc270;
-  box-shadow: 0 0 0 1px rgba(255, 180, 84, 0.5), 0 10px 32px -10px rgba(255, 180, 84, 0.85);
+  background: #bdec66;
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px rgba(17, 24, 39, 0.9), 0 14px 34px rgba(177, 231, 79, 0.5);
 }
+.btn-launch:not(:disabled):active { transform: translateY(0); }
 
 .btn-stop {
-  border-color: var(--line);
-  background: var(--panel-hi);
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.95);
+  color: var(--muted);
 }
-.btn-stop:not(:disabled):hover { border-color: var(--amber); color: var(--amber); }
+.btn-stop:not(:disabled):hover { border-color: var(--accent); color: var(--accent); }
 
 .btn-force {
-  background: rgba(255, 93, 93, 0.12);
-  border-color: var(--danger);
-  color: #ff8b8b;
+  background: rgba(248, 113, 113, 0.14);
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fca5a5;
 }
-.btn-force:hover { background: rgba(255, 93, 93, 0.22); color: #ffb0b0; }
+.btn-force:hover { background: rgba(248, 113, 113, 0.24); color: #fecaca; }
 
 .btn-ghost {
-  padding: 6px 12px;
+  padding: 6px 14px;
   font-size: 12px;
   color: var(--muted);
-  border-color: var(--line);
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.95);
 }
-.btn-ghost:hover { color: var(--text); border-color: var(--muted); }
+.btn-ghost:hover { color: var(--accent); border-color: var(--accent); }
 
 :focus-visible {
-  outline: 2px solid var(--amber);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: 4px;
 }
 
 .notice {
   font-size: 13px;
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 10px 12px;
-  border: 1px solid rgba(255, 93, 93, 0.4);
-  background: rgba(255, 93, 93, 0.08);
-  color: #ffb0b0;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  background: rgba(248, 113, 113, 0.1);
+  color: #fca5a5;
 }
-.notice code { color: #ffd0d0; }
+.notice code { color: #fecdd3; }
 .notice-empty {
   border-color: var(--line);
   background: transparent;
@@ -162,18 +169,18 @@ code, textarea, input, .mono { font-family: var(--mono); }
   justify-content: space-between;
   gap: 16px;
   padding: 16px 24px;
-  border-bottom: 1px solid var(--line-soft);
-  background: linear-gradient(180deg, rgba(30, 40, 56, 0.5), rgba(18, 22, 29, 0));
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.65), rgba(10, 15, 30, 0));
 }
 
 .brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
 .brand .mark { width: 26px; height: 26px; flex: none; }
 .brand .mark circle, .brand .mark path {
   fill: none;
-  stroke: var(--amber);
+  stroke: var(--accent);
   stroke-width: 1.4;
 }
-.brand .mark .mark-core { fill: var(--amber); stroke: none; }
+.brand .mark .mark-core { fill: var(--accent); stroke: none; }
 
 .brand-name {
   font-family: var(--mono);
@@ -190,7 +197,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .run-preset {
   font-family: var(--mono);
   font-size: 14px;
-  color: var(--amber);
+  color: var(--accent);
   letter-spacing: 0.02em;
 }
 .run-elapsed {
@@ -204,7 +211,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
   width: 10px; height: 10px;
   border-radius: 50%;
   background: var(--muted-dim);
-  box-shadow: 0 0 0 3px rgba(139, 149, 164, 0.12);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.12);
   flex: none;
 }
 .lamp-label {
@@ -217,21 +224,21 @@ code, textarea, input, .mono { font-family: var(--mono); }
 
 [data-status="booting"] .lamp,
 [data-status="stopping"] .lamp {
-  background: var(--amber);
-  box-shadow: 0 0 0 3px rgba(255, 180, 84, 0.16), 0 0 10px 1px rgba(255, 180, 84, 0.6);
+  background: var(--warn);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.16), 0 0 10px 1px rgba(251, 191, 36, 0.6);
 }
 [data-status="booting"] .lamp-label,
-[data-status="stopping"] .lamp-label { color: var(--amber); }
+[data-status="stopping"] .lamp-label { color: var(--warn); }
 
 [data-status="running"] .lamp {
   background: var(--green);
-  box-shadow: 0 0 0 3px rgba(79, 208, 140, 0.16), 0 0 10px 1px rgba(79, 208, 140, 0.55);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.16), 0 0 10px 1px rgba(74, 222, 128, 0.55);
 }
 [data-status="running"] .lamp-label { color: var(--green); }
 
 [data-status="failed"] .lamp {
   background: var(--danger);
-  box-shadow: 0 0 0 3px rgba(255, 93, 93, 0.16), 0 0 10px 1px rgba(255, 93, 93, 0.55);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.16), 0 0 10px 1px rgba(248, 113, 113, 0.55);
 }
 [data-status="failed"] .lamp-label { color: var(--danger); }
 
@@ -321,10 +328,10 @@ code, textarea, input, .mono { font-family: var(--mono); }
 }
 .preset-item:hover { background: var(--panel-hi); }
 .preset-item[aria-selected="true"] {
-  color: var(--amber);
-  background: linear-gradient(90deg, rgba(255, 180, 84, 0.14), rgba(255, 180, 84, 0.02));
-  border-left-color: var(--amber);
-  box-shadow: inset 0 0 22px -14px rgba(255, 180, 84, 0.8);
+  color: var(--accent);
+  background: linear-gradient(90deg, rgba(177, 231, 79, 0.14), rgba(177, 231, 79, 0.02));
+  border-left-color: var(--accent);
+  box-shadow: inset 0 0 22px -14px rgba(177, 231, 79, 0.8);
 }
 
 /* Args panels */
@@ -345,9 +352,9 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .arg.boilerplate { opacity: 0.42; }
 .arg.key .arg-name { color: var(--text); }
 .arg.key .arg-val {
-  color: var(--amber);
+  color: var(--accent);
   font-weight: 600;
-  text-shadow: 0 0 12px rgba(255, 180, 84, 0.35);
+  text-shadow: 0 0 12px rgba(177, 231, 79, 0.35);
 }
 .args-session .arg-name { color: var(--muted-dim); }
 .args-session .arg-val { color: var(--seg-session); }
@@ -360,7 +367,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .field textarea, .field input {
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--text);
   font-size: 13.5px;
   padding: 10px 12px;
@@ -370,8 +377,8 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .field textarea::placeholder, .field input::placeholder { color: var(--muted-dim); }
 .field textarea:focus, .field input:focus {
   outline: none;
-  border-color: var(--amber);
-  box-shadow: 0 0 0 3px rgba(255, 180, 84, 0.12);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(177, 231, 79, 0.12);
 }
 
 /* ── Command strip — the signature element ─────────────────────── */
@@ -380,12 +387,12 @@ code, textarea, input, .mono { font-family: var(--mono); }
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background:
-    linear-gradient(180deg, rgba(255, 180, 84, 0.05), rgba(255, 180, 84, 0) 40%),
-    #161d27;
+    linear-gradient(180deg, rgba(177, 231, 79, 0.05), rgba(177, 231, 79, 0) 40%),
+    #0b1120;
   padding: 14px 18px 18px;
   box-shadow:
-    inset 0 0 0 1px rgba(255, 180, 84, 0.06),
-    0 0 46px -14px rgba(255, 180, 84, 0.3);
+    inset 0 0 0 1px rgba(177, 231, 79, 0.06),
+    0 0 46px -14px rgba(177, 231, 79, 0.3);
 }
 .command-head {
   display: flex;
@@ -422,7 +429,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
   font-size: 13.5px;
   line-height: 1.75;
 }
-.command-line .prompt { color: var(--amber); flex: none; user-select: none; }
+.command-line .prompt { color: var(--accent); flex: none; user-select: none; }
 .command-line code {
   white-space: pre-wrap;
   word-break: break-word;
@@ -432,13 +439,13 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .command-line .session { color: var(--seg-session); }
 .command-line .preset {
   color: var(--seg-preset);
-  text-shadow: 0 0 14px rgba(255, 180, 84, 0.45);
+  text-shadow: 0 0 14px rgba(177, 231, 79, 0.45);
 }
 .command-line .mach { color: var(--muted-dim); }
 .command-line .task { color: var(--seg-task); }
 .command-line .extra {
   color: var(--seg-extra);
-  text-decoration: underline dotted rgba(255, 217, 160, 0.5);
+  text-decoration: underline dotted rgba(205, 240, 138, 0.5);
   text-underline-offset: 3px;
 }
 
@@ -465,8 +472,8 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .boot-spinner {
   width: 34px; height: 34px;
   border-radius: 50%;
-  border: 3px solid rgba(255, 180, 84, 0.18);
-  border-top-color: var(--amber);
+  border: 3px solid rgba(177, 231, 79, 0.18);
+  border-top-color: var(--accent);
   flex: none;
 }
 @media (prefers-reduced-motion: no-preference) {
@@ -476,7 +483,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .boot-title {
   font-family: var(--mono);
   font-size: 15px;
-  color: var(--amber);
+  color: var(--accent);
   letter-spacing: 0.02em;
   margin-bottom: 4px;
 }
@@ -490,7 +497,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
 .console-bar { display: flex; align-items: center; justify-content: space-between; }
 .new-tab {
   font-size: 13px;
-  color: var(--amber);
+  color: var(--accent);
   text-decoration: none;
   font-weight: 600;
 }
@@ -501,7 +508,7 @@ code, textarea, input, .mono { font-family: var(--mono); }
   min-height: 420px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: #0d1116;
+  background: #0b1120;
 }
 
 /* ── Log panel ─────────────────────────────────────────────────── */
@@ -537,8 +544,8 @@ code, textarea, input, .mono { font-family: var(--mono); }
   font-family: var(--sans);
   font-size: 12px;
   font-weight: 600;
-  color: #14181f;
-  background: var(--amber);
+  color: var(--accent-ink);
+  background: var(--accent);
   border: none;
   border-radius: 999px;
   padding: 6px 14px;

--- a/positronic/server/static/launcher.css
+++ b/positronic/server/static/launcher.css
@@ -1,0 +1,562 @@
+/* Positronic launch console — a robotics flight-deck at dusk. */
+
+:root {
+  --bg: #12161d;
+  --panel: #1a2029;
+  --panel-hi: #1e2530;
+  --line: #2a3240;
+  --line-soft: #222a36;
+  --text: #d7dde6;
+  --muted: #8b95a4;
+  --muted-dim: #6b7686;
+
+  --amber: #ffb454;
+  --amber-soft: #ffd9a0;
+  --green: #4fd08c;
+  --danger: #ff5d5d;
+
+  /* command-strip provenance */
+  --seg-runner: #7b8698;
+  --seg-session: #6f8aa6;
+  --seg-preset: var(--amber);
+  --seg-task: var(--green);
+  --seg-extra: var(--amber-soft);
+
+  --mono: ui-monospace, 'JetBrains Mono', 'Cascadia Code', Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+
+  --radius: 10px;
+  --maxw: 1200px;
+}
+
+* { box-sizing: border-box; }
+
+/* Keep the `hidden` attribute authoritative even where a class sets `display`. */
+[hidden] { display: none !important; }
+
+html, body { height: 100%; }
+
+body {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  background:
+    radial-gradient(130% 62% at 50% -12%, rgba(64, 84, 116, 0.38), rgba(18, 22, 29, 0) 62%),
+    var(--bg);
+  background-attachment: fixed;
+}
+
+code, textarea, input, .mono { font-family: var(--mono); }
+
+/* ── Shared primitives ─────────────────────────────────────────── */
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.eyebrow-sub {
+  margin-left: 0.5em;
+  letter-spacing: 0.04em;
+  color: var(--amber);
+  text-transform: none;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+}
+
+.btn {
+  font-family: var(--sans);
+  font-size: 13.5px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 9px 16px;
+  cursor: pointer;
+  color: var(--text);
+  background: transparent;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, transform 60ms ease;
+}
+.btn:active { transform: translateY(1px); }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.btn-launch {
+  background: var(--amber);
+  color: #14181f;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  padding: 11px 30px;
+  box-shadow: 0 0 0 1px rgba(255, 180, 84, 0.35), 0 8px 28px -12px rgba(255, 180, 84, 0.7);
+}
+.btn-launch:not(:disabled):hover {
+  background: #ffc270;
+  box-shadow: 0 0 0 1px rgba(255, 180, 84, 0.5), 0 10px 32px -10px rgba(255, 180, 84, 0.85);
+}
+
+.btn-stop {
+  border-color: var(--line);
+  background: var(--panel-hi);
+}
+.btn-stop:not(:disabled):hover { border-color: var(--amber); color: var(--amber); }
+
+.btn-force {
+  background: rgba(255, 93, 93, 0.12);
+  border-color: var(--danger);
+  color: #ff8b8b;
+}
+.btn-force:hover { background: rgba(255, 93, 93, 0.22); color: #ffb0b0; }
+
+.btn-ghost {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  border-color: var(--line);
+}
+.btn-ghost:hover { color: var(--text); border-color: var(--muted); }
+
+:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.notice {
+  font-size: 13px;
+  border-radius: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 93, 93, 0.4);
+  background: rgba(255, 93, 93, 0.08);
+  color: #ffb0b0;
+}
+.notice code { color: #ffd0d0; }
+.notice-empty {
+  border-color: var(--line);
+  background: transparent;
+  color: var(--muted);
+}
+.notice-empty code { color: var(--text); }
+.notice-inline { flex: 1; }
+.notice-banner {
+  padding: 14px 16px;
+  font-size: 13.5px;
+  border-left-width: 3px;
+  border-left-color: var(--danger);
+}
+
+/* ── Top bar ───────────────────────────────────────────────────── */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--line-soft);
+  background: linear-gradient(180deg, rgba(30, 40, 56, 0.5), rgba(18, 22, 29, 0));
+}
+
+.brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.brand .mark { width: 26px; height: 26px; flex: none; }
+.brand .mark circle, .brand .mark path {
+  fill: none;
+  stroke: var(--amber);
+  stroke-width: 1.4;
+}
+.brand .mark .mark-core { fill: var(--amber); stroke: none; }
+
+.brand-name {
+  font-family: var(--mono);
+  font-size: 14px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.brand-name b { color: var(--text); font-weight: 600; }
+
+.status { display: flex; align-items: center; gap: 12px; }
+
+.run-preset {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--amber);
+  letter-spacing: 0.02em;
+}
+.run-elapsed {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.lamp {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: var(--muted-dim);
+  box-shadow: 0 0 0 3px rgba(139, 149, 164, 0.12);
+  flex: none;
+}
+.lamp-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+[data-status="booting"] .lamp,
+[data-status="stopping"] .lamp {
+  background: var(--amber);
+  box-shadow: 0 0 0 3px rgba(255, 180, 84, 0.16), 0 0 10px 1px rgba(255, 180, 84, 0.6);
+}
+[data-status="booting"] .lamp-label,
+[data-status="stopping"] .lamp-label { color: var(--amber); }
+
+[data-status="running"] .lamp {
+  background: var(--green);
+  box-shadow: 0 0 0 3px rgba(79, 208, 140, 0.16), 0 0 10px 1px rgba(79, 208, 140, 0.55);
+}
+[data-status="running"] .lamp-label { color: var(--green); }
+
+[data-status="failed"] .lamp {
+  background: var(--danger);
+  box-shadow: 0 0 0 3px rgba(255, 93, 93, 0.16), 0 0 10px 1px rgba(255, 93, 93, 0.55);
+}
+[data-status="failed"] .lamp-label { color: var(--danger); }
+
+@media (prefers-reduced-motion: no-preference) {
+  [data-status="booting"] .lamp,
+  [data-status="running"] .lamp,
+  [data-status="stopping"] .lamp {
+    animation: lamp-pulse 1.8s ease-in-out infinite;
+  }
+}
+@keyframes lamp-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+/* ── Content shell ─────────────────────────────────────────────── */
+
+.content {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+[data-view="idle"] .running-view { display: none; }
+[data-view="running"] .idle-view { display: none; }
+
+.idle-view { display: flex; flex-direction: column; gap: 20px; }
+
+/* ── Last-run strip ────────────────────────────────────────────── */
+
+.last-run {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding: 12px 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  border-left-width: 3px;
+  background: var(--panel);
+  font-size: 13px;
+}
+.last-run.clean { border-left-color: var(--green); }
+.last-run.failed { border-left-color: var(--danger); }
+.last-run .lr-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.last-run .lr-preset { font-family: var(--mono); color: var(--text); }
+.last-run .lr-code { font-family: var(--mono); }
+.last-run.clean .lr-code { color: var(--green); }
+.last-run.failed .lr-code { color: var(--danger); font-weight: 600; }
+.last-run .lr-when { color: var(--muted); margin-left: auto; }
+
+/* ── Idle grid ─────────────────────────────────────────────────── */
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 300px) 1fr;
+  gap: 20px;
+  align-items: start;
+}
+.detail { display: flex; flex-direction: column; gap: 20px; }
+
+/* Preset rail */
+.rail { padding: 14px; }
+.rail .eyebrow { padding: 2px 6px 12px; }
+.preset-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.preset-item {
+  font-family: var(--mono);
+  font-size: 15px;
+  color: var(--text);
+  padding: 10px 12px 10px 14px;
+  border-radius: 8px;
+  border-left: 2px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 100ms ease, color 100ms ease;
+}
+.preset-item:hover { background: var(--panel-hi); }
+.preset-item[aria-selected="true"] {
+  color: var(--amber);
+  background: linear-gradient(90deg, rgba(255, 180, 84, 0.14), rgba(255, 180, 84, 0.02));
+  border-left-color: var(--amber);
+  box-shadow: inset 0 0 22px -14px rgba(255, 180, 84, 0.8);
+}
+
+/* Args panels */
+.args {
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.95;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-top: 12px;
+  overflow-x: auto;
+}
+.arg { white-space: pre; }
+.arg-name { color: var(--muted); }
+.arg-eq { color: var(--muted-dim); }
+.arg-val { color: var(--text); }
+.arg.boilerplate { opacity: 0.42; }
+.arg.key .arg-name { color: var(--text); }
+.arg.key .arg-val {
+  color: var(--amber);
+  font-weight: 600;
+  text-shadow: 0 0 12px rgba(255, 180, 84, 0.35);
+}
+.args-session .arg-name { color: var(--muted-dim); }
+.args-session .arg-val { color: var(--seg-session); }
+.args .empty { color: var(--muted); font-style: italic; }
+
+/* ── Task + extra inputs ───────────────────────────────────────── */
+
+.inputs { display: grid; grid-template-columns: 1.4fr 1fr; gap: 20px; }
+.field { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+.field textarea, .field input {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 13.5px;
+  padding: 10px 12px;
+  resize: vertical;
+  line-height: 1.5;
+}
+.field textarea::placeholder, .field input::placeholder { color: var(--muted-dim); }
+.field textarea:focus, .field input:focus {
+  outline: none;
+  border-color: var(--amber);
+  box-shadow: 0 0 0 3px rgba(255, 180, 84, 0.12);
+}
+
+/* ── Command strip — the signature element ─────────────────────── */
+
+.command-block {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg, rgba(255, 180, 84, 0.05), rgba(255, 180, 84, 0) 40%),
+    #161d27;
+  padding: 14px 18px 18px;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 180, 84, 0.06),
+    0 0 46px -14px rgba(255, 180, 84, 0.3);
+}
+.command-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+.legend { display: flex; flex-wrap: wrap; gap: 12px; margin-right: auto; margin-left: 6px; }
+.swatch {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.swatch::before {
+  content: "";
+  width: 9px; height: 9px;
+  border-radius: 2px;
+  background: currentColor;
+}
+.swatch.seg-preset { color: var(--seg-preset); }
+.swatch.seg-task { color: var(--seg-task); }
+.swatch.seg-extra { color: var(--seg-extra); }
+.swatch.seg-session { color: var(--seg-session); }
+
+.command-line {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-family: var(--mono);
+  font-size: 13.5px;
+  line-height: 1.75;
+}
+.command-line .prompt { color: var(--amber); flex: none; user-select: none; }
+.command-line code {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+.command-line .runner { color: var(--seg-runner); }
+.command-line .session { color: var(--seg-session); }
+.command-line .preset {
+  color: var(--seg-preset);
+  text-shadow: 0 0 14px rgba(255, 180, 84, 0.45);
+}
+.command-line .mach { color: var(--muted-dim); }
+.command-line .task { color: var(--seg-task); }
+.command-line .extra {
+  color: var(--seg-extra);
+  text-decoration: underline dotted rgba(255, 217, 160, 0.5);
+  text-underline-offset: 3px;
+}
+
+/* ── Launch row ────────────────────────────────────────────────── */
+
+.launch-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  justify-content: flex-end;
+}
+
+/* ── Running view ──────────────────────────────────────────────── */
+
+.boot {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 40px 28px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+.boot-spinner {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 180, 84, 0.18);
+  border-top-color: var(--amber);
+  flex: none;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .boot-spinner { animation: spin 0.9s linear infinite; }
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.boot-title {
+  font-family: var(--mono);
+  font-size: 15px;
+  color: var(--amber);
+  letter-spacing: 0.02em;
+  margin-bottom: 4px;
+}
+.boot-copy p { margin: 0; color: var(--muted); max-width: 60ch; }
+
+.console-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.console-bar { display: flex; align-items: center; justify-content: space-between; }
+.new-tab {
+  font-size: 13px;
+  color: var(--amber);
+  text-decoration: none;
+  font-weight: 600;
+}
+.new-tab:hover { text-decoration: underline; }
+#consoleFrame {
+  width: 100%;
+  height: 68vh;
+  min-height: 420px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #0d1116;
+}
+
+/* ── Log panel ─────────────────────────────────────────────────── */
+
+.log-panel { padding: 0; position: relative; overflow: hidden; }
+.log-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.log-sub { font-size: 12px; color: var(--muted); font-family: var(--mono); }
+.log-body {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--muted);
+  padding: 12px 16px;
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.log-body .log-line { display: block; }
+.log-body .log-truncated { color: var(--muted-dim); font-style: italic; }
+.log-body .log-empty { color: var(--muted-dim); font-style: italic; }
+
+.jump-latest {
+  position: absolute;
+  right: 18px;
+  bottom: 14px;
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: #14181f;
+  background: var(--amber);
+  border: none;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+  box-shadow: 0 6px 20px -8px rgba(0, 0, 0, 0.7);
+}
+
+/* ── Responsive ────────────────────────────────────────────────── */
+
+@media (max-width: 860px) {
+  .grid { grid-template-columns: 1fr; }
+  .inputs { grid-template-columns: 1fr; }
+  .legend { display: none; }
+  .content { padding: 16px; }
+}
+
+@media (max-width: 560px) {
+  .topbar { flex-wrap: wrap; padding: 14px 16px; }
+  .run-preset, .run-elapsed { display: none; }
+  .brand-name { font-size: 12px; }
+}

--- a/positronic/server/static/launcher.js
+++ b/positronic/server/static/launcher.js
@@ -271,7 +271,12 @@ function assembledSegments() {
   if (runner) segs.push(['runner', runner], ['plain', ' ']);
   if (preset) segs.push(['preset', preset.raw], ['plain', ' ']);
   if (commonRaw) segs.push(['session', commonRaw], ['plain', ' ']);
-  segs.push(['mach', "--driver.task='"], ['task', task], ['mach', "'"]);
+  if (task) {
+    // Mirror the backend's shlex.quote so the copied command stays a valid shell line
+    // even when the task contains apostrophes; an empty task omits the flag, as the backend does.
+    const quoted = "'" + task.replace(/'/g, "'\\''") + "'";
+    segs.push(['mach', '--driver.task='], ['task', quoted]);
+  }
   if (extra) segs.push(['plain', ' '], ['extra', extra]);
   return segs;
 }

--- a/positronic/server/static/launcher.js
+++ b/positronic/server/static/launcher.js
@@ -355,8 +355,10 @@ function applyState() {
     renderRunning(s);
     ensureLogsFor(s.run.started_at);
   } else {
+    // The latest run's logs stay available while idle — including a run that died
+    // before polling ever saw it as running (bad command, boot crash).
+    if (s.last_run) ensureLogsFor(s.last_run.started_at);
     renderIdle(s);
-    // A run just ended: keep its logs visible; do one final flush.
     if (runStartedAt != null) pollLogs();
   }
 }

--- a/positronic/server/static/launcher.js
+++ b/positronic/server/static/launcher.js
@@ -1,0 +1,556 @@
+'use strict';
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Mock hook — `?mock=1` (idle), `?mock=running`, `?mock=console`,
+ * `?mock=stopping`, `?mock=error`. Stubs fetch with canned fixtures matching
+ * the API contract so the page renders fully with no backend. Kept isolated.
+ * ───────────────────────────────────────────────────────────────────────── */
+(function installMock() {
+  const mock = new URLSearchParams(location.search).get('mock');
+  if (!mock) return;
+
+  const now = Date.now() / 1000;
+  const presets = {
+    error: mock === 'error'
+      ? "presets.toml: expected ']' at line 12 (parse error)"
+      : null,
+    runner: 'LOG_LEVEL=info uv run --extra hardware positronic-inference phail',
+    default_task: 'pick up the red block and place it in the bin',
+    common: {
+      raw: "--output.dir=s3://pos-runs/$(date +%Y-%m-%d)/session --output.fps=30 --session.operator=$USER",
+      args: ['--output.dir=s3://pos-runs/$(date +%Y-%m-%d)/session', '--output.fps=30', '--session.operator=$USER'],
+    },
+    common_resolved: [
+      '--output.dir=s3://pos-runs/2026-07-18/session',
+      '--output.fps=30',
+      '--session.operator=vertix',
+    ],
+    presets: {
+      'pi0_franka_v3': {
+        raw: '--policy.host=infer-a.lan --policy.port=8443 --policy.secure=true --policy.history_frames=8 --policy.pad_start=true --policy.checkpoint=s3://ckpt/pi0/v3',
+        args: ['--policy.host=infer-a.lan', '--policy.port=8443', '--policy.secure=true', '--policy.history_frames=8', '--policy.pad_start=true', '--policy.checkpoint=s3://ckpt/pi0/v3'],
+      },
+      'gr00t_n15_droid': {
+        raw: '--policy.host=infer-b.lan --policy.port=8443 --policy.secure=true --policy.history_frames=1 --policy.pad_start=false --policy.checkpoint=s3://ckpt/gr00t/n15',
+        args: ['--policy.host=infer-b.lan', '--policy.port=8443', '--policy.secure=true', '--policy.history_frames=1', '--policy.pad_start=false', '--policy.checkpoint=s3://ckpt/gr00t/n15'],
+      },
+      'openpi_fast_local': {
+        raw: '--policy.host=localhost --policy.port=9000 --policy.secure=false --policy.history_frames=4 --policy.pad_start=true',
+        args: ['--policy.host=localhost', '--policy.port=9000', '--policy.secure=false', '--policy.history_frames=4', '--policy.pad_start=true'],
+      },
+    },
+  };
+
+  const running = {
+    preset: 'pi0_franka_v3',
+    task: 'pick up the red block and place it in the bin',
+    command: presets.runner + ' ' + presets.presets.pi0_franka_v3.raw,
+    started_at: now - (mock === 'running' ? 22 : 128),
+    console_ready: mock === 'console' || mock === 'stopping',
+    stop_requested_at: mock === 'stopping' ? now - 30 : null,
+  };
+
+  const state = {
+    '1': { status: 'idle', run: null,
+           last_run: { preset: 'gr00t_n15_droid', exit_code: 0, started_at: now - 900, ended_at: now - 300, stopped: false },
+           console_port: 8009, log_length: 3 },
+    'error': { status: 'idle', run: null, last_run: null, console_port: 8009, log_length: 0 },
+    'running': { status: 'running', run: running, last_run: null, console_port: 8009, log_length: 6 },
+    'console': { status: 'running', run: running, last_run: null, console_port: 8009, log_length: 12 },
+    'stopping': { status: 'stopping', run: running, last_run: null, console_port: 8009, log_length: 14 },
+  }[mock] || null;
+
+  const logLines = [
+    '[12:00:01] launcher: starting subprocess',
+    '[12:00:01] positronic-inference phail --policy.host=infer-a.lan …',
+    '[12:00:03] desk: opening brakes',
+    '[12:00:11] desk: FCI activated',
+    '[12:00:12] robot: homing',
+    '[12:00:28] policy: connecting to infer-a.lan:8443 (secure)',
+    '[12:00:31] policy: session established, warming up model',
+    '[12:00:44] policy: model ready (warmup 13.2s)',
+    '[12:00:45] console: listening on :8009',
+    '[12:00:45] launcher: child console is answering',
+    '[12:00:46] loop: waiting for operator',
+    '[12:01:02] loop: task received',
+  ];
+
+  const json = (obj) => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(obj) });
+
+  window.fetch = function (url, opts) {
+    const u = String(url);
+    if (u.startsWith('/api/presets')) return json(presets.error ? { ...presets, presets: {} } : presets);
+    if (u.startsWith('/api/state')) return json(state);
+    if (u.startsWith('/api/logs')) {
+      const off = Number(new URLSearchParams(u.split('?')[1] || '').get('offset') || 0);
+      const count = state && state.status !== 'idle' ? logLines.length : 3;
+      return json({ next: count, lines: logLines.slice(off, count), truncated: false });
+    }
+    if (u.startsWith('/api/start') || u.startsWith('/api/stop')) return json({ ok: true });
+    return json({});
+  };
+})();
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * App
+ * ───────────────────────────────────────────────────────────────────────── */
+
+const $ = (id) => document.getElementById(id);
+const app = document.querySelector('.app');
+
+const els = {
+  runPreset: $('runPreset'), runElapsed: $('runElapsed'),
+  lampLabel: $('lampLabel'), stopBtn: $('stopBtn'), forceBtn: $('forceBtn'),
+  presetList: $('presetList'), presetError: $('presetError'), presetEmpty: $('presetEmpty'),
+  policyName: $('policyName'), policyArgs: $('policyArgs'), sessionArgs: $('sessionArgs'),
+  taskInput: $('taskInput'), extraInput: $('extraInput'),
+  commandText: $('commandText'), copyBtn: $('copyBtn'),
+  launchBtn: $('launchBtn'), startError: $('startError'), lastRun: $('lastRun'),
+  bootPlaceholder: $('bootPlaceholder'), consoleWrap: $('consoleWrap'),
+  consoleFrame: $('consoleFrame'), newTabLink: $('newTabLink'),
+  logPanel: $('logPanel'), logBody: $('logBody'), logSub: $('logSub'), jumpLatest: $('jumpLatest'),
+};
+
+const LAMP_LABELS = { idle: 'idle', booting: 'booting', running: 'live', stopping: 'stopping', failed: 'failed' };
+
+// Arg-name heuristics: which values distinguish one model from another.
+const KEY_ARGS = ['host', 'history_frames', 'pad_start', 'checkpoint', 'model', 'endpoint', 'action_horizon', 'steps'];
+const BOILERPLATE_ARGS = ['port', 'secure', 'header', 'headers', 'token', 'api_key', 'apikey', 'timeout', 'retries', 'tls', 'ssl', 'verify'];
+
+let presetsData = null;      // last /api/presets payload
+let selectedPreset = null;   // preset name
+let userEditedTask = false;  // don't clobber operator's edits on refetch
+
+let stateData = null;
+let runStartedAt = null;     // started_at of the run whose logs we're showing
+let forceRevealed = false;
+
+// log streaming
+let logOffset = 0;
+let logsPinned = true;
+let truncationShown = false;
+
+/* ── Fetch helpers ─────────────────────────────────────────────── */
+
+async function getJSON(url) {
+  const r = await fetch(url);
+  return r.json();
+}
+async function postJSON(url, body) {
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  let data = {};
+  try { data = await r.json(); } catch (e) { /* empty body */ }
+  return { ok: r.ok, status: r.status, data };
+}
+
+/* ── Presets ───────────────────────────────────────────────────── */
+
+async function loadPresets() {
+  presetsData = await getJSON('/api/presets');
+  renderPresets();
+}
+
+function renderPresets() {
+  const d = presetsData;
+  const hasError = d.error != null;
+
+  els.presetError.hidden = !hasError;
+  if (hasError) {
+    els.presetError.textContent = d.error + ' — fix presets.toml and refresh.';
+  }
+
+  const names = Object.keys(d.presets || {});
+  els.presetEmpty.hidden = hasError || names.length > 0;
+
+  // keep current selection if still valid, else first
+  if (!selectedPreset || !names.includes(selectedPreset)) {
+    selectedPreset = names[0] || null;
+  }
+
+  els.presetList.innerHTML = '';
+  for (const name of names) {
+    const li = document.createElement('li');
+    li.className = 'preset-item';
+    li.textContent = name;
+    li.setAttribute('role', 'button');
+    li.tabIndex = 0;
+    li.setAttribute('aria-selected', String(name === selectedPreset));
+    li.addEventListener('click', () => selectPreset(name));
+    li.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectPreset(name); }
+    });
+    els.presetList.appendChild(li);
+  }
+
+  if (!userEditedTask) {
+    els.taskInput.value = d.default_task || '';
+  }
+
+  renderDetail();
+  updateLaunchEnabled();
+}
+
+function selectPreset(name) {
+  selectedPreset = name;
+  for (const li of els.presetList.children) {
+    li.setAttribute('aria-selected', String(li.textContent === name));
+  }
+  renderDetail();
+}
+
+function argClass(arg) {
+  const m = arg.match(/^--?([^=]+)/);
+  if (!m) return 'normal';
+  const leaf = m[1].split('.').pop().toLowerCase();
+  if (KEY_ARGS.includes(leaf)) return 'key';
+  if (BOILERPLATE_ARGS.includes(leaf)) return 'boilerplate';
+  return 'normal';
+}
+
+function renderArg(arg, cls) {
+  const row = document.createElement('div');
+  row.className = 'arg ' + cls;
+  const eq = arg.indexOf('=');
+  if (eq === -1) {
+    const n = document.createElement('span');
+    n.className = 'arg-name';
+    n.textContent = arg;
+    row.appendChild(n);
+  } else {
+    const n = document.createElement('span');
+    n.className = 'arg-name';
+    n.textContent = arg.slice(0, eq);
+    const e = document.createElement('span');
+    e.className = 'arg-eq';
+    e.textContent = '=';
+    const v = document.createElement('span');
+    v.className = 'arg-val';
+    v.textContent = arg.slice(eq + 1);
+    row.append(n, e, v);
+  }
+  return row;
+}
+
+function renderDetail() {
+  const d = presetsData;
+  const preset = d.presets && selectedPreset ? d.presets[selectedPreset] : null;
+
+  els.policyName.textContent = selectedPreset || '';
+  els.policyArgs.innerHTML = '';
+  if (preset && preset.args.length) {
+    for (const arg of preset.args) els.policyArgs.appendChild(renderArg(arg, argClass(arg)));
+  } else {
+    const e = document.createElement('div');
+    e.className = 'empty';
+    e.textContent = 'Select a preset to see its policy arguments.';
+    els.policyArgs.appendChild(e);
+  }
+
+  els.sessionArgs.innerHTML = '';
+  const common = d.common_resolved || [];
+  for (const arg of common) els.sessionArgs.appendChild(renderArg(arg, 'normal'));
+
+  renderCommand();
+}
+
+/* ── Command strip ─────────────────────────────────────────────── */
+
+function assembledSegments() {
+  const d = presetsData || {};
+  const preset = d.presets && selectedPreset ? d.presets[selectedPreset] : null;
+  const runner = d.runner || '';
+  const commonRaw = (d.common && d.common.raw) || '';
+  const task = els.taskInput.value;
+  const extra = els.extraInput.value.trim();
+
+  const segs = [];
+  if (runner) segs.push(['runner', runner], ['plain', ' ']);
+  if (preset) segs.push(['preset', preset.raw], ['plain', ' ']);
+  if (commonRaw) segs.push(['session', commonRaw], ['plain', ' ']);
+  segs.push(['mach', "--driver.task='"], ['task', task], ['mach', "'"]);
+  if (extra) segs.push(['plain', ' '], ['extra', extra]);
+  return segs;
+}
+
+function renderCommand() {
+  els.commandText.innerHTML = '';
+  for (const [cls, text] of assembledSegments()) {
+    if (cls === 'plain') {
+      els.commandText.appendChild(document.createTextNode(text));
+    } else {
+      const s = document.createElement('span');
+      s.className = cls;
+      s.textContent = text;
+      els.commandText.appendChild(s);
+    }
+  }
+}
+
+function commandPlainText() {
+  return assembledSegments().map(([, t]) => t).join('').trim();
+}
+
+/* ── Launch / stop ─────────────────────────────────────────────── */
+
+function updateLaunchEnabled() {
+  const d = presetsData;
+  const ok = d && d.error == null && selectedPreset != null;
+  els.launchBtn.disabled = !ok;
+}
+
+async function launch() {
+  els.startError.hidden = true;
+  els.launchBtn.disabled = true;
+  const res = await postJSON('/api/start', {
+    preset: selectedPreset,
+    task: els.taskInput.value,
+    extra_args: els.extraInput.value.trim(),
+  });
+  if (!res.ok) {
+    els.startError.hidden = false;
+    els.startError.textContent = (res.data && res.data.error) || `Launch failed (${res.status}).`;
+    updateLaunchEnabled();
+    return;
+  }
+  await refreshState();
+}
+
+async function stop(force) {
+  const res = await postJSON('/api/stop', { force: !!force });
+  if (!res.ok && res.data && res.data.error) {
+    els.logSub.textContent = res.data.error;
+  }
+  await refreshState();
+}
+
+/* ── State polling + view routing ──────────────────────────────── */
+
+async function refreshState() {
+  stateData = await getJSON('/api/state');
+  applyState();
+}
+
+function applyState() {
+  const s = stateData;
+  const running = s.status === 'running' || s.status === 'stopping';
+
+  // Effective status for the lamp: booting until the console answers.
+  let effStatus = s.status;
+  if (s.status === 'running' && s.run && !s.run.console_ready) effStatus = 'booting';
+  app.dataset.status = effStatus;
+  els.lampLabel.textContent = LAMP_LABELS[effStatus] || effStatus;
+
+  app.dataset.view = running ? 'running' : 'idle';
+
+  if (running) {
+    renderRunning(s);
+    ensureLogsFor(s.run.started_at);
+  } else {
+    renderIdle(s);
+    // A run just ended: keep its logs visible; do one final flush.
+    if (runStartedAt != null) pollLogs();
+  }
+}
+
+function renderRunning(s) {
+  const run = s.run;
+  els.runPreset.textContent = run.preset;
+  els.runPreset.hidden = false;
+  els.runElapsed.hidden = false;
+
+  const stopping = s.status === 'stopping';
+  els.stopBtn.hidden = false;
+  els.stopBtn.disabled = stopping;
+  els.stopBtn.textContent = stopping ? 'Stopping…' : 'Stop';
+
+  // Force kill only after the graceful stop has clearly stalled.
+  let showForce = false;
+  if (stopping && run.stop_requested_at != null) {
+    showForce = (Date.now() / 1000 - run.stop_requested_at) > 25;
+  }
+  if (showForce) forceRevealed = true;
+  els.forceBtn.hidden = !forceRevealed;
+
+  els.logSub.textContent = stopping
+    ? 'stopping — robot shutdown and S3 sync can take a while'
+    : (run.console_ready ? '' : 'booting — this takes 30–60s');
+
+  // console vs boot placeholder
+  if (run.console_ready) {
+    const url = `http://${location.hostname}:${s.console_port}/`;
+    if (els.consoleFrame.src !== url) els.consoleFrame.src = url;
+    els.newTabLink.href = url;
+    els.consoleWrap.hidden = false;
+    els.bootPlaceholder.hidden = true;
+  } else {
+    els.consoleWrap.hidden = true;
+    els.bootPlaceholder.hidden = false;
+  }
+
+  els.logPanel.hidden = false;
+}
+
+function renderIdle(s) {
+  els.runPreset.hidden = true;
+  els.runElapsed.hidden = true;
+  els.stopBtn.hidden = true;
+  els.forceBtn.hidden = true;
+  forceRevealed = false;
+  if (els.consoleFrame.src && !els.consoleFrame.src.startsWith('about:')) {
+    els.consoleFrame.src = 'about:blank';
+  }
+
+  renderLastRun(s.last_run);
+  updateLaunchEnabled();
+
+  // Logs from the finished run stay visible until the next launch.
+  els.logPanel.hidden = runStartedAt == null;
+}
+
+function renderLastRun(lr) {
+  if (!lr) { els.lastRun.hidden = true; return; }
+  // A run the operator stopped exits by SIGINT (code 130) — that is the intended
+  // outcome, not a failure. "Failed" is reserved for exits nobody asked for.
+  const clean = lr.exit_code === 0 || lr.stopped;
+  els.lastRun.hidden = false;
+  els.lastRun.className = 'last-run ' + (clean ? 'clean' : 'failed');
+  const code = lr.exit_code == null ? 'no exit code' : `exit ${lr.exit_code}`;
+  els.lastRun.innerHTML = '';
+  const label = lr.stopped ? 'Last run · stopped' : (clean ? 'Last run · clean' : 'Last run · failed');
+  const parts = [
+    ['lr-label', label],
+    ['lr-preset', lr.preset],
+    ['lr-code', code],
+    ['lr-when', `ended ${agoText(lr.ended_at)}`],
+  ];
+  for (const [cls, text] of parts) {
+    const span = document.createElement('span');
+    span.className = cls;
+    span.textContent = text;
+    els.lastRun.appendChild(span);
+  }
+}
+
+/* ── Elapsed / relative time ───────────────────────────────────── */
+
+function fmtElapsed(sec) {
+  sec = Math.max(0, Math.floor(sec));
+  const h = Math.floor(sec / 3600), m = Math.floor((sec % 3600) / 60), s = sec % 60;
+  const pad = (n) => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}
+
+function agoText(unixSec) {
+  const d = Math.max(0, Date.now() / 1000 - unixSec);
+  if (d < 60) return 'just now';
+  if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h ago`;
+  return `${Math.floor(d / 86400)}d ago`;
+}
+
+function tickElapsed() {
+  const s = stateData;
+  if (s && s.run && (s.status === 'running' || s.status === 'stopping')) {
+    els.runElapsed.textContent = fmtElapsed(Date.now() / 1000 - s.run.started_at);
+  }
+}
+
+/* ── Log streaming ─────────────────────────────────────────────── */
+
+function ensureLogsFor(startedAt) {
+  if (runStartedAt !== startedAt) {
+    // New run — reset the stream.
+    runStartedAt = startedAt;
+    logOffset = 0;
+    logsPinned = true;
+    truncationShown = false;
+    els.logBody.innerHTML = '';
+    els.jumpLatest.hidden = true;
+  }
+}
+
+async function pollLogs() {
+  if (runStartedAt == null) return;
+  const data = await getJSON(`/api/logs?offset=${logOffset}`);
+
+  if (data.truncated && !truncationShown) {
+    truncationShown = true;
+    const row = document.createElement('span');
+    row.className = 'log-line log-truncated';
+    row.textContent = '… earlier output dropped …';
+    els.logBody.appendChild(row);
+  }
+
+  if (data.lines && data.lines.length) {
+    for (const line of data.lines) {
+      const row = document.createElement('span');
+      row.className = 'log-line';
+      row.textContent = line;
+      els.logBody.appendChild(row);
+    }
+    if (logsPinned) els.logBody.scrollTop = els.logBody.scrollHeight;
+  }
+
+  if (!els.logBody.children.length) {
+    const row = document.createElement('span');
+    row.className = 'log-line log-empty';
+    row.textContent = 'Waiting for output…';
+    els.logBody.appendChild(row);
+  } else {
+    const empty = els.logBody.querySelector('.log-empty');
+    if (empty && els.logBody.children.length > 1) empty.remove();
+  }
+
+  logOffset = data.next != null ? data.next : logOffset;
+}
+
+function onLogScroll() {
+  const b = els.logBody;
+  const atBottom = b.scrollHeight - b.scrollTop - b.clientHeight < 24;
+  logsPinned = atBottom;
+  els.jumpLatest.hidden = atBottom;
+}
+
+/* ── Wiring ────────────────────────────────────────────────────── */
+
+els.taskInput.addEventListener('input', () => { userEditedTask = true; renderCommand(); });
+els.extraInput.addEventListener('input', renderCommand);
+els.launchBtn.addEventListener('click', launch);
+els.stopBtn.addEventListener('click', () => stop(false));
+els.forceBtn.addEventListener('click', () => stop(true));
+els.logBody.addEventListener('scroll', onLogScroll);
+els.jumpLatest.addEventListener('click', () => {
+  els.logBody.scrollTop = els.logBody.scrollHeight;
+  logsPinned = true;
+  els.jumpLatest.hidden = true;
+});
+els.copyBtn.addEventListener('click', async () => {
+  const text = commandPlainText();
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (e) {
+    const ta = document.createElement('textarea');
+    ta.value = text; document.body.appendChild(ta); ta.select();
+    document.execCommand('copy'); ta.remove();
+  }
+  els.copyBtn.textContent = 'Copied';
+  setTimeout(() => { els.copyBtn.textContent = 'Copy'; }, 1200);
+});
+
+// Presets can change on disk; refetch when the operator returns to the tab.
+window.addEventListener('focus', () => { if (app.dataset.view === 'idle') loadPresets(); });
+
+/* ── Boot ──────────────────────────────────────────────────────── */
+
+async function init() {
+  await Promise.all([loadPresets(), refreshState()]);
+  setInterval(refreshState, 1000);
+  setInterval(() => { if (app.dataset.view === 'running') pollLogs(); }, 700);
+  setInterval(tickElapsed, 250);
+}
+
+init();

--- a/positronic/server/templates/launcher.html
+++ b/positronic/server/templates/launcher.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Positronic launch console</title>
+  <meta name="description" content="Operator console for launching robot-policy inference sessions." />
+  <link rel="stylesheet" href="/static/launcher.css" />
+</head>
+<body>
+  <div class="app" data-view="idle" data-status="idle">
+    <header class="topbar">
+      <div class="brand">
+        <svg class="mark" viewBox="0 0 32 32" aria-hidden="true">
+          <circle cx="16" cy="16" r="11" />
+          <circle cx="16" cy="16" r="3.2" class="mark-core" />
+          <path d="M16 1.5V6M16 26v4.5M1.5 16H6M26 16h4.5" />
+        </svg>
+        <span class="brand-name">Positronic <b>launch&nbsp;console</b></span>
+      </div>
+
+      <div class="status" id="status">
+        <span class="run-preset" id="runPreset"></span>
+        <span class="run-elapsed" id="runElapsed"></span>
+        <span class="lamp" id="lamp"></span>
+        <span class="lamp-label" id="lampLabel">idle</span>
+        <button class="btn btn-stop" id="stopBtn" hidden>Stop</button>
+        <button class="btn btn-force" id="forceBtn" hidden>Force kill</button>
+      </div>
+    </header>
+
+    <main class="content">
+      <!-- ───────────────────────── IDLE VIEW ───────────────────────── -->
+      <section class="idle-view" id="idleView">
+
+        <div class="notice notice-banner" id="presetError" hidden></div>
+        <div class="last-run" id="lastRun" hidden></div>
+
+        <div class="grid">
+          <aside class="rail panel">
+            <div class="eyebrow">Presets</div>
+            <ul class="preset-list" id="presetList"></ul>
+            <div class="notice notice-empty" id="presetEmpty" hidden>
+              No presets defined. Add entries to <code>presets.toml</code> and refresh.
+            </div>
+          </aside>
+
+          <div class="detail">
+            <section class="panel">
+              <div class="eyebrow">Policy <span class="eyebrow-sub" id="policyName"></span></div>
+              <div class="args" id="policyArgs"></div>
+            </section>
+            <section class="panel">
+              <div class="eyebrow">Session lands at</div>
+              <div class="args args-session" id="sessionArgs"></div>
+            </section>
+          </div>
+        </div>
+
+        <div class="inputs">
+          <label class="field field-task">
+            <span class="eyebrow">Task</span>
+            <textarea id="taskInput" rows="2" spellcheck="false"
+              placeholder="What the robot should do"></textarea>
+          </label>
+          <label class="field field-extra">
+            <span class="eyebrow">Extra args</span>
+            <input id="extraInput" type="text" spellcheck="false" autocomplete="off"
+              placeholder="one-off overrides, e.g. --policy.temperature=0.2" />
+          </label>
+        </div>
+
+        <section class="command-block" id="commandBlock" aria-label="Assembled command">
+          <div class="command-head">
+            <div class="eyebrow">Command</div>
+            <div class="legend" id="legend">
+              <span class="swatch seg-preset">preset</span>
+              <span class="swatch seg-task">task</span>
+              <span class="swatch seg-extra">extra</span>
+              <span class="swatch seg-session">session &amp; runner</span>
+            </div>
+            <button class="btn btn-ghost copy-btn" id="copyBtn" type="button">Copy</button>
+          </div>
+          <div class="command-line"><span class="prompt">$</span><code id="commandText"></code></div>
+        </section>
+
+        <div class="launch-row">
+          <div class="notice notice-inline" id="startError" hidden></div>
+          <button class="btn btn-launch" id="launchBtn" type="button">Launch</button>
+        </div>
+      </section>
+
+      <!-- ─────────────────────── RUNNING VIEW ──────────────────────── -->
+      <section class="running-view" id="runningView">
+        <div class="boot" id="bootPlaceholder">
+          <div class="boot-spinner" aria-hidden="true"></div>
+          <div class="boot-copy">
+            <div class="boot-title">Bringing the robot online</div>
+            <p>Unlocking brakes, activating FCI, warming up the model. This usually
+               takes 30&ndash;60 seconds. The console appears here once it answers.</p>
+          </div>
+        </div>
+
+        <div class="console-wrap" id="consoleWrap" hidden>
+          <div class="console-bar">
+            <span class="eyebrow">Robot console</span>
+            <a class="new-tab" id="newTabLink" target="_blank" rel="noopener">Open console in new tab ↗</a>
+          </div>
+          <iframe id="consoleFrame" title="Robot console" referrerpolicy="no-referrer"></iframe>
+        </div>
+      </section>
+
+      <!-- ─────────────────────── LOG PANEL ─────────────────────────── -->
+      <section class="log-panel panel" id="logPanel" hidden>
+        <div class="log-head">
+          <div class="eyebrow">Launcher log</div>
+          <span class="log-sub" id="logSub"></span>
+        </div>
+        <div class="log-body" id="logBody" tabindex="0"></div>
+        <button class="jump-latest" id="jumpLatest" type="button" hidden>Jump to latest ↓</button>
+      </section>
+    </main>
+  </div>
+
+  <script src="/static/launcher.js"></script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ positronic-server="positronic.server.positronic_server:_internal_main"
 positronic-inference="positronic.inference:_internal_main"
 positronic-probe="positronic.probe:_internal_main"
 positronic-data-collection="positronic.data_collection:_internal_main"
+positronic-launcher="positronic.server.launcher:_internal_main"
 
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Replaces the retype-a-huge-CLI-line-in-tmux workflow for switching inference models with a small web console.

- **`positronic-launcher`** (new `positronic/server/launcher.py` + static page, entry point in `pyproject.toml`): a FastAPI app that manages named presets of `positronic-inference` invocations. A preset is literally the `--policy.*`/`--wrap.*` fragment of the CLI line, stored in a git-ignored `presets.toml` that is re-read on every request — edit the file, refresh the browser. Launching runs the assembled command through `bash -c` (so `$(date …)` and `$MODAL_*` env refs expand exactly as in a shell), streams the subprocess log to the page, detects when the child's WebEvalUI answers and embeds it in an iframe, and stops the run with SIGINT to the process group (Ctrl-C semantics; SIGKILL only via an explicit force button). Token env vars are never expanded for display, only inside the launched shell.
- **Wall-paced attended sim**: `World.run` gains `pace_to_wall=` — the virtual-time pacing loop moves out of `data_collection.py` into `pimm`, and the attended path in `cli/eval/run.py` uses it so a live operator can drive a simulated robot at real-time pace (unattended evals still free-run).
- **`mujoco_franka_table`** embodiment config: the stack-cubes table scene without the eval/trials wrapper, making attended sim reachable from the CLI (`positronic-inference web --embodiment=.mujoco_franka_table …`). With a sim presets file the same launcher drives the simulator instead of the robot — sim vs real is decided by which presets file the launcher is started with.

## Test plan

- Full suite: `uv run --locked pytest --no-cov` — 606 passed, 4 skipped (run after the pacing change).
- Launcher lifecycle against a fake runner (scripted subprocess): presets parsing with date resolution and symbolic tokens, exact command assembly, double-start rejected with 409, incremental log streaming, console-readiness detection, SIGINT stop recorded as a stopped (not failed) run, and launcher shutdown forwarding SIGINT to the child without orphaning it.
- Attended sim end-to-end without hardware: launched the Mujoco preset through the console against a local stub policy server (`offboard.InferenceServer` returning `JointDelta` chunks) — WebEvalUI came up embedded, an episode ran, and the H264 `/video` stream was decoded offline to confirm the arm visibly moves; clean finish/stop afterwards.
- Not yet run against the real robot; the real-robot presets reproduce the exact CLI lines used in production tmux sessions.
