### PR TITLE
Enforce `.basedpyright/baseline.json` as a one-way per-file ratchet

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -52,3 +52,10 @@ jobs:
         if [ -n "$CHANGED_PY_FILES" ]; then
           echo "$CHANGED_PY_FILES" | xargs python3 utilities/check_tests_location.py
         fi
+    - name: Check basedpyright baseline ratchet
+      # Runs unconditionally: cheap, and fast-passes when no baseline file grew. RATCHET_BASE is the
+      # PR base sha ($BASE_SHA); the script diffs against its merge-base with HEAD, since origin/main
+      # does not resolve in this detached-HEAD checkout.
+      env:
+        RATCHET_BASE: ${{ env.BASE_SHA }}
+      run: python3 utilities/check_basedpyright_baseline_ratchet.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,15 @@ repos:
         language: system
         files: '(^|/)(test_[^/]+\.py|[^/]+_test\.py)$'
         stages: [pre-commit]
+      - id: basedpyright-baseline-ratchet
+        name: basedpyright baseline is a one-way ratchet
+        # Reads the baseline and git directly, so takes no filenames; scoped to fire only when
+        # the baseline changes (the only time a file's entry count can grow).
+        entry: python3 utilities/check_basedpyright_baseline_ratchet.py
+        language: system
+        files: '^\.basedpyright/baseline\.json$'
+        pass_filenames: false
+        stages: [pre-commit]
 
   # General pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -77,26 +77,32 @@ def resolve_base_ref(arg: str | None, env: str | None) -> str:
 
 
 def _parse_renames(out: str | None) -> dict[str, str]:
-    """Parse `git diff --name-status -M -C` output into new path -> base path (git-style)."""
+    """Parse `git diff --name-status -M` output into new path -> base path (git-style).
+
+    Only `R` (rename) is mapped, never `C` (copy): a rename moves a file's entries to a new key, so
+    the new path must inherit the base counts; a copy leaves the source in place and duplicates its
+    diagnostics into a genuinely new file, which must face the new-file check, not reuse the source's
+    grandfathered allowances.
+    """
     renames: dict[str, str] = {}
     for line in (out or '').splitlines():
         parts = line.split('\t')
-        if len(parts) == 3 and parts[0][:1] in ('R', 'C'):
+        if len(parts) == 3 and parts[0][:1] == 'R':
             _status, old, new = parts
             renames[new] = old
     return renames
 
 
 def build_rename_map(base: str) -> dict[str, str]:
-    """Map new path -> base path for files renamed/copied from `base` to the commit under check.
+    """Map new path -> base path for files renamed from `base` to the commit under check.
 
     Unions committed renames (`base..HEAD`) with staged renames (`base` vs the index): under
     pre-commit the rename is staged but not yet in HEAD, so `--cached` is what carries it; in CI
     HEAD already holds it. Staged entries win on conflict, matching the tree being committed. Fails
     open (empty map) if the git calls fail, so rename-detection trouble never blocks a commit.
     """
-    committed = _parse_renames(_run_git('diff', '--name-status', '-M', '-C', base, 'HEAD'))
-    staged = _parse_renames(_run_git('diff', '--cached', '--name-status', '-M', '-C', base))
+    committed = _parse_renames(_run_git('diff', '--name-status', '-M', base, 'HEAD'))
+    staged = _parse_renames(_run_git('diff', '--cached', '--name-status', '-M', base))
     return {**committed, **staged}
 
 

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -1,18 +1,24 @@
 """Enforce the basedpyright baseline as a one-way ratchet: a file's entry count may shrink, never grow.
 
-Compares the working-tree `.basedpyright/baseline.json` against the merge-base with `origin/main`
-(the merge-base, not the tip, so an unrelated main-side shrink cannot flag an untouched file here).
-Any file whose entry count exceeds its merge-base count has a new error grandfathered into the
-baseline; the fix is to resolve the error, not to widen the baseline.
+Compares the working-tree `.basedpyright/baseline.json` against the merge-base with a base ref (the
+merge-base, not the tip, so an unrelated base-side shrink cannot flag an untouched file here). Any
+file whose entry count exceeds its merge-base count has a new error grandfathered into the baseline;
+the fix is to resolve the error, not to widen the baseline.
+
+The base ref is `--base <ref>`, else the `RATCHET_BASE` env var, else `origin/main` (the local
+pre-commit default). CI runs a detached-HEAD checkout where `origin/main` may not resolve, so it
+passes the PR base sha explicitly.
 
 Counts, never raw lines: re-anchoring an existing entry shifts its line numbers legitimately, so only
 the number of entries per file is compared.
 
 Fails open (exit 0, note on stderr) when the base ref or either baseline cannot be resolved, so an
