### PR TITLE
Document the loop-ownership and dataset invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Monitor performance, collect edge cases, and iterate. See [Inference Guide](docs
 - [LeRobot ACT](positronic/vendors/lerobot_0_3_3/README.md) — Single-task transformer
 
 **Guides:**
+- [Architecture Invariants](docs/architecture.md) — who owns the control loop, and how foreign components plug in
 - [Model Selection](docs/model-selection.md) | [Codecs](docs/codecs.md) | [Training](docs/training-workflow.md)
 - [Data Collection](docs/data-collection.md) | [Inference](docs/inference.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,10 +15,10 @@ Positronic; Positronic runs the loop and calls into it.
 ## Every run produces a Positronic dataset
 
 The dataset is the invariant output. Any run — eval or collection, sim or real, whatever the
-scoring — records the complete episode as a Positronic dataset (signals, episode meta, per-episode
-`.rrd`) under its output directory. Scores, videos, and metrics are derived from data the loop
-recorded; they never replace the dataset, and an integration path that yields scores without the
-dataset is not acceptable.
+scoring — records the complete episode as a Positronic dataset (signal files plus episode meta, in
+the native dataset layout) under its output directory. Scores, videos, and metrics are derived from
+data the loop recorded; they never replace the dataset, and an integration path that yields scores
+without the dataset is not acceptable.
 
 ## Foreign components plug in through shims
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,18 +16,21 @@ Positronic; Positronic runs the loop and calls into it.
 
 The dataset is the invariant output. Any run — eval or collection, sim or real, whatever the
 scoring — records the complete episode as a Positronic dataset (signal files plus episode meta, in
-the native dataset layout) under its output directory. Scores, videos, and metrics are derived from
-data the loop recorded; they never replace the dataset, and an integration path that yields scores
-without the dataset is not acceptable.
+the native dataset layout) under its output directory. An operator may omit the output directory to
+throw a smoke run away; that is a per-run choice, not an integration shape — every integration
+records through the same writer path, and none may exist that can only produce scores without the
+dataset. Scores, videos, and metrics are derived from data the loop recorded; they never replace
+the dataset.
 
 ## Foreign components plug in through shims
 
 A third-party component joins by having its interface wrapped into Positronic's APIs — never by
-Positronic's components being wrapped into its:
+Positronic's components being wrapped into its. (Positronic's own MuJoCo sim is native: it runs
+in-process inside the world and needs no shim.)
 
 | Foreign component | Runs as | Shim into our API |
 |---|---|---|
-| Simulator (LIBERO, Isaac Lab / RoboLab, MuJoCo) | env server in its own interpreter, behind the `env_server` wire | client-side `EnvAdapter` mapping the canonical embodiment contract ↔ the sim's raw payloads |
+| Foreign simulator (LIBERO, Isaac Lab / RoboLab) | env server in its own interpreter, behind the `env_server` wire | client-side `EnvAdapter` mapping the canonical embodiment contract ↔ the sim's raw payloads |
 | Model stack (LeRobot, GR00T, OpenPI) | inference server behind the WebSocket wire | vendor `Codec` translating raw observations ↔ model I/O |
 | Scenes / task batteries | instantiated inside the env server | reset tokens (suite, task, seed) carried through the `EnvAdapter` |
 | Scoring / success criteria | computed where the ground truth lives (usually the env server) | reported alongside observations and recorded into the dataset; aggregation happens on the Positronic side |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture invariants
+
+Every integration in Positronic — a simulator, a model stack, a scene catalog, a scoring method, a
+real rig — is shaped by two invariants. They are not conventions of individual modules; they define
+what an integration is allowed to look like.
+
+## Positronic owns the control loop
+
+The world runner and harness execute every episode: they drive the clock, deliver observations to
+the policy, schedule and play back action chunks, and own resets and episode boundaries. This holds
+for every evaluation and data-collection run — in simulation and on real hardware, for any
+embodiment, scene source, or scoring method. A foreign component never runs the loop and calls into
+Positronic; Positronic runs the loop and calls into it.
+
+## Every run produces a Positronic dataset
+
+The dataset is the invariant output. Any run — eval or collection, sim or real, whatever the
+scoring — records the complete episode as a Positronic dataset (signals, episode meta, per-episode
+`.rrd`) under its output directory. Scores, videos, and metrics are derived from data the loop
+recorded; they never replace the dataset, and an integration path that yields scores without the
+dataset is not acceptable.
+
+## Foreign components plug in through shims
+
+A third-party component joins by having its interface wrapped into Positronic's APIs — never by
+Positronic's components being wrapped into its:
+
+| Foreign component | Runs as | Shim into our API |
+|---|---|---|
+| Simulator (LIBERO, Isaac Lab / RoboLab, MuJoCo) | env server in its own interpreter, behind the `env_server` wire | client-side `EnvAdapter` mapping the canonical embodiment contract ↔ the sim's raw payloads |
+| Model stack (LeRobot, GR00T, OpenPI) | inference server behind the WebSocket wire | vendor `Codec` translating raw observations ↔ model I/O |
+| Scenes / task batteries | instantiated inside the env server | reset tokens (suite, task, seed) carried through the `EnvAdapter` |
+| Scoring / success criteria | computed where the ground truth lives (usually the env server) | reported alongside observations and recorded into the dataset; aggregation happens on the Positronic side |
+| Hardware embodiment | pimm drivers inside the world | the same canonical embodiment contract the sims speak |
+
+The corollary for frameworks that ship their own eval harness: when a third-party benchmark expects
+a policy object plugged into *its* loop, the integration still separates that framework's sim/task
+layer and serves it behind the env wire. Handing a Positronic policy to a foreign loop forfeits
+both invariants — the run produces no dataset, and execution is scheduled by code we don't control.


### PR DESCRIPTION
Adds `docs/architecture.md` stating the two invariants every integration must preserve, and links it from the README guides list.

- **Positronic owns the control loop** — the world runner + harness execute every episode (clock, observation delivery, chunk scheduling, resets), for every eval and collection run, sim or real, any embodiment/scene/scoring.
- **Every run produces a Positronic dataset** — signals, episode meta, per-episode `.rrd`; scores and metrics derive from what the loop recorded, never replace it.
- **Foreign components plug in through shims** wrapping their interface into our APIs: sims as env servers behind the `env_server` wire + client-side `EnvAdapter`; model stacks as inference servers behind the wire + vendor `Codec`; scenes via reset tokens; scoring reported through the env server and recorded into the dataset. A benchmark that ships its own harness still integrates by serving its sim/task layer behind the env wire — a Positronic policy is never handed to a foreign loop.

Principle stated by Vladimir in #positronic-team, 2026-07-23 (context: MolmoSpaces integration direction).

<!-- opened-by: posi-agent -->