### PR TITLE
Fix `pimm.utils` typing: real `map` signature, T→U generic, variance

### DIFF
--- a/pimm/tests/test_utils.py
+++ b/pimm/tests/test_utils.py
@@ -135,6 +135,28 @@ class TestMapSignalReceiver:
         assert result is not None
         assert result.updated is False
 
+    def test_filter_does_not_mutate_previously_returned_message(self):
+        """Regression: a filtered read returns a fresh stale copy, not the cached message.
+
+        Flipping ``updated`` on the cached object and handing it back aliases any
+        reference a caller still holds from an earlier read.
+        """
+        mock_reader = Mock(spec=SignalReceiver)
+        map_reader = MapSignalReceiver(mock_reader, lambda x: x if x < 20 else None)
+
+        mock_reader.read.return_value = Message(data=10, ts=100)
+        first = map_reader.read()
+        assert first is not None
+        assert first.updated is True
+
+        mock_reader.read.return_value = Message(data=30, ts=200)
+        stale = map_reader.read()
+        assert stale is not None
+        assert stale.data == 10
+        assert stale.updated is False
+        assert stale is not first
+        assert first.updated is True
+
 
 class TestMapSignalEmitter:
     """Test the MapSignalEmitter class."""

--- a/pimm/utils.py
+++ b/pimm/utils.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, overload
 
 from pimm import Message, SignalEmitter, SignalReceiver
 from pimm.core import Clock, Command, Sleep, Yield
@@ -65,9 +65,32 @@ class MapSignalEmitter(SignalEmitter[T], Generic[T, U]):
             self.emitter.emit(transformed_data, ts)
 
 
-def map(
-    func: Callable[[T], U | None],
-) -> Callable[[SignalReceiver[T] | SignalEmitter[U]], SignalReceiver[U] | SignalEmitter[T]]:
+class SignalMapWrapper(Generic[T, U]):
+    """The wrapper ``map`` returns: it preserves the signal kind while mapping T->U.
+
+    A ``SignalReceiver[T]`` in yields a ``SignalReceiver[U]``; a ``SignalEmitter[U]``
+    in yields a ``SignalEmitter[T]``. The overloads keep the two kinds from mixing.
+    """
+
+    def __init__(self, func: Callable[[T], U | None]):
+        self.func = func
+
+    @overload
+    def __call__(self, signal: SignalReceiver[T]) -> SignalReceiver[U]: ...
+
+    @overload
+    def __call__(self, signal: SignalEmitter[U]) -> SignalEmitter[T]: ...
+
+    def __call__(self, signal: SignalReceiver[T] | SignalEmitter[U]) -> SignalReceiver[U] | SignalEmitter[T]:
+        if isinstance(signal, SignalReceiver):
+            return MapSignalReceiver(signal, self.func)
+        elif isinstance(signal, SignalEmitter):
+            return MapSignalEmitter(signal, self.func)
+        else:
+            raise ValueError(f'Invalid signal type: {type(signal)}')
+
+
+def map(func: Callable[[T], U | None]) -> SignalMapWrapper[T, U]:
     """Transform or filter values passing through a signal.
 
     Returns a wrapper that applies func to all values. If func returns None,
@@ -78,21 +101,13 @@ def map(
         func: Callable that maps a value of type T to U, or returns None to filter.
 
     Returns:
-        A function that wraps a SignalReceiver or SignalEmitter with the transform.
+        A wrapper that maps a SignalReceiver[T] to a SignalReceiver[U], or a
+        SignalEmitter[U] to a SignalEmitter[T].
 
     Raises:
         ValueError: If the provided signal is not a SignalReceiver or SignalEmitter.
     """
-
-    def wrapper(signal: SignalReceiver[T] | SignalEmitter[U]) -> SignalReceiver[U] | SignalEmitter[T]:
-        if isinstance(signal, SignalReceiver):
-            return MapSignalReceiver(signal, func)
-        elif isinstance(signal, SignalEmitter):
-            return MapSignalEmitter(signal, func)
-        else:
-            raise ValueError(f'Invalid signal type: {type(signal)}')
-
-    return wrapper
+    return SignalMapWrapper(func)
 
 
 class RateLimiter:

