### PR TITLE
docs: genericize hardcoded `vertix` home path in remote-docker docs

### DIFF
--- a/.claude/skills/remote-training/SKILL.md
+++ b/.claude/skills/remote-training/SKILL.md
@@ -243,7 +243,7 @@ truth** for which machine/GPU/service to use (`desktop` = RTX 3060 12GB,
 `notebook` = RTX 4060 8GB). OpenPI/DreamZero and GR00T *training* still need
 H100 (use the Nebius pipeline above).
 
-Run from `docker/`. Set `CACHE_ROOT=/home/vertix` when targeting a remote
+Run from `docker/`. Set `CACHE_ROOT=/home/<user>` when targeting a remote
 context from a Mac (the `${HOME}` volume path differs). `--service-ports`
 exposes the WebSocket API on port 8000. Servers take a subcommand: `serve` for
 a custom `--checkpoints_dir`, or a named preset (`phail`, `sim_stack`, …) —
@@ -251,15 +251,15 @@ check the vendor's `server.py` for available presets.
 
 ```bash
 # Named preset (desktop)
-CACHE_ROOT=/home/vertix docker --context desktop compose run --rm --pull always \
+CACHE_ROOT=/home/<user> docker --context desktop compose run --rm --pull always \
   --service-ports lerobot-0_3_3-server sim_stack
 
 # Custom checkpoint
-CACHE_ROOT=/home/vertix docker --context desktop compose run --rm --pull always \
+CACHE_ROOT=/home/<user> docker --context desktop compose run --rm --pull always \
   --service-ports lerobot-server serve --checkpoints_dir=<ckpt-dir>
 
 # GR00T inference — codec subcommand required
-CACHE_ROOT=/home/vertix docker --context notebook compose run --rm --pull always \
+CACHE_ROOT=/home/<user> docker --context notebook compose run --rm --pull always \
   --service-ports groot-server ee_rot6d --checkpoints_dir=<ckpt-dir>
 ```
 

--- a/docker/CONTEXTS.md
+++ b/docker/CONTEXTS.md
@@ -25,13 +25,13 @@ Build and push all: `make push`
 
 ## Remote docker compose
 
-When running `docker --context <remote> compose run ...`, volume paths in `docker-compose.yml` expand `${HOME}` locally (e.g. `/Users/vertix`), but the remote machine expects `/home/vertix`. Set `CACHE_ROOT` to the remote home:
+When running `docker --context <remote> compose run ...`, volume paths in `docker-compose.yml` expand `${HOME}` locally (e.g. `/Users/<user>`), but the remote machine expects `/home/<user>`. Set `CACHE_ROOT` to the remote home:
 
 ```bash
-CACHE_ROOT=/home/vertix docker --context vm-train compose run -d --service-ports openpi-server ...
+CACHE_ROOT=/home/<user> docker --context vm-train compose run -d --service-ports openpi-server ...
 ```
 
 ## VM management
 
 Start: `../internal/scripts/start.sh train`
-Check: `ssh -o ConnectTimeout=5 vertix@vm-train 'echo ok'`
+Check: `ssh -o ConnectTimeout=5 <user>@vm-train 'echo ok'`

--- a/docker/docker-compose.spoons-ablation.yml
+++ b/docker/docker-compose.spoons-ablation.yml
@@ -1,7 +1,7 @@
 # GR00T spoons data ablation servers (~4.6GB each, 2 fit on desktop, 1 on notebook)
 #
 # Desktop (2 servers):
-#   IMAGE_TAG=latest CACHE_ROOT=/home/vertix docker --context desktop compose -f docker-compose.spoons-ablation.yml up spoons-100 spoons-50
+#   IMAGE_TAG=latest CACHE_ROOT=/home/<user> docker --context desktop compose -f docker-compose.spoons-ablation.yml up spoons-100 spoons-50
 # Notebook (1 server):
 #   IMAGE_TAG=latest docker --context notebook compose -f docker-compose.spoons-ablation.yml up spoons-25
 services:


### PR DESCRIPTION
The remote docker-compose docs hardcoded `/home/vertix` (also `/Users/vertix`, `vertix@vm-train`) as `CACHE_ROOT` for a remote context. This is a **public** repo — an external user's home isn't `/home/vertix`, so the documented command is wrong for them, and it needlessly bakes in a personal username.

Replaced with the `<user>` placeholder the repo already uses elsewhere (`positronic/vendors/dreamzero/README.md` uses `/home/<user>` / `$HOME`).

**Files:**
- `docker/CONTEXTS.md`
- `.claude/skills/remote-training/SKILL.md`
- `docker/docker-compose.spoons-ablation.yml`

Docs-only; no behavior change.

**Not touched (deliberately):** the Nebius project/subnet/cache-FS ID defaults in `workflows/nebius/*` — opaque resource handles with no auth value (same class as the project ID `AGENTS.md` already blesses), and the README already flags them for external override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)