### PR TITLE
Make every command channel carry a trajectory

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -2,14 +2,6 @@
     "files": {
         "./pimm/core.py": [
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 8,
@@ -112,8 +104,24 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
+                    "startColumn": 27,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -144,14 +152,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 27,
                     "endColumn": 29,
                     "lineCount": 1
@@ -170,46 +170,6 @@
                 "range": {
                     "startColumn": 39,
                     "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -242,14 +202,6 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -328,14 +280,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 40,
                     "endColumn": 44,
                     "lineCount": 1
@@ -344,24 +288,8 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 40,
                     "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -390,14 +318,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 29,
@@ -410,14 +330,6 @@
                 "range": {
                     "startColumn": 39,
                     "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -438,42 +350,10 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -512,14 +392,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 27,
                     "endColumn": 29,
                     "lineCount": 1
@@ -538,14 +410,6 @@
                 "range": {
                     "startColumn": 39,
                     "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -694,26 +558,10 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 30,
                     "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             }
@@ -1062,16 +910,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 28,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./pimm/utils.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -1606,14 +1444,6 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 61,
@@ -1640,8 +1470,8 @@
             {
                 "code": "reportPossiblyUnboundVariable",
                 "range": {
-                    "startColumn": 83,
-                    "endColumn": 99,
+                    "startColumn": 64,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -1834,14 +1664,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 55,
@@ -1902,24 +1724,8 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 57,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
@@ -1996,14 +1802,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 73,
@@ -2024,14 +1822,6 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -4478,14 +4268,6 @@
                 "range": {
                     "startColumn": 65,
                     "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -8698,14 +8480,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 64,
@@ -8828,14 +8602,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 35,
                     "endColumn": 39,
                     "lineCount": 1
@@ -8846,14 +8612,6 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -9568,8 +9326,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 77,
+                    "startColumn": 97,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             },
@@ -10316,54 +10074,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 49,
                     "endColumn": 53,
                     "lineCount": 1
@@ -10380,30 +10090,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 58,
                     "endColumn": 62,
                     "lineCount": 1
@@ -10414,22 +10100,6 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -10501,14 +10171,6 @@
             },
             {
                 "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
                 "range": {
                     "startColumn": 15,
                     "endColumn": 33,

--- a/pimm/core.py
+++ b/pimm/core.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
-from typing import Generic, TypeVar, final
+from typing import Generic, TypeVar, cast, final
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -24,7 +24,7 @@ class Message(Generic[T]):
     If no timestamp is provided, the current system time is used.
     """
 
-    data: T | None
+    data: T
     ts: int = -1  # -1 means no value
     updated: bool = True
 
@@ -188,7 +188,8 @@ class ControlSystemReceiver(SignalReceiver[T]):
             if value is not None:
                 return value
         if self._default is not NODEFAULT:
-            return Message(self._default, -1, False)  # Default value is always not-updated
+            # Always not-updated; the check above excludes the sentinel, which `T | None` cannot express.
+            return Message(cast(T, self._default), -1, False)
         return None
 
 

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -159,9 +159,9 @@ class DataCollectionController(pimm.ControlSystem):
                         self.sound.emit(abort_wav_path)
                     tracker.turn_off()
                     recording = False
-                    self.robot_commands.emit(roboarm.command.Reset())
+                    self.robot_commands.emit([(clock.now_ns(), roboarm.command.Reset())])
 
-                self.target_grip.emit(button_handler.get_value('right_trigger'))
+                self.target_grip.emit([(clock.now_ns(), button_handler.get_value('right_trigger'))])
                 cp_msg = self.controller_positions.read()
                 if cp_msg.updated:
                     target_robot_pos = tracker.update(cp_msg.data['right'])
@@ -173,7 +173,8 @@ class DataCollectionController(pimm.ControlSystem):
                     if entered_error:
                         self.sound.emit(error_wav_path)
                     if not in_error and cp_msg.updated:
-                        self.robot_commands.emit(roboarm.command.CartesianPosition(target_robot_pos))
+                        cmd = roboarm.command.CartesianPosition(target_robot_pos)
+                        self.robot_commands.emit([(clock.now_ns(), cmd)])
 
                 yield pimm.Sleep(0.001)
 

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -64,10 +64,6 @@ class TrajectoryOverrideSerializer(StatefulSerializer):
     only once a newer trajectory starting after it proves it final; the
     remainder is drained by :meth:`flush` at episode end.
 
-    Bare (non-trajectory) inputs — teleop single commands / scalar grip — pass
-    straight through ``inner`` at the agent timestamp (legacy behaviour), so the
-    shared ``wire.wire`` path keeps working for data collection and replay.
-
     HACK: lossy. Drops the notion of a *predicted* trajectory and cannot
     represent overlapping schedulers (RTC/temporal ensembling) that replan into
     the already-committed past — such points are dropped to keep timestamps
@@ -96,10 +92,7 @@ class TrajectoryOverrideSerializer(StatefulSerializer):
             self._last_ts = points[-1][0]
         return [Timestamped(ts, self._encode(v)) for ts, v in points]
 
-    def __call__(self, message: Any) -> Any | list[Timestamped]:
-        if not isinstance(message, list):
-            # Bare value (teleop Reset/Cartesian, scalar grip): one-shot, agent-timestamped.
-            return self._encode(message)
+    def __call__(self, message: list[tuple[int, Any]]) -> list[Timestamped]:
         if not message:
             # Empty trajectory is the cancel signal (the Harness emits it at episode end):
             # drop the buffered tail so flush() does not commit canceled waypoints.

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -481,9 +481,6 @@ def test_trajectory_override_serializer():
     # Episode end drains the still-live buffer.
     assert [(t.ts, t.value) for t in s.flush()] == [(2, 'B'), (3, 'C'), (4, 'D')]
 
-    # Bare (teleop) values bypass buffering entirely.
-    assert s('reset') == 'reset'
-
 
 def test_serializer_plain_list_value(world):
     """A serializer returning a plain list (non-`Timestamped`) is appended as one sample.

--- a/positronic/drivers/gripper/dh.py
+++ b/positronic/drivers/gripper/dh.py
@@ -4,14 +4,14 @@ from ctypes import c_uint16
 import pymodbus.client as ModbusClient
 
 import pimm
-from positronic.drivers.roboarm.command import TrajectoryPlayer
+from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
 
 
 class DHGripper(pimm.ControlSystem):
     def __init__(self, port: str):
         self.port = port
         self.grip: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)
-        self.target_grip: pimm.SignalReceiver = pimm.ControlSystemReceiver(self, default=0)
+        self.target_grip: pimm.SignalReceiver[Trajectory[float]] = pimm.ControlSystemReceiver(self, default=[])
         self.force: pimm.SignalReceiver = pimm.ControlSystemReceiver(self, default=100)
         self.speed: pimm.SignalReceiver = pimm.ControlSystemReceiver(self, default=100)
 
@@ -76,7 +76,7 @@ if __name__ == '__main__':
         force.emit(100)
 
         for width in np.sin(np.linspace(0, 10 * np.pi, 60)) + 1:
-            target_grip.emit(width)
+            target_grip.emit([(world.clock.now_ns(), width)])
             time.sleep(0.5)
             try:
                 print(f'Real grip position: {grip.value}')

--- a/positronic/drivers/gripper/robotiq.py
+++ b/positronic/drivers/gripper/robotiq.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 import pymodbus.client as ModbusClient
 
 import pimm
-from positronic.drivers.roboarm.command import TrajectoryPlayer
+from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
 
 _REG_CMD = 0x03E8
 _REG_IN_POS = 0x07D2
@@ -20,7 +20,7 @@ class Robotiq2F(pimm.ControlSystem):
     def __init__(self, port: str):
         self._port = port
         self.grip = pimm.ControlSystemEmitter(self)
-        self.target_grip = pimm.ControlSystemReceiver(self, default=None)
+        self.target_grip: pimm.ControlSystemReceiver[Trajectory[float]] = pimm.ControlSystemReceiver(self, default=[])
         self.force = pimm.ControlSystemReceiver(self, default=255)  # device scale 0..255
         self.speed = pimm.ControlSystemReceiver(self, default=255)  # device scale 0..255
 
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
         while True:
             if time.time() - start > i * 1.0:
-                tgt.emit(waypoints[i])
+                tgt.emit([(world.clock.now_ns(), waypoints[i])])
                 i += 1
                 if i >= len(waypoints):
                     break

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -1,7 +1,7 @@
 """Collection of commands that can be sent to the robot."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias, TypeVar
 
 import numpy as np
 
@@ -56,6 +56,12 @@ class CartesianDelta:
 
 CommandType = Reset | CartesianPosition | JointPosition | JointDelta | CartesianDelta
 
+_T = TypeVar('_T')
+
+# The wire shape of every command channel: waypoints stamped with absolute clock ns. A single immediate
+# command is the one-waypoint trajectory ``[(clock.now_ns(), value)]``; ``[]`` cancels whatever is in flight.
+Trajectory: TypeAlias = list[tuple[int, _T]]
+
 
 def apply_cartesian_delta(current: geom.Transform3D, delta: geom.Transform3D) -> geom.Transform3D:
     """Compose a world-frame ``delta`` onto a measured ``current`` pose for the absolute target a driver drives to.
@@ -79,7 +85,7 @@ def _combine(acc: CommandType, cmd: CommandType) -> CommandType:
             return cmd
 
 
-def reduce(due: list[tuple[float, CommandType]]) -> CommandType:
+def reduce(due: Trajectory[CommandType]) -> CommandType:
     """Collapse the commands due in one control tick into the single command to execute.
 
     Folds the batch in timestamp order. A run of same-space deltas accumulates (their motion is summed, so a
@@ -93,7 +99,7 @@ def reduce(due: list[tuple[float, CommandType]]) -> CommandType:
     return result
 
 
-def _reduce_last(due: list[tuple[float, Any]]) -> Any:
+def _reduce_last(due: Trajectory[Any]) -> Any:
     """The trailing value wins -- the right collapse for absolute setpoints and gripper targets."""
     return due[-1][1]
 
@@ -121,18 +127,15 @@ class TrajectoryPlayer:
     """
 
     def __init__(self, reduce=_reduce_last):
-        self._trajectory: list[tuple[float, Any]] = []
+        self._trajectory: Trajectory[Any] = []
         self._index: int = 0
         self._reduce = reduce
 
-    def set(self, data):
-        if isinstance(data, list):
-            self._trajectory = data
-        else:
-            self._trajectory = [(0.0, data)]
+    def set(self, trajectory: Trajectory[Any]):
+        self._trajectory = trajectory
         self._index = 0
 
-    def advance(self, current_time: float):
+    def advance(self, current_time: int):
         """Collapse every waypoint whose timestamp <= current_time into the single value to apply, or None."""
         due = []
         while self._index < len(self._trajectory):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -117,7 +117,9 @@ class Robot(pimm.ControlSystem):
         self._home_joints_variation = (
             home_joints_variation if home_joints_variation is not None else [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
         )
-        self.commands: pimm.SignalReceiver = pimm.ControlSystemReceiver(self, default=None)
+        self.commands: pimm.SignalReceiver[command.Trajectory[command.CommandType]] = pimm.ControlSystemReceiver(
+            self, default=[]
+        )
         self.state: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)
         self.robot_meta = pimm.ControlSystemEmitter(self)
         self._load = load
@@ -318,7 +320,8 @@ if __name__ == '__main__':
             pos = np.asarray(pos) * alpha
             if time.monotonic() > start + duration:
                 print(f'Moving to {pos + origin.translation}')
-                commands.emit(command.CartesianPosition(geom.Transform3D(pos + origin.translation, origin.rotation)))
+                target = command.CartesianPosition(geom.Transform3D(pos + origin.translation, origin.rotation))
+                commands.emit([(world.clock.now_ns(), target)])
                 i += 1
             else:
                 time.sleep(0.01)

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -68,7 +68,9 @@ class Robot(pimm.ControlSystem):
         self.relative_dynamics_factor = relative_dynamics_factor
         self.solver = KinematicsSolver()
         self.home_joints = home_joints if home_joints is not None else [0.0, -0, 0.5, -1.5, 0.0, -0.5, 1.57079633]
-        self.commands: pimm.SignalReceiver[command.CommandType] = pimm.ControlSystemReceiver(self, default=None)
+        self.commands: pimm.SignalReceiver[command.Trajectory[command.CommandType]] = pimm.ControlSystemReceiver(
+            self, default=[]
+        )
         self.state: pimm.SignalEmitter[KinovaState] = pimm.ControlSystemEmitter(self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -55,8 +55,12 @@ class Robot(pimm.ControlSystem):
         self.kinematic = Kinematics(_SO101_URDF_PATH, 'gripper_frame_joint')
         self.joint_limits = self.kinematic.joint_limits
         self.home_joints = home_joints if home_joints is not None else [0.0, 0.0, 0.0, 0.0, 0.0]
-        self.commands: pimm.SignalReceiver[roboarm_command.CommandType] = pimm.ControlSystemReceiver(self, default=None)
-        self.target_grip: pimm.SignalReceiver[float] = pimm.ControlSystemReceiver(self, default=0.0)
+        self.commands: pimm.SignalReceiver[roboarm_command.Trajectory[roboarm_command.CommandType]] = (
+            pimm.ControlSystemReceiver(self, default=[])
+        )
+        self.target_grip: pimm.SignalReceiver[roboarm_command.Trajectory[float]] = pimm.ControlSystemReceiver(
+            self, default=[]
+        )
         self._last_grip: float = 0.0
 
         self.grip: pimm.SignalEmitter[float] = pimm.ControlSystemEmitter(self)

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -122,7 +122,7 @@ class FakeRobot(pimm.ControlSystem):
         self._q = INITIAL_Q.copy()
         self._status = RobotStatus.AVAILABLE
         self._error_pending = False
-        self.commands = pimm.ControlSystemReceiver(self, default=None)
+        self.commands = pimm.ControlSystemReceiver(self, default=[])
         self.state = pimm.ControlSystemEmitter(self)
         self.robot_meta = pimm.ControlSystemEmitter(self)
 
@@ -145,7 +145,7 @@ class FakeRobot(pimm.ControlSystem):
         player = TrajectoryPlayer()
         while not should_stop.value:
             cmd_msg = self.commands.read()
-            if cmd_msg.updated and cmd_msg.data is not None:
+            if cmd_msg.updated:
                 player.set(cmd_msg.data)
             if self._status == RobotStatus.ERROR:
                 self._status = RobotStatus.AVAILABLE
@@ -167,14 +167,14 @@ class FakeGripper(pimm.ControlSystem):
 
     def __init__(self):
         self._grip = 0.0
-        self.target_grip = pimm.ControlSystemReceiver(self, default=0.0)
+        self.target_grip = pimm.ControlSystemReceiver(self, default=[])
         self.grip = pimm.ControlSystemEmitter(self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
         player = TrajectoryPlayer()
         while not should_stop.value:
             msg = self.target_grip.read()
-            if msg.updated and msg.data is not None:
+            if msg.updated:
                 player.set(msg.data)
             grip = player.advance(clock.now_ns())
             if grip is not None:

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -25,6 +25,13 @@ from positronic.utils import package_assets_path
 from positronic.utils.logging import init_logging
 
 
+class _TrajectoryEmitter(pimm.ControlSystemEmitter):
+    """Sends each replayed value as the one-waypoint trajectory the command channels carry, at its playback time."""
+
+    def emit(self, data: Any, ts: int = -1) -> None:
+        super().emit([(ts, data)], ts)
+
+
 class Replay(DsPlayerAgent):
     """Adapts `DsPlayerAgent` to be used as a policy control system."""
 
@@ -35,6 +42,8 @@ class Replay(DsPlayerAgent):
         self.gripper_state = pimm.FakeReceiver(self)
         self.robot_meta_in = pimm.FakeReceiver(self)
         self.frames = pimm.ReceiverDict(self, fake=True)
+        self.outputs['robot_commands'] = _TrajectoryEmitter(self)
+        self.outputs['target_grip'] = _TrajectoryEmitter(self)
 
     @property
     def robot_commands(self) -> pimm.ControlSystemEmitter:

--- a/positronic/robot_controller.py
+++ b/positronic/robot_controller.py
@@ -18,14 +18,15 @@ def main(robot):
 
             match text_command.split(' '):
                 case ['reset']:
-                    command_emmiter.emit(command.Reset())
+                    command_emmiter.emit([(world.clock.now_ns(), command.Reset())])
                 case ['move', x, y, z, qw, qx, qy, qz]:
                     pos = [float(x) for x in [x, y, z]]
                     quat = geom.Rotation.from_quat([float(qw), float(qx), float(qy), float(qz)])
-                    command_emmiter.emit(command.CartesianPosition(geom.Transform3D(translation=pos, rotation=quat)))
+                    move = command.CartesianPosition(geom.Transform3D(translation=pos, rotation=quat))
+                    command_emmiter.emit([(world.clock.now_ns(), move)])
                 case ['joint_move', *args]:
                     args = [float(x) for x in args]
-                    command_emmiter.emit(command.JointPosition(positions=args))
+                    command_emmiter.emit([(world.clock.now_ns(), command.JointPosition(positions=args))])
                 case ['info']:
                     print('Q', state_receiver.value.q)
                     print('DQ', state_receiver.value.dq)

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -116,7 +116,7 @@ class WireCommandAdapter(EnvAdapter):
     def action(self, commands: dict[str, pimm.Message], now_ns: int) -> dict[str, Any]:
         for name, msg in commands.items():
             player = self._players[name]
-            if msg.updated and msg.data is not None:
+            if msg.updated:
                 player.set(msg.data)
                 if not msg.data:  # an empty trajectory cancels: stop replaying the held waypoint
                     self._held.pop(name, None)

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -35,7 +35,7 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
         self._cleanup = ExitStack()
         self._conn: EnvConnection | None = None
 
-        self.commands: pimm.ReceiverDict = pimm.ReceiverDict(self, default=None)
+        self.commands: pimm.ReceiverDict = pimm.ReceiverDict(self, default=[])
         self.observations: pimm.EmitterDict = pimm.EmitterDict(self)
         self.privileged: pimm.EmitterDict = pimm.EmitterDict(self)
         self.robot_meta: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -122,22 +122,21 @@ class MujocoEnv(EnvProtocol):
         command = action['command']
         match command['type']:
             case 'hold':
-                pass
+                cmd = None
             case 'joint_pos':
-                self._cmd_emit.emit(roboarm_command.JointPosition(np.asarray(command['q'], dtype=np.float64)))
+                cmd = roboarm_command.JointPosition(np.asarray(command['q'], dtype=np.float64))
             case 'joint_vel':
-                self._cmd_emit.emit(roboarm_command.JointDelta(np.asarray(command['dq'], dtype=np.float64)))
+                cmd = roboarm_command.JointDelta(np.asarray(command['dq'], dtype=np.float64))
             case 'cartesian':
-                self._cmd_emit.emit(
-                    roboarm_command.CartesianPosition(geom.Transform3D.from_vector(command['pose'], _ROTMAT))
-                )
+                cmd = roboarm_command.CartesianPosition(geom.Transform3D.from_vector(command['pose'], _ROTMAT))
             case 'cartesian_delta':
-                self._cmd_emit.emit(
-                    roboarm_command.CartesianDelta(geom.Transform3D.from_vector(command['delta'], _ROTMAT))
-                )
+                cmd = roboarm_command.CartesianDelta(geom.Transform3D.from_vector(command['delta'], _ROTMAT))
             case other:
                 raise ValueError(f'MujocoEnv got unsupported command type {other!r}')
-        self._grip_emit.emit(float(action['grip']))
+        now_ns = self._clock.now_ns()
+        if cmd is not None:
+            self._cmd_emit.emit([(now_ns, cmd)])
+        self._grip_emit.emit([(now_ns, float(action['grip']))])
         self._advance(self._timestep)
         return {'obs': self._read_obs(), 'done': False, 'control_dt': self._timestep}
 

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -146,10 +146,14 @@ class MujocoSim(pimm.ControlSystem):
         # Set by ``reset``; the run loop publishes frame-0 (instead of stepping) on its next turn and clears it.
         self._reset_pending = False
 
-        self.commands: pimm.SignalReceiver[roboarm_command.CommandType] = pimm.ControlSystemReceiver(self, default=None)
+        self.commands: pimm.SignalReceiver[roboarm_command.Trajectory[roboarm_command.CommandType]] = (
+            pimm.ControlSystemReceiver(self, default=[])
+        )
         self.state: pimm.SignalEmitter[MujocoFrankaState] = pimm.ControlSystemEmitter(self)
         self.robot_meta = pimm.ControlSystemEmitter(self)
-        self.target_grip: pimm.SignalReceiver[float] = pimm.ControlSystemReceiver(self, default=0.0)
+        self.target_grip: pimm.SignalReceiver[roboarm_command.Trajectory[float]] = pimm.ControlSystemReceiver(
+            self, default=[]
+        )
         self.grip: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)
         self.cameras: pimm.EmitterDict = pimm.EmitterDict(self)
         # Privileged ground truth: the full ``save_state`` dict, spec keys prefixed with '.' so the

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -7,7 +7,12 @@ import pytest
 import pimm
 from positronic import wire
 from positronic.data_collection import DataCollectionController, OperatorPosition, controller_positions_serializer
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType
+from positronic.dataset.ds_writer_agent import (
+    DsWriterAgent,
+    DsWriterCommand,
+    DsWriterCommandType,
+    TrajectoryOverrideSerializer,
+)
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
 from positronic.geom import Rotation, Transform3D
@@ -155,8 +160,8 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
 
         writer_cm = LocalDatasetWriter(tmp_path)
         agent = DsWriterAgent(writer_cm.__enter__())
-        agent.add_signal('target_grip')
-        agent.add_signal('robot_command', Serializers.robot_command)
+        agent.add_signal('target_grip', TrajectoryOverrideSerializer(None))
+        agent.add_signal('robot_command', TrajectoryOverrideSerializer(Serializers.robot_command))
         agent.add_signal('controller_positions', controller_positions_serializer)
         agent.add_signal('robot_state', Serializers.robot_state)
         agent.add_signal('grip')
@@ -257,9 +262,9 @@ def test_mujoco_grip_one_is_closed():
         grip = world.pair(sim.grip)
 
         driver = ManualDriver([
-            (lambda: target_grip.emit(1.0), 0.5),
+            (lambda: target_grip.emit([(world.clock.now_ns(), 1.0)]), 0.5),
             (lambda: snapshots.update(closed=finger_qpos(), closed_grip=grip.read().data), 0.0),
-            (lambda: target_grip.emit(0.0), 0.5),
+            (lambda: target_grip.emit([(world.clock.now_ns(), 0.0)]), 0.5),
             (lambda: snapshots.update(opened=finger_qpos(), opened_grip=grip.read().data), 0.0),
         ])
 

--- a/positronic/utils/registration.py
+++ b/positronic/utils/registration.py
@@ -185,7 +185,8 @@ def perform_registration(webxr, robot_arm):
 
         while not w.should_stop:
             if move_throttler.wait_time() <= 0:
-                commands.emit(roboarm_command.CartesianPosition(WAYPOINTS[current_point]))
+                waypoint = roboarm_command.CartesianPosition(WAYPOINTS[current_point])
+                commands.emit([(w.clock.now_ns(), waypoint)])
                 current_point += 1
                 if current_point >= len(WAYPOINTS):
                     break

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -35,9 +35,8 @@ def wire(
         for signal_name in cameras.keys():
             ds_agent.add_signal(signal_name, Serializers.camera_images)
         if robot_arm is not None:
-            # Policies emit whole trajectories; flatten with last-writer-wins so the
-            # recording is a dense per-command stream (teleop emits bare commands,
-            # which pass straight through). See TrajectoryOverrideSerializer.
+            # Command channels carry whole trajectories; flatten with last-writer-wins so the
+            # recording is a dense per-command stream. See TrajectoryOverrideSerializer.
             ds_agent.add_signal('robot_command', TrajectoryOverrideSerializer(Serializers.robot_command))
             ds_agent.add_signal('robot_state', Serializers.robot_state)
         if gripper is not None:
@@ -96,7 +95,7 @@ def wire_embodiment(
             ds_agent.add_signal(name, obs.serializer)
             world.connect(obs.source, ds_agent.inputs[name])
         for name, cmd in embodiment.commands.items():
-            # Policies emit whole trajectories; flatten with last-writer-wins so the
+            # Command channels carry whole trajectories; flatten with last-writer-wins so the
             # recording is a dense per-command stream. See TrajectoryOverrideSerializer.
             ds_agent.add_signal(name, TrajectoryOverrideSerializer(cmd.serializer))
             world.connect(harness.commands[name], ds_agent.inputs[name])


### PR DESCRIPTION
Closes #518.

Every command channel (`robot_command`, `target_grip`, and each embodiment channel) carried two
different wire shapes: policies emitted `[(ts_ns, value)]` trajectories, teleop and the CLIs emitted
a bare value. Both `TrajectoryPlayer.set` and `TrajectoryOverrideSerializer` branched on
`isinstance(..., list)` to tell them apart, so no receiver could state an honest type — the
annotations that existed (`SignalReceiver[CommandType]`, `SignalReceiver[float]`) described only the
teleop half.

Now there is one shape. A single immediate command is the one-waypoint trajectory
`[(clock.now_ns(), value)]`; `[]` still cancels. Both branches are gone, the receivers say
`Trajectory[CommandType]` / `Trajectory[float]`, and their default is `[]` — an empty trajectory,
which is what "nothing commanded yet" means.

## What moved

Producers now stamp their own commands: `data_collection` (teleop), `robot_controller`,
`utils/registration`, the three driver `__main__` demos, and the env-server test env. `Replay` wraps
its two command outputs so each replayed sample goes out as a waypoint at its playback time — the
knowledge that those channels are command channels belongs to the replay adapter, not to the generic
`DsPlayerAgent`.

Two dead None-guards went with them (`env_server/adapter.py`, the golden-pipeline fakes): they
existed only because the channel might have carried something other than a list.

## Recording

`TrajectoryOverrideSerializer` no longer has a bare-value passthrough, so teleop commands are now
recorded at the timestamp the operator's command was *emitted* rather than the one the writer
happened to observe. Two consequences worth knowing:

- `robot_command` and `target_grip` samples from teleop no longer carry the `message`/`system`/`world`
  `extra_ts` columns. Waypoints carry their own timestamp; "when the writer saw the chunk" is not
  defined per-waypoint. The policy path already recorded them this way.
- `SimpleSignalWriter` rejects appends whose `extra_ts` keys differ from earlier ones on the same
  signal. Under the old two-shape world, any run that mixed teleop and policy commands on one channel
  would have hit that. It can't happen now.

## `pimm.Message.data`

`Message[T].data` was typed `T | None`, so every `msg.data` in the repo read as optional even though
`read()` already returns `None` for "nothing yet". That was invisible until the command receivers
gained real types, at which point `player.set(msg.data)` failed on all eight drivers. `data` is now
`T`; the sentinel branch in `ControlSystemReceiver.read` casts, because `T | None` cannot express
"not `NODEFAULT`". This dropped 42 grandfathered basedpyright errors — 27 of them
`reportOptionalMemberAccess` — which is why the baseline shrinks by ~340 lines. Two unrelated
entries in `data_collection` and `robot_controller` just moved column, since edits shifted their
lines.

## Test plan

- `uv run --locked pytest --no-cov` -> 744 passed, 7 skipped (same counts as `main`)
- `uv run --locked pre-commit run --from-ref upstream/main --to-ref HEAD` -> all hooks pass,
  including the basedpyright ratchet
- The honest types found one real bug the tests did not: `FakeGripper` in `test_golden_pipeline`
  declared `default=0.0` on a trajectory channel. Harmless at runtime (the `updated` guard kept the
  default out of `set()`), but it was the last bare value in the tree
- Not verified: the three `__main__` demos (`franka`, `dh`, `robotiq`) and `utils/registration` need
  real hardware. They are read-only-reviewed; each now stamps with `world.clock.now_ns()`, the same
  `SystemClock` epoch the background driver process reads