--- a/pimm/utils.py
+++ b/pimm/utils.py
@@ -37,6 +37,7 @@ class MapSignalReceiver(SignalReceiver[U], Generic[T, U]):
         if transformed_data is None:
             if self.last_message is None:
                 return None
+            # Return a fresh stale copy, not the cached mutable Message, so earlier callers' references don't flip.
             return Message(self.last_message.data, self.last_message.ts, False)
 
         self.last_message = Message(transformed_data, orig_message.ts, orig_message.updated)

--- a/pimm/utils.py
+++ b/pimm/utils.py
@@ -1,42 +1,43 @@
 import logging
 import time
 from collections.abc import Callable
-from typing import TypeVar, overload
+from typing import Generic, TypeVar
 
 from pimm import Message, SignalEmitter, SignalReceiver
 from pimm.core import Clock, Command, Sleep, Yield
 
-T = TypeVar('T', covariant=True)
-K = TypeVar('K', covariant=True)
+T = TypeVar('T')
+U = TypeVar('U')
 
 
 def identity(x):
     return x
 
 
-class MapSignalReceiver(SignalReceiver[T]):
+class MapSignalReceiver(SignalReceiver[U], Generic[T, U]):
     """Transform and filter signal data on read.
 
-    If func returns None, the value is filtered out and receiver behaves
-    like it didn't see the filtered message.
+    The wrapped receiver produces ``T``; ``func`` maps it to ``U`` and this
+    receiver reads ``U`` out. If func returns None, the value is filtered out
+    and the receiver behaves like it didn't see the filtered message.
     """
 
-    def __init__(self, receiver: SignalReceiver[T], func: Callable[[T], T | None]):
+    def __init__(self, receiver: SignalReceiver[T], func: Callable[[T], U | None]):
         self.receiver = receiver
         self.func = func
 
-        self.last_message: Message[T] | None = None
+        self.last_message: Message[U] | None = None
 
-    def read(self):
+    def read(self) -> Message[U] | None:
         orig_message = self.receiver.read()
         if orig_message is None:
             return None
 
         transformed_data = self.func(orig_message.data)
         if transformed_data is None:
-            if self.last_message is not None:
-                self.last_message.updated = False
-            return self.last_message
+            if self.last_message is None:
+                return None
+            return Message(self.last_message.data, self.last_message.ts, False)
 
         self.last_message = Message(transformed_data, orig_message.ts, orig_message.updated)
         return self.last_message
@@ -45,14 +46,16 @@ class MapSignalReceiver(SignalReceiver[T]):
         self.receiver = receiver
 
 
-class MapSignalEmitter(SignalEmitter[T]):
+class MapSignalEmitter(SignalEmitter[T], Generic[T, U]):
     """Transform and filter signal data on emit.
 
-    If func returns None, the value is filtered out and nothing is emitted.
-    This enables conditional filtering at the emission point.
+    The caller emits ``T``; ``func`` maps it to ``U`` and this emitter forwards
+    ``U`` to the wrapped emitter. If func returns None, the value is filtered
+    out and nothing is emitted. This enables conditional filtering at the
+    emission point.
     """
 
-    def __init__(self, emitter: SignalEmitter[T], func: Callable[[T], T | None]):
+    def __init__(self, emitter: SignalEmitter[U], func: Callable[[T], U | None]):
         self.emitter = emitter
         self.func = func
 
@@ -62,17 +65,9 @@ class MapSignalEmitter(SignalEmitter[T]):
             self.emitter.emit(transformed_data, ts)
 
 
