### PR TITLE
Clarify the linter-suppression rule in `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@
 - Configuronic: never define a function whose only purpose is to build a config — decorate it with `@cfn.config`
   directly. When wrapping a class or function usable as-is (without configuronic), assign `NAME = cfn.Config(Thing)`
   rather than writing a wrapper. Define variants with `.override`
-- No suppressions or guards for problems never observed: a `noqa` must suppress an error that actually fires; no
-  defensive idioms with explanatory comments
+- Linter suppressions (`noqa`, `type: ignore`, `pyright: ignore`) must be narrowly scoped to a specific rule and
+  suppress an error that actually fires — no blanket or speculative suppressions
 
 # Comments & docstrings
 - Write for a fresh reader: no references to past or future state ("no longer", "previously", "step N", "today").


### PR DESCRIPTION
Scope the code-style rule to **linter suppressions** (narrow, must actually fire) instead of the broader "no suppressions or guards for problems never observed / no defensive idioms" phrasing.

The old wording conflated three things and read as "don't anticipate future problems," which collides with the Design-discipline section's push for durable designs that prevent future problems. It also duplicated the exception-swallowing concern that the try-catch rule under `# Contributor behavior` already owns.

Before:
> - No suppressions or guards for problems never observed: a `noqa` must suppress an error that actually fires; no defensive idioms with explanatory comments

After:
> - Linter suppressions (`noqa`, `type: ignore`, `pyright: ignore`) must be narrowly scoped to a specific rule and suppress an error that actually fires — no blanket or speculative suppressions

Exception handling stays owned by the existing "Don't hide errors with try-catch blocks" rule; general durable-design thinking is untouched.

<!-- opened-by: posi-agent -->