-offline commit is never blocked; CI always has origin/main, where the gate holds.
+offline commit is never blocked; CI always has the base sha, where the gate holds.
 """
 
+import argparse
 import json
+import os
 import subprocess
 import sys
 from typing import Any
@@ -38,6 +44,11 @@ def grown_files(base: Any, current: Any) -> list[tuple[str, int, int]]:
     return grown
 
 
+def resolve_base_ref(arg: str | None, env: str | None) -> str:
+    """Pick the base ref: an explicit `--base` arg wins, then `RATCHET_BASE` env, else `origin/main`."""
+    return arg or env or 'origin/main'
+
+
 def _run_git(*args: str) -> str | None:
     try:
         r = subprocess.run(['git', *args], capture_output=True, text=True, timeout=10)
@@ -46,11 +57,12 @@ def _run_git(*args: str) -> str | None:
     return r.stdout.strip() if r.returncode == 0 else None
 
 
-def _resolve_base() -> str | None:
-    merge_base = _run_git('merge-base', 'HEAD', 'origin/main')
+def _resolve_merge_base(ref: str) -> str | None:
+    merge_base = _run_git('merge-base', 'HEAD', ref)
     if merge_base:
         return merge_base
-    return _run_git('rev-parse', 'origin/main') or None
+    # merge-base unavailable (shallow history, unrelated ref): use the ref directly if it resolves.
+    return _run_git('rev-parse', ref) or None
 
 
 def _load_base_baseline(base: str) -> Any | None:
@@ -71,10 +83,15 @@ def _load_working_baseline() -> Any | None:
         return None
 
 
-def main() -> int:
-    base = _resolve_base()
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description='Fail if any basedpyright baseline file grew vs the base ref.')
+    parser.add_argument('--base', default=None, help='base ref to diff against (else $RATCHET_BASE, else origin/main)')
+    args = parser.parse_args(argv)
+
+    ref = resolve_base_ref(args.base, os.environ.get('RATCHET_BASE') or None)
+    base = _resolve_merge_base(ref)
     if base is None:
-        print('baseline-ratchet: could not resolve merge-base with origin/main; skipping check', file=sys.stderr)
+        print(f'baseline-ratchet: could not resolve base {ref!r}; skipping check', file=sys.stderr)
         return 0
 
     base_baseline = _load_base_baseline(base)
@@ -100,4 +117,4 @@ def main() -> int:
 
 
 if __name__ == '__main__':
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -27,8 +27,12 @@ Residual: a swap WITHIN the same code — resolving one `reportReturnType` while
 baseline diff (entries re-anchor by column, so there is no stable position identity). Distinguishing
 it would require re-running basedpyright on both base and branch, out of scope for a fast guard.
 
-Fails open (exit 0, note on stderr) when the base ref or either baseline cannot be resolved, so an
-offline commit is never blocked; CI always has the base sha, where the gate holds.
+Fails open (exit 0, note on stderr) when the base ref cannot be resolved or the base baseline cannot
+be read (offline, shallow history, or the baseline being added for the first time), so an offline
+commit is never blocked and CI — which always has the base sha — is where the gate holds. But an
+unreadable *working* baseline fails closed (exit 1): reaching that check means the base baseline was
+readable, so a missing/malformed working copy means this change deleted or corrupted the guarded file
+and must not silently disable the ratchet.
 """
 
 import argparse
@@ -158,8 +162,12 @@ def main(argv: list[str]) -> int:
 
     current_baseline = _load_working_baseline()
     if current_baseline is None:
-        print(f'baseline-ratchet: could not read working-tree {BASELINE_PATH}; skipping check', file=sys.stderr)
-        return 0
+        # Reaching here means the base baseline WAS readable, so an unreadable working baseline means
+        # this change deleted or malformed it — a hole in the guarded file itself. Fail closed (unlike
+        # the fail-open base-ref/base-baseline cases above, which are legitimate offline/first-add).
+        print(f'baseline-ratchet: working-tree {BASELINE_PATH} is missing or malformed but exists at', file=sys.stderr)
+        print(f'{base} — the ratchet cannot run; restore or fix the baseline instead of removing it.', file=sys.stderr)
+        return 1
 
     grown = grown_files(base_baseline, current_baseline, build_rename_map(base))
     if not grown:

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -15,6 +15,11 @@ flagged if any diagnostic `code` occurs more times than at the base. That catche
 rule-kind, more entries of an existing kind, AND a swap of one code for a different one (which a bare
 per-file entry-count comparison would miss, since the total stays flat).
 
+Renames re-key the baseline (the entries move to the new path), so a rename map from
+`git diff --name-status -M -C <base> HEAD` routes each moved file's counts back to its base path;
+a pure rename/move of a file carrying existing entries is therefore not flagged. Rename detection
+fails open (empty map, every file compared under its own path) if the git call fails.
+
 Residual: a swap WITHIN the same code — resolving one `reportReturnType` while introducing a different
 `reportReturnType` in the same file — leaves the multiset identical and cannot be caught by a static
 baseline diff (entries re-anchor by column, so there is no stable position identity). Distinguishing
@@ -35,21 +40,29 @@ from typing import Any
 BASELINE_PATH = '.basedpyright/baseline.json'
 
 
