### PR TITLE
Add driver-managed Desk with `SafetyError` reboot recovery

### DIFF
--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -9,6 +9,8 @@ import positronic.cfg.hardware.motors
     home_joints=[0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0],
     load=None,
     collision_coeff=2.0,
+    manage_desk=True,
+    reboot_on_safety_error=False,
 )
 def franka(
     ip: str,
@@ -16,6 +18,8 @@ def franka(
     home_joints: list[float],
     load: tuple | None = None,
     collision_coeff: float = 2.0,
+    manage_desk: bool = True,
+    reboot_on_safety_error: bool = False,
 ):
     from positronic.drivers.roboarm import franka  # noqa: F401
 
@@ -25,6 +29,8 @@ def franka(
         home_joints=home_joints,
         load=load,
         collision_coeff=collision_coeff,
+        manage_desk=manage_desk,
+        reboot_on_safety_error=reboot_on_safety_error,
     )
 
 

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -11,7 +11,7 @@ import numpy as np
 
 try:
     import positronic_franka._franka as pf
-    from positronic_franka.desk import Desk
+    from positronic_franka.desk import Desk, SafetyControllerError
 except ImportError as e:
     raise ImportError(
         'Franka support is not installed. Install the hardware extra:\n'
@@ -29,6 +29,22 @@ from .models import attach_robotiq_2f85
 
 def _check_error(is_error, was_error):
     return is_error, is_error and not was_error
+
+
+def _read_desk_credentials() -> tuple[str, str]:
+    """Franka Desk login and password from the environment. Credentials stay out of the config so they never reach
+    the command line, which is recorded verbatim in every run's metadata."""
+    login, password = os.environ.get('FRANKA_DESK_USER'), os.environ.get('FRANKA_DESK_PASSWORD')
+    if not (login and password):
+        missing = ' and '.join(
+            name for name, value in (('FRANKA_DESK_USER', login), ('FRANKA_DESK_PASSWORD', password)) if not value
+        )
+        raise RuntimeError(
+            f'{missing} not set in the environment. The driver needs Desk credentials to open the brakes and '
+            f'activate FCI. Export them, or pass manage_desk=False to open the brakes and activate FCI yourself '
+            f'in Desk before starting.'
+        )
+    return login, password
 
 
 class FrankaState(State, pimm.shared_memory.NumpySMAdapter):
@@ -100,8 +116,8 @@ class Robot(pimm.ControlSystem):
         home_joints_variation: list[float] | None = None,
         load: tuple | None = None,
         collision_coeff: float = 2.0,
-        desk_login: str | None = None,
-        desk_password: str | None = None,
+        manage_desk: bool = True,
+        reboot_on_safety_error: bool = False,
     ) -> None:
         """
         :param ip: IP address of the robot.
@@ -110,9 +126,13 @@ class Robot(pimm.ControlSystem):
         :param home_joints_variation: Max random deviation per joint in radians. Set to [0]*7 to disable.
         :param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
             Default 2.0 (data collection). Use 6.0 for inference.
-        :param desk_login: Franka Desk login; defaults to the ``FRANKA_DESK_USER`` env var. When set with
-            ``desk_password``, the driver opens brakes and activates FCI via Desk on start and closes them on stop.
-        :param desk_password: Franka Desk password; defaults to the ``FRANKA_DESK_PASSWORD`` env var.
+        :param manage_desk: Run the Desk session from the driver: open the brakes and activate FCI on start, close
+            them on stop. Requires ``FRANKA_DESK_USER`` and ``FRANKA_DESK_PASSWORD`` in the environment. Set to
+            False to leave brakes and FCI to the operator; the driver then never contacts Desk and expects FCI to
+            be up already.
+        :param reboot_on_safety_error: When the control box is in an unrecoverable ``SafetyError`` on start, reboot
+            it, wait for it to come back, and try once more before giving up. Only applies when ``manage_desk`` is
+            set.
         """
         self._ip = ip
         self._relative_dynamics_factor = relative_dynamics_factor
@@ -126,8 +146,8 @@ class Robot(pimm.ControlSystem):
         self._load = load
         self._collision_coeff = collision_coeff
         self._robot: pf.Robot | None = None
-        self._desk_login = desk_login if desk_login is not None else os.environ.get('FRANKA_DESK_USER')
-        self._desk_password = desk_password if desk_password is not None else os.environ.get('FRANKA_DESK_PASSWORD')
+        self._desk_credentials = _read_desk_credentials() if manage_desk else None
+        self._reboot_on_safety_error = reboot_on_safety_error
 
     @staticmethod
     def _build_robot_meta(robot) -> dict:
@@ -189,8 +209,7 @@ class Robot(pimm.ControlSystem):
             lower_force_threshold_nominal=(coeff * force_threshold_nominal).tolist(),
             upper_force_threshold_nominal=(coeff * force_threshold_nominal * 2).tolist(),
         )
-        robot.set_joint_impedance([3000, 3000, 3000, 2500, 2500, 2000, 2000])
-        robot.set_cartesian_impedance([3000, 3000, 3000, 300, 300, 300])
+        robot.set_control_mode(pf.InternalImpedance([3000, 3000, 3000, 2500, 2500, 2000, 2000]))
         if self._load is not None:
             logging.info(f'Setting load to {self._load}')
             robot.set_load(*self._load)
@@ -215,13 +234,28 @@ class Robot(pimm.ControlSystem):
     @contextlib.contextmanager
     def _desk_session(self):
         """Bracket the run with a Franka Desk session that opens brakes and activates FCI, and always releases
-        control on exit. A no-op when Desk credentials are not configured (manual brake control, or simulation)."""
-        if not (self._desk_login and self._desk_password):
+        control on exit. Hands both over to the operator when the driver does not manage Desk. When configured,
+        recover a control box stuck in ``SafetyError`` by rebooting it once and retrying."""
+        if self._desk_credentials is None:
+            logging.info('Desk is not managed by the driver; brakes must be open and FCI active before the run')
             yield
             return
-        with Desk(self._ip, self._desk_login, self._desk_password) as desk:
-            desk.prepare()
-            yield
+        rebooted = False
+        while True:
+            with Desk(self._ip, *self._desk_credentials) as desk:
+                try:
+                    desk.prepare()
+                except SafetyControllerError:
+                    if rebooted or not self._reboot_on_safety_error:
+                        raise
+                    logging.warning('Control box in SafetyError; rebooting it (unreachable ~40s) and retrying once')
+                    desk.reboot(wait=True)
+                    rebooted = True
+                else:
+                    if rebooted:
+                        logging.info('Control box recovered after reboot')
+                    yield desk
+                    return
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         with self._desk_session():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ openpi = [
 ]
 hardware = [
     "feetech-servo-sdk", # for feetech motors
-    "positronic-franka>=0.5.0; sys_platform == 'linux'",
+    "positronic-franka>=0.6.2; sys_platform == 'linux'",
     # "kortex_api; sys_platform == 'linux'",  # Kinova: disabled, artifactory.kinovaapps.com is unreliable
     "linuxpy",  # For Linux video capture
     "placo",
@@ -141,6 +141,8 @@ pos3 = false
 positronic-franka = false
 
 [tool.uv.sources]
+# Track the unreleased Franka driver from git until 0.6.2 is published to the index, then drop this entry.
+positronic-franka = { git = "https://github.com/Positronic-Robotics/positronic-franka.git", branch = "desk-reboot-wait" }
 # ZED SDK ships one ABI-specific wheel per CPython version; pick by interpreter.
 pyzed = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl", marker = "python_full_version < '3.12'" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,6 @@ pos3 = false
 positronic-franka = false
 
 [tool.uv.sources]
-# Track the unreleased Franka driver from git until 0.6.2 is published to the index, then drop this entry.
-positronic-franka = { git = "https://github.com/Positronic-Robotics/positronic-franka.git", branch = "desk-reboot-wait" }
 # ZED SDK ships one ABI-specific wheel per CPython version; pick by interpreter.
 pyzed = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl", marker = "python_full_version < '3.12'" },

--- a/uv.lock
+++ b/uv.lock
@@ -4323,7 +4323,7 @@ requires-dist = [
     { name = "placo", marker = "extra == 'hardware'" },
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pos3", specifier = ">=0.3.1" },
-    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", git = "https://github.com/Positronic-Robotics/positronic-franka.git?branch=desk-reboot-wait" },
+    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.6.2" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "protobuf", marker = "extra == 'molmoact2'" },
     { name = "pyarrow" },
@@ -4365,11 +4365,12 @@ provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2"
 [[package]]
 name = "positronic-franka"
 version = "0.6.2"
-source = { git = "https://github.com/Positronic-Robotics/positronic-franka.git?branch=desk-reboot-wait#66fbc7c407fcd766ff5997520c466db2c64fd597" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "requests", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/22/ceca0817ee0693d1c9b31ad12934e82c41fd39ee470f5765f264bfa3caec/positronic_franka-0.6.2.tar.gz", hash = "sha256:7f429c3bdd8624493a74e152051e0e43b325df7710cf42058be32fb0787affe4", size = 1805370, upload-time = "2026-07-26T21:23:16.754Z" }
 
 [[package]]
 name = "pre-commit"

--- a/uv.lock
+++ b/uv.lock
@@ -4323,7 +4323,7 @@ requires-dist = [
     { name = "placo", marker = "extra == 'hardware'" },
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pos3", specifier = ">=0.3.1" },
-    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.5.0" },
+    { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", git = "https://github.com/Positronic-Robotics/positronic-franka.git?branch=desk-reboot-wait" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "protobuf", marker = "extra == 'molmoact2'" },
     { name = "pyarrow" },
@@ -4364,13 +4364,12 @@ provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2"
 
 [[package]]
 name = "positronic-franka"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.6.2"
+source = { git = "https://github.com/Positronic-Robotics/positronic-franka.git?branch=desk-reboot-wait#66fbc7c407fcd766ff5997520c466db2c64fd597" }
 dependencies = [
     { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
     { name = "requests", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c7/ea8132fd80a7e064b462df39b87ec6b750874b54885bfe45162cc32af3b8/positronic_franka-0.5.0.tar.gz", hash = "sha256:0937c3654b6d026d6a87a2892094c20459980683d14ce19604f8a8b41d1d5e40", size = 1796271, upload-time = "2026-07-14T21:32:24.866Z" }
 
 [[package]]
 name = "pre-commit"


### PR DESCRIPTION
## Summary
- **Explicit `manage_desk` mode.** The driver owns brakes + FCI (requires `FRANKA_DESK_USER`/`FRANKA_DESK_PASSWORD`), or `manage_desk=False` leaves both to the operator. Missing credentials now fail fast in the main process with a clear message, instead of the opaque libfranka "Connection to FCI refused" surfacing from a background process.
- **`reboot_on_safety_error` recovery.** On an unrecoverable `SafetyError` at start, the driver reboots the control box, waits for the safety controller to settle, retries once, and reraises if it persists.
- **Impedance API migration.** `_init_robot` now uses the positronic-franka 0.6.x `InternalImpedance` control mode; `set_joint_impedance`/`set_cartesian_impedance` were removed upstream (the latter was dead config).
- **Dependency.** Tracks the unreleased positronic-franka from git (branch `desk-reboot-wait`, Positronic-Robotics/positronic-franka#10) until **0.6.2** is published; swap the git source for the wheel then.

## Test plan
- `uv run --locked pytest positronic/cfg positronic/drivers --no-cov` passes.
- Retry-flow (5 paths) and reboot-wait readiness logic covered by fakes.
- **Live:** reboot recovery confirmed on the real control box to clear `SafetyError` and reach `_init_robot`; the settle-wait hardening and full end-to-end await a fresh `SafetyError`.

> Depends on Positronic-Robotics/positronic-franka#10. This PR cannot merge until 0.6.2 is released and the git source is swapped for the published wheel.
