### PR TITLE
Make three review-enforced conventions machine-checked

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -34,9 +34,7 @@ jobs:
       - name: "Run tests (coverage: term, html)"
         env:
           PYTHONPATH: ${{ env.PYTHONPATH }}:$PWD
-        run: >-
-          uv run pytest --cov-report=html
-          --override-ini='testpaths=pimm/tests positronic/cfg/tests positronic/dataset/tests positronic/geom/tests positronic/offboard/tests positronic/policy/tests positronic/tests positronic/utils/tests'
+        run: uv run pytest --cov-report=html
 
       - name: Coverage summary (job summary)
         if: always()

--- a/positronic/dataset/tests/test_remote.py
+++ b/positronic/dataset/tests/test_remote.py
@@ -6,6 +6,7 @@ import socket
 import threading
 import time
 
+import httpx
 import numpy as np
 import pos3
 import pytest
@@ -159,8 +160,6 @@ def running_server(dataset_with_video):
     # Wait for server to start
     for _ in range(50):
         try:
-            import httpx
-
             httpx.get(f'http://127.0.0.1:{port}/api/v1/dataset/info', timeout=0.1)
             break
         except Exception:
@@ -267,8 +266,6 @@ def test_migrate_remote_dataset_numeric_only(tmp_path):
 
     for _ in range(50):
         try:
-            import httpx
-
             httpx.get(f'http://127.0.0.1:{port}/api/v1/dataset/info', timeout=0.1)
             break
         except Exception:

--- a/positronic/dataset/tests/test_video.py
+++ b/positronic/dataset/tests/test_video.py
@@ -142,8 +142,6 @@ class TestVideoSignalWriter:
 
 class TestVideoSignalStartLastTs:
     def test_video_start_last_ts_basic(self, video_paths):
-        from positronic.dataset.video import VideoSignal
-
         with VideoSignalWriter(video_paths['video'], video_paths['frames'], gop_size=5, fps=30) as writer:
             writer.append(create_frame(10), 1000)
             writer.append(create_frame(20), 2000)
@@ -154,8 +152,6 @@ class TestVideoSignalStartLastTs:
         assert s.last_ts == 4000
 
     def test_video_start_last_ts_empty_raises(self, video_paths):
-        from positronic.dataset.video import VideoSignal
-
         with VideoSignalWriter(video_paths['video'], video_paths['frames']):
             pass
         s = VideoSignal(video_paths['video'], video_paths['frames'])

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -15,9 +15,9 @@ try:
 except ImportError as e:
     raise ImportError(
         'Franka support is not installed. Install the hardware extra:\n'
-        '  pip install "positronic[hardware]"\n'
+        '  uv sync --locked --extra hardware\n'
         'or install the Franka core directly:\n'
-        '  pip install positronic-franka\n'
+        '  uv pip install positronic-franka\n'
     ) from e
 
 import pimm

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -14,10 +14,7 @@ try:
     from positronic_franka.desk import Desk
 except ImportError as e:
     raise ImportError(
-        'Franka support is not installed. In a positronic checkout, install the hardware extra:\n'
-        '  uv sync --locked --extra hardware\n'
-        'or, into whichever environment is active:\n'
-        '  uv pip install "positronic[hardware]"\n'
+        'Franka support is not installed. Re-run with the hardware extra:\n  uv run --locked --extra hardware ...\n'
     ) from e
 
 import pimm

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -14,10 +14,10 @@ try:
     from positronic_franka.desk import Desk
 except ImportError as e:
     raise ImportError(
-        'Franka support is not installed. Install the hardware extra:\n'
+        'Franka support is not installed. In a positronic checkout, install the hardware extra:\n'
         '  uv sync --locked --extra hardware\n'
-        'or install the Franka core directly:\n'
-        '  uv pip install positronic-franka\n'
+        'or, into whichever environment is active:\n'
+        '  uv pip install "positronic[hardware]"\n'
     ) from e
 
 import pimm

--- a/positronic/gui/__init__.py
+++ b/positronic/gui/__init__.py
@@ -3,6 +3,6 @@ import pimm
 
 def dpg_ui() -> pimm.ControlSystem:
     """Builds the Dearpygui desktop UI, importing `dearpygui` only when one is asked for."""
-    from positronic.gui.dpg import DearpyguiUi
+    from positronic.gui.dpg import DearpyguiUi  # noqa: PLC0415
 
     return DearpyguiUi()

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -38,7 +38,8 @@ class KeyboardHandler:
 @cfn.config(ui_scale=1)
 def eval_ui(ui_scale):
     def make(output_dir: Path | None) -> Driver:
