### PR TITLE
Record each episode's `.rrd` filename in its dataset meta

### DIFF
--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -302,6 +302,7 @@ class Recorder:
         self._timelines = dict(timelines) if timelines is not None else dict(DEFAULT_TIMELINES)
         self._blueprint = blueprint
         self._stream: rr.RecordingStream | None = None
+        self._rrd_path: Path | None = None
         self._live = 0
         self._depth = 0
         self._timeline_values: dict[str, Any] = {}
@@ -322,8 +323,9 @@ class Recorder:
         if self._live == 0:
             episode_num = next(_EPISODE_COUNTER)
             ts = datetime.now().strftime('%y%m%d_%H%M%S')
+            self._rrd_path = self._dir / f'{ts}_{episode_num:04d}.rrd'
             self._stream = rr.RecordingStream(application_id='positronic_inference')
-            self._stream.save(str(self._dir / f'{ts}_{episode_num:04d}.rrd'))
+            self._stream.save(str(self._rrd_path))
         self._live += 1
         return self._stream
 
@@ -352,6 +354,10 @@ class _RecordingTapSession(DelegatingSession):
         self._name = name
         self._stream = stream
         self._step = 0
+
+    @property
+    def meta(self):
+        return {**self._inner.meta, 'recording.rrd': self._rec._rrd_path.name}
 
     def _set_timelines(self) -> None:
         for timeline, value in self._rec._timeline_values.items():

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -357,7 +357,7 @@ class _RecordingTapSession(DelegatingSession):
 
     @property
     def meta(self):
-        return {**self._inner.meta, 'recording.rrd': self._rec._rrd_path.name}
+        return {**self._inner.meta, 'recording.rrd': str(self._rec._rrd_path)}
 
     def _set_timelines(self) -> None:
         for timeline, value in self._rec._timeline_values.items():


### PR DESCRIPTION
## Summary
- The client-side inference `Recorder` now retains the `.rrd` path it opens for each episode and surfaces its basename through `session.meta` as `recording.rrd`.
- `Harness._build_episode_meta` already folds `session.meta` into each recorded episode, so this lands in every episode's meta as `inference.policy.recording.rrd`.
- A recorded rollout episode can now be matched to its RRD by a metadata lookup instead of correlating wall-clock timestamps.

The recorder reports its own filename *up* the existing meta channel — no episode ids are threaded *down* into the policy API, and the `Harness`/`Policy`/`Session` interfaces are untouched.

## Test plan
- `uv run --locked --extra dev pytest --no-cov` — 603 passed, 7 skipped.
- Verified a recording session's `.meta` carries `recording.rrd` = the created `.rrd` basename, and that it appears in flattened episode meta as `inference.policy.recording.rrd`.