### PR TITLE
Run ruff at commit time only, drop edit-time hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,18 +42,6 @@
           }
         ]
       }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path' | { read file_path; if echo \"$file_path\" | grep -qE '\\.py$'; then uv run ruff check --fix -q \"$file_path\" 2>/dev/null; uv run ruff format -q \"$file_path\" 2>/dev/null; fi; }",
-            "timeout": 30
-          }
-        ]
-      }
     ]
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff - linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.2
     hooks:
       # Run the linter
       - id: ruff


### PR DESCRIPTION
Ruff was running on every file edit via a Claude Code `PostToolUse` hook — redundant with pre-commit and wasteful. This moves ruff to commit time only.

- Remove the edit-time ruff hook from `.claude/settings.json`
- Bump `ruff-pre-commit` `v0.8.4` → `v0.15.2` to match the locked ruff (prevents commit-time vs `uv run ruff` drift)

pre-commit was already configured and installed in the repo, so ruff still runs on every commit.