-        from positronic.gui.eval import EvalUI
+        # Deferred: `dearpygui` has no ARM Linux wheel, so the desktop UI is imported only when one is asked for.
+        from positronic.gui.eval import EvalUI  # noqa: PLC0415
 
         gui = EvalUI(output_dir, ui_scale=ui_scale)
         return Driver(gui, gui.directive, pimm.utils.identity, [])

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -38,7 +38,6 @@ class KeyboardHandler:
 @cfn.config(ui_scale=1)
 def eval_ui(ui_scale):
     def make(output_dir: Path | None) -> Driver:
-        # Deferred: `dearpygui` has no ARM Linux wheel, so the desktop UI is imported only when one is asked for.
         from positronic.gui.eval import EvalUI  # noqa: PLC0415
 
         gui = EvalUI(output_dir, ui_scale=ui_scale)

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -18,6 +18,7 @@ from positronic.policy.codec import (
     FlipGrip,
 )
 from positronic.policy.observation import ObservationCodec
+from positronic.vendors.gr00t.codecs import ee_quat, joints_traj
 
 
 def test_observation_encode_images_and_state_shapes():
@@ -594,8 +595,6 @@ def test_groot_ee_codec_decodes_modality_keyed_actions():
     GR00T models return ``{'ee_pose': ..., 'grip': ...}`` per action step,
     not a flat ``action`` vector. The codec chain must convert this format.
     """
-    from positronic.vendors.gr00t.codecs import ee_quat
-
     codec = ee_quat()
 
     # Simulate GR00T model output: list of modality-keyed dicts (one per action step)
@@ -613,8 +612,6 @@ def test_groot_ee_codec_decodes_modality_keyed_actions():
 
 def test_groot_joints_codec_decodes_modality_keyed_actions():
     """GR00T joints_traj codec decodes joint_position-keyed model output."""
-    from positronic.vendors.gr00t.codecs import joints_traj
-
     codec = joints_traj()
 
     joint_pos = np.array([0.1, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7], dtype=np.float32)

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import av
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
@@ -276,8 +277,6 @@ class _BinaryStreamDrainer:
 
 def _encode_frames_as_video(entity_path: str, sig) -> None:
     """Encode raw image frames into an H.265 video stream via pyav."""
-    import av
-
     codec = rr.VideoCodec.H265
     container = av.open('/dev/null', 'w', format='hevc')
 

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -237,8 +237,8 @@ _ik_action = codecs.ik_joints_action.override(tgt_joints_key='robot_command.join
 @cfn.config(solver='dls_limits')
 def _ik_dreamzero_action(solver: str):
     """IK signal derivation composed with DreamZero action codec."""
-    from positronic.drivers.roboarm.ik import DLSIKSolver, DLSIKSolverWithLimits, LMIKSolver
-    from positronic.policy.action import IKJointsAction
+    from positronic.drivers.roboarm.ik import DLSIKSolver, DLSIKSolverWithLimits, LMIKSolver  # noqa: PLC0415
+    from positronic.policy.action import IKJointsAction  # noqa: PLC0415
 
     solver_map = {'lm': LMIKSolver, 'dls': DLSIKSolver, 'dls_limits': DLSIKSolverWithLimits}
     ik = IKJointsAction(solver_cls=solver_map[solver])

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -13,6 +13,8 @@ from positronic.dataset.episode import Episode
 from positronic.dataset.transforms import image
 from positronic.dataset.transforms.episode import Derive, Get
 from positronic.drivers.roboarm import command
+from positronic.drivers.roboarm.ik import DLSIKSolver, DLSIKSolverWithLimits, LMIKSolver
+from positronic.policy.action import IKJointsAction
 from positronic.policy.codec import Codec, lerobot_action, lerobot_image, lerobot_state
 
 IMAGE_WIDTH = 320
@@ -237,9 +239,6 @@ _ik_action = codecs.ik_joints_action.override(tgt_joints_key='robot_command.join
 @cfn.config(solver='dls_limits')
 def _ik_dreamzero_action(solver: str):
     """IK signal derivation composed with DreamZero action codec."""
-    from positronic.drivers.roboarm.ik import DLSIKSolver, DLSIKSolverWithLimits, LMIKSolver  # noqa: PLC0415
-    from positronic.policy.action import IKJointsAction  # noqa: PLC0415
-
     solver_map = {'lm': LMIKSolver, 'dls': DLSIKSolver, 'dls_limits': DLSIKSolverWithLimits}
     ik = IKJointsAction(solver_cls=solver_map[solver])
     return ik | DreamZeroActionCodec(tgt_joints_key='robot_command.joints', tgt_grip_key='target_grip')

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -12,6 +12,7 @@ from typing import Any
 import configuronic as cfn
 import numpy as np
 import pos3
+import websockets.sync.client
 from fastapi import WebSocket
 from huggingface_hub import snapshot_download
 
@@ -66,8 +67,6 @@ class RoboarenaClient:
         self._server_metadata: dict | None = None
 
     def connect(self):
-        import websockets.sync.client
-
         self._ws = websockets.sync.client.connect(
             f'ws://{self._host}:{self._port}', compression=None, max_size=None, ping_interval=60, ping_timeout=600
         )

--- a/positronic/vendors/lerobot/train.py
+++ b/positronic/vendors/lerobot/train.py
@@ -225,7 +225,7 @@ def train(
 
     logging.info('Starting training...')
     # Deferred: lerobot_train triggers heavy CUDA/model registry init on import.
-    from lerobot.scripts.lerobot_train import train as lerobot_train  # noqa: E402
+    from lerobot.scripts.lerobot_train import train as lerobot_train  # noqa: E402, PLC0415
 
     lerobot_train(cfg)
     logging.info('Training finished.')

--- a/positronic/vendors/lerobot/train.py
+++ b/positronic/vendors/lerobot/train.py
@@ -31,6 +31,7 @@ from lerobot.configs.policies import PreTrainedConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.envs.configs import EnvConfig, FeatureType, PolicyFeature
 from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig  # noqa: F401 — registers policy
+from lerobot.scripts.lerobot_train import train as lerobot_train
 from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
 
 from positronic import utils
@@ -224,9 +225,6 @@ def train(
     utils.save_run_metadata_deferred(Path(cfg.output_dir), patterns=['*.py', '*.toml'])
 
     logging.info('Starting training...')
-    # Deferred: lerobot_train triggers heavy CUDA/model registry init on import.
-    from lerobot.scripts.lerobot_train import train as lerobot_train  # noqa: E402, PLC0415
-
     lerobot_train(cfg)
     logging.info('Training finished.')
 

--- a/positronic/vendors/lerobot_0_3_3/train.py
+++ b/positronic/vendors/lerobot_0_3_3/train.py
@@ -27,6 +27,7 @@ import pos3
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
 from lerobot.envs.configs import EnvConfig, FeatureType, PolicyFeature
+from lerobot.scripts import train as lerobot_train
 
 from positronic import utils
 from positronic.policy import Codec
@@ -171,9 +172,6 @@ def train(
     utils.save_run_metadata_deferred(Path(cfg.output_dir), patterns=['*.py', '*.toml'])
 
     logging.info('Starting training...')
-    # Deferred: lerobot_train triggers heavy CUDA/model registry init on import.
-    from lerobot.scripts import train as lerobot_train  # noqa: PLC0415
-
     lerobot_train.init_logging()
     lerobot_train.train(cfg)
     logging.info('Training finished.')

--- a/positronic/vendors/lerobot_0_3_3/train.py
+++ b/positronic/vendors/lerobot_0_3_3/train.py
@@ -171,7 +171,8 @@ def train(
     utils.save_run_metadata_deferred(Path(cfg.output_dir), patterns=['*.py', '*.toml'])
 
     logging.info('Starting training...')
-    from lerobot.scripts import train as lerobot_train
+    # Deferred: lerobot_train triggers heavy CUDA/model registry init on import.
+    from lerobot.scripts import train as lerobot_train  # noqa: PLC0415
 
     lerobot_train.init_logging()
     lerobot_train.train(cfg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,8 +150,7 @@ pyzed = [
 openpi-client = { git = "https://github.com/Positronic-Robotics/openpi.git", rev = "main-positronic", subdirectory = "packages/openpi-client" }
 
 [tool.pytest.ini_options]
-# Search roots, not a list of suites: a new `tests/` directory is collected without being registered
-# here. Suites that cannot run in the default environment are excluded below, one line each.
+# Search roots, not a list of suites, so a new `tests/` directory is collected without being registered
 testpaths = ["pimm", "positronic", "utilities"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = [
@@ -195,9 +194,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py files
-# Configs import hardware inside their `@cfn.config` bodies, so that selecting one config does not
-# drag in every driver's dependencies. Elsewhere a deferred import needs its own `# noqa: PLC0415`.
-"positronic/cfg/**" = ["PLC0415"]
+"positronic/cfg/**" = ["PLC0415"]  # Configs defer hardware imports into their `@cfn.config` bodies
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,26 +150,16 @@ pyzed = [
 openpi-client = { git = "https://github.com/Positronic-Robotics/openpi.git", rev = "main-positronic", subdirectory = "packages/openpi-client" }
 
 [tool.pytest.ini_options]
-testpaths = [
-    "pimm/tests",
-    "positronic/cfg/tests",
-    "positronic/dataset/tests",
-    "positronic/geom/tests",
-    "positronic/offboard/tests",
-    "positronic/policy/tests",
-    "positronic/simulator/env_server/tests",
-    "positronic/tests",
-    "positronic/utils/tests",
-    "positronic/vendors/gr00t/tests",
-    "positronic/vendors/lerobot_0_3_3/tests",
-    "positronic/vendors/lerobot/tests",
-    "utilities/tests",
-]
+# Search roots, not a list of suites: a new `tests/` directory is collected without being registered
+# here. Suites that cannot run in the default environment are excluded below, one line each.
+testpaths = ["pimm", "positronic", "utilities"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = [
     "--cov=pimm",
     "--cov=positronic",
     "--cov-report=term-missing",
+    # Needs the `libero` extra and OSMesa; `libero-e2e.yaml` runs it by path, which `--ignore` allows.
+    "--ignore=positronic/simulator/libero/tests",
 ]
 filterwarnings = [
     "ignore:.*DISPLAY environment variable is missing:glfw.GLFWError",
@@ -196,6 +186,7 @@ select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
+    "PLC0415",  # imports belong at the top of the file
 ]
 ignore = [
     "E203",  # whitespace before ':'
@@ -204,6 +195,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py files
+# Configs import hardware inside their `@cfn.config` bodies, so that selecting one config does not
+# drag in every driver's dependencies. Elsewhere a deferred import needs its own `# noqa: PLC0415`.
+"positronic/cfg/**" = ["PLC0415"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
Three conventions this repo enforces by review now fail on their own. Fixes #519 and #520, and
takes the enforcement half of the problem described in #518's discussion.

## Collect every test suite

`testpaths` was a hand-maintained allowlist of 13 paths, so a new `tests/` directory stayed
invisible until someone remembered to register it. Four had accumulated. It is now three search
roots, which picks up `dataset/transforms`, `drivers/roboarm` and `vendors/dreamzero`.

The core CI job then had to stop overriding it. `unit-test.yaml` passed
`--override-ini` with its own eight-path list — narrower still than `testpaths`, so
`simulator/env_server/tests`, `vendors/gr00t/tests` and `utilities/tests` were configured and
then overridden away, running in no job at all. Between the two, the core job goes from **585
collected tests to 748**.

`simulator/libero/tests` stays out through `--ignore` — it needs the `libero` extra and OSMesa.
`libero-e2e.yaml` passes that path explicitly, which `--ignore` does not block, so it keeps
running there.

## Enforce top-level imports

Ruff already ships this rule as `PLC0415`, so no new script. `positronic/cfg/**` is exempt:
configs defer hardware imports so that selecting one config does not drag in every driver's
dependencies.

Of the 14 deferred imports elsewhere, 12 turned out to be unnecessary and moved to the top.
`av`, `websockets` and `httpx` are hard dependencies; `gr00t.codecs` imports fine without its
extra; two were plain duplicates of an import already at the top of the same file; and the
`dreamzero` and `lerobot` ones were deferring what their own modules already import at module
scope — both `train.py` files import lerobot at the top, including the `SmolVLAConfig` import
whose comment notes it registers the policy.

Only the two `dearpygui` deferrals from #516 are real, and they carry a narrow
`# noqa: PLC0415`.

## Point the franka hint at uv

`franka.py` told you to run `pip install`, which installs outside the locked venv and leaves the
import failing.

## Test plan

- `uv run --locked pytest --no-cov` → 744 passed, 7 skipped
- The lerobot and dreamzero import moves are not covered by CI, which never imports either
  `train.py`. Verified by hand in throwaway environments: each module imports under its own
  extra, and `TrainPipelineConfig.save_pretrained` is still the patched function once
  `lerobot.scripts` is imported at module scope
- `uv run --locked pre-commit run --from-ref upstream/main --to-ref HEAD` → all hooks pass on the
  changed files, including the basedpyright ratchet, which needed no re-baselining
- Not verified: `pre-commit run --all-files` does not pass on `main` today. `trailing-whitespace`
  and `end-of-file-fixer` rewrite `LICENSE`, the so101 URDF and assets, and
  `.basedpyright/baseline.json`. Pre-existing, unrelated to this branch, left alone
- The core job's own command reproduced in a clean `--extra dev` environment → 744 passed,
  7 skipped. The 7 skip on their own import guards (absent `torch`, `lerobot`, `pyzed`, `depthai`)
- Collection: the old allowlist and the new roots both collect 748 locally, and 750 without the
  libero `--ignore`. Under the CI override it was 585
- `uv run --locked pytest --no-cov --collect-only positronic/simulator/libero/tests` still collects
  its 2 tests, confirming `libero-e2e.yaml` is unaffected