+def _norm(path: str) -> str:
+    """Drop the leading `./` that baseline keys carry, so paths match git's (`positronic/foo.py`)."""
+    return path[2:] if path.startswith('./') else path
+
+
 def _code_counts(baseline: Any) -> dict[str, Counter[str]]:
-    return {path: Counter(str(e['code']) for e in entries) for path, entries in baseline.get('files', {}).items()}
+    files = baseline.get('files', {})
+    return {_norm(path): Counter(str(e['code']) for e in entries) for path, entries in files.items()}
 
 
-def grown_files(base: Any, current: Any) -> list[tuple[str, str, int, int]]:
+def grown_files(base: Any, current: Any, rename_map: dict[str, str] | None = None) -> list[tuple[str, str, int, int]]:
     """Return (path, code, base_count, current_count) for every diagnostic `code` a file gained.
 
     Compares the per-file multiset of diagnostic codes; a code absent from `base` counts as 0, so a
     new rule-kind (including a swap to a different code at flat total) or a newly-appearing file is
-    flagged.
+    flagged. `rename_map` (new path -> base path, git-style without `./`) routes a moved file's
+    counts back to its base path, so a pure rename of a file with existing entries is not flagged.
     """
+    renames = rename_map or {}
     base_counts = _code_counts(base)
     grown: list[tuple[str, str, int, int]] = []
     for path, cur_codes in sorted(_code_counts(current).items()):
-        base_codes = base_counts.get(path, Counter())
+        base_codes = base_counts.get(renames.get(path, path), Counter())
         for code, cur_n in sorted(cur_codes.items()):
             if cur_n > base_codes[code]:
                 grown.append((path, code, base_codes[code], cur_n))
@@ -59,6 +72,23 @@ def grown_files(base: Any, current: Any) -> list[tuple[str, str, int, int]]:
 def resolve_base_ref(arg: str | None, env: str | None) -> str:
     """Pick the base ref: an explicit `--base` arg wins, then `RATCHET_BASE` env, else `origin/main`."""
     return arg or env or 'origin/main'
+
+
+def build_rename_map(base: str) -> dict[str, str]:
+    """Map new path -> base path for files renamed or copied between `base` and HEAD (git-style paths).
+
+    Fails open (empty map) if the git call fails, so rename-detection trouble never blocks a commit.
+    """
+    out = _run_git('diff', '--name-status', '-M', '-C', base, 'HEAD')
+    if out is None:
+        return {}
+    renames: dict[str, str] = {}
+    for line in out.splitlines():
+        parts = line.split('\t')
+        if len(parts) == 3 and parts[0][:1] in ('R', 'C'):
+            _status, old, new = parts
+            renames[new] = old
+    return renames
 
 
 def _run_git(*args: str) -> str | None:
@@ -116,7 +146,7 @@ def main(argv: list[str]) -> int:
         print(f'baseline-ratchet: could not read working-tree {BASELINE_PATH}; skipping check', file=sys.stderr)
         return 0
 
-    grown = grown_files(base_baseline, current_baseline)
+    grown = grown_files(base_baseline, current_baseline, build_rename_map(base))
     if not grown:
         return 0
 

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -15,10 +15,12 @@ flagged if any diagnostic `code` occurs more times than at the base. That catche
 rule-kind, more entries of an existing kind, AND a swap of one code for a different one (which a bare
 per-file entry-count comparison would miss, since the total stays flat).
 
-Renames re-key the baseline (the entries move to the new path), so a rename map from
-`git diff --name-status -M -C <base> HEAD` routes each moved file's counts back to its base path;
-a pure rename/move of a file carrying existing entries is therefore not flagged. Rename detection
-fails open (empty map, every file compared under its own path) if the git call fails.
+Renames re-key the baseline (the entries move to the new path), so a rename map routes each moved
+file's counts back to its base path; a pure rename/move of a file carrying existing entries is
+therefore not flagged. The map unions committed renames (`base..HEAD`) with staged renames (`base`
+vs the index) — under pre-commit the rename is staged but not yet in HEAD, so `--cached` is what
+carries it. Rename detection fails open (empty map, every file compared under its own path) if the
+git calls fail.
 
 Residual: a swap WITHIN the same code — resolving one `reportReturnType` while introducing a different
 `reportReturnType` in the same file — leaves the multiset identical and cannot be caught by a static
@@ -74,21 +76,28 @@ def resolve_base_ref(arg: str | None, env: str | None) -> str:
     return arg or env or 'origin/main'
 
 
-def build_rename_map(base: str) -> dict[str, str]:
-    """Map new path -> base path for files renamed or copied between `base` and HEAD (git-style paths).
-
-    Fails open (empty map) if the git call fails, so rename-detection trouble never blocks a commit.
-    """
-    out = _run_git('diff', '--name-status', '-M', '-C', base, 'HEAD')
-    if out is None:
-        return {}
+def _parse_renames(out: str | None) -> dict[str, str]:
+    """Parse `git diff --name-status -M -C` output into new path -> base path (git-style)."""
     renames: dict[str, str] = {}
-    for line in out.splitlines():
+    for line in (out or '').splitlines():
         parts = line.split('\t')
         if len(parts) == 3 and parts[0][:1] in ('R', 'C'):
             _status, old, new = parts
             renames[new] = old
     return renames
+
+
+def build_rename_map(base: str) -> dict[str, str]:
+    """Map new path -> base path for files renamed/copied from `base` to the commit under check.
+
+    Unions committed renames (`base..HEAD`) with staged renames (`base` vs the index): under
+    pre-commit the rename is staged but not yet in HEAD, so `--cached` is what carries it; in CI
+    HEAD already holds it. Staged entries win on conflict, matching the tree being committed. Fails
+    open (empty map) if the git calls fail, so rename-detection trouble never blocks a commit.
+    """
+    committed = _parse_renames(_run_git('diff', '--name-status', '-M', '-C', base, 'HEAD'))
+    staged = _parse_renames(_run_git('diff', '--cached', '--name-status', '-M', '-C', base))
+    return {**committed, **staged}
 
 
 def _run_git(*args: str) -> str | None:

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -1,0 +1,103 @@
+"""Enforce the basedpyright baseline as a one-way ratchet: a file's entry count may shrink, never grow.
+
+Compares the working-tree `.basedpyright/baseline.json` against the merge-base with `origin/main`
+(the merge-base, not the tip, so an unrelated main-side shrink cannot flag an untouched file here).
+Any file whose entry count exceeds its merge-base count has a new error grandfathered into the
+baseline; the fix is to resolve the error, not to widen the baseline.
+
+Counts, never raw lines: re-anchoring an existing entry shifts its line numbers legitimately, so only
+the number of entries per file is compared.
+
+Fails open (exit 0, note on stderr) when the base ref or either baseline cannot be resolved, so an
+offline commit is never blocked; CI always has origin/main, where the gate holds.
+"""
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+BASELINE_PATH = '.basedpyright/baseline.json'
+
+
+def _counts(baseline: Any) -> dict[str, int]:
+    return {path: len(entries) for path, entries in baseline.get('files', {}).items()}
+
+
+def grown_files(base: Any, current: Any) -> list[tuple[str, int, int]]:
+    """Return (path, base_count, current_count) for every file whose baseline entry count grew.
+
+    A file absent from `base` counts as 0, so a newly-appearing file with entries is a growth.
+    """
+    base_counts = _counts(base)
+    grown: list[tuple[str, int, int]] = []
+    for path, cur_n in sorted(_counts(current).items()):
+        base_n = base_counts.get(path, 0)
+        if cur_n > base_n:
+            grown.append((path, base_n, cur_n))
+    return grown
+
+
+def _run_git(*args: str) -> str | None:
+    try:
+        r = subprocess.run(['git', *args], capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def _resolve_base() -> str | None:
+    merge_base = _run_git('merge-base', 'HEAD', 'origin/main')
+    if merge_base:
+        return merge_base
+    return _run_git('rev-parse', 'origin/main') or None
+
+
+def _load_base_baseline(base: str) -> Any | None:
+    raw = _run_git('show', f'{base}:{BASELINE_PATH}')
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _load_working_baseline() -> Any | None:
+    try:
+        with open(BASELINE_PATH, encoding='utf-8') as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def main() -> int:
+    base = _resolve_base()
+    if base is None:
+        print('baseline-ratchet: could not resolve merge-base with origin/main; skipping check', file=sys.stderr)
+        return 0
+
+    base_baseline = _load_base_baseline(base)
+    if base_baseline is None:
+        print(f'baseline-ratchet: could not read {BASELINE_PATH} at {base}; skipping check', file=sys.stderr)
+        return 0
+
+    current_baseline = _load_working_baseline()
+    if current_baseline is None:
+        print(f'baseline-ratchet: could not read working-tree {BASELINE_PATH}; skipping check', file=sys.stderr)
+        return 0
+
+    grown = grown_files(base_baseline, current_baseline)
+    if not grown:
+        return 0
+
+    print('basedpyright baseline is a one-way ratchet — it may shrink, never grow per file.', file=sys.stderr)
+    print('These files gained baseline entries; fix the new issue instead of grandfathering it', file=sys.stderr)
+    print('(see the no_grandfather_new_code discipline):', file=sys.stderr)
+    for path, base_n, cur_n in grown:
+        print(f'  {path}: {base_n} -> {cur_n} entries', file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -1,16 +1,24 @@
-"""Enforce the basedpyright baseline as a one-way ratchet: a file's entry count may shrink, never grow.
+"""Enforce the basedpyright baseline as a one-way ratchet: a file's diagnostics may shrink, never grow.
 
 Compares the working-tree `.basedpyright/baseline.json` against the merge-base with a base ref (the
-merge-base, not the tip, so an unrelated base-side shrink cannot flag an untouched file here). Any
-file whose entry count exceeds its merge-base count has a new error grandfathered into the baseline;
-the fix is to resolve the error, not to widen the baseline.
+merge-base, not the tip, so an unrelated base-side shrink cannot flag an untouched file here). A new
+error grandfathered into the baseline is flagged; the fix is to resolve the error, not widen it.
 
 The base ref is `--base <ref>`, else the `RATCHET_BASE` env var, else `origin/main` (the local
 pre-commit default). CI runs a detached-HEAD checkout where `origin/main` may not resolve, so it
 passes the PR base sha explicitly.
 
-Counts, never raw lines: re-anchoring an existing entry shifts its line numbers legitimately, so only
-the number of entries per file is compared.
+Per-code multiset, never raw lines: each baseline entry is `{"code": <rule>, "range": {startColumn,
+endColumn, lineCount}}` — there is no absolute line, so re-anchoring on re-indentation shifts an
+entry's columns but not its `code`. The re-anchor-safe identity is therefore the `code`: a file is
+flagged if any diagnostic `code` occurs more times than at the base. That catches a brand-new
+rule-kind, more entries of an existing kind, AND a swap of one code for a different one (which a bare
+per-file entry-count comparison would miss, since the total stays flat).
+
+Residual: a swap WITHIN the same code — resolving one `reportReturnType` while introducing a different
+`reportReturnType` in the same file — leaves the multiset identical and cannot be caught by a static
+baseline diff (entries re-anchor by column, so there is no stable position identity). Distinguishing
+it would require re-running basedpyright on both base and branch, out of scope for a fast guard.
 
 Fails open (exit 0, note on stderr) when the base ref or either baseline cannot be resolved, so an
 offline commit is never blocked; CI always has the base sha, where the gate holds.
@@ -21,26 +29,30 @@ import json
 import os
 import subprocess
 import sys
+from collections import Counter
 from typing import Any
 
 BASELINE_PATH = '.basedpyright/baseline.json'
 
 
-def _counts(baseline: Any) -> dict[str, int]:
-    return {path: len(entries) for path, entries in baseline.get('files', {}).items()}
+def _code_counts(baseline: Any) -> dict[str, Counter[str]]:
+    return {path: Counter(str(e['code']) for e in entries) for path, entries in baseline.get('files', {}).items()}
 
 
-def grown_files(base: Any, current: Any) -> list[tuple[str, int, int]]:
-    """Return (path, base_count, current_count) for every file whose baseline entry count grew.
+def grown_files(base: Any, current: Any) -> list[tuple[str, str, int, int]]:
+    """Return (path, code, base_count, current_count) for every diagnostic `code` a file gained.
 
-    A file absent from `base` counts as 0, so a newly-appearing file with entries is a growth.
+    Compares the per-file multiset of diagnostic codes; a code absent from `base` counts as 0, so a
+    new rule-kind (including a swap to a different code at flat total) or a newly-appearing file is
+    flagged.
     """
-    base_counts = _counts(base)
-    grown: list[tuple[str, int, int]] = []
-    for path, cur_n in sorted(_counts(current).items()):
-        base_n = base_counts.get(path, 0)
-        if cur_n > base_n:
-            grown.append((path, base_n, cur_n))
+    base_counts = _code_counts(base)
+    grown: list[tuple[str, str, int, int]] = []
+    for path, cur_codes in sorted(_code_counts(current).items()):
+        base_codes = base_counts.get(path, Counter())
+        for code, cur_n in sorted(cur_codes.items()):
+            if cur_n > base_codes[code]:
+                grown.append((path, code, base_codes[code], cur_n))
     return grown
 
 
@@ -108,11 +120,11 @@ def main(argv: list[str]) -> int:
     if not grown:
         return 0
 
-    print('basedpyright baseline is a one-way ratchet — it may shrink, never grow per file.', file=sys.stderr)
-    print('These files gained baseline entries; fix the new issue instead of grandfathering it', file=sys.stderr)
+    print('basedpyright baseline is a one-way ratchet — a file may shrink, never grow per code.', file=sys.stderr)
+    print('These files gained baseline diagnostics; fix the new issue instead of grandfathering it', file=sys.stderr)
     print('(see the no_grandfather_new_code discipline):', file=sys.stderr)
-    for path, base_n, cur_n in grown:
-        print(f'  {path}: {base_n} -> {cur_n} entries', file=sys.stderr)
+    for path, code, base_n, cur_n in grown:
+        print(f'  {path}: {code} {base_n} -> {cur_n}', file=sys.stderr)
     return 1
 
 

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -5,36 +5,43 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import check_basedpyright_baseline_ratchet as ratchet  # noqa: E402
 
 
-def _entry(line: int) -> dict[str, object]:
-    return {'code': 'reportReturnType', 'range': {'startColumn': 1, 'endColumn': 2, 'lineCount': 1, 'line': line}}
+def _entry(code: str, col: int = 1) -> dict[str, object]:
+    return {'code': code, 'range': {'startColumn': col, 'endColumn': col + 1, 'lineCount': 1}}
 
 
-def _baseline(counts: dict[str, int]) -> dict[str, object]:
-    return {'files': {path: [_entry(i) for i in range(n)] for path, n in counts.items()}}
+def _baseline(files: dict[str, list[str]]) -> dict[str, object]:
+    """Build a baseline from {path: [code, code, ...]}; columns are auto-assigned distinctly."""
+    return {'files': {path: [_entry(c, i + 1) for i, c in enumerate(codes)] for path, codes in files.items()}}
 
 
-def test_passes_when_every_file_at_or_below_base():
-    base = _baseline({'./a.py': 3, './b.py': 2})
-    current = _baseline({'./a.py': 3, './b.py': 1})  # b shrank, a unchanged
+def test_reanchor_same_codes_changed_columns_passes():
+    base = {'files': {'./a.py': [_entry('reportReturnType', 1), _entry('reportArgumentType', 5)]}}
+    current = {'files': {'./a.py': [_entry('reportReturnType', 40), _entry('reportArgumentType', 88)]}}
     assert ratchet.grown_files(base, current) == []
 
 
-def test_fails_when_a_file_grew():
-    base = _baseline({'./a.py': 2})
-    current = _baseline({'./a.py': 5})
-    assert ratchet.grown_files(base, current) == [('./a.py', 2, 5)]
+def test_cross_code_swap_same_total_fails():
+    base = _baseline({'./a.py': ['reportReturnType', 'reportReturnType']})
+    current = _baseline({'./a.py': ['reportReturnType', 'reportArgumentType']})  # dropped one, added a new code
+    assert ratchet.grown_files(base, current) == [('./a.py', 'reportArgumentType', 0, 1)]
 
 
-def test_fails_when_new_file_appears_with_entries():
-    base = _baseline({'./a.py': 2})
-    current = _baseline({'./a.py': 2, './new.py': 1})
-    assert ratchet.grown_files(base, current) == [('./new.py', 0, 1)]
-
-
-def test_passes_on_reanchor_same_count_different_lines():
-    base = {'files': {'./a.py': [_entry(10), _entry(20)]}}
-    current = {'files': {'./a.py': [_entry(99), _entry(120)]}}  # same count, shifted lines
+def test_genuine_fix_fewer_entries_passes():
+    base = _baseline({'./a.py': ['reportReturnType', 'reportReturnType']})
+    current = _baseline({'./a.py': ['reportReturnType']})
     assert ratchet.grown_files(base, current) == []
+
+
+def test_new_file_with_entries_fails():
+    base = _baseline({'./a.py': ['reportReturnType']})
+    current = _baseline({'./a.py': ['reportReturnType'], './new.py': ['reportUnknownMemberType']})
+    assert ratchet.grown_files(base, current) == [('./new.py', 'reportUnknownMemberType', 0, 1)]
+
+
+def test_more_of_existing_code_fails():
+    base = _baseline({'./a.py': ['reportReturnType']})
+    current = _baseline({'./a.py': ['reportReturnType', 'reportReturnType']})
+    assert ratchet.grown_files(base, current) == [('./a.py', 'reportReturnType', 1, 2)]
 
 
 def test_base_ref_arg_wins_then_env_then_default():

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -88,6 +88,14 @@ def test_build_rename_map_includes_staged_rename(tmp_path, monkeypatch):
     assert ratchet.build_rename_map(base) == {'new.py': 'old.py'}
 
 
+def test_parse_renames_maps_renames_not_copies():
+    # A rename (R) moves entries to a new key and must map back; a copy (C) leaves the source in
+    # place and duplicates its diagnostics into a genuinely new file, which must face the new-file
+    # check rather than reuse the source's grandfathered allowances — so C must NOT be mapped.
+    out = 'R100\told.py\tmoved.py\nC100\tkept.py\tcopy.py\n'
+    assert ratchet._parse_renames(out) == {'moved.py': 'old.py'}
+
+
 def test_base_ref_arg_wins_then_env_then_default():
     assert ratchet.resolve_base_ref('abc123', 'def456') == 'abc123'  # --base wins over env
     assert ratchet.resolve_base_ref(None, 'def456') == 'def456'  # RATCHET_BASE env used

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -96,6 +96,22 @@ def test_parse_renames_maps_renames_not_copies():
     assert ratchet._parse_renames(out) == {'moved.py': 'old.py'}
 
 
+def test_main_rejects_unreadable_working_baseline(monkeypatch):
+    # A PR that deletes or malforms the working baseline (while base still has it) must fail closed —
+    # otherwise the ratchet silently disables itself and the CI gate passes.
+    monkeypatch.setattr(ratchet, '_resolve_merge_base', lambda ref: 'basesha')
+    monkeypatch.setattr(ratchet, '_load_base_baseline', lambda base: {'files': {}})
+    monkeypatch.setattr(ratchet, '_load_working_baseline', lambda: None)
+    assert ratchet.main([]) == 1
+
+
+def test_main_fails_open_on_unresolvable_base(monkeypatch):
+    # An unresolvable base ref (offline, shallow history) stays fail-open so a local commit is never
+    # blocked; CI always has the base sha.
+    monkeypatch.setattr(ratchet, '_resolve_merge_base', lambda ref: None)
+    assert ratchet.main([]) == 0
+
+
 def test_base_ref_arg_wins_then_env_then_default():
     assert ratchet.resolve_base_ref('abc123', 'def456') == 'abc123'  # --base wins over env
     assert ratchet.resolve_base_ref(None, 'def456') == 'def456'  # RATCHET_BASE env used

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -1,8 +1,13 @@
+import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import check_basedpyright_baseline_ratchet as ratchet  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(['git', *args], cwd=repo, check=True, capture_output=True, text=True)
 
 
 def _entry(code: str, col: int = 1) -> dict[str, object]:
@@ -64,6 +69,23 @@ def test_rename_without_map_flags_every_entry_as_new():
     base = _baseline({'./positronic/old.py': ['reportReturnType']})
     current = _baseline({'./positronic/new.py': ['reportReturnType']})
     assert ratchet.grown_files(base, current) == [('positronic/new.py', 'reportReturnType', 0, 1)]
+
+
+def test_build_rename_map_includes_staged_rename(tmp_path, monkeypatch):
+    # Under pre-commit the rename is staged (in the index), not yet in HEAD. build_rename_map must
+    # still map it, or a moved baselined file reads as brand-new and the local commit is wrongly
+    # blocked while CI (where HEAD holds the rename) passes.
+    repo = tmp_path
+    _git(repo, 'init', '-q')
+    _git(repo, 'config', 'user.email', 't@t')
+    _git(repo, 'config', 'user.name', 't')
+    (repo / 'old.py').write_text('x = 1\n' * 20)
+    _git(repo, 'add', 'old.py')
+    _git(repo, 'commit', '-qm', 'base')
+    base = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=repo, capture_output=True, text=True).stdout.strip()
+    _git(repo, 'mv', 'old.py', 'new.py')  # staged, NOT committed
+    monkeypatch.chdir(repo)
+    assert ratchet.build_rename_map(base) == {'new.py': 'old.py'}
 
 
 def test_base_ref_arg_wins_then_env_then_default():

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import check_basedpyright_baseline_ratchet as ratchet  # noqa: E402
+
+
+def _entry(line: int) -> dict[str, object]:
+    return {'code': 'reportReturnType', 'range': {'startColumn': 1, 'endColumn': 2, 'lineCount': 1, 'line': line}}
+
+
+def _baseline(counts: dict[str, int]) -> dict[str, object]:
+    return {'files': {path: [_entry(i) for i in range(n)] for path, n in counts.items()}}
+
+
+def test_passes_when_every_file_at_or_below_base():
+    base = _baseline({'./a.py': 3, './b.py': 2})
+    current = _baseline({'./a.py': 3, './b.py': 1})  # b shrank, a unchanged
+    assert ratchet.grown_files(base, current) == []
+
+
+def test_fails_when_a_file_grew():
+    base = _baseline({'./a.py': 2})
+    current = _baseline({'./a.py': 5})
+    assert ratchet.grown_files(base, current) == [('./a.py', 2, 5)]
+
+
+def test_fails_when_new_file_appears_with_entries():
+    base = _baseline({'./a.py': 2})
+    current = _baseline({'./a.py': 2, './new.py': 1})
+    assert ratchet.grown_files(base, current) == [('./new.py', 0, 1)]
+
+
+def test_passes_on_reanchor_same_count_different_lines():
+    base = {'files': {'./a.py': [_entry(10), _entry(20)]}}
+    current = {'files': {'./a.py': [_entry(99), _entry(120)]}}  # same count, shifted lines
+    assert ratchet.grown_files(base, current) == []

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -23,7 +23,7 @@ def test_reanchor_same_codes_changed_columns_passes():
 def test_cross_code_swap_same_total_fails():
     base = _baseline({'./a.py': ['reportReturnType', 'reportReturnType']})
     current = _baseline({'./a.py': ['reportReturnType', 'reportArgumentType']})  # dropped one, added a new code
-    assert ratchet.grown_files(base, current) == [('./a.py', 'reportArgumentType', 0, 1)]
+    assert ratchet.grown_files(base, current) == [('a.py', 'reportArgumentType', 0, 1)]
 
 
 def test_genuine_fix_fewer_entries_passes():
@@ -35,13 +35,35 @@ def test_genuine_fix_fewer_entries_passes():
 def test_new_file_with_entries_fails():
     base = _baseline({'./a.py': ['reportReturnType']})
     current = _baseline({'./a.py': ['reportReturnType'], './new.py': ['reportUnknownMemberType']})
-    assert ratchet.grown_files(base, current) == [('./new.py', 'reportUnknownMemberType', 0, 1)]
+    assert ratchet.grown_files(base, current) == [('new.py', 'reportUnknownMemberType', 0, 1)]
 
 
 def test_more_of_existing_code_fails():
     base = _baseline({'./a.py': ['reportReturnType']})
     current = _baseline({'./a.py': ['reportReturnType', 'reportReturnType']})
-    assert ratchet.grown_files(base, current) == [('./a.py', 'reportReturnType', 1, 2)]
+    assert ratchet.grown_files(base, current) == [('a.py', 'reportReturnType', 1, 2)]
+
+
+def test_pure_rename_with_identical_entries_passes():
+    base = _baseline({'./positronic/old.py': ['reportReturnType', 'reportArgumentType']})
+    current = _baseline({'./positronic/new.py': ['reportReturnType', 'reportArgumentType']})
+    rename_map = {'positronic/new.py': 'positronic/old.py'}  # git-style, no leading ./
+    assert ratchet.grown_files(base, current, rename_map) == []
+
+
+def test_rename_that_also_grew_fails_on_new_path():
+    base = _baseline({'./positronic/old.py': ['reportReturnType']})
+    current = _baseline({'./positronic/new.py': ['reportReturnType', 'reportArgumentType']})  # renamed AND grew
+    rename_map = {'positronic/new.py': 'positronic/old.py'}
+    assert ratchet.grown_files(base, current, rename_map) == [('positronic/new.py', 'reportArgumentType', 0, 1)]
+
+
+def test_rename_without_map_flags_every_entry_as_new():
+    # A rename NOT reflected in the map (empty map) reads the moved file as brand-new — the exact
+    # false-positive build_rename_map prevents; asserts the map is what suppresses it.
+    base = _baseline({'./positronic/old.py': ['reportReturnType']})
+    current = _baseline({'./positronic/new.py': ['reportReturnType']})
+    assert ratchet.grown_files(base, current) == [('positronic/new.py', 'reportReturnType', 0, 1)]
 
 
 def test_base_ref_arg_wins_then_env_then_default():

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -35,3 +35,10 @@ def test_passes_on_reanchor_same_count_different_lines():
     base = {'files': {'./a.py': [_entry(10), _entry(20)]}}
     current = {'files': {'./a.py': [_entry(99), _entry(120)]}}  # same count, shifted lines
     assert ratchet.grown_files(base, current) == []
+
+
+def test_base_ref_arg_wins_then_env_then_default():
+    assert ratchet.resolve_base_ref('abc123', 'def456') == 'abc123'  # --base wins over env
+    assert ratchet.resolve_base_ref(None, 'def456') == 'def456'  # RATCHET_BASE env used
+    assert ratchet.resolve_base_ref(None, None) == 'origin/main'  # local pre-commit default
+    assert ratchet.resolve_base_ref(None, '') == 'origin/main'  # empty env falls through


### PR DESCRIPTION
## What

Adds a `repo: local` pre-commit hook that fails if any file's entry count in `.basedpyright/baseline.json` **exceeds its merge-base-with-`origin/main` count**. The basedpyright baseline may shrink, never grow per file — so a new type error can't be silently grandfathered in (`no_grandfather_new_code` discipline).

## How

- `utilities/check_basedpyright_baseline_ratchet.py` (pure stdlib): resolves `git merge-base HEAD origin/main` (falls back to the `origin/main` tip), loads the base baseline via `git show <base>:.basedpyright/baseline.json` and the working-tree baseline, and reports every file whose entry count grew.
- **Merge-base, not tip:** an unrelated PR that shrinks main's baseline can't false-positive an untouched file on this branch.
- **Counts, not raw lines:** re-anchoring an existing entry shifts line numbers legitimately, so only per-file entry counts are compared.
- **Fails open** (exit 0 + stderr note) when the base ref or either baseline can't be resolved — an offline commit is never blocked, and the gate still holds in CI where `origin/main` is always present.
- Wired after `check-tests-location` as a `repo: local` hook scoped to `files: ^\.basedpyright/baseline\.json$` (fires only when the baseline changes). CI runs pre-commit, so this binds every PR.

## Tests

`utilities/tests/test_check_basedpyright_baseline_ratchet.py` calls the pure `grown_files` comparison directly (no git shell-out): passes when every file is ≤ base, fails when a file grew, fails when a new file appears with entries, passes on re-anchor (same count, shifted lines).

## Verification

- Hook passes on this clean branch (baseline == merge-base).
- Injecting a fake baseline entry makes the hook exit 1 and name the grown file (`./pimm/core.py: 3 -> 4 entries`); reverting restores exit 0.
- `basedpyright` full run: 0 errors. Full pytest suite: 681 passed, 7 skipped.

Separate, self-contained tooling change — does not touch the eval-timing work (PR #479).

<!-- opened-by: posi-agent -->