### PR TITLE
Opt-in wall-clock telemetry for `positronic eval run` + `eval timing-report`

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1156,14 +1156,6 @@
         ],
         "./positronic/cfg/policy.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 26,
@@ -10827,14 +10819,6 @@
             }
         ],
         "./positronic/simulator/robolab/validate.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingImports",
                 "range": {

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -634,14 +634,6 @@
         ],
         "./pimm/tests/test_world.py": [
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 8,
@@ -1164,6 +1156,14 @@
         ],
         "./positronic/cfg/policy.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 26,
@@ -1366,22 +1366,6 @@
                 "range": {
                     "startColumn": 31,
                     "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 27,
                     "lineCount": 1
                 }
             }
@@ -1632,14 +1616,6 @@
         ],
         "./positronic/dataset/ds_player_agent.py": [
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 23,
@@ -1678,14 +1654,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
                     "lineCount": 1
                 }
             },
@@ -1780,8 +1748,8 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 44,
+                    "startColumn": 44,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -4183,14 +4151,6 @@
             }
         ],
         "./positronic/drivers/camera/opencv.py": [
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -8006,14 +7966,6 @@
                 }
             },
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 29,
@@ -9490,34 +9442,26 @@
         ],
         "./positronic/simulator/env_server/proxy.py": [
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalSubscript",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 50,
+                    "startColumn": 43,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 32,
+                    "startColumn": 32,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 54,
-                    "endColumn": 62,
+                    "startColumn": 58,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             }
@@ -10544,6 +10488,14 @@
             {
                 "code": "reportMissingImports",
                 "range": {
+                    "startColumn": 7,
+                    "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
                     "startColumn": 5,
                     "endColumn": 17,
                     "lineCount": 1
@@ -10554,22 +10506,6 @@
                 "range": {
                     "startColumn": 5,
                     "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -10891,6 +10827,14 @@
             }
         ],
         "./positronic/simulator/robolab/validate.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingImports",
                 "range": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,23 @@
   rather than adding to it
 
 # Design discipline
+- Land the correct design in the first PR. A change carrying a design or storage-model decision gets that decision
+  right up front — reject a wrong shape at design/review time; never merge a known-wrong approach and fix-forward or
+  revert it later
 - When a change has a design thesis ("World owns time", "Harness is name-free"), enumerate its consequences for
   every touched interface before coding, and implement the end state — old pathways (constructor args, public
   mutators, parallel flags) must not survive the refactor
 - Every value has one owner. When a value gains a new home, re-route consumers to it; don't plumb the new source
   into the old parameter
+- Persist through the existing dataset (signals, static, meta) for anything that fits it — per-step telemetry is a
+  time-series signal, per-episode facts are static/meta, and aggregates are an offline reduce/transform over that
+  raw data, never a stored record. Do not add a side storage or IO channel (a parallel file, a `*.jsonl`, a
+  separate serializer) unless the need fundamentally cannot be served by the dataset
+- A real-world signal (wall time, GPU/sensor load, latencies) is recorded raw at full fidelity — every sample with
+  its real timestamp — even under a virtual/simulated clock. That clock is a placement convenience, never a licence
+  to drop, downsample, or collapse real samples to fit the scheduler, nor to synthesize the timestamps that carry
+  their meaning: where the virtual timeline can't place a sample precisely, record its real time as data and let
+  consumers project it
 - When current code conflicts with the target design, resolve it now (rename + migrate) or bridge loudly with a
   TODO/HACK comment. Never bridge silently with an extra field, class, or indirection
 - Internal code breaks cleanly — no speculative compat shims. Before a migrate-everywhere change, grep for

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Monitor performance, collect edge cases, and iterate. See [Inference Guide](docs
 **Guides:**
 - [Architecture](docs/architecture.md) — the goals and principles behind the design, who owns the control loop, and how foreign components plug in
 - [Model Selection](docs/model-selection.md) | [Codecs](docs/codecs.md) | [Training](docs/training-workflow.md)
-- [Data Collection](docs/data-collection.md) | [Inference](docs/inference.md)
+- [Data Collection](docs/data-collection.md) | [Inference](docs/inference.md) | [Eval Timing](docs/eval-timing.md)
 
 **Hardware:**
 - [Drivers](positronic/drivers/) — Robot arms, cameras, grippers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,3 +133,11 @@ rollout, many cheap criteria experiments. A stop-signal may end a trial early, a
 may report its own success at termination; both are captured as original data from where the
 ground truth lives, not as scores — analysis is free to use, recompute, or override them. A
 criterion baked into the run is bound too early: changing it would mean re-running the robot.
+
+**Telemetry is a producer like any other.** Wall-clock and GPU telemetry are not a privileged side
+channel: anything sampling the world over time is a control system whose output flows through the
+standard writer path (per-tick costs and GPU samples as signals), per-episode facts are statics, and
+every roll-up is an offline reduce over that recording — no side file, no ambient subprocess. Forced
+by *components are functions over flowing data* (a sampler is just a component, its telemetry just
+its output) and *every run produces a Positronic dataset* (the telemetry rides in the dataset the run
+already produces, so nothing exists outside it to lose or to keep in sync).

--- a/docs/eval-timing.md
+++ b/docs/eval-timing.md
@@ -1,0 +1,94 @@
+# Eval Timing
+
+Opt-in wall-clock telemetry for sim evals. A sim eval runs on a **virtual clock**, so the recorded
+episode timestamps say nothing about how much real compute a rollout cost. `--timing` captures the
+wall-clock split a sizing or perf pass needs — policy inference, env reset/step, record IO, GPU
+util/VRAM — that the recorded dataset cannot recover on its own.
+
+It is a **producer → reducer** pipeline: `eval run --timing` records raw per-rollout timings into the
+dataset itself *during* the eval; `eval timing-report` reduces them *offline* into a pass-level report.
+They are separate so the reducer stores nothing beyond the recorded raw data, and can re-run any time
+against a finished dataset without re-running the eval.
+
+## Collect (producer)
+
+Add `--timing` to any sim `eval run`:
+
+```bash
+uv run positronic eval run \
+  --eval=@positronic.cfg.eval.sim.robolab.banana_in_bowl \
+  --eval.trial_count=10 \
+  --policy=@positronic.cfg.policy.remote --policy.host=<endpoint-ip> \
+  --output_dir=s3://<bucket>/evals/robolab_banana/ \
+  --timing
+```
+
+This records the telemetry into each episode of the dataset — no side files:
+
+- `timing.*` signals — the per-tick wall costs (env step, record IO, and the env server's own
+  disjoint step decomposition as `timing.env_*` phases) plus one `timing.infer_ms` sample per policy
+  round-trip.
+- `timing.gpu_*` signals — the eval box's GPU, sampled ~1 Hz by a foreground control system: `timing.gpu_util`
+  (whole-box utilisation %), `timing.gpu_mem` (whole-box memory used, MiB), `timing.gpu_mem_proc` (the memory
+  attributed to **this eval's process tree** — the harness and its env-server/Isaac children, MiB), and
+  `timing.gpu_wall_ns` (the real epoch each probe was captured at). Absent on a box without `nvidia-smi`. A
+  wall-cadence background thread does the sampling into a buffer and the cooperative loop drains every buffered
+  probe each tick, so GPU taken while the scheduler is blocked in a synchronous span (a long reset or env step)
+  is retained in full — the readings are all recorded, and `timing.gpu_wall_ns` carries each probe's true
+  capture time, so a reducer reconstructs the real load-over-time even though the virtual placement of a
+  blocked span's probes is coarse (they share the drain instant).
+- `timing.wall_s` / `timing.finished_at` / `timing.reset_s` statics — the once-per-episode wall scalars.
+
+**Concurrent-sim footgun:** `timing.gpu_util` and `timing.gpu_mem` are **whole-box** — they measure the whole
+GPU, not this eval. With several sims co-located on one GPU, do **not** sum or average utilisation across
+concurrent episodes: they all report the same shared-box number. Memory *is* attributable per eval
+(`timing.gpu_mem_proc`); utilisation is not (per-process util is unreliable under MPS / co-location, so it is
+deliberately not recorded).
+
+`--timing` is sim-only and off by default — with the flag absent every hook is a no-op, so a normal
+eval is unaffected.
+
+> **Caveat (temporary):** a `timing.*` stream's first sample lands a beat after the episode opens (up to one
+> ~1 Hz GPU sampling interval), so episode bounds shrink by that much — a visualisation/replay concern only.
+> [#508](https://github.com/Positronic-Robotics/positronic/issues/508) removes the distortion: the timing
+> signals declare `default=0.0` and bounds stop intersecting them.
+
+## Report (reducer)
+
+Point `timing-report` at the dataset dir (a local path, or the same `s3://` URI):
+
+```bash
+uv run positronic eval timing-report --dataset_dir=s3://<bucket>/evals/robolab_banana/
+```
+
+It reduces each episode's `timing.*` signals and statics — joined with the duration, on-disk size, and
+the `eval.scored` success verdict the episode already records — and prints a pass report:
+
+- `real_time_factor` — recorded episode seconds per wall second.
+- `policy_busy_fraction`, `infer_p50_ms` / `infer_p95_ms` — how much of the pass the policy gated, and
+  its per-call latency.
+- `wall_split` — the fraction of W_pass in each phase: reset / env_step / policy_wait / record_io / overhead
+  / between_episodes (episode writer close — parquet/video flush — plus teardown, homing, world rebuild);
+  sums to 1.
+- `env_step_split` — the env server's own reported phases (for robolab: physics / render / server_other)
+  plus wire / materialize inside the env step, when the env reports a decomposition. The phase set is the
+  env's own; the reducer sums whatever `timing.env_*` columns it recorded.
+- `mean_bytes_per_rollout`, `success_rate`, and GPU mean-util / peak-VRAM for the sim box — reduced from the
+  recorded `timing.gpu_*` signals (with this eval's peak process-tree VRAM alongside the whole-box peak). The
+  policy endpoint (a different box) folds in the same numbers from an optional `--gpu_policy_log`; collect
+  that log with `nvidia-smi dmon -s um`, which emits the `fb` framebuffer column the reducer needs (a plain
+  `dmon` log, lacking `fb`, is rejected).
+
+> **Caveat (known):** each episode's timing is sealed while its writer is open, so the writer-close flush
+> (parquet/video finalize) lands in `between_episodes` — and the final episode's close, with no next episode
+> to absorb it, falls outside `W_pass` entirely. This under-counts pass wall by one close flush: negligible
+> across a many-episode pass, but material for a single-episode run (flagged in the report output). A precise
+> fix needs a writer `flush()` seam separable from close — [internal#105](https://github.com/Positronic-Robotics/internal/issues/105).
+
+The report also lands as `timing_summary.json` next to the input (a sibling `<dataset_dir>.timing_summary.json`
+for an `s3://` input).
+
+## See Also
+
+- [Inference Guide](inference.md) — running evals and recording datasets
+- `positronic/eval_timing.py` — the collector; `positronic/cli/eval/timing_report.py` — the reducer

--- a/pimm/core.py
+++ b/pimm/core.py
@@ -129,12 +129,13 @@ class ControlSystem(ABC):
       should shut down.
     - ``clock``: the ``Clock`` instance the world uses for timestamping messages.
 
-    Implementations must advance their internal work by yielding ``Sleep``
-    instances, allowing the ``World`` interleaver to sequence multiple systems.
+    Implementations advance their internal work by yielding ``Sleep`` (wake me
+    after a duration) or ``Yield`` (run me again at the next instant) commands,
+    allowing the ``World`` interleaver to sequence multiple systems.
     """
 
     @abstractmethod
-    def run(self, should_stop: SignalReceiver, clock: Clock) -> Iterator[Sleep]:
+    def run(self, should_stop: SignalReceiver, clock: Clock) -> Iterator[Command]:
         pass
 
 

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -62,6 +62,7 @@ def _libero_eval(
         privileged=privileged,
         reset=proxy.reset,
         done=proxy.done,
+        scored=True,  # the LIBERO adapter's terminal emits ``eval.success``
     )
     # One scene per (suite, task) pair: an unbound ``task_id`` sweeps each suite, a pinned one runs that task
     # in every bound suite. The scene spec rides each trial's reset token, so the single task-agnostic env

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -151,8 +151,10 @@ def _resolve_tasks(task) -> list[str]:
     instruction_type='default',
     trial_count=1,
     timeout=None,
+    camera_res=(320, 180),
+    render_viewport=True,
 )
-def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
+def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict, camera_res, render_viewport):
     """A RoboLab eval: the embodiment proxies a remote RoboLab env, the task carries the scenario.
 
     RoboLab (https://github.com/NVLabs/RoboLab) is NVIDIA's Isaac Lab benchmark: 120 tabletop manipulation
@@ -172,13 +174,23 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     per-trial seed: RoboLab's eval path exposes no seed hook, so trial contexts carry none. The env's live
     subtask progress ``[status, completed, total, score]`` is the privileged ground truth (recorded, never
     fed to the policy).
+
+    ``camera_res`` is the render size (width, height) of both policy cameras. RoboLab renders natively at
+    16:9 (stock 1280x720) while pi05-class policies consume ~224x224, so the default downsizes to a small
+    16:9 320x180 to cut render cost. Keep any override 16:9: the policies letterbox-pad each frame to a
+    square, so an off-aspect render (e.g. 4:3) shifts the scene's scale and padding in the policy input,
+    while a smaller 16:9 size only cuts render cost. ``render_viewport=False`` stops the default viewport
+    render product. At a fixed 16:9 aspect both only shift sim render cost, and the wire contract is
+    unchanged.
     """
     names = _resolve_tasks(task)
     if timeout is None:
         # The env truncates itself at each task's episode_length_s; the harness deadline is a backstop above
         # the longest selected task.
         timeout = max(_TASKS[name][1] for name in names) + 10.0
-    proxy = RemoteEnvControlSystem(RobolabAdapter(camera_dict), serve_robolab())
+    proxy = RemoteEnvControlSystem(
+        RobolabAdapter(camera_dict), serve_robolab(camera_res=camera_res, render_viewport=render_viewport)
+    )
     # The DROID rig's model (Franka arm + Robotiq 2F-85) rides the env's ``robot_meta`` — the launcher
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
@@ -196,6 +208,7 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
             privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
             reset=proxy.reset,
             done=proxy.done,
+            scored=True,  # the RoboLab adapter's terminal emits ``eval.success``
         ),
         trials,
     )

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -19,7 +19,7 @@ def placeholder():
 
 @cfn.config(checkpoint=None)
 def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None = None, device=None):
-    from lerobot.policies.act.modeling_act import ACTPolicy
+    from lerobot.policies.act.modeling_act import ACTPolicy  # pyright: ignore[reportMissingImports]
 
     from positronic.vendors.lerobot_0_3_3.backbone import register_all
     from positronic.vendors.lerobot_0_3_3.policy import LerobotPolicy

--- a/positronic/cli/eval/__init__.py
+++ b/positronic/cli/eval/__init__.py
@@ -1,4 +1,5 @@
 from positronic.cli.eval.run import run
+from positronic.cli.eval.timing_report import timing_report
 
 # Subcommands of `positronic eval`.
-commands = {'run': run}
+commands = {'run': run, 'timing-report': timing_report}

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -9,10 +9,11 @@ import pos3
 
 import pimm
 import positronic.cfg.policy as policy_cfg
-from positronic import utils, wire
+from positronic import eval_timing, utils, wire
 from positronic.cfg.eval import placeholder
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
+from positronic.drivers.gpu_monitor import GpuMonitor
 from positronic.eval import Embodiment, Eval, Task
 from positronic.gui import dpg_ui
 from positronic.policy.base import SampledPolicy
@@ -69,6 +70,7 @@ def _run_world(
     output_dir: Path | None,
     show_gui: bool,
     on_complete,
+    timing: bool,
 ):
     """Wire one embodiment under a fresh Harness + World and run it to completion.
 
@@ -83,8 +85,18 @@ def _run_world(
     with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
         privileged = task.privileged if task is not None else {}
         done = task.done if task is not None else None
+        # Under --timing on a sim run, sample the box's GPU into the episodes as a foreground control
+        # system; a real run records in separate processes that never see the timer, so no GPU signal.
+        gpu_monitor = GpuMonitor() if timing and dataset_writer is not None and embodiment.simulated else None
         ds_agent = wire.wire_embodiment(
-            world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
+            world,
+            harness,
+            embodiment,
+            dataset_writer,
+            time_mode,
+            privileged=privileged,
+            done=done,
+            gpu_monitor=gpu_monitor,
         )
         if gui is not None:
             # HACK: GUI cameras are matched to observations by the `image.` name prefix, which
@@ -110,10 +122,13 @@ def _run_world(
         # driver, and GUI placement is otherwise identical.
         producers = [cs for cs in embodiment.control_systems if cs is not None]
         foreground = driver.control_systems if driver is not None else []
-        if embodiment.simulated:
-            world.run([*foreground, harness, ds_agent, *producers], gui)
-        else:
-            world.run([harness, *foreground], [*producers, ds_agent, gui])
+        # Start the GPU sampling thread before the World runs so it is already sampling during the
+        # harness's first synchronous reset (server startup + scene reset), and stop it after the run.
+        with gpu_monitor or nullcontext():
+            if embodiment.simulated:
+                world.run([*foreground, harness, ds_agent, gpu_monitor, *producers], gui)
+            else:
+                world.run([harness, *foreground], [*producers, ds_agent, gui])
 
 
 def main(
@@ -124,6 +139,7 @@ def main(
     driver: Callable[[Path | None], Driver] | None = None,
     output_dir: str | Path | None = None,
     show_gui: bool = False,
+    timing: bool = False,
 ):
     """Run inference for an embodiment, real or simulated.
 
@@ -134,6 +150,30 @@ def main(
     after the last World, so a multi-eval sweep reuses one live policy across the rebuilds.
     """
     assert (driver is None) != (evals is None), 'Provide exactly one of driver or evals'
+    # Timing is validated up front, before the policy warmup and the bind: a rejected sweep must fail
+    # before it spends anything.
+    if timing:
+        if output_dir is None:
+            raise ValueError('--timing needs --output_dir: the per-rollout telemetry is recorded into the dataset')
+        # Sim-only by construction: a real embodiment runs the recorder and producers as separate
+        # processes that do not inherit the timer context, so its episodes carry no timing signal. A
+        # mixed sweep still times its simulated evals; only a sweep with nothing to time fails.
+        if evals is not None:
+            simulated = [ev.embodiment.simulated for ev in evals]
+        else:
+            assert embodiment is not None, 'the attended (driver) path runs a single embodiment'
+            simulated = [embodiment.simulated]
+        if not any(simulated):
+            raise ValueError(
+                'eval timing needs a simulated embodiment: a real embodiment carries no timing signal, and '
+                'this sweep has none to time. Drop --timing for a real run.'
+            )
+        if not all(simulated):
+            logger.warning(
+                'eval timing is sim-only: %d real embodiment(s) in this sweep run untimed; only the '
+                'simulated evals are timed.',
+                sum(not s for s in simulated),
+            )
 
     # Drive the policy's remote endpoints through their cold start before hardware and the operator
     # surface come up: opening a session blocks on the server handshake, which returns only once the
@@ -152,20 +192,34 @@ def main(
     # One completion sink — so one ``SampledPolicy`` counter — across every eval, keeping sampling balanced
     # over the whole sweep.
     on_complete = _completion_sink(policy)
+    # Bind one collector around the whole sweep, not per eval, so a mixed sweep's sim evals share one.
+    timing_cm = eval_timing.bind() if timing and output_dir is not None else nullcontext()
     try:
-        if driver is not None:
-            _run_world(policy, embodiment, None, None, driver(output_dir), output_dir, show_gui, on_complete)
-        else:
-            for ev in evals:
-                _run_world(policy, ev.embodiment, ev.task, ev.trials, None, output_dir, show_gui, on_complete)
+        with timing_cm:
+            if driver is not None:
+                assert embodiment is not None, 'the attended (driver) path runs a single embodiment'
+                _run_world(
+                    policy, embodiment, None, None, driver(output_dir), output_dir, show_gui, on_complete, timing
+                )
+            else:
+                assert evals is not None  # driver/evals XOR asserted up front
+                for ev in evals:
+                    _run_world(
+                        policy, ev.embodiment, ev.task, ev.trials, None, output_dir, show_gui, on_complete, timing
+                    )
     finally:
         policy.close()
 
 
 @cfn.config(eval=placeholder, policy=policy_cfg.placeholder, show_gui=False)
-def run(eval: Eval, policy, show_gui, output_dir=None, inference_latency=False):
-    """Run a selected eval (embodiment + task + its trial sweep) through the shared inference harness."""
+def run(eval: Eval, policy, show_gui, output_dir=None, inference_latency=False, timing=False):
+    """Run a selected eval (embodiment + task + its trial sweep) through the shared inference harness.
+
+    ``timing`` records per-rollout wall-clock telemetry into the dataset under ``output_dir`` (a
+    ``timing.*`` signal + statics per episode); it needs an ``output_dir`` and applies to sim evals
+    only. Reduce it with ``positronic eval timing-report``.
+    """
     # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob
     # (sim inference-cost simulation). Overlay it onto every trial context, then self-drive the eval.
     eval = replace(eval, trials=[{**trial, 'inference_latency': inference_latency} for trial in eval.trials])
-    main(policy=policy, evals=[eval], show_gui=show_gui, output_dir=output_dir)
+    main(policy=policy, evals=[eval], show_gui=show_gui, output_dir=output_dir, timing=timing)

--- a/positronic/cli/eval/timing_report.py
+++ b/positronic/cli/eval/timing_report.py
@@ -1,0 +1,513 @@
+"""Reduce the per-rollout timing recorded by ``positronic eval run --timing`` into a pass-level report.
+
+Everything is read back from the recorded episodes: the wall-clock costs a virtual-clock rollout cannot
+recover from its own timestamps (the per-step ``timing.*`` signal + wall/finish/inference statics, summed
+here per rollout), joined with the virtual duration (for the real-time factor), the on-disk size (bytes
+per rollout) and the terminal flag. The sim box's GPU utilisation and VRAM ride in as recorded
+``timing.gpu_*`` signals; the policy endpoint (a different box) folds in from an optional ``nvidia-smi
+dmon`` log.
+"""
+
+import json
+import logging
+import re
+from bisect import bisect_right
+from dataclasses import asdict, dataclass, fields
+from datetime import UTC, datetime
+from pathlib import Path
+
+import configuronic as cfn
+import numpy as np
+import pos3
+
+from positronic.dataset.episode import Episode
+from positronic.dataset.local_dataset import load_all_datasets
+from positronic.eval_timing import FINISHED_AT_KEY, INFER_MS_SIGNAL, RESET_S_KEY, TELEMETRY_PREFIX, WALL_S_KEY
+
+logger = logging.getLogger(__name__)
+
+# The namespace the env server's own step phases record under, and the two client-measured step signals that
+# share it but are not env phases (excluded when gathering the env decomposition).
+_ENV_PHASE_PREFIX = f'{TELEMETRY_PREFIX}env_'
+_CLIENT_ENV_SIGNALS = {f'{TELEMETRY_PREFIX}env_step_s', f'{TELEMETRY_PREFIX}env_client_s'}
+
+# The sim box's per-tick GPU telemetry, recorded as signals by ``GpuMonitor`` (whole-box utilisation %,
+# whole-box memory MiB, and this eval's process-tree memory MiB).
+_GPU_UTIL_SIGNAL = f'{TELEMETRY_PREFIX}gpu_util'
+_GPU_MEM_SIGNAL = f'{TELEMETRY_PREFIX}gpu_mem'
+_GPU_MEM_PROC_SIGNAL = f'{TELEMETRY_PREFIX}gpu_mem_proc'
+_MIB_PER_GB = 1024.0
+
+
+@dataclass
+class _RecordedFacts:
+    """What the recorded episode contributes to the join, keyed by ``episode_uid``."""
+
+    duration_s: float
+    size_mb: float
+    success: bool | None  # the env's eval.success verdict; None when it recorded none
+    terminated: bool | None  # eval.terminated: the trial ended within budget vs timed out; None if unrecorded
+    scored: bool  # eval.scored: the eval has a live success oracle, so a no-success termination is a failure
+
+
+@dataclass
+class _EpisodeTiming:
+    """One rollout's wall-clock aggregate, recreated by summing its recorded ``timing.*`` signal and reading
+    its statics — the per-episode reduce the recorder never stores. Fields are seconds unless named otherwise;
+    ``env_step_s`` includes materialisation, ``env_client_s`` is materialisation alone. ``overhead_s`` is the
+    wall unattributed to a measured phase. ``infer_ms`` is the raw per-call latency list."""
+
+    episode_uid: str
+    wall_s: float
+    reset_s: float
+    env_step_s: float
+    policy_wait_s: float
+    record_io_s: float
+    overhead_s: float
+    infer_ms: list[float]
+    finished_at: float
+    env_client_s: float
+    env_phases: dict[str, float]  # env-reported phase name -> summed seconds; the env owns this key space
+    gpu_util: list[float]  # whole-box utilisation % samples recorded during the episode (empty on a CPU box)
+    gpu_mem_mib: list[float]  # whole-box memory-used MiB samples
+    gpu_proc_mib: list[float]  # this eval's process-tree memory MiB samples
+
+
+@dataclass
+class GpuSummary:
+    """Mean utilisation and peak VRAM for one box.
+
+    ``peak_proc_vram_gb`` is the peak memory attributed to this eval's process tree; it is ``None`` for a
+    policy ``dmon`` log, which carries no per-process attribution (only the whole box).
+    """
+
+    mean_util_pct: float
+    peak_vram_gb: float
+    peak_proc_vram_gb: float | None
+
+
+@dataclass
+class GpuReport:
+    """GPU summaries per box: the sim box (from the recorded ``timing.gpu_*`` signals) and the policy endpoint.
+
+    ``sim`` is ``None`` on a CPU sim box (no GPU signals recorded); ``policy`` is ``None`` when no policy
+    ``dmon`` log was passed in.
+    """
+
+    sim: GpuSummary | None
+    policy: GpuSummary | None
+
+
+@dataclass
+class WallSplit:
+    """Each phase's share of pass wall time; all fractions sum to 1.
+
+    ``overhead`` is the within-episode wall unattributed to a measured phase; ``between_episodes`` is the
+    inter-episode wall (episode writer close — parquet/video flush — plus session teardown, homing, world
+    rebuild) between one simulated episode's finish and the next's start within a timed run, which a
+    per-episode sum drops (a real eval that splits the runs is excluded, not counted here). An episode seals
+    its timing statics while its writer is open — they are statics written into the episode, so ``wall_s``
+    cannot be re-stamped after the close — so each writer-close flush lands in ``between_episodes`` rather than
+    its own ``record_io``, and the final episode's close, with no next episode to absorb it, falls outside the
+    pass span entirely. This under-counts pass wall by one close flush: negligible across a many-episode pass,
+    but material for a single- or short-episode run (surfaced then by the ``_render`` caveat). Accounting the
+    close flush precisely needs a writer ``flush()`` seam separable from close — deferred to
+    Positronic-Robotics/internal#105.
+    """
+
+    reset: float
+    env_step: float
+    policy_wait: float
+    record_io: float
+    overhead: float
+    between_episodes: float
+
+
+@dataclass
+class EnvStepSplit:
+    """Fractions of the client-observed env-step wall, from the env server's own decomposition.
+
+    ``phases`` maps each env-reported phase (its own decomposition — physics, rendering, its other in-step
+    wall) to that phase's share of the client step wall; the env owns the phase set, so it is a map, not
+    fixed fields. ``wire`` is the client step wall minus the server's whole in-step wall and the client
+    materialisation (socket + codec); ``materialize`` is the client-side observation materialisation
+    (shared-memory image allocation + camera copies). ``None`` when no episode carried a server decomposition.
+    """
+
+    phases: dict[str, float]
+    wire: float
+    materialize: float
+
+
+@dataclass
+class PassReport:
+    """Pass-level wall-clock roll-up reduced from the recorded episodes' timing signals, statics and facts."""
+
+    episodes: int
+    wall_pass_s: float
+    real_time_factor: float
+    policy_busy_fraction: float
+    infer_calls: int
+    infer_p50_ms: float
+    infer_p95_ms: float
+    wall_split: WallSplit
+    env_step_split: EnvStepSplit | None
+    mean_bytes_per_rollout: float
+    success_rate: float | None  # None when no episode carried a success verdict (scored downstream)
+    gpu: GpuReport
+
+
+def _episode_timing(ep: Episode, uid: str) -> _EpisodeTiming | None:
+    """Recreate one rollout's wall-clock aggregate from its recorded ``timing.*`` signals and statics.
+
+    ``None`` when the episode carries no timing (recorded without ``--timing``). Each ``timing.<phase>_s``
+    signal is the per-tick cost stream, summed here to the episode total; ``policy_wait_s`` is the sum of the
+    per-call ``timing.infer_ms`` signal; ``reset_s`` and the wall scalars come from statics; ``overhead_s`` is
+    the wall left unattributed after the measured phases.
+    """
+    if WALL_S_KEY not in ep.static:
+        return None
+
+    def phase_total(name: str) -> float:
+        sig = ep.signals.get(f'{TELEMETRY_PREFIX}{name}')
+        return float(sum(np.asarray(value).sum() for value, _ in sig)) if sig is not None else 0.0
+
+    def samples(name: str) -> list[float]:
+        sig = ep.signals.get(name)
+        return [float(value) for value, _ in sig] if sig is not None else []
+
+    # The env server's own decomposition rides in as ``timing.env_<phase>`` signals with an env-owned key
+    # space; the report never enumerates them. The two client-measured step signals share the ``env_`` prefix
+    # but are not env phases, so they are excluded here.
+    env_phases = {
+        name[len(_ENV_PHASE_PREFIX) :]: phase_total(name[len(TELEMETRY_PREFIX) :])
+        for name in ep.signals
+        if name.startswith(_ENV_PHASE_PREFIX) and name not in _CLIENT_ENV_SIGNALS
+    }
+
+    infer_sig = ep.signals.get(INFER_MS_SIGNAL)
+    infer_ms = [float(value) for value, _ in infer_sig] if infer_sig is not None else []
+    policy_wait_s = sum(infer_ms) / 1000.0
+    reset_s = float(ep.static[RESET_S_KEY])
+    env_step_s = phase_total('env_step_s')
+    record_io_s = phase_total('record_io_s')
+    wall_s = float(ep.static[WALL_S_KEY])
+    measured = reset_s + env_step_s + policy_wait_s + record_io_s
+    return _EpisodeTiming(
+        episode_uid=uid,
+        wall_s=wall_s,
+        reset_s=reset_s,
+        env_step_s=env_step_s,
+        policy_wait_s=policy_wait_s,
+        record_io_s=record_io_s,
+        overhead_s=max(wall_s - measured, 0.0),
+        infer_ms=infer_ms,
+        finished_at=float(ep.static[FINISHED_AT_KEY]),
+        env_client_s=phase_total('env_client_s'),
+        env_phases=env_phases,
+        gpu_util=samples(_GPU_UTIL_SIGNAL),
+        gpu_mem_mib=samples(_GPU_MEM_SIGNAL),
+        gpu_proc_mib=samples(_GPU_MEM_PROC_SIGNAL),
+    )
+
+
+def _rollout_duration_s(ep: Episode) -> float:
+    """The episode's virtual duration over its rollout content alone.
+
+    ``Episode.duration_ns`` spans the window where every signal has data, and each ``timing.*`` telemetry
+    signal starts at its phase's first nonzero sample — one tick or more into the rollout — which would pull
+    the window's start later and shorten the duration the real-time factor divides by.
+    """
+    signals = ep.signals
+    content = [sig for name, sig in signals.items() if not name.startswith(TELEMETRY_PREFIX)]
+    if not content or len(content) == len(signals):
+        return ep.duration_ns / 1e9
+    return (max(sig.last_ts for sig in content) - max(sig.start_ts for sig in content)) / 1e9
+
+
+def _invocation_starts(dataset_dir: Path) -> list[int]:
+    """Wall-clock (epoch ns) start of each ``eval run`` invocation into this dir, parsed from the
+    ``run_metadata_<YYYYMMDD_HHMMSS>.yaml`` marker each invocation writes, sorted ascending.
+
+    Two timed passes appended to one ``output_dir`` are adjacent in dataset order with no untimed episode
+    between them, so ordering alone cannot tell them apart; these markers are the boundary that keeps them as
+    separate runs, so the wall gap between two independently appended passes is never counted as pass time.
+    """
+    starts = []
+    for path in dataset_dir.glob('run_metadata_*.yaml'):
+        match = re.fullmatch(r'run_metadata_(\d{8}_\d{6})\.yaml', path.name)
+        if match is not None:
+            started = datetime.strptime(match.group(1), '%Y%m%d_%H%M%S').replace(tzinfo=UTC)
+            starts.append(int(started.timestamp()) * 1_000_000_000)
+    return sorted(starts)
+
+
+def _load_episodes(dataset_dir: Path) -> tuple[list[list[_EpisodeTiming]], dict[str, _RecordedFacts]]:
+    """One pass over the recorded episodes: the per-rollout timing records grouped into contiguous runs, and
+    the recorded facts (duration/size/success) every episode contributes to the join, keyed by uid.
+
+    A run is a maximal sequence of timed episodes from one ``eval run`` invocation with no untimed one between
+    them. An untimed (real) episode carries no timing and splits the runs around it, so its wall stays out of
+    the pass span — only the simulated spans are reported, even in a mixed sim/real sweep. A reused
+    ``output_dir`` holding a later timed pass splits there too (by the invocation window each episode's
+    ``created_ts_ns`` falls in), so the hours between two independently appended passes are never merged into
+    one run's wall.
+    """
+    dataset = load_all_datasets(dataset_dir)
+    starts = _invocation_starts(dataset_dir)
+    runs: list[list[_EpisodeTiming]] = []
+    facts: dict[str, _RecordedFacts] = {}
+    split = True  # the next timed episode opens a fresh run (first one, or one after an untimed episode)
+    invocation = -1  # invocation window (index into `starts`) the current run belongs to
+    for i, ep in enumerate(dataset):
+        uid = str(ep.meta.get('uid', f'ts-{ep.meta.get("created_ts_ns", i)}'))
+        # ``eval.success`` is the env's task-success verdict; ``eval.terminated`` only means the episode
+        # ended within budget, so a failed-but-done rollout is terminated=True, success=False and a
+        # timed-out one is terminated=False with no success verdict. ``eval.scored`` says whether the eval
+        # scores success at all, which is what makes a no-success termination a failure rather than unscored.
+        verdict = ep.static.get('eval.success')
+        terminated = ep.static.get('eval.terminated')
+        facts[uid] = _RecordedFacts(
+            duration_s=_rollout_duration_s(ep),
+            size_mb=float(ep.meta.get('size_mb', 0.0)),
+            success=None if verdict is None else bool(verdict),
+            terminated=None if terminated is None else bool(terminated),
+            scored=bool(ep.static.get('eval.scored', False)),
+        )
+        timing = _episode_timing(ep, uid)
+        if timing is None:
+            split = True
+            continue
+        # A timed episode recorded in a later invocation than the current run opens a fresh run, so a second
+        # timed pass into a reused output_dir is not merged into the first.
+        episode_invocation = bisect_right(starts, int(ep.meta.get('created_ts_ns', 0))) - 1
+        if episode_invocation != invocation:
+            split = True
+        invocation = episode_invocation
+        if split:
+            runs.append([])
+            split = False
+        runs[-1].append(timing)
+    return runs, facts
+
+
+def _timed_spans(runs: list[list[_EpisodeTiming]]) -> list[tuple[float, float]]:
+    """The wall-clock (epoch) span each contiguous run of timed episodes occupied, first episode's start to
+    last's finish — the span the pass wall covers, excluding any real eval between runs."""
+    return [(run[0].finished_at - run[0].wall_s, run[-1].finished_at) for run in runs]
+
+
+def _sim_gpu_summary(records: list[_EpisodeTiming]) -> GpuSummary | None:
+    """The sim box's GPU summary from the recorded ``timing.gpu_*`` samples across all timed episodes: mean
+    whole-box utilisation, peak whole-box VRAM, and this eval's peak process-tree VRAM. ``None`` on a CPU sim
+    box, where ``GpuMonitor`` recorded no GPU samples."""
+    util = [u for r in records for u in r.gpu_util]
+    mem_mib = [m for r in records for m in r.gpu_mem_mib]
+    proc_mib = [p for r in records for p in r.gpu_proc_mib]
+    if not util and not mem_mib:
+        return None
+    return GpuSummary(
+        mean_util_pct=float(np.mean(util)) if util else 0.0,
+        peak_vram_gb=(max(mem_mib) / _MIB_PER_GB) if mem_mib else 0.0,
+        peak_proc_vram_gb=(max(proc_mib) / _MIB_PER_GB) if proc_mib else None,
+    )
+
+
+def _parse_dmon(log_path: Path) -> GpuSummary:
+    """Mean SM utilisation and peak framebuffer (GB) from a policy endpoint's ``nvidia-smi dmon`` log.
+
+    Column layout varies — ``-o DT`` prepends date/time, ``-s u`` adds encoder/decoder (and, on newer
+    drivers, JPEG/OFA) columns before the framebuffer — so the positions are read from the ``# ... sm ...
+    fb ...`` name header rather than hard-coded. ``sm`` is SM utilisation (%) and ``fb`` the framebuffer
+    use (MiB). Rows before the header, or with missing numeric fields, are skipped; a log whose header has
+    ``sm`` but no ``fb`` (plain ``dmon`` / ``-s u``) fails loudly rather than silently reporting 0. A dmon
+    log carries no per-process attribution, so ``peak_proc_vram_gb`` is ``None``.
+    """
+    sm_idx: int | None = None
+    fb_idx: int | None = None
+    utils: list[float] = []
+    fb_mib: list[float] = []
+    for line in log_path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith('#'):
+            # The name header carries the column names ('sm', 'fb', ...); the units line ('%', 'MB') has no 'sm'.
+            names = stripped.lstrip('#').split()
+            if 'sm' in names:
+                if 'fb' not in names:
+                    # Plain ``nvidia-smi dmon`` (or ``-s u``) omits the framebuffer column, so every row would
+                    # be skipped and peak VRAM silently read as 0. Fail loudly instead of under-reporting.
+                    raise ValueError(
+                        f'{log_path}: nvidia-smi dmon log has an `sm` column but no `fb` (framebuffer) column, so '
+                        f'peak VRAM cannot be read and every sample would be dropped. Re-collect it with '
+                        f'`nvidia-smi dmon -s um` (u=utilisation, m=memory), which emits the `fb` column.'
+                    )
+                sm_idx, fb_idx = names.index('sm'), names.index('fb')
+            continue
+        if sm_idx is None or fb_idx is None:
+            continue
+        fields = line.split()
+        try:
+            utils.append(float(fields[sm_idx]))
+            fb_mib.append(float(fields[fb_idx]))
+        except (IndexError, ValueError):
+            continue
+    return GpuSummary(
+        mean_util_pct=float(np.mean(utils)) if utils else 0.0,
+        peak_vram_gb=(max(fb_mib) / _MIB_PER_GB) if fb_mib else 0.0,
+        peak_proc_vram_gb=None,
+    )
+
+
+def _success_outcome(facts: _RecordedFacts) -> bool | None:
+    """Whether the episode is a success (True), a failure (False), or unscored (None).
+
+    A recorded ``eval.success`` is taken as-is. With none, an episode of a *scored* eval that reached a
+    verdict or timed out (``eval.terminated`` recorded) is a failure — this is the timed-out rollout an
+    adapter only marks on live success. An episode of an unscored eval (success computed downstream) is not
+    scored here at all.
+    """
+    if facts.success is not None:
+        return facts.success
+    if facts.scored and facts.terminated is not None:
+        return False
+    return None
+
+
+def _build_report(
+    runs: list[list[_EpisodeTiming]], facts: dict[str, _RecordedFacts], policy_gpu: GpuSummary | None
+) -> PassReport:
+    # ``runs`` and ``facts`` come from the same pass over the dataset, so every record's uid is a facts key by
+    # construction: the episode count and wall come from the timed ``records``, RTF/bytes/success from facts.
+    records = [r for run in runs for r in run]
+
+    # W_pass is the timed span — each contiguous run's first-episode start to its last-episode finish, summed —
+    # so inter-episode teardown (session close, homing, world rebuild) between simulated episodes counts in the
+    # denominator, while a real eval that split the runs does not. A per-episode sum would drop the teardown,
+    # inflating the real-time factor and sizing numbers.
+    episode_wall_sum = float(sum(r.wall_s for r in records))
+    wall_pass = float(sum(hi - lo for lo, hi in _timed_spans(runs)))
+    all_infer_ms = np.array([ms for r in records for ms in r.infer_ms], dtype=float)
+
+    # Aggregate fraction = summed phase over W_pass, so long episodes weigh proportionally.
+    def phase_fraction(attr: str) -> float:
+        return float(sum(getattr(r, attr) for r in records) / wall_pass) if wall_pass else 0.0
+
+    # The split covers only the episodes whose env reports its own decomposition: in a sweep mixing a
+    # decomposing env server with a sim that reports none, the undecomposed episodes' env-step wall would
+    # otherwise all land in ``wire``. The env server reports disjoint additive phases summing to its whole
+    # in-step wall, so their sum is that wall and each phase's share is its column over ``env_step``.
+    decomposed = [r for r in records if r.env_phases]
+    env_step_sum = float(sum(r.env_step_s for r in decomposed))
+    env_step_split = None
+    if env_step_sum:
+        client_sum = float(sum(r.env_client_s for r in decomposed))
+        phase_names = sorted({name for r in decomposed for name in r.env_phases})
+        phase_sums = {name: float(sum(r.env_phases.get(name, 0.0) for r in decomposed)) for name in phase_names}
+        server_sum = float(sum(phase_sums.values()))
+        env_step_split = EnvStepSplit(
+            phases={name: total / env_step_sum for name, total in phase_sums.items()},
+            wire=(env_step_sum - server_sum - client_sum) / env_step_sum,
+            materialize=client_sum / env_step_sum,
+        )
+
+    matched = [facts[r.episode_uid] for r in records]
+    sim_seconds = sum(f.duration_s for f in matched)
+    # Each episode carries whether its eval scores success (``eval.scored``), so scoring needs no pass-wide
+    # oracle: a scored eval's timeouts count as failures (even an all-timeout eval reads 0%), while an
+    # unscored eval's episodes stay out of the rate entirely regardless of what else ran in the sweep.
+    judged = [outcome for outcome in (_success_outcome(f) for f in matched) if outcome is not None]
+    return PassReport(
+        episodes=len(records),
+        wall_pass_s=wall_pass,
+        real_time_factor=(sim_seconds / wall_pass) if wall_pass else 0.0,
+        policy_busy_fraction=phase_fraction('policy_wait_s'),
+        infer_calls=int(all_infer_ms.size),
+        infer_p50_ms=float(np.percentile(all_infer_ms, 50)) if all_infer_ms.size else 0.0,
+        infer_p95_ms=float(np.percentile(all_infer_ms, 95)) if all_infer_ms.size else 0.0,
+        wall_split=WallSplit(
+            reset=phase_fraction('reset_s'),
+            env_step=phase_fraction('env_step_s'),
+            policy_wait=phase_fraction('policy_wait_s'),
+            record_io=phase_fraction('record_io_s'),
+            overhead=phase_fraction('overhead_s'),
+            between_episodes=float((wall_pass - episode_wall_sum) / wall_pass) if wall_pass else 0.0,
+        ),
+        env_step_split=env_step_split,
+        mean_bytes_per_rollout=(sum(f.size_mb for f in matched) / len(matched) * 1024 * 1024) if matched else 0.0,
+        success_rate=(sum(judged) / len(judged)) if judged else None,
+        gpu=GpuReport(sim=_sim_gpu_summary(records), policy=policy_gpu),
+    )
+
+
+def _render(report: PassReport) -> str:
+    lines = [
+        f'episodes:            {report.episodes}',
+        f'W_pass (wall):       {report.wall_pass_s:.1f} s ({report.wall_pass_s / 3600:.2f} h)',
+        f'real-time factor:    {report.real_time_factor:.3f} (sim-s per wall-s)',
+        f'policy busy (k):     {report.policy_busy_fraction:.3f}  -> ~{1 / report.policy_busy_fraction:.1f} sims/H100'
+        if report.policy_busy_fraction
+        else 'policy busy (k):     n/a',
+        f'infer calls:         {report.infer_calls}',
+        f'infer p50 / p95:     {report.infer_p50_ms:.1f} / {report.infer_p95_ms:.1f} ms',
+        f'bytes / rollout:     {report.mean_bytes_per_rollout / 1e6:.1f} MB',
+        f'success rate:        {report.success_rate:.3f}'
+        if report.success_rate is not None
+        else 'success rate:        n/a',
+        'wall split (fraction of W_pass):',
+    ]
+    lines += [f'  {f.name:<12} {getattr(report.wall_split, f.name):.3f}' for f in fields(WallSplit)]
+    if report.env_step_split is not None:
+        split = report.env_step_split
+        lines.append('env-step split (fraction of env_step):')
+        lines += [f'  {name:<14} {frac:.3f}' for name, frac in split.phases.items()]
+        lines.append(f'  {"wire":<14} {split.wire:.3f}')
+        lines.append(f'  {"materialize":<14} {split.materialize:.3f}')
+    for f in fields(GpuReport):
+        summary = getattr(report.gpu, f.name)
+        if summary is not None:
+            line = f'gpu[{f.name}]: util {summary.mean_util_pct:.0f}%  peak VRAM {summary.peak_vram_gb:.1f} GB'
+            if summary.peak_proc_vram_gb is not None:
+                line += f'  (this eval {summary.peak_proc_vram_gb:.1f} GB)'
+            lines.append(line)
+    if report.episodes == 1:
+        lines.append(
+            "note: W_pass omits the single episode's writer-close flush (parquet/video finalize), which runs "
+            'after its timing is sealed — a one-episode pass under-reports wall and record_io (internal#105).'
+        )
+    return '\n'.join(lines)
+
+
+@cfn.config(gpu_policy_log=None)
+def timing_report(dataset_dir: str, gpu_policy_log: str | None):
+    """Reduce the recorded per-rollout timing (the ``timing.*`` signal + statics on each episode) into a pass report.
+
+    ``dataset_dir`` may be an ``s3://`` URI — the documented Nebius eval path writes there — in which case
+    it is pulled local first, mirroring how the eval command syncs its output. The sim box's GPU utilisation
+    and VRAM come from the recorded ``timing.gpu_*`` signals; ``gpu_policy_log`` is an optional
+    ``nvidia-smi dmon -s um`` log for the policy endpoint (a different box) folded in the same way. Writes
+    ``timing_summary.json`` next to the input — for an ``s3://`` input to the sibling key
+    ``<dataset_dir>.timing_summary.json`` (pos3 forbids uploading inside the downloaded prefix) — and prints
+    the report.
+    """
+    # Pull a remote dataset local before reading; a plain local path is used as-is (never handed to pos3,
+    # whose download would prune it).
+    root = Path(pos3.download(dataset_dir)) if '://' in dataset_dir else Path(dataset_dir)
+    runs, facts = _load_episodes(root)
+    if not runs:
+        raise ValueError(f'no timed episodes under {root} (recorded without --timing?)')
+
+    # The policy endpoint is a different box, so its GPU is folded from a passed-in dmon log; the sim box's
+    # GPU is reduced from the recorded ``timing.gpu_*`` signals inside ``_build_report``.
+    policy_gpu = _parse_dmon(Path(gpu_policy_log)) if gpu_policy_log is not None else None
+    report = _build_report(runs, facts, policy_gpu)
+    summary_path = root / 'timing_summary.json'
+    summary_path.write_text(json.dumps(asdict(report), indent=2))
+    if '://' in dataset_dir:
+        # A remote input was only downloaded, so the write above lands in the local cache. pos3 rejects an
+        # upload inside a registered download prefix, so push the summary to a sibling key next to the
+        # dataset dir (the CLI's @pos3.with_mirror flushes it on exit; delete=False never prunes the bucket).
+        pos3.upload(f'{dataset_dir.rstrip("/")}.timing_summary.json', summary_path, delete=False)
+    logger.info(f'wrote {summary_path}')
+    print(_render(report))

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -38,7 +38,20 @@ Recordings are immutable. All post-hoc modification goes through one mechanism: 
 
 `duration_ns`, `start_ts`, `last_ts` are **first-class properties on Episode**, always derived from signals. They are never stored in meta. If a transform changes signals, these properties reflect the change.
 
+Bounds and time sampling (`episode.time[...]`) cover every signal — the core reserves no name and gives no signal special bounds treatment.
+
 Implementations may cache these values internally (e.g. `DiskEpisode` reads a cached `duration_ns` from `meta.json`), but this is a private optimization — `episode.meta` must not expose `duration_ns`.
+
+## The dataset holds no opinions
+
+The core — `Signal`, `Episode`, `Dataset`, and the writer — is agnostic to the nature, source, and structure of every signal. There are **no reserved names, no name-based dispatch, and no signal classes**: recording appends whatever `(name, value)` pairs it is handed, at the original resolution and fidelity, and never interprets them. A telemetry producer — the eval's per-tick wall-clock costs and inference latencies — is just another source feeding the standard append path as opaque pairs; the writer cannot tell those signals from a camera's. Meaning is a consumer's job, never the core's.
+
+Two consumer classes read the raw recording, each supplying its own interpretation:
+
+- **Replay / debug** — first-party code. It decides how to reconcile sparse and dense signals, and derives whatever boundary or alignment notion it needs directly from the raw signals.
+- **Training-set conversion** — codec-driven. `apply_codec` wraps the dataset in `TransformedDataset(codec.training_encoder)`, and every `training_encoder` is a pure **projection** (`Derive`) that yields only the keys the codec declares. An undeclared signal is a no-op *by construction* — it never reaches the training columns, and no whitelist is needed. Keep it so: a training encoder is a pure projection, so **never add an `Identity()` passthrough to one** (that would leak every raw signal into the training set).
+
+Bounds (`start_ts`, `last_ts`, `duration_ns`, `time`) are a **convenience projection over the signals, not semantics**: a consumer that needs a different episode extent derives it from the raw signals rather than expecting the core to carve one out. Today they are the plain intersection over all signals; after #508 they intersect only the non-defaulted signals, so a sparse stream that declares its pre-first-sample default stops pulling `start_ts` inward.
 
 ## Laziness
 

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -1,7 +1,10 @@
+import contextlib
 import logging
+from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
-from typing import Any
+from typing import Any, Protocol
 
 import pimm
 from positronic.utils import frozen_keys_dict
@@ -12,6 +15,41 @@ from .serializers import Serializer, StatefulSerializer, Timestamped, _PureSeria
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+class TimingHooks(Protocol):
+    """Optional wall-clock telemetry taps the writer drives without knowing what they measure.
+
+    The writer appends whatever ``drain`` yields and sets whatever ``finish`` yields as opaque ``(name,
+    value)`` pairs — it never learns their meaning, so no telemetry concept leaks into the dataset core. The
+    default (``_NO_TIMING``) is inert: no extra samples, an unmeasured record-IO span."""
+
+    def record_io(self) -> AbstractContextManager: ...
+
+    def drain(self) -> Iterator[tuple[str, float]]: ...
+
+    def finish(self) -> Iterator[tuple[str, float]]: ...
+
+    def discard(self) -> None: ...
+
+
+class _NoTiming:
+    """Inert ``TimingHooks``: the writer records only its inputs, with an unmeasured record-IO span."""
+
+    def record_io(self) -> AbstractContextManager:
+        return contextlib.nullcontext()
+
+    def drain(self) -> Iterator[tuple[str, float]]:
+        return iter(())
+
+    def finish(self) -> Iterator[tuple[str, float]]:
+        return iter(())
+
+    def discard(self) -> None:
+        pass
+
+
+_NO_TIMING = _NoTiming()
 
 
 class DsWriterCommandType(Enum):
@@ -162,15 +200,23 @@ class DsWriterAgent(pimm.ControlSystem):
         poll_hz: float = 1000.0,
         time_mode: TimeMode = TimeMode.CLOCK,
         virtual_time: bool = False,
+        timing: TimingHooks = _NO_TIMING,
     ):
         self.ds_writer = ds_writer
         self._poll_hz = float(poll_hz)
         self._time_mode = time_mode
         self._virtual_time = virtual_time
+        self._timing = timing
         self.command = pimm.ControlSystemReceiver[DsWriterCommand](self, default=None)
 
         self._inputs: dict[str, pimm.ControlSystemReceiver[Any]] = {}
         self._serializers: dict[str, StatefulSerializer] = {}
+
+    def _drain_timing(self, ep_writer: EpisodeWriter, ts_ns: int) -> None:
+        """Append the timing hooks' drained ``(name, value)`` pairs at ``ts_ns`` — opaque to the writer, inert
+        when no hooks are bound."""
+        for name, value in self._timing.drain():
+            _append(ep_writer, name, value, ts_ns)
 
     def add_signal(self, name: str, serializer: Serializer | StatefulSerializer | None = None):
         self._inputs[name] = pimm.ControlSystemReceiver[Any](self, default=None)
@@ -224,18 +270,25 @@ class DsWriterAgent(pimm.ControlSystem):
                             if not isinstance(clock, pimm.world.SystemClock):
                                 extra_ts['world'] = world_time_ns
 
-                            serializer = self._serializers.get(name)
-                            value = msg.data
-                            if serializer is not None:
-                                value = serializer(value)
-                            # Gate on `Timestamped` so plain list-valued samples
-                            # (e.g. list-state vectors) still go through `_append`.
-                            # Empty list matches too — used as the cancel signal.
-                            if isinstance(value, list) and (not value or isinstance(value[0], Timestamped)):
-                                for sample in value:
-                                    _append(ep_writer, name, sample.value, sample.ts, None)
-                            else:
-                                _append(ep_writer, name, value, primary_ts, extra_ts)
+                            with self._timing.record_io():
+                                serializer = self._serializers.get(name)
+                                value = msg.data
+                                if serializer is not None:
+                                    value = serializer(value)
+                                # Gate on `Timestamped` so plain list-valued samples
+                                # (e.g. list-state vectors) still go through `_append`.
+                                # Empty list matches too — used as the cancel signal.
+                                if isinstance(value, list) and (not value or isinstance(value[0], Timestamped)):
+                                    for sample in value:
+                                        _append(ep_writer, name, sample.value, sample.ts, None)
+                                else:
+                                    _append(ep_writer, name, value, primary_ts, extra_ts)
+
+                    # Append this tick's drained timing pairs (inert when no hooks are bound). The closing turn
+                    # is skipped here — STOP does the final drain after its own record IO, at the command ts, so
+                    # the last sample stays monotonic against these per-tick ones.
+                    if not closing:
+                        self._drain_timing(ep_writer, clock.now_ns())
 
                 if closing:
                     ep_writer, ep_counter = self._handle_command(cmd_msg.data, ep_writer, ep_counter, cmd_msg.ts)
@@ -252,6 +305,7 @@ class DsWriterAgent(pimm.ControlSystem):
                 finally:
                     ep_writer.__exit__(None, None, None)
                     logger.info(f'DsWriterAgent: [ABORT] Episode {ep_counter}')
+                    self._timing.discard()
 
     def _handle_command(
         self, cmd: DsWriterCommand, ep_writer: EpisodeWriter | None, ep_counter: int, now_ns: int | None = None
@@ -270,9 +324,16 @@ class DsWriterAgent(pimm.ControlSystem):
                     logger.warning('Episode already started, ignoring start command')
             case DsWriterCommandType.STOP_EPISODE:
                 if ep_writer is not None:
-                    for name, ser in self._serializers.items():
-                        for sample in ser.flush(now_ns):
-                            _append(ep_writer, name, sample.value, sample.ts, None)
+                    with self._timing.record_io():
+                        for name, ser in self._serializers.items():
+                            for sample in ser.flush(now_ns):
+                                _append(ep_writer, name, sample.value, sample.ts, None)
+                    # Append the final drained timing pairs, then set the sealed episode's timing statics —
+                    # both opaque (name, value) pairs the hooks supply; the writer never learns their meaning.
+                    if now_ns is not None:
+                        self._drain_timing(ep_writer, now_ns)
+                    for key, value in self._timing.finish():
+                        ep_writer.set_static(key, value)
                     for k, v in cmd.static_data.items():
                         ep_writer.set_static(k, v)
                     ep_writer.__exit__(None, None, None)
@@ -285,6 +346,7 @@ class DsWriterAgent(pimm.ControlSystem):
                     ep_writer.abort()
                     ep_writer.__exit__(None, None, None)
                     logger.info(f'DsWriterAgent: [ABORT] Episode {ep_counter}')
+                    self._timing.discard()
                     ep_writer = None
                 else:
                     logger.warning('Episode not started, ignoring abort command')

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -1,3 +1,4 @@
+import contextlib
 from functools import partial
 from typing import Any
 
@@ -551,3 +552,50 @@ def test_stop_commits_due_drops_future_trajectory(world):
     # 'due' (ts <= stop time) is committed; the future 'tail' is dropped.
     assert [(s, v) for (s, v, _, _) in w.appends] == [('traj', 'due')]
     assert w.exited is True
+
+
+class _FakeTiming:
+    """A ``TimingHooks`` that hands the writer fixed opaque ``(name, value)`` pairs, to prove they are
+    recorded verbatim — no signal name carries behavior in the writer."""
+
+    def __init__(self, drain_items: list[tuple[str, float]], finish_items: list[tuple[str, Any]]) -> None:
+        self._drain_items = list(drain_items)
+        self._finish_items = list(finish_items)
+
+    def record_io(self):
+        return contextlib.nullcontext()
+
+    def drain(self):
+        items, self._drain_items = self._drain_items, []  # yield once, then nothing (one sample per name)
+        return iter(items)
+
+    def finish(self):
+        return iter(self._finish_items)
+
+    def discard(self) -> None:
+        pass
+
+
+def test_writer_records_timing_hook_pairs_verbatim(world):
+    """The writer appends whatever the timing hooks drain and sets whatever they finish, as opaque
+    ``(name, value)`` pairs — arbitrary names land unchanged, so no name is special-cased in the writer."""
+    ds = FakeDatasetWriter()
+    timing = _FakeTiming(drain_items=[('custom.alpha', 1.5), ('weird_name', 2.5)], finish_items=[('custom.stat', 9.0)])
+    agent = DsWriterAgent(ds, time_mode=TimeMode.CLOCK, timing=timing)
+    agent.add_signal('a', None)
+    cmd_em = world.pair(agent.command)
+    a_em = world.pair(agent.inputs['a'])
+
+    script = [
+        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(a_em.emit, 1), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+    ]
+    run_scripted_agent(agent, script, world=world)
+
+    w = ds.created[-1]
+    recorded = {s: v for (s, v, _, _) in w.appends}
+    assert recorded['custom.alpha'] == 1.5
+    assert recorded['weird_name'] == 2.5
+    assert recorded['a'] == 1  # the ordinary input records alongside the opaque timing pairs
+    assert w.statics.get('custom.stat') == 9.0

--- a/positronic/dataset/transforms/tests/test_episode.py
+++ b/positronic/dataset/transforms/tests/test_episode.py
@@ -3,7 +3,7 @@ import pytest
 
 from positronic.dataset.episode import EpisodeContainer
 from positronic.dataset.transforms import Elementwise, TransformedEpisode
-from positronic.dataset.transforms.episode import Concat, Derive, Group, Identity, Rename
+from positronic.dataset.transforms.episode import Concat, Derive, Get, Group, Identity, Rename
 
 from ...tests.utils import DummySignal, DummyTransform
 
@@ -290,3 +290,23 @@ def test_identity_transform_remove(sig_simple):
         _ = selected['note']
     with pytest.raises(KeyError):
         _ = selected['extra']
+
+
+def test_derive_projection_drops_unknown_signals(sig_simple):
+    """A training encoder is a pure projection (``Derive``): it yields only its declared keys, so a signal
+    the encoder never names is a no-op — the transformed output is identical with or without it. This is the
+    structural whitelist that makes a training-set conversion ignore any signal the codec did not declare."""
+    encoder = Derive(state=Get('s', None), label=Get('id', None))
+    base = EpisodeContainer(data={'s': sig_simple, 'id': 3})
+    with_unknown = EpisodeContainer(
+        data={'s': sig_simple, 'id': 3, 'unknown_signal': DummySignal([1500, 2500], [1, 2]), 'unknown_static': 'x'}
+    )
+
+    out_base = encoder(base)
+    out_unknown = encoder(with_unknown)
+
+    assert list(out_base.keys()) == list(out_unknown.keys()) == ['state', 'label']
+    assert 'unknown_signal' not in out_unknown
+    assert 'unknown_static' not in out_unknown
+    assert [v for v, _ in out_unknown['state']] == [v for v, _ in out_base['state']] == [v for v, _ in base['s']]
+    assert out_unknown['label'] == out_base['label'] == 3

--- a/positronic/drivers/gpu_monitor.py
+++ b/positronic/drivers/gpu_monitor.py
@@ -1,0 +1,193 @@
+"""``GpuMonitor``: a foreground control system that samples the box's GPU and emits it as a signal.
+
+Opt-in eval telemetry (``positronic eval run --timing``): a bundled ``timing.gpu`` sample per tick that the
+recorder fans out to ``timing.gpu_util`` (whole-box utilisation %), ``timing.gpu_mem`` (whole-box memory,
+MiB) and ``timing.gpu_mem_proc`` (the memory attributed to this eval's process tree, MiB). Per-process
+*utilisation* is deliberately not attempted — it is unreliable under MPS / co-location — so only memory is
+attributed.
+
+``start`` spins a background daemon thread that does the blocking ``nvidia-smi`` reads at true wall cadence,
+appending each probe to a buffer; it is started before the World runs so the thread is already sampling
+during the harness's first synchronous reset. The cooperative ``run`` loop drains the whole buffer every
+scheduler tick and emits the probes as one timestamped batch, so every probe is retained — a synchronous
+span longer than the sampling interval (a long reset or env step) no longer collapses to a single reading.
+Each probe carries its real capture wall-clock time as a ``timing.gpu_wall_ns`` value, so a reducer
+reconstructs the true load-over-time from that. With no ``nvidia-smi`` on PATH the system is inert (a CPU
+box): no thread starts, it emits nothing, and it keeps yielding so it never stops the eval.
+
+A sim eval runs on a virtual clock that is frozen while the scheduler is blocked in a synchronous span, so a
+batch's probes cannot each get a distinct virtual instant; they are placed at the drain instant with strictly
+increasing timestamps (which the signal writer requires) while their real capture times ride in the
+``timing.gpu_wall_ns`` values. The virtual placement is therefore coarse for a blocked span, but no probe and
+no value is lost.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pimm
+from positronic.dataset.serializers import Timestamped
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _GpuSample:
+    """One box GPU reading: whole-box utilisation (%), whole-box memory used (MiB), the memory used by this
+    eval's process tree (MiB), and the real wall-clock time it was captured (epoch ns)."""
+
+    util_pct: float
+    mem_mib: float
+    proc_mem_mib: float
+    wall_ns: int
+
+
+def _run_nvidia_smi(args: list[str]) -> str | None:
+    """``nvidia-smi`` stdout for ``args``, or ``None`` when the call fails (no binary, driver error, timeout)."""
+    try:
+        proc = subprocess.run(['nvidia-smi', *args], capture_output=True, text=True, timeout=5, check=True)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.stdout
+
+
+def _process_tree_pids() -> set[int]:
+    """This process and all its descendants — the env server subprocess and its Isaac children are spawned
+    under the harness process, so the tree rooted here is exactly this eval's processes."""
+    children: dict[int, list[int]] = {}
+    for entry in os.listdir('/proc'):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f'/proc/{entry}/stat') as stat_file:
+                # After the ``(comm)`` field (comm may hold spaces/parens): state, ppid, ...
+                ppid = int(stat_file.read().rsplit(')', 1)[1].split()[1])
+        except (OSError, IndexError, ValueError):
+            continue
+        children.setdefault(ppid, []).append(int(entry))
+    tree = {os.getpid()}
+    stack = [os.getpid()]
+    while stack:
+        for child in children.get(stack.pop(), ()):
+            if child not in tree:
+                tree.add(child)
+                stack.append(child)
+    return tree
+
+
+def _read_gpu_sample(device: str) -> _GpuSample | None:
+    """One sample for ``device``: whole-box util+memory, plus this eval's process-tree memory. ``None`` when
+    the whole-box query fails (no GPU / driver error) or reports a metric as non-numeric — ``N/A`` /
+    ``[Not Supported]``, e.g. on some MIG configurations — so the caller records nothing this sample and the
+    daemon thread keeps sampling instead of dying on the conversion."""
+    box = _run_nvidia_smi(['--query-gpu=utilization.gpu,memory.used', '--format=csv,noheader,nounits', '-i', device])
+    if box is None:
+        return None
+    util_s, mem_s = (part.strip() for part in box.strip().splitlines()[0].split(','))
+    try:
+        util_pct, mem_mib = float(util_s), float(mem_s)
+    except ValueError:
+        return None
+
+    pids = _process_tree_pids()
+    proc_mib = 0.0
+    apps = _run_nvidia_smi(['--query-compute-apps=pid,used_gpu_memory', '--format=csv,noheader,nounits', '-i', device])
+    for line in (apps or '').strip().splitlines():
+        if not line.strip():
+            continue
+        pid_s, used_s = (part.strip() for part in line.split(','))
+        try:
+            if int(pid_s) in pids:
+                proc_mib += float(used_s)  # ``[Not Supported]`` / permission strings raise and are skipped
+        except ValueError:
+            continue
+    return _GpuSample(util_pct=util_pct, mem_mib=mem_mib, proc_mem_mib=proc_mib, wall_ns=time.time_ns())
+
+
+class GpuMonitor(pimm.ControlSystem):
+    """Samples the box's GPU and emits the probes buffered since the last tick as one batch of ``timing.gpu``
+    samples the recorder fans out to ``timing.gpu_*`` (``_util``, ``_mem``, ``_mem_proc``, ``_wall_ns``).
+    ``sampling_hz`` is the wall cadence of the underlying ``nvidia-smi`` reads."""
+
+    def __init__(self, sampling_hz: float = 1.0):
+        self._interval = 1.0 / sampling_hz
+        # Sample only the GPU this eval runs on — the first CUDA-visible device, else device 0. Left unpinned,
+        # nvidia-smi reports every visible GPU and idle/unrelated devices would dilute the numbers.
+        self._device = (os.environ.get('CUDA_VISIBLE_DEVICES', '') or '0').split(',')[0]
+        self._lock = threading.Lock()
+        self._buffer: list[_GpuSample] = []
+        self._last_emit_ts = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.output = pimm.ControlSystemEmitter(self)
+
+    def _sample_loop(self) -> None:
+        while not self._stop.is_set():
+            sample = _read_gpu_sample(self._device)
+            if sample is not None:
+                with self._lock:
+                    self._buffer.append(sample)
+            self._stop.wait(self._interval)
+
+    def start(self) -> None:
+        """Spin the wall-cadence sampling thread. Started before the World runs so it is already sampling
+        during the harness's first synchronous reset. Inert (no thread) without ``nvidia-smi`` on PATH."""
+        if self._thread is not None:
+            return
+        if shutil.which('nvidia-smi') is None:
+            logger.info('GpuMonitor: no nvidia-smi on PATH; GPU telemetry disabled')
+            return
+        self._thread = threading.Thread(target=self._sample_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the sampling thread and join it. Safe to call when never started."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> 'GpuMonitor':
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+    def _drain_batch(self, now_ns: int) -> list[Timestamped]:
+        """Every probe buffered since the last tick as one timestamped batch, retaining all of them (a
+        blocked span's probes are not collapsed to the latest). The virtual clock is frozen during a blocked
+        span, so the probes share one instant; they are placed at ``now_ns`` with strictly increasing ts (what
+        the signal writer requires) while each carries its real capture wall-ns as ``timing.gpu_wall_ns`` data,
+        from which a reducer recovers the true load-over-time regardless of the coarse virtual placement."""
+        with self._lock:
+            batch, self._buffer = self._buffer, []
+        samples = []
+        for probe in batch:
+            ts = max(now_ns, self._last_emit_ts + 1)
+            self._last_emit_ts = ts
+            value = {
+                '_util': probe.util_pct,
+                '_mem': probe.mem_mib,
+                '_mem_proc': probe.proc_mem_mib,
+                '_wall_ns': probe.wall_ns,
+            }
+            samples.append(Timestamped(ts, value))
+        return samples
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
+        # Yield every scheduler round (not a Sleep(interval)): the wall cadence lives in the sampling thread,
+        # so the loop drains every probe buffered since the last tick and emits them as one timestamped batch.
+        # Probes captured while the scheduler was blocked in a synchronous span are all retained, not collapsed
+        # to the latest. The sim simulator sleeps each step and paces the clock, so this Yield is non-pacing.
+        while not should_stop.value:
+            batch = self._drain_batch(clock.now_ns())
+            if batch:
+                self.output.emit(batch, clock.now_ns())
+            yield pimm.Yield()

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -84,6 +84,10 @@ class Task:
     ``done`` is the optional terminating signal: a source that delivers a dict payload when the
     trial ends. The Harness reads it to stop the trial early and records the payload into the
     episode's static data.
+
+    ``scored`` declares that the ``done`` payload carries a live ``eval.success`` verdict, so a trial
+    ending without one (a timeout) is a real failure. A task whose ``done`` only marks trial lifecycle —
+    success judged downstream over the recorded episodes — stays unscored.
     """
 
     def __init__(
@@ -93,12 +97,14 @@ class Task:
         privileged: dict[str, Observation] | None = None,
         reset: Callable[[dict[str, Any]], None] | None = None,
         done: pimm.SignalEmitter | None = None,
+        scored: bool = False,
     ):
         self._instruction = (lambda: instruction) if isinstance(instruction, str) else instruction
         self.timeout = timeout
         self.privileged = privileged or {}
         self.reset = reset
         self.done = done
+        self.scored = scored
 
     @property
     def instruction(self) -> str:

--- a/positronic/eval_timing.py
+++ b/positronic/eval_timing.py
@@ -1,0 +1,291 @@
+"""Opt-in wall-clock telemetry for ``positronic eval run``.
+
+A sim eval runs on a virtual clock, so the *virtual* time it advances (recorded in the episode's
+signal timestamps) says nothing about how much real compute a rollout cost. This module captures the
+wall-clock split a sizing/perf pass needs — policy inference, env reset, env step, record IO — that the
+virtual-clock timestamps cannot recover, and hands it to the recorder to store *in the episode itself*:
+the per-tick phase costs and per-call inference latencies as ``timing.*`` signals, and the once-per-episode
+wall/finish/reset scalars as statics. The pass-level roll-up is then an offline reduce over those recorded
+raw values (`positronic.cli.eval.timing_report`) — nothing is stored twice and no side channel is written.
+
+The collector is bound around an eval sweep via a ``ContextVar`` (`bind`) and reached at the hook sites
+through this module's hook functions (`begin_episode`, `record_infer`, `timed`, ...), each a no-op while
+unbound — the default — so a normal eval pays nothing.
+Because a sim eval schedules the harness, recorder and env proxy as cooperative generators in one thread,
+a single bound collector sees all of their timings. A real eval runs the recorder and producers as
+separate processes, which do not inherit the context — so this telemetry is sim-only by construction.
+"""
+
+import contextlib
+import logging
+import time
+from collections.abc import Iterator, Mapping
+from contextvars import ContextVar
+from dataclasses import dataclass, field, fields
+from enum import IntEnum, auto
+
+logger = logging.getLogger(__name__)
+
+# The name prefix under which this module's telemetry signals and statics live — a producer-side naming
+# convention this module owns, not something the dataset core interprets or dispatches on.
+TELEMETRY_PREFIX = 'timing.'
+
+# The episode signal + static keys the recorder writes and the reduce step reads back — one source of truth
+# so the writer and `timing_report` never drift on a name. All share the ``TELEMETRY_PREFIX`` namespace: the
+# per-tick phase costs and the per-call inference latencies as signals, the once-per-episode wall scalars as
+# statics.
+INFER_MS_SIGNAL = f'{TELEMETRY_PREFIX}infer_ms'
+WALL_S_KEY = f'{TELEMETRY_PREFIX}wall_s'
+FINISHED_AT_KEY = f'{TELEMETRY_PREFIX}finished_at'
+RESET_S_KEY = f'{TELEMETRY_PREFIX}reset_s'
+
+
+class Phase(IntEnum):
+    """A rollout span timed via ``timed``; it accumulates into the matching timing field."""
+
+    RESET = auto()
+    ENV_STEP = auto()
+    MATERIALIZE = auto()  # client-side observation assembly — part of the env step, tracked apart from wire
+    RECORD_IO = auto()
+
+
+@dataclass
+class StepTiming:
+    """The per-tick wall-clock costs accumulated between two recorder drains, in seconds. The scalar field
+    names are the ``timing.*`` signal suffixes the recorder appends, so the reduce step sums each column back
+    to an episode total.
+
+    ``env_step_s`` includes the client-side materialisation; ``env_client_s`` is that materialisation alone
+    (shared-memory image allocation + camera copies), so ``env_step_s`` minus the env server's whole in-step
+    wall and ``env_client_s`` is the wire + codec cost. ``env_phases`` is the env server's own decomposition
+    (physics substeps, sensor rendering, its other in-step wall) — an env-owned map of phase name to seconds
+    that this module never enumerates; each entry becomes a ``timing.env_<phase>`` signal.
+    """
+
+    env_step_s: float = 0.0
+    record_io_s: float = 0.0
+    env_client_s: float = 0.0
+    env_phases: dict[str, float] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        return all(
+            (not value) if isinstance(value, dict) else (value == 0.0)
+            for value in (getattr(self, f.name) for f in fields(self))
+        )
+
+
+@dataclass
+class EpisodeTimingStatics:
+    """The per-episode wall scalars the recorder stores as statics alongside the ``timing.*`` signals.
+
+    ``reset_s`` is the once-per-episode env reset span, which is not part of the per-tick rollout loop.
+    ``wall_s`` is the whole rollout wall and ``finished_at`` the epoch at which it sealed; together they let
+    the reduce recover each episode's start and so the pass span (first start to last finish), counting
+    inter-episode teardown that a per-episode sum would drop.
+    """
+
+    wall_s: float
+    finished_at: float
+    reset_s: float
+
+
+@dataclass
+class _Episode:
+    """The in-flight rollout: its wall start, the reset span, the un-drained step, and the un-drained
+    per-call inference latencies (ms)."""
+
+    wall_start: float  # perf_counter at begin
+    step: StepTiming = field(default_factory=StepTiming)
+    reset_s: float = 0.0
+    pending_infer_ms: list[float] = field(default_factory=list)
+
+
+class EvalTimer:
+    """Collects one rollout's wall-clock costs and hands them to the recorder to store in the episode.
+
+    The harness opens each episode (`begin_episode`); the recorder drains the accumulated per-tick costs and
+    inference latencies once per control tick (`drain_step`/`drain_infers`) and seals the episode at STOP
+    (`finish_episode`) — the same single thread, in order — so at most one episode is ever in flight.
+    """
+
+    def __init__(self) -> None:
+        self._current: _Episode | None = None
+
+    def begin_episode(self) -> None:
+        if self._current is not None:
+            logger.warning('EvalTimer: new episode began before the previous one finished; dropping the previous')
+        self._current = _Episode(wall_start=time.perf_counter())
+
+    def _record(self, phase: Phase, seconds: float) -> None:
+        """Accumulate a timed span. ``RESET`` is the once-per-episode reset; the rest fold into the in-flight
+        step. ``MATERIALIZE`` is part of the env step and also tracked apart (``env_client_s``) so the reduce
+        can split it out of the wire cost."""
+        if self._current is None:
+            return
+        step = self._current.step
+        match phase:
+            case Phase.RESET:
+                self._current.reset_s += seconds
+            case Phase.ENV_STEP:
+                step.env_step_s += seconds
+            case Phase.MATERIALIZE:
+                step.env_step_s += seconds
+                step.env_client_s += seconds
+            case Phase.RECORD_IO:
+                step.record_io_s += seconds
+
+    def add_infer(self, seconds: float) -> None:
+        """One policy round-trip: one pending sample of the per-call inference-latency signal (whole wait)."""
+        if self._current is not None:
+            self._current.pending_infer_ms.append(seconds * 1000.0)
+
+    def add_env_phases(self, phases: Mapping[str, float]) -> None:
+        """One env step's server-reported decomposition, an env-owned map of phase name to seconds; the phase
+        set is the env's own and is never enumerated here."""
+        if self._current is not None:
+            env_phases = self._current.step.env_phases
+            for name, seconds in phases.items():
+                env_phases[name] = env_phases.get(name, 0.0) + seconds
+
+    def drain_step(self) -> StepTiming | None:
+        """Return the per-tick costs accumulated since the last drain and reset the step. ``None`` when no
+        episode is in flight — the recorder then appends no timing sample this tick."""
+        if self._current is None:
+            return None
+        step = self._current.step
+        self._current.step = StepTiming()
+        return step
+
+    def drain_infers(self) -> list[float]:
+        """Return the policy round-trip latencies (ms) recorded since the last drain and clear them — each is
+        one sample of the per-call ``timing.infer_ms`` signal. Empty when no episode is in flight."""
+        if self._current is None:
+            return []
+        infers = self._current.pending_infer_ms
+        self._current.pending_infer_ms = []
+        return infers
+
+    def discard_episode(self) -> None:
+        """Drop the in-flight episode without sealing it (an abort)."""
+        self._current = None
+
+    def finish_episode(self) -> EpisodeTimingStatics | None:
+        """Seal the in-flight rollout and return its per-episode statics. ``None`` when none is in flight."""
+        acc = self._current
+        if acc is None:
+            return None
+        self._current = None
+        return EpisodeTimingStatics(
+            wall_s=time.perf_counter() - acc.wall_start, finished_at=time.time(), reset_s=acc.reset_s
+        )
+
+
+_ACTIVE: ContextVar[EvalTimer | None] = ContextVar('eval_timer', default=None)
+
+# Hook sites call these module functions, never the timer directly — each is a no-op when telemetry is off,
+# so a normal eval pays nothing and no site carries a ``None`` check.
+
+
+def begin_episode() -> None:
+    """Open a new rollout's timing span."""
+    if (timer := _ACTIVE.get()) is not None:
+        timer.begin_episode()
+
+
+def discard_episode() -> None:
+    """Drop the in-flight rollout without sealing it — an abort."""
+    if (timer := _ACTIVE.get()) is not None:
+        timer.discard_episode()
+
+
+def record_infer(seconds: float) -> None:
+    """Record one policy round-trip's wall time (one latency sample)."""
+    if (timer := _ACTIVE.get()) is not None:
+        timer.add_infer(seconds)
+
+
+def record_env_phases(phases: Mapping[str, float]) -> None:
+    """Record an env step's server-reported decomposition — a map of env-owned phase name to seconds. Each
+    phase ``<name>`` becomes a ``timing.env_<name>`` signal; this module never enumerates the phase set."""
+    if (timer := _ACTIVE.get()) is not None:
+        timer.add_env_phases(phases)
+
+
+def drain_signal_items() -> Iterator[tuple[str, float]]:
+    """One tick's drained wall-clock telemetry as ``(signal_name, seconds)`` pairs: each non-zero client-side
+    cost as its ``timing.<field>`` signal, each env-reported phase as its ``timing.env_<phase>`` signal, then
+    each policy round-trip as one ``timing.infer_ms`` sample. Empty when telemetry is off or the tick
+    accumulated nothing — the recorder appends whatever it yields, without knowing what the names mean."""
+    timer = _ACTIVE.get()
+    if timer is None:
+        return
+    step = timer.drain_step()
+    if step is not None and not step.is_empty():
+        for f in fields(step):
+            if f.name == 'env_phases':
+                continue
+            seconds = getattr(step, f.name)
+            if seconds != 0.0:
+                yield f'{TELEMETRY_PREFIX}{f.name}', seconds
+        for phase, seconds in step.env_phases.items():
+            if seconds != 0.0:
+                yield f'{TELEMETRY_PREFIX}env_{phase}', seconds
+    for infer_ms in timer.drain_infers():
+        yield INFER_MS_SIGNAL, infer_ms
+
+
+def finish_static_items() -> Iterator[tuple[str, float]]:
+    """Seal the in-flight rollout and yield the ``(static_key, value)`` pairs the recorder sets on it — the
+    per-episode wall scalars. Empty when telemetry is off or no rollout is in flight."""
+    timer = _ACTIVE.get()
+    if timer is None:
+        return
+    statics = timer.finish_episode()
+    if statics is not None:
+        yield WALL_S_KEY, statics.wall_s
+        yield FINISHED_AT_KEY, statics.finished_at
+        yield RESET_S_KEY, statics.reset_s
+
+
+class WriterHooks:
+    """The recorder's opaque view of this module's telemetry: per-tick ``(name, value)`` drains, a record-IO
+    span, and the seal/discard lifecycle. Every method is inert when no collector is bound (a normal eval), so
+    the recorder carries one unconditionally and pays nothing off the timing path."""
+
+    def record_io(self) -> contextlib.AbstractContextManager:
+        return timed(Phase.RECORD_IO)
+
+    def drain(self) -> Iterator[tuple[str, float]]:
+        return drain_signal_items()
+
+    def finish(self) -> Iterator[tuple[str, float]]:
+        return finish_static_items()
+
+    def discard(self) -> None:
+        discard_episode()
+
+
+@contextlib.contextmanager
+def bind() -> Iterator[EvalTimer]:
+    """Bind a fresh collector for the enclosed run; the hook functions are live only within it, so a normal
+    eval (no bind) pays nothing."""
+    timer = EvalTimer()
+    token = _ACTIVE.set(timer)
+    try:
+        yield timer
+    finally:
+        _ACTIVE.reset(token)
+
+
+@contextlib.contextmanager
+def timed(phase: Phase) -> Iterator[None]:
+    """Time the enclosed block into ``phase``. A no-op when telemetry is off, so a normal eval pays nothing."""
+    timer = _ACTIVE.get()
+    if timer is None:
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        timer._record(phase, time.perf_counter() - start)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -5,9 +5,11 @@ from enum import Enum
 from typing import Any
 
 import pimm
+from positronic import eval_timing
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.eval import Embodiment, Task
+from positronic.eval_timing import Phase
 from positronic.policy.base import Policy, Session
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils import flatten_dict, frozen_view
@@ -137,6 +139,11 @@ class Harness(pimm.ControlSystem):
             meta['eval.universe'] = 'sim' if self._embodiment.simulated else 'real'
             meta['eval.embodiment'] = self._embodiment.descriptor
             meta['eval.timeout'] = self._task.timeout
+            # Whether the eval scores success live: a scored task's ``done`` oracle emits ``eval.success``
+            # on a terminal, so its timeouts are real failures. An unscored eval (success judged downstream)
+            # leaves an episode with no ``eval.success`` simply unscored, not a failure — even when a
+            # ``done`` port is wired for trial lifecycle alone.
+            meta['eval.scored'] = self._task.scored
         # ``policy.meta`` is the static baseline (the wrapped policy aggregates model +
         # codec meta); the session overlays per-episode specifics (e.g. the sampled
         # sub-policy) and wins on conflict.
@@ -213,11 +220,13 @@ class Harness(pimm.ControlSystem):
         self.context = context
         # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
         self._inference_latency = self.context.get('inference_latency', False)
+        eval_timing.begin_episode()
         # Reset the scene before opening the session: a resettable task only learns its instruction on reset
         # (a remote env reports it then), so the session context — and the task-grouped sampling/counting it
         # drives — must read the instruction here, once it is known.
         if self._task is not None and self._task.reset is not None:
-            self._task.reset(self.context)
+            with eval_timing.timed(Phase.RESET):
+                self._task.reset(self.context)
         if self._task is not None:
             self.context = {**self.context, 'task': self._task.instruction}
         self._session = self.policy.new_session(self.context, clock.now)
@@ -328,6 +337,9 @@ class Harness(pimm.ControlSystem):
         actions = self._session(frozen_view(obs))
         if actions is None:
             return
+        # Only a chunk-producing call actually round-tripped the policy server; a ``None`` was the
+        # scheduler replaying a live chunk, no inference, so it is not a policy wait.
+        eval_timing.record_infer(time.monotonic() - wall_start)
         delay = self._inference_delay(wall_start)
         if delay > 0.0:
             yield pimm.Sleep(delay)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -745,6 +745,32 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
 
 
 @pytest.mark.timeout(3.0)
+@pytest.mark.parametrize('scored', [False, True])
+def test_scored_comes_from_task_not_done_wiring(world, scored):
+    """``eval.scored`` records the task's declared success oracle, not the presence of a ``done`` port
+    (regression: a lifecycle-only ``done`` stamped a downstream-scored eval as scored, so its timeouts
+    read as failures instead of unscored)."""
+
+    class _LifecycleOnly(pimm.ControlSystem):
+        def __init__(self):
+            self.done = pimm.ControlSystemEmitter(self)
+
+        def run(self, should_stop, clock):
+            yield pimm.Sleep(0.01)
+
+    task = Task(instruction='t', timeout=0.05, done=_LifecycleOnly().done, scored=scored)
+    harness = Harness(StubPolicy(), make_embodiment(), task=task, trials=[{}])
+    p = _pair_all(world, harness)
+
+    scheduler = world.start([harness])
+    drive_scheduler(scheduler, steps=400)
+
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert len(stops) == 1
+    assert stops[0].static_data['eval.scored'] is scored
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_plan_self_drives(world):
     """With a trial plan the harness runs unattended: no driver, one episode per entry."""
     policy = StubPolicy()

--- a/positronic/simulator/env_server/client.py
+++ b/positronic/simulator/env_server/client.py
@@ -23,14 +23,34 @@ class EnvConnection:
     bringing its runtime up — compiling shaders, loading assets — before it binds the port.
     """
 
-    def __init__(self, host: str, port: int, *, open_timeout: float = 10.0, connect_deadline: float = 1800.0):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        open_timeout: float = 10.0,
+        connect_deadline: float = 1800.0,
+        step_timeout: float = 120.0,
+        reset_timeout: float = 900.0,
+        close_timeout: float = 10.0,
+    ):
         uri = f'ws://{host}:{port}/'
+        # A single step is sub-second; a reset builds the scene (a RoboLab Isaac build runs into the minutes).
+        # Each bound is generous over its legitimate case, so it fires only on a wedged server, not a slow one.
+        self._step_timeout = step_timeout
+        self._reset_timeout = reset_timeout
+        self._close_timeout = close_timeout
         deadline = time.monotonic() + connect_deadline
         backoff = 0.5
         while True:
             try:
                 # Camera + full-state observations routinely exceed websockets' 1 MiB default frame size.
-                self._ws = connect(uri, open_timeout=open_timeout, max_size=None)
+                # Keepalive stays off: a multi-minute Isaac scene build holds the server's GIL in native code,
+                # starving its pong thread, so a client ping would kill a healthy connection mid-reset (observed
+                # as a 1011 close during a 10-minute RoboLab scene build). A wedged (alive but unresponsive)
+                # server is bounded instead per request by ``_request``'s recv timeout, and the connection's
+                # own liveness by the connect deadline.
+                self._ws = connect(uri, open_timeout=open_timeout, max_size=None, ping_interval=None)
                 break
             except (TimeoutError, OSError) as e:
                 if time.monotonic() >= deadline:
@@ -39,25 +59,30 @@ class EnvConnection:
                 backoff = min(backoff * 2, 5.0)
 
     def reset(self, token: Any) -> dict[str, Any]:
-        return self._request({'cmd': 'reset', 'token': token})
+        return self._request({'cmd': 'reset', 'token': token}, self._reset_timeout)
 
     def step(self, action: dict[str, Any]) -> dict[str, Any]:
-        return self._request({'cmd': 'step', 'action': action})
+        return self._request({'cmd': 'step', 'action': action}, self._step_timeout)
 
-    def _request(self, msg: dict[str, Any]) -> dict[str, Any]:
+    def _request(self, msg: dict[str, Any], timeout: float) -> dict[str, Any]:
         self._ws.send(encode(msg))
-        result = decode(self._ws.recv())
+        try:
+            raw = self._ws.recv(timeout=timeout)
+        except TimeoutError as e:
+            raise TimeoutError(f'env server did not respond to {msg["cmd"]!r} within {timeout:.0f}s') from e
+        result = decode(raw)
         if 'error' in result:
             raise RuntimeError(f'env server: {result["error"]}')
         return result
 
     def close(self) -> None:
-        # Best-effort: ask the server to release, but a peer that is already gone (a crashed or killed server) is
-        # success too — the socket is closed regardless.
+        # Best-effort: ask the server to release, but a peer that is already gone (crashed or killed) — or wedged
+        # and unresponsive — is success too; the socket closes regardless. Bound the ack wait so a wedged server
+        # (the case the request timeouts recover from) can't hang teardown here instead of at the request.
         try:
             self._ws.send(encode({'cmd': 'close'}))
-            self._ws.recv()
-        except ConnectionClosed:
+            self._ws.recv(timeout=self._close_timeout)
+        except (ConnectionClosed, TimeoutError):
             pass
         finally:
             self._ws.close()

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -14,9 +14,11 @@ from contextlib import AbstractContextManager, ExitStack
 from typing import Any
 
 import pimm
+from positronic import eval_timing
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation
+from positronic.eval_timing import Phase
 from positronic.simulator.env_server.adapter import EnvAdapter
 from positronic.simulator.env_server.client import EnvConnection
 
@@ -106,11 +108,20 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
                     # terminal, so the recorder samples it before any step advances the env.
                     self._reset_pending = False
                     self.robot_meta.emit(self._robot_meta)
-                    self._emit_payload(self._frame['obs'])
+                    # Frame-0 materialisation (allocating shared-memory image buffers and copying each camera
+                    # frame) is part of the reset cost, like ``_conn.reset``'s server-side render already under
+                    # ``reset_s`` — time it there so it isn't billed to ``overhead_s``.
+                    with eval_timing.timed(Phase.RESET):
+                        self._emit_payload(self._frame['obs'])
                     self.done.emit({})
                 elif self._active:
                     self._frame = self._step_env(clock)
-                    self._emit_payload(self._frame['obs'])
+                    # The step's observation is materialised client-side here (the adapter allocates
+                    # shared-memory image buffers and copies each camera frame). It is part of the env step —
+                    # matching the native path, so image-heavy remote runs don't bill it to ``overhead_s`` — but
+                    # tracked apart (``env_client_s``) so the reduce charges it to materialisation, not wire.
+                    with eval_timing.timed(Phase.MATERIALIZE):
+                        self._emit_payload(self._frame['obs'])
         finally:
             # Closes the connection then the server, in that order (reverse of acquisition); a no-op if no reset
             # ever connected.
@@ -118,7 +129,14 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
 
     def _step_env(self, clock: pimm.Clock) -> dict[str, Any]:
         commands = {name: receiver.read() for name, receiver in self.commands.items()}
-        result = self._conn.step(self._adapter.action(commands, clock.now_ns()))
+        with eval_timing.timed(Phase.ENV_STEP):
+            result = self._conn.step(self._adapter.action(commands, clock.now_ns()))
+        # An env server that decomposes its own step cost reports a disjoint phase map in the response; forward
+        # it unchanged so the reduce can split it out of the client-observed ``env_step_s``. The proxy neither
+        # names nor sums the phases — the env owns its decomposition.
+        timing = result.get('timing')
+        if timing is not None:
+            eval_timing.record_env_phases(timing)
         payload = self._adapter.terminal(result)
         if payload:  # truthy-valued done: a non-empty payload ends the trial, an empty/``None`` one continues
             self.done.emit(payload)

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -7,11 +7,12 @@ import mujoco as mj
 import numpy as np
 
 import pimm
-from positronic import geom
+from positronic import eval_timing, geom
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.ik import qpos_from_site_pose
 from positronic.drivers.roboarm.models import bundled_panda_model
+from positronic.eval_timing import Phase
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
 
 logger = logging.getLogger(__name__)
@@ -176,7 +177,10 @@ class MujocoSim(pimm.ControlSystem):
                 # the recorder samples it before any step advances the sim. ``reset`` already loaded the scene.
                 self._reset_pending = False
                 self._emit_robot_meta()
-                self._publish_frame()
+                # Frame-0 rendering is part of the reset cost, not overhead: the remote path likewise charges
+                # its reset's rendered first observation to ``reset_s``, so time this publish there too.
+                with eval_timing.timed(Phase.RESET):
+                    self._publish_frame()
                 continue
             now = clock.now()
             cmd_msg = self.commands.read()
@@ -199,16 +203,21 @@ class MujocoSim(pimm.ControlSystem):
                 self._last_grip = grip
             self._apply_grip(self._last_grip)
 
-            self.step()
-            self.fps_counter.tick()
-            if state_due(now):
-                self._emit_state()
-            if grip_due(now):
-                self._emit_grip()
-            if sim_state_due(now):
-                self._emit_sim_state()
-            if cameras_due(now):
-                self._emit_cameras()
+            # Charge the sim advance *and* the observation production it feeds (notably ``_emit_cameras`` ->
+            # ``_render``) to the env step: the remote env-server path times ``_conn.step()``, which returns
+            # rendered observations, so an image-heavy native sim must count rendering here too or its wall
+            # split reads rendering as ``overhead_s`` and is not comparable to the remote path.
+            with eval_timing.timed(Phase.ENV_STEP):
+                self.step()
+                self.fps_counter.tick()
+                if state_due(now):
+                    self._emit_state()
+                if grip_due(now):
+                    self._emit_grip()
+                if sim_state_due(now):
+                    self._emit_sim_state()
+                if cameras_due(now):
+                    self._emit_cameras()
 
         if self._renderer is not None:
             self._renderer.close()

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -22,6 +22,9 @@ path has no seed hook, so a recorded seed would only mislead.
 import argparse
 import os
 import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import cv2  # noqa: F401 -- robolab requires cv2 imported before isaaclab
@@ -29,7 +32,7 @@ import numpy as np
 import torch
 from isaaclab.app import AppLauncher
 from protocol import decode
-from server import EnvProtocol, EnvServer
+from server import EnvProtocol, EnvServer  # pyright: ignore[reportAttributeAccessIssue]
 
 # Isaac's rigid bring-up order: parse CLI args, launch the app, and only then import anything that touches the
 # omni/isaaclab runtime — which forces the second import block below and the module-level parse. ``validate.py``
@@ -37,6 +40,8 @@ from server import EnvProtocol, EnvServer
 parser = argparse.ArgumentParser(description='Serve RoboLab over the env-server protocol.')
 parser.add_argument('--host', default='localhost')
 parser.add_argument('--port', type=int)
+parser.add_argument('--camera-res', type=int, nargs=2, default=(1280, 720), metavar=('WIDTH', 'HEIGHT'))
+parser.add_argument('--disable-viewport', action='store_true')
 AppLauncher.add_app_launcher_args(parser)
 args, _ = parser.parse_known_args()
 args.enable_cameras = True  # not a CLI flag: every robolab runner forces it (the image obs need rendering)
@@ -45,6 +50,7 @@ simulation_app = AppLauncher(args).app
 import omni.kit.app  # noqa: E402
 import omni.timeline  # noqa: E402
 from isaaclab.controllers import DifferentialIKController, DifferentialIKControllerCfg  # noqa: E402
+from isaaclab.sensors import TiledCameraCfg  # noqa: E402  # pyright: ignore[reportMissingImports]
 from isaaclab.utils.math import (  # noqa: E402
     matrix_from_quat,
     quat_from_matrix,
@@ -52,13 +58,16 @@ from isaaclab.utils.math import (  # noqa: E402
     quat_mul,
     subtract_frame_transforms,
 )
+from omni.kit.viewport.utility import get_active_viewport  # noqa: E402  # pyright: ignore[reportMissingImports]
 
 import robolab.constants  # noqa: E402
 from robolab.core.environments.factory import get_envs  # noqa: E402
 from robolab.core.environments.runtime import create_env  # noqa: E402
 from robolab.core.logging.results import get_all_env_subtask_infos  # noqa: E402
 from robolab.registrations.droid.auto_env_registrations_jointpos import auto_register_droid_envs  # noqa: E402
+from robolab.robots import droid  # noqa: E402  # pyright: ignore[reportMissingImports]
 from robolab.robots.droid import EEF_OFFSET_ROT  # noqa: E402
+from robolab.variations.camera import OverShoulderLeftCameraCfg  # noqa: E402  # pyright: ignore[reportMissingImports]
 
 # Both flags gate recorder construction in the env cfg's ``__post_init__``, so they are set before any
 # ``create_env``: subtask progress feeds the wire ``subtask`` observation; per-step image recording only bloats
@@ -67,6 +76,30 @@ from robolab.robots.droid import EEF_OFFSET_ROT  # noqa: E402
 robolab.constants.ENABLE_SUBTASK_PROGRESS_CHECKING = True
 robolab.constants.RECORD_IMAGE_DATA = False
 robolab.constants.set_output_dir(tempfile.mkdtemp(prefix='robolab-env-'))
+
+# The policy cameras (RoboLab's WRIST_LEFT preset) render at a stock 1280x720 (16:9) while pi05-class
+# policies consume ~224x224, so most of the tile render is discarded. Keep any ``--camera-res`` override at
+# 16:9: the policies letterbox-pad each frame to a square, so an off-aspect render shifts the scene's
+# scale/padding in the policy input. The resolution override mutates the ORIGINAL
+# ``TiledCameraCfg`` objects: isaaclab's ``configclass`` strips class-level mutables into dataclass fields
+# whose ``default_factory`` deepcopies the captured original on every cfg instantiation, so writing the
+# originals (before any registration) reaches every task's scene. The wrist original is the ``droid`` module
+# global (``DroidCfg`` and ``WristCameraCfg`` both capture it); the over-shoulder original exists only inside
+# its factory's closure.
+_over_shoulder = (
+    OverShoulderLeftCameraCfg
+    .__dataclass_fields__['over_shoulder_left_camera']
+    .default_factory.__closure__[0]
+    .cell_contents
+)
+assert isinstance(_over_shoulder, TiledCameraCfg), _over_shoulder
+for _camera in (droid._WRIST_CAM, _over_shoulder):
+    _camera.width, _camera.height = args.camera_res
+
+if args.disable_viewport:
+    # The default viewport ('/OmniverseKit_Persp', 1280x720) renders every render step even headless, and
+    # nothing in this server consumes it.
+    get_active_viewport().updates_enabled = False
 
 
 def _load_robot_meta() -> dict[str, Any]:
@@ -79,6 +112,29 @@ def _load_robot_meta() -> dict[str, Any]:
         return {}
     with open(path, 'rb') as f:
         return decode(f.read())
+
+
+# Float slack tolerated on the phase-sum invariant: the measured spans and the whole-step wall are separate
+# ``perf_counter`` reads, so their difference can dip a hair below zero without any real double-count.
+_PHASE_SLACK_S = 1e-6
+
+
+@dataclass
+class _PhaseTimes:
+    """Wall time (seconds) of the native phases inside one RoboLab ``env.step``, zeroed each step."""
+
+    physics: float = 0.0
+    render: float = 0.0
+
+    def add_physics(self, seconds: float) -> None:
+        self.physics += seconds
+
+    def add_render(self, seconds: float) -> None:
+        self.render += seconds
+
+    def reset(self) -> None:
+        self.physics = 0.0
+        self.render = 0.0
 
 
 class RobolabEnv(EnvProtocol):
@@ -111,6 +167,18 @@ class RobolabEnv(EnvProtocol):
         self._timeline = omni.timeline.get_timeline_interface()
         self._kit_app = omni.kit.app.get_app()
 
+    def _timed_phase(self, method, add: Callable[[float], None]):
+        """``method`` wrapped to accumulate its wall time via ``add`` (one of ``_phase_s``'s phase adders)."""
+
+        def timed(*args, **kwargs):
+            start = time.perf_counter()
+            try:
+                return method(*args, **kwargs)
+            finally:
+                add(time.perf_counter() - start)
+
+        return timed
+
     def _build(self, task: str, instruction_type: str) -> None:
         if self._env is not None:
             self._env.close()  # release the prior task's env before create_env opens a fresh USD stage
@@ -122,6 +190,13 @@ class RobolabEnv(EnvProtocol):
             env_name, device=args.device, num_envs=1, instruction_type=instruction_type
         )
         self._control_dt = self._env_cfg.sim.dt * self._env_cfg.decimation
+        # The sim context's ``step`` (physics substeps) and ``render`` are the two native phases inside
+        # ``env.step``; both are re-wrapped per build (a new env brings a fresh SimulationContext). The sums
+        # feed the step response's ``timing`` and are zeroed at each ``step`` call, so reset-time rendering
+        # never leaks into a step's decomposition.
+        self._phase_s = _PhaseTimes()
+        self._env.sim.step = self._timed_phase(self._env.sim.step, self._phase_s.add_physics)
+        self._env.sim.render = self._timed_phase(self._env.sim.render, self._phase_s.add_render)
         # ``instruction`` is the resolved language goal (``create_env`` picks the variant); the rest is the
         # task identity the episode records.
         self._meta = {
@@ -172,6 +247,8 @@ class RobolabEnv(EnvProtocol):
         }
 
     def step(self, action: dict[str, Any]) -> dict[str, Any]:
+        start = time.perf_counter()
+        self._phase_s.reset()
         # Isaac pauses its timeline while assets stream in; stepping a paused sim stalls, so pump the kit
         # update loop until it plays again (robolab's episode loop does the same before every step).
         while not self._timeline.is_playing():
@@ -185,12 +262,27 @@ class RobolabEnv(EnvProtocol):
         # termination within the first two steps is a physics artifact its env resets in place and keeps
         # running (never frozen, no verdict), while a real success/time-out freezes the env and records one.
         done = self._env.all_terminated
-        return {
+        result = {
             'obs': self._observe(obs, self._subtask_progress()),
             'done': done,
             'success': done and bool(self._env.get_env_results()[0]['success']),
             'control_dt': self._control_dt,
         }
+        # The server's own step decomposition as disjoint additive phases summing to this call's whole wall
+        # (observation materialisation included): physics substeps, sensor/viewport rendering, and the residual
+        # ``server_other_s`` (managers, IK, plumbing) the client normalises against its socket-level step time.
+        # A phase timed inside another (e.g. rendering inside the physics loop) double-counts that wall and
+        # drives the residual negative, so raise rather than emit an untrustworthy split; a float dip is clamped.
+        wall_s = time.perf_counter() - start
+        physics_s, render_s = self._phase_s.physics, self._phase_s.render
+        server_other_s = wall_s - physics_s - render_s
+        if server_other_s < -_PHASE_SLACK_S:
+            raise ValueError(
+                f'env step wall {wall_s:.6f}s is below physics {physics_s:.6f}s + render {render_s:.6f}s: a '
+                f'phase is double-counted (timed inside another), so the step decomposition is not disjoint'
+            )
+        result['timing'] = {'physics_s': physics_s, 'render_s': render_s, 'server_other_s': max(server_other_s, 0.0)}
+        return result
 
     def _joint_targets(self, command: dict[str, Any]) -> torch.Tensor:
         """The wire command as the 7 absolute joint targets the jointpos substrate steps."""

--- a/positronic/simulator/robolab/launcher.py
+++ b/positronic/simulator/robolab/launcher.py
@@ -8,6 +8,7 @@ project.
 """
 
 import fcntl
+import functools
 import os
 import subprocess
 import tempfile
@@ -66,7 +67,7 @@ def _checkout_lock() -> Iterator[None]:
         yield
 
 
-def _spawn(host: str, port: int) -> subprocess.Popen:
+def _spawn(host: str, port: int, camera_res: tuple[int, int], render_viewport: bool) -> subprocess.Popen:
     with _checkout_lock():
         src = _ensure_robolab_src()
         # Install the dependency stack before spawning: a cold first install (~15 GB of Isaac wheels) far
@@ -87,8 +88,13 @@ def _spawn(host: str, port: int) -> subprocess.Popen:
         host,
         '--port',
         str(port),
+        '--camera-res',
+        str(camera_res[0]),
+        str(camera_res[1]),
         '--headless',
     ]
+    if not render_viewport:
+        command.append('--disable-viewport')
     # The DROID rig's model (URDF + meshes + gripper) for the viewer and offline IK. env.py runs in RoboLab's
     # interpreter and cannot build it, so it is serialized here (wire codec) and env.py emits it as
     # ``robot_meta``. A fresh temp file per spawn, in the container-local tmpdir — never the shared cache
@@ -110,6 +116,16 @@ def _spawn(host: str, port: int) -> subprocess.Popen:
     return subprocess.Popen(command, env=env)
 
 
-def serve_robolab(host: str = 'localhost') -> AbstractContextManager[tuple[str, int]]:
-    """The RoboLab env server as a ``serve`` context manager (the ``serve_subprocess`` contract)."""
-    return serve_subprocess(_spawn, host)
+def serve_robolab(
+    host: str = 'localhost', camera_res: tuple[int, int] = (320, 180), render_viewport: bool = True
+) -> AbstractContextManager[tuple[str, int]]:
+    """The RoboLab env server as a ``serve`` context manager (the ``serve_subprocess`` contract).
+
+    ``camera_res`` is the render size (width, height) of both policy cameras. Prefer a 16:9 ratio: RoboLab
+    renders natively at 16:9 (stock 1280x720) and the pi05-class policies letterbox-pad every frame to a
+    square (224x224), so a non-16:9 ``camera_res`` changes the scene's scale and padding inside that square
+    and shifts the policy off its training distribution. A smaller 16:9 size only cuts render cost, not the
+    aspect the policy sees. ``render_viewport=False`` stops the default viewport render product; at a fixed
+    aspect both only shift sim render cost, the wire contract is unchanged.
+    """
+    return serve_subprocess(functools.partial(_spawn, camera_res=camera_res, render_viewport=render_viewport), host)

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -88,7 +88,8 @@ def _check_obs_contract(env: RobolabEnv) -> None:
     out = env.reset(_TOKEN)
     assert abs(out['control_dt'] - 1 / 15) < 1e-6, f'control_dt {out["control_dt"]} != 1/15'
     step = env.step(_HOLD)
-    assert step.keys() == {'obs', 'done', 'success', 'control_dt'}, f'step keys {sorted(step)}'
+    assert step.keys() == {'obs', 'done', 'success', 'control_dt', 'timing'}, f'step keys {sorted(step)}'
+    assert step['timing'].keys() == {'physics_s', 'render_s', 'server_other_s'}, f'timing keys {sorted(step["timing"])}'
     for obs in (out['obs'], step['obs']):
         for key, (shape, dtype) in _OBS_SPECS.items():
             arr = obs[key]

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -26,7 +26,7 @@ import math
 import sys
 
 import numpy as np
-import torch
+import torch  # pyright: ignore[reportMissingImports]
 
 # Importing ``env`` launches the Isaac app — a precondition for every isaaclab/robolab import below.
 from env import RobolabEnv, simulation_app

--- a/positronic/tests/test_dataset_timing_boundary.py
+++ b/positronic/tests/test_dataset_timing_boundary.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import positronic.dataset
+
+_DATASET_ROOT = Path(positronic.dataset.__file__).parent
+
+
+def test_dataset_package_has_no_eval_timing_dependency():
+    """The dataset core stays agnostic to telemetry (comment 4): no module under ``positronic/dataset``
+    imports ``positronic.eval_timing`` or hard-codes the producer's ``timing.`` name prefix. Timing rides in
+    as opaque ``(name, value)`` pairs through ``TimingHooks``; the writer never learns what they mean."""
+    imports_eval_timing = []
+    hardcodes_prefix = []
+    for path in _DATASET_ROOT.rglob('*.py'):
+        src = path.read_text()
+        if 'eval_timing' in src:
+            imports_eval_timing.append(str(path.relative_to(_DATASET_ROOT)))
+        if "'timing.'" in src:
+            hardcodes_prefix.append(str(path.relative_to(_DATASET_ROOT)))
+    assert not imports_eval_timing, f'dataset modules must not reference eval_timing: {imports_eval_timing}'
+    assert not hardcodes_prefix, f"dataset modules must not hard-code the 'timing.' prefix: {hardcodes_prefix}"

--- a/positronic/tests/test_eval_timing.py
+++ b/positronic/tests/test_eval_timing.py
@@ -1,0 +1,76 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from positronic import eval_timing
+from positronic.cli.eval.timing_report import _load_episodes
+from positronic.dataset.local_dataset import LocalDatasetWriter
+from positronic.drivers import gpu_monitor
+from positronic.drivers.gpu_monitor import GpuMonitor, _GpuSample
+from positronic.eval_timing import FINISHED_AT_KEY, RESET_S_KEY, WALL_S_KEY
+
+
+def test_record_env_phases_maps_each_key_to_a_timing_env_signal():
+    """``record_env_phases`` namespaces each env-reported phase into a ``timing.env_<phase>`` signal and sums
+    repeated reports within a drain, with no phase set baked into the telemetry module (comment 2)."""
+    with eval_timing.bind():
+        eval_timing.begin_episode()
+        eval_timing.record_env_phases({'physics_s': 0.5, 'render_s': 0.25})
+        eval_timing.record_env_phases({'physics_s': 0.125, 'server_other_s': 0.4})
+        pairs = dict(eval_timing.drain_signal_items())
+    assert pairs == pytest.approx({
+        'timing.env_physics_s': 0.625,
+        'timing.env_render_s': 0.25,
+        'timing.env_server_other_s': 0.4,
+    })
+
+
+def test_gpu_monitor_retains_all_buffered_probes():
+    """A synchronous span longer than the sampling interval buffers several probes before the cooperative loop
+    runs; all are retained as one batch (not collapsed to the latest — Codex P1), each keeping its real capture
+    wall-ns, at strictly increasing timestamps placed at the drain instant."""
+    monitor = GpuMonitor()
+    monitor._buffer = [
+        _GpuSample(util_pct=10.0, mem_mib=100.0, proc_mem_mib=50.0, wall_ns=1),
+        _GpuSample(util_pct=20.0, mem_mib=200.0, proc_mem_mib=60.0, wall_ns=2),
+        _GpuSample(util_pct=30.0, mem_mib=300.0, proc_mem_mib=70.0, wall_ns=3),
+    ]
+    batch = monitor._drain_batch(now_ns=1000)
+    assert [sample.value['_util'] for sample in batch] == [10.0, 20.0, 30.0]
+    assert [sample.value['_wall_ns'] for sample in batch] == [1, 2, 3]
+    assert [sample.ts for sample in batch] == [1000, 1001, 1002]
+    assert monitor._buffer == []
+    assert monitor._drain_batch(now_ns=1000) == []  # an empty buffer on the next tick emits nothing
+
+
+def test_gpu_sample_none_on_nonnumeric_metric(monkeypatch):
+    """A metric reported as `[Not Supported]` / `N/A` (some MIG configs) is a successful nvidia-smi call with
+    non-numeric output; it must yield None (skip the sample), not raise in the daemon thread and permanently
+    stop sampling (Codex P2)."""
+    monkeypatch.setattr(gpu_monitor, '_run_nvidia_smi', lambda args: '[Not Supported], 1024\n')
+    assert gpu_monitor._read_gpu_sample('0') is None
+
+
+def test_timing_report_splits_reused_output_dir_into_runs(tmp_path):
+    """Two timed passes appended to one output_dir must not merge into one run — else the wall gap between them
+    counts as pass time and understates the real-time factor (Codex P1). Runs split at the invocation window
+    each episode was recorded in, read from the run_metadata_<ts>.yaml markers each invocation writes."""
+
+    def invocation_ns(hour):
+        return int(datetime(2026, 1, 1, hour, tzinfo=UTC).timestamp()) * 1_000_000_000
+
+    with LocalDatasetWriter(tmp_path) as writer:
+        for hour in (0, 2):  # two eval-run invocations, two hours apart, into the same dir
+            marker = datetime(2026, 1, 1, hour, tzinfo=UTC).strftime('%Y%m%d_%H%M%S')
+            (tmp_path / f'run_metadata_{marker}.yaml').write_text('')
+            for episode in range(2):
+                created = invocation_ns(hour) + (episode + 1) * 1_000_000_000
+                with writer.new_episode(created_ts_ns=created) as ep_writer:
+                    ep_writer.append('gpu_load', 0.0, ts_ns=created)
+                    ep_writer.set_static(WALL_S_KEY, 1.0)
+                    ep_writer.set_static(RESET_S_KEY, 0.1)
+                    ep_writer.set_static(FINISHED_AT_KEY, created / 1e9 + 1.0)
+
+    runs, facts = _load_episodes(tmp_path)
+    assert [len(run) for run in runs] == [2, 2]  # the two passes stay separate, not merged into one run
+    assert len(facts) == 4

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -1,7 +1,9 @@
 import pimm
+from positronic import eval_timing
 from positronic.dataset import DatasetWriter
 from positronic.dataset.ds_writer_agent import DsWriterAgent, TimeMode, TrajectoryOverrideSerializer
 from positronic.dataset.serializers import Serializers, StatefulSerializer
+from positronic.drivers.gpu_monitor import GpuMonitor
 from positronic.eval import ROBOT_STATIC_META, Embodiment, Observation
 
 __all__ = ['ROBOT_STATIC_META', 'wire', 'wire_embodiment']
@@ -31,7 +33,7 @@ def wire(
 
     ds_agent = None
     if dataset_writer is not None:
-        ds_agent = DsWriterAgent(dataset_writer, time_mode=time_mode)
+        ds_agent = DsWriterAgent(dataset_writer, time_mode=time_mode, timing=eval_timing.WriterHooks())
         for signal_name in cameras.keys():
             ds_agent.add_signal(signal_name, Serializers.camera_images)
         if robot_arm is not None:
@@ -67,6 +69,7 @@ def wire_embodiment(
     time_mode: TimeMode = TimeMode.CLOCK,
     privileged: dict[str, Observation] | None = None,
     done: pimm.SignalEmitter | None = None,
+    gpu_monitor: GpuMonitor | None = None,
 ):
     """Wire an embodiment to the Harness for the inference path.
 
@@ -75,6 +78,9 @@ def wire_embodiment(
     chunks, and the task's privileged ground-truth into the dataset. The task's ``done``
     terminating signal, when present, is connected to ``harness.done``. GUI camera wiring
     stays with the caller — it is a presentation concern, not part of the embodiment contract.
+
+    ``gpu_monitor`` (present only under ``--timing``) records the box's GPU as a ``timing.gpu``
+    signal fanned out to ``timing.gpu_*``; the caller runs it as a foreground control system.
     """
     privileged = privileged or {}
     for name, obs in embodiment.observations.items():
@@ -88,7 +94,9 @@ def wire_embodiment(
 
     ds_agent = None
     if dataset_writer is not None:
-        ds_agent = DsWriterAgent(dataset_writer, time_mode=time_mode, virtual_time=embodiment.simulated)
+        ds_agent = DsWriterAgent(
+            dataset_writer, time_mode=time_mode, virtual_time=embodiment.simulated, timing=eval_timing.WriterHooks()
+        )
         for name, obs in embodiment.observations.items():
             if isinstance(obs.serializer, StatefulSerializer):
                 raise TypeError(f"observation '{name}': stateful serializer can't be shared by policy and record paths")
@@ -102,5 +110,8 @@ def wire_embodiment(
         for name, priv in privileged.items():
             ds_agent.add_signal(name, priv.serializer)
             world.connect(priv.source, ds_agent.inputs[name])
+        if gpu_monitor is not None:
+            ds_agent.add_signal('timing.gpu')
+            world.connect(gpu_monitor.output, ds_agent.inputs['timing.gpu'])
 
     return ds_agent


### PR DESCRIPTION
## What

Adds opt-in per-rollout wall-clock telemetry to `positronic eval run` (`--timing`) and a `positronic eval timing-report` reduce step. Built to produce the measured sizing inputs for the Nebius competition (`internal#55`), but general: it works for any sim eval, not just RoboLab.

## How it works (the flow)

Two commands, a **producer → reducer** pipeline over the recorded dataset:

1. **`positronic eval run … --timing`** (producer) — runs the eval exactly as normal; the flag binds an `EvalTimer` for the `World` run. Instrumented hook sites stamp each rollout's wall costs (policy-inference wait, env reset, env step, record IO) with `perf_counter` and record them **onto the recorded episode itself** — the per-tick phase costs and per-call inference latencies as `timing.*` signals, the once-per-episode wall/finish scalars as episode statics — plus a background `nvidia-smi dmon` → **`gpu_dmon.log`**. With the flag off, every hook is a no-op — a normal eval pays nothing.

2. **`positronic eval timing-report <dataset_dir>`** (reducer) — reads each episode's `timing.*` signals + statics, **joined to the recorded episode by `episode_uid`** to recover what the dataset already holds (duration → RTF, on-disk size → bytes/rollout, `eval.scored` → success rate), and emits the pass-level wall-clock roll-up: phase split, real-time factor, policy-busy fraction, p50/p95 inference latency, bytes/rollout, GPU util/VRAM. Prints locally, or writes a sibling `<dataset_dir>.timing_summary.json` when the dataset lives on S3.

**Why two commands, not one (and not duplicates):** the producer *must* run inside the live eval on its virtual clock to catch wall time the recorded dataset can never recover; the reducer is a pure offline reduce that stores nothing the dataset can already reconstruct — so it re-runs any time against a finished dataset without re-running the eval.

## Design notes

- A sim eval runs on a **virtual clock**, so recorded signal timestamps say nothing about real compute. The timer captures *only* the wall costs that are otherwise unrecoverable, written into the dataset's own signals/statics; everything the dataset can recover is left to the join (nothing stored twice — per `dataset/CLAUDE.md`). Telemetry lands under a reserved `timing.` signal namespace so it never perturbs episode bounds.
- The collector is bound around an eval sweep via a `ContextVar`; hook sites reach it through this module's hook functions (`begin_episode`, `record_infer`, `timed`, ...). **Unbound (the default), every hook is a no-op.** Sim-only by construction — a real eval runs recorder/producers in separate processes that don't inherit the context, so `--timing` currently raises for a real embodiment instead of recording an empty signal.
- The env server decomposes its own in-step wall (physics / render / server plumbing) and reports it back, so `timing-report` can split the env step into physics, render, and wire+codec.
- `--timing` also spawns `nvidia-smi dmon` pinned to the eval's GPU (no-op when absent); the reducer folds it (and an optional policy-endpoint log) into the pass report.

## Files

- **Collector:** `positronic/eval_timing.py` — `EvalTimer`, `EpisodeTimingStatics`, `bind`/`begin_episode`/`timed`, GPU sampler.
- **Reducer:** `positronic/cli/eval/timing_report.py` — the offline dataset join + `nvidia-smi dmon` parser; `cli/eval/__init__.py`, `cli/eval/run.py` wire the `--timing` flag and the subcommand.
- **Telemetry namespace:** `positronic/dataset/episode.py` — reserved `timing.` prefix; episode bounds derive from content signals only.
- **Hook sites** (guarded, ~2–4 lines each): `policy/harness.py` (infer wait, episode begin/`eval.scored`, reset), `simulator/mujoco/sim.py` (native env step + reset render), `simulator/env_server/proxy.py` (remote env step + frame materialisation), `dataset/ds_writer_agent.py` (record IO + finish/discard).
- **Env-server decomposition:** `simulator/robolab/{env,launcher}.py`, `simulator/env_server/client.py` — report the physics/render/server split; `cfg/eval/sim/robolab.py` adds `camera_res` / `render_viewport` render knobs.

## Testing

- `ruff check` / `ruff format` clean.
- Existing harness / dataset / env_server / inference-integration suites pass — hooks don't perturb the loop.
- Functional smoke of the timer round-trip, report join, dmon parse, and abort-discard path. No new test files per repo convention (`Testing` in CLAUDE.md).

## Notes for review

- **`eval.scored` metadata** — the harness now records `eval.scored` per episode, declared by the `Task` (not derived from `done` wiring), so the reducer reports success rate only over episodes that are actually scored live (native sim scores downstream → unscored; RoboLab/LIBERO score live). New recorded key worth a look.
- **Native-sim timing scope** — instrumenting `mujoco/sim.py` widened coverage beyond the original remote-RoboLab focus; the env-step timer there includes camera rendering, matching the remote path.
- **S3 summary upload is unexercised in sandbox** — the sibling-key path (`<dataset_dir>.timing_summary.json`) is conflict-check-proven against pos3's own `_s3_paths_conflict` and green locally, but the first real `timing-report` on an S3 dataset is the true confirmation. Happy to drop the S3 convenience and keep the PR to the local path if preferred.