-@overload
-def map(signal: SignalReceiver[T], func: Callable[[T], T | None]) -> SignalReceiver[T]: ...
-
-
-@overload
-def map(signal: SignalEmitter[T], func: Callable[[T], T | None]) -> SignalEmitter[T]: ...
-
-
 def map(
-    func: Callable[[T], T | None],
-) -> Callable[[SignalReceiver[T] | SignalEmitter[T]], SignalReceiver[T] | SignalEmitter[T]]:
+    func: Callable[[T], U | None],
+) -> Callable[[SignalReceiver[T] | SignalEmitter[U]], SignalReceiver[U] | SignalEmitter[T]]:
     """Transform or filter values passing through a signal.
 
     Returns a wrapper that applies func to all values. If func returns None,
@@ -80,7 +75,7 @@ def map(
     skip emission entirely.
 
     Args:
-        func: Callable that transforms type T to T, or returns None to filter.
+        func: Callable that maps a value of type T to U, or returns None to filter.
 
     Returns:
         A function that wraps a SignalReceiver or SignalEmitter with the transform.
@@ -89,7 +84,7 @@ def map(
         ValueError: If the provided signal is not a SignalReceiver or SignalEmitter.
     """
 
-    def wrapper(signal: SignalReceiver[T] | SignalEmitter[T]) -> SignalReceiver[T] | SignalEmitter[T]:
+    def wrapper(signal: SignalReceiver[T] | SignalEmitter[U]) -> SignalReceiver[U] | SignalEmitter[T]:
         if isinstance(signal, SignalReceiver):
             return MapSignalReceiver(signal, func)
         elif isinstance(signal, SignalEmitter):


### PR DESCRIPTION
Fixes the typing bugs in `pimm/utils.py` tracked in `Positronic-Robotics/internal#53` — the outright-wrong signatures the typing ratchet (`#52`) would surface first over `pimm/`. No runtime behavior changes except the `read()` aliasing fix.

## What was wrong

- **`map`'s `@overload`s described a function that doesn't exist.** They declared a 2-arg `map(signal, func) -> wrapped signal`, but the implementation is 1-arg curried `map(func) -> wrapper`. `map(signal, func)` raises `TypeError` at runtime, and every real call site (`pimm.map(func)` in `inference.py:57`, `data_collection.py:213/260`, `replay_record.py:150`) matched *neither* overload. Because `@overload` replaces the implementation signature for type checkers, the typing was exactly inverted from reality.
- **`Callable[[T], T | None]` was counterfactual.** All three call sites map *across* types (`State`→`float`, `NumpySMAdapter`→`np.ndarray`, keyboard input→`Directive`). The single-`T` signature contradicted every usage.
- **Covariant `T` used in a parameter position** (`utils.py:9` → `MapSignalEmitter.emit(self, data: T)`) — illegal, and wrong in principle (receivers produce `T`, emitters consume it; one covariant `T` can't serve both). Plus an unused covariant `K`.
- **`MapSignalReceiver.read` aliasing bug (adjacent, not typing):** on a filtered value it mutated the cached `Message.updated = False` and returned that same object, so a caller holding a reference from an earlier read saw `updated` flip underneath it. `Message` is a mutable dataclass, so this is real aliasing.

## The fix

- Keep the real 1-arg curried `map`; delete the wrong overloads; give it a truthful signature.
- `MapSignalReceiver(SignalReceiver[U], Generic[T, U])` / `MapSignalEmitter(SignalEmitter[T], Generic[T, U])` — map across types, invariant `T`/`U` matching `pimm.core`. Drop covariant `T` and unused `K`.
- `read()` returns a fresh stale `Message` copy on filter instead of mutating the cache.

## Verification

- `basedpyright` (standard mode, the ratchet's checker) on `pimm/utils.py`: **6 errors → 1**. The remaining one is the pre-existing repo-wide `Message.data: T | None` → `func` pattern that lives in `core.py`'s `Message`/`value` contract — explicitly out of scope for this ticket (`#52` P3 handles it per-module).
- `pytest pimm/` — 110 pass, incl. a new regression test (`test_filter_does_not_mutate_previously_returned_message`) that fails on the old `read()` and passes on the new.
- `ruff check` / `ruff format --check` clean.

Refs `Positronic-Robotics/internal#53`.