### PR TITLE
Fail when a control system is listed twice in `World.start`

### DIFF
--- a/pimm/tests/test_world.py
+++ b/pimm/tests/test_world.py
@@ -592,6 +592,17 @@ class TestWorldControlSystems:
             with pytest.raises(ValueError, match='Receiver .* is not in any control system'):
                 world.start(main_process=producer)
 
+    def test_start_rejects_duplicate_control_systems(self):
+        main_cs = DummyControlSystem('main')
+        background_cs = DummyControlSystem('background')
+
+        with World() as world:
+            with pytest.raises(ValueError, match='listed more than once'):
+                world.start(main_process=main_cs, background=[background_cs, background_cs])
+
+            with pytest.raises(ValueError, match='listed more than once'):
+                world.start(main_process=main_cs, background=[background_cs, main_cs])
+
 
 # Integration tests
 class TestIntegration:

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -8,7 +8,7 @@ import os
 import sys
 import time
 import traceback
-from collections import defaultdict, deque
+from collections import Counter, defaultdict, deque
 from collections.abc import Callable, Iterator
 from enum import IntEnum
 from multiprocessing import resource_tracker
@@ -698,12 +698,21 @@ class World:
         world wires control system emitters and receivers together using local
         queues or multiprocessing queues. Returns an iterator produced by
         ``interleave`` so callers can drive the cooperative scheduler.
+
+        A control system may appear only once across ``main_process`` and ``background``.
         """
         main_process = main_process if isinstance(main_process, list) else [main_process]
         main_process = [m for m in main_process if m is not None]
         background = background or []
         background = background if isinstance(background, list) else [background]
         background = [b for b in background if b is not None]
+
+        dupes = [cs for cs, n in Counter(main_process + background).items() if n > 1]
+        if dupes:
+            raise ValueError(
+                f'Control systems listed more than once: {[type(cs).__name__ for cs in dupes]}. '
+                'A control system owns its ports and runs exactly once — if one device fills two roles, list it once.'
+            )
 
         local_cs = set(main_process)
         all_cs = local_cs | set(background)

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -250,7 +250,9 @@ def main(
         ds_agent = wire.wire(world, data_collection, dataset_writer, camera_emitters, robot_arm, gripper, None)
         _wire(world, ds_agent, data_collection, webxr, robot_arm, sound)
 
-        bg_cs = [webxr, *camera_instances.values(), ds_agent, robot_arm, gripper, sound]
+        # SO-101 fills both the arm and gripper slots with one object; a control system runs in exactly one process.
+        gripper_cs = [] if gripper is robot_arm else [gripper]
+        bg_cs = [webxr, *camera_instances.values(), ds_agent, robot_arm, *gripper_cs, sound]
 
         if stream_video_to_webxr is not None:
             world.connect(


### PR DESCRIPTION
## Summary

- `World.start` resolved connections against a *set* of control systems (`local_cs = set(main_process)`) but spawned background processes from the raw list. Passing the same control system object twice therefore started two processes running the same `run()` over the same, already-bound ports. It now raises `ValueError` naming the duplicated types.
- Collapsing duplicates silently would be worse: a caller would keep believing it has two devices. A control system owns its ports and runs exactly once, so listing it twice is always a wiring bug.
- `data_collection.main` hit this for real: `so101cfg` calls `main(robot_arm=robot_arm, gripper=robot_arm, ...)` because the SO-101 carries its gripper on the arm's own bus, and `bg_cs` listed both slots — double-spawning the arm, i.e. two processes opening the same bus. The gripper now only adds a process when it is a distinct object; port wiring through `wire.wire` is unchanged.
- `main_sim` and `replay_record` also pass `sim` into both wiring slots, but each already lists `sim` once in `world.start`, so they are unaffected.

## Test plan

- New unit test `pimm/tests/test_world.py::TestWorldControlSystems::test_start_rejects_duplicate_control_systems` covers both a duplicate within `background` and a control system appearing in both `main_process` and `background`.
- `uv run --locked pytest --no-cov` — full suite green (678 passed, 7 skipped).
- No hardware verification: the SO-101 path was not run on a real robot.