### PR TITLE
Give every optional-dep driver an actionable import error

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -4182,8 +4182,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 25,
+                    "startColumn": 9,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -4224,8 +4224,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 14,
+                    "startColumn": 11,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             }
@@ -4300,8 +4300,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 15,
+                    "startColumn": 11,
+                    "endColumn": 19,
                     "lineCount": 1
                 }
             },
@@ -4358,8 +4358,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 22,
+                    "startColumn": 11,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
@@ -4448,8 +4448,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 22,
+                    "startColumn": 11,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
@@ -4514,8 +4514,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 18,
+                    "startColumn": 11,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -4964,8 +4964,8 @@
             {
                 "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 12,
+                    "startColumn": 11,
+                    "endColumn": 16,
                     "lineCount": 1
                 }
             },
@@ -5716,8 +5716,8 @@
             {
                 "code": "reportMissingModuleSource",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 14,
+                    "startColumn": 11,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },

--- a/positronic/drivers/__init__.py
+++ b/positronic/drivers/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pkgutil import extend_path as _extend_path
@@ -10,16 +11,28 @@ HARDWARE_EXTRA_HINT = 'Re-run with the hardware extra:\n  uv run --locked --extr
 
 
 @contextmanager
-def vendor_import(package: str, description: str, hint: str = HARDWARE_EXTRA_HINT) -> Iterator[None]:
+def vendor_import(
+    package: str, description: str, hint: str = HARDWARE_EXTRA_HINT, platforms: tuple[str, ...] = ()
+) -> Iterator[None]:
     """Wrap a driver's vendor import so a missing ``package`` says how to install it.
 
     Only ``package`` being absent is rewritten. A vendor that is installed but cannot import — a failed
     initialization, or a dependency of its own that is missing — raises with its own name in ``e.name`` and
     propagates untouched, because its diagnostic is the one that says what is actually wrong.
+
+    ``platforms`` names the ``sys.platform`` values whose dependency set carries ``package``. Elsewhere the
+    extra resolves to nothing for it, so pointing at the install command would send the reader in a circle;
+    the error names the platform instead. It speaks only once the import has already failed, so a package
+    installed by hand on an unlisted platform still works.
     """
     try:
         yield
     except ModuleNotFoundError as e:
         if e.name != package:
             raise
+        if platforms and sys.platform not in platforms:
+            supported = ' or '.join(platforms)
+            raise ModuleNotFoundError(
+                f'{description} is not available on {sys.platform}; {package} needs {supported}.'
+            ) from e
         raise ModuleNotFoundError(f'{description} is not installed. {hint}') from e

--- a/positronic/drivers/__init__.py
+++ b/positronic/drivers/__init__.py
@@ -1,3 +1,7 @@
 from pkgutil import extend_path as _extend_path
 
 __path__ = _extend_path(__path__, __name__)
+
+# Tail of the ImportError every driver raises when its vendor package is missing. Shared so the drivers cannot
+# drift into naming different install paths for the same extra.
+HARDWARE_EXTRA_HINT = 'Re-run with the hardware extra:\n  uv run --locked --extra hardware ...\n'

--- a/positronic/drivers/__init__.py
+++ b/positronic/drivers/__init__.py
@@ -1,7 +1,25 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pkgutil import extend_path as _extend_path
 
 __path__ = _extend_path(__path__, __name__)
 
-# Tail of the ImportError every driver raises when its vendor package is missing. Shared so the drivers cannot
-# drift into naming different install paths for the same extra.
+# Tail of the error a driver raises when its vendor package is missing. Shared so the drivers cannot drift into
+# naming different install paths for the same extra.
 HARDWARE_EXTRA_HINT = 'Re-run with the hardware extra:\n  uv run --locked --extra hardware ...\n'
+
+
+@contextmanager
+def vendor_import(package: str, description: str, hint: str = HARDWARE_EXTRA_HINT) -> Iterator[None]:
+    """Wrap a driver's vendor import so a missing ``package`` says how to install it.
+
+    Only ``package`` being absent is rewritten. A vendor that is installed but cannot import — a failed
+    initialization, or a dependency of its own that is missing — raises with its own name in ``e.name`` and
+    propagates untouched, because its diagnostic is the one that says what is actually wrong.
+    """
+    try:
+        yield
+    except ModuleNotFoundError as e:
+        if e.name != package:
+            raise
+        raise ModuleNotFoundError(f'{description} is not installed. {hint}') from e

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -5,12 +5,10 @@ import cv2
 import numpy as np
 
 import pimm
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 
-try:
+with vendor_import('linuxpy', 'Linux video capture'):
     from linuxpy.video.device import Device, PixelFormat
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Linux video capture is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class LinuxVideo(pimm.ControlSystem):

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -3,9 +3,14 @@ from collections.abc import Iterator
 import av
 import cv2
 import numpy as np
-from linuxpy.video.device import Device, PixelFormat
 
 import pimm
+from positronic.drivers import HARDWARE_EXTRA_HINT
+
+try:
+    from linuxpy.video.device import Device, PixelFormat
+except ImportError as e:
+    raise ImportError(f'Linux video capture is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class LinuxVideo(pimm.ControlSystem):

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -7,7 +7,7 @@ import numpy as np
 import pimm
 from positronic.drivers import vendor_import
 
-with vendor_import('linuxpy', 'Linux video capture'):
+with vendor_import('linuxpy', 'Linux video capture', platforms=('linux',)):
     from linuxpy.video.device import Device, PixelFormat
 
 

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -9,8 +9,8 @@ from positronic.drivers import HARDWARE_EXTRA_HINT
 
 try:
     from linuxpy.video.device import Device, PixelFormat
-except ImportError as e:
-    raise ImportError(f'Linux video capture is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Linux video capture is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class LinuxVideo(pimm.ControlSystem):

--- a/positronic/drivers/camera/luxonis.py
+++ b/positronic/drivers/camera/luxonis.py
@@ -4,10 +4,12 @@ import pimm
 
 try:
     import depthai as dai
-except ImportError as e:
+except ModuleNotFoundError as e:
     # TODO: `depthai` is in no extra, so this driver has no supported install path. Add it to `hardware`
     # (with the platform markers the SDK needs) or drop the driver.
-    raise ImportError('Luxonis camera support is not installed: `depthai` is in no extra of this project.') from e
+    raise ModuleNotFoundError(
+        'Luxonis camera support is not installed: `depthai` is in no extra of this project.'
+    ) from e
 
 
 # TODO: make this configurable

--- a/positronic/drivers/camera/luxonis.py
+++ b/positronic/drivers/camera/luxonis.py
@@ -1,15 +1,12 @@
 from collections.abc import Iterator
 
 import pimm
+from positronic.drivers import vendor_import
 
-try:
+# TODO: `depthai` is in no extra, so this driver has no supported install path. Add it to `hardware` (with the
+# platform markers the SDK needs) or drop the driver.
+with vendor_import('depthai', 'Luxonis camera support', '`depthai` is in no extra of this project.'):
     import depthai as dai
-except ModuleNotFoundError as e:
-    # TODO: `depthai` is in no extra, so this driver has no supported install path. Add it to `hardware`
-    # (with the platform markers the SDK needs) or drop the driver.
-    raise ModuleNotFoundError(
-        'Luxonis camera support is not installed: `depthai` is in no extra of this project.'
-    ) from e
 
 
 # TODO: make this configurable

--- a/positronic/drivers/camera/luxonis.py
+++ b/positronic/drivers/camera/luxonis.py
@@ -1,8 +1,13 @@
 from collections.abc import Iterator
 
-import depthai as dai
-
 import pimm
+
+try:
+    import depthai as dai
+except ImportError as e:
+    # TODO: `depthai` is in no extra, so this driver has no supported install path. Add it to `hardware`
+    # (with the platform markers the SDK needs) or drop the driver.
+    raise ImportError('Luxonis camera support is not installed: `depthai` is in no extra of this project.') from e
 
 
 # TODO: make this configurable

--- a/positronic/drivers/camera/zed.py
+++ b/positronic/drivers/camera/zed.py
@@ -6,12 +6,10 @@ import numpy as np
 
 import pimm
 from pimm.shared_memory import NumpySMAdapter
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 
-try:
+with vendor_import('pyzed', 'ZED camera support'):
     import pyzed.sl as sl
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'ZED camera support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class SLCamera(pimm.ControlSystem):

--- a/positronic/drivers/camera/zed.py
+++ b/positronic/drivers/camera/zed.py
@@ -10,8 +10,8 @@ from positronic.drivers import HARDWARE_EXTRA_HINT
 
 try:
     import pyzed.sl as sl
-except ImportError as e:
-    raise ImportError(f'ZED camera support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'ZED camera support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class SLCamera(pimm.ControlSystem):

--- a/positronic/drivers/camera/zed.py
+++ b/positronic/drivers/camera/zed.py
@@ -8,7 +8,7 @@ import pimm
 from pimm.shared_memory import NumpySMAdapter
 from positronic.drivers import vendor_import
 
-with vendor_import('pyzed', 'ZED camera support'):
+with vendor_import('pyzed', 'ZED camera support', platforms=('linux',)):
     import pyzed.sl as sl
 
 

--- a/positronic/drivers/camera/zed.py
+++ b/positronic/drivers/camera/zed.py
@@ -3,10 +3,15 @@ from collections.abc import Iterator
 from typing import Literal
 
 import numpy as np
-import pyzed.sl as sl
 
 import pimm
 from pimm.shared_memory import NumpySMAdapter
+from positronic.drivers import HARDWARE_EXTRA_HINT
+
+try:
+    import pyzed.sl as sl
+except ImportError as e:
+    raise ImportError(f'ZED camera support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class SLCamera(pimm.ControlSystem):

--- a/positronic/drivers/gripper/dh.py
+++ b/positronic/drivers/gripper/dh.py
@@ -2,13 +2,11 @@ import time
 from ctypes import c_uint16
 
 import pimm
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
 
-try:
+with vendor_import('pymodbus', 'Gripper support'):
     import pymodbus.client as ModbusClient
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class DHGripper(pimm.ControlSystem):

--- a/positronic/drivers/gripper/dh.py
+++ b/positronic/drivers/gripper/dh.py
@@ -7,8 +7,8 @@ from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
 
 try:
     import pymodbus.client as ModbusClient
-except ImportError as e:
-    raise ImportError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class DHGripper(pimm.ControlSystem):

--- a/positronic/drivers/gripper/dh.py
+++ b/positronic/drivers/gripper/dh.py
@@ -1,10 +1,14 @@
 import time
 from ctypes import c_uint16
 
-import pymodbus.client as ModbusClient
-
 import pimm
+from positronic.drivers import HARDWARE_EXTRA_HINT
 from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
+
+try:
+    import pymodbus.client as ModbusClient
+except ImportError as e:
+    raise ImportError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class DHGripper(pimm.ControlSystem):

--- a/positronic/drivers/gripper/robotiq.py
+++ b/positronic/drivers/gripper/robotiq.py
@@ -3,13 +3,11 @@
 from collections.abc import Iterator
 
 import pimm
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
 
-try:
+with vendor_import('pymodbus', 'Gripper support'):
     import pymodbus.client as ModbusClient
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 _REG_CMD = 0x03E8
 _REG_IN_POS = 0x07D2

--- a/positronic/drivers/gripper/robotiq.py
+++ b/positronic/drivers/gripper/robotiq.py
@@ -2,10 +2,14 @@
 
 from collections.abc import Iterator
 
-import pymodbus.client as ModbusClient
-
 import pimm
+from positronic.drivers import HARDWARE_EXTRA_HINT
 from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
+
+try:
+    import pymodbus.client as ModbusClient
+except ImportError as e:
+    raise ImportError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 _REG_CMD = 0x03E8
 _REG_IN_POS = 0x07D2

--- a/positronic/drivers/gripper/robotiq.py
+++ b/positronic/drivers/gripper/robotiq.py
@@ -8,8 +8,8 @@ from positronic.drivers.roboarm.command import Trajectory, TrajectoryPlayer
 
 try:
     import pymodbus.client as ModbusClient
-except ImportError as e:
-    raise ImportError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Gripper support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 _REG_CMD = 0x03E8
 _REG_IN_POS = 0x07D2

--- a/positronic/drivers/motors/feetech.py
+++ b/positronic/drivers/motors/feetech.py
@@ -6,8 +6,8 @@ from positronic.drivers import HARDWARE_EXTRA_HINT
 
 try:
     import scservo_sdk as scs
-except ImportError as e:
-    raise ImportError(f'Feetech motor support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Feetech motor support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 PROTOCOL_VERSION = 0
 TIMEOUT_MS = 1000

--- a/positronic/drivers/motors/feetech.py
+++ b/positronic/drivers/motors/feetech.py
@@ -2,12 +2,10 @@
 
 import numpy as np
 
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 
-try:
+with vendor_import('scservo_sdk', 'Feetech motor support'):
     import scservo_sdk as scs
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Feetech motor support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 PROTOCOL_VERSION = 0
 TIMEOUT_MS = 1000

--- a/positronic/drivers/motors/feetech.py
+++ b/positronic/drivers/motors/feetech.py
@@ -1,7 +1,13 @@
 """This code is adopted from https://github.com/huggingface/lerobot/blob/0878c6880fa4fbadf0742751cf7b015f2d63a769/src/lerobot/motors/feetech/feetech.py"""  # noqa: E501
 
 import numpy as np
-import scservo_sdk as scs
+
+from positronic.drivers import HARDWARE_EXTRA_HINT
+
+try:
+    import scservo_sdk as scs
+except ImportError as e:
+    raise ImportError(f'Feetech motor support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 PROTOCOL_VERSION = 0
 TIMEOUT_MS = 1000

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -16,7 +16,7 @@ from positronic.drivers import vendor_import
 from . import RobotStatus, State, command
 from .models import attach_robotiq_2f85
 
-with vendor_import('positronic_franka', 'Franka support'):
+with vendor_import('positronic_franka', 'Franka support', platforms=('linux',)):
     import positronic_franka._franka as pf
     from positronic_franka.desk import Desk, SafetyControllerError
 

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -19,8 +19,8 @@ from .models import attach_robotiq_2f85
 try:
     import positronic_franka._franka as pf
     from positronic_franka.desk import Desk, SafetyControllerError
-except ImportError as e:
-    raise ImportError(f'Franka support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Franka support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 def _check_error(is_error, was_error):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -11,16 +11,14 @@ import numpy as np
 
 import pimm
 from positronic import geom
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 
 from . import RobotStatus, State, command
 from .models import attach_robotiq_2f85
 
-try:
+with vendor_import('positronic_franka', 'Franka support'):
     import positronic_franka._franka as pf
     from positronic_franka.desk import Desk, SafetyControllerError
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Franka support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 def _check_error(is_error, was_error):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -9,19 +9,18 @@ from typing import Any
 
 import numpy as np
 
+import pimm
+from positronic import geom
+from positronic.drivers import HARDWARE_EXTRA_HINT
+
+from . import RobotStatus, State, command
+from .models import attach_robotiq_2f85
+
 try:
     import positronic_franka._franka as pf
     from positronic_franka.desk import Desk, SafetyControllerError
 except ImportError as e:
-    raise ImportError(
-        'Franka support is not installed. Re-run with the hardware extra:\n  uv run --locked --extra hardware ...\n'
-    ) from e
-
-import pimm
-from positronic import geom
-
-from . import RobotStatus, State, command
-from .models import attach_robotiq_2f85
+    raise ImportError(f'Franka support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 def _check_error(is_error, was_error):

--- a/positronic/drivers/roboarm/kinematics.py
+++ b/positronic/drivers/roboarm/kinematics.py
@@ -1,12 +1,10 @@
 import numpy as np
 
 from positronic import geom
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 
-try:
+with vendor_import('placo', 'Kinematics support'):
     import placo
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Kinematics support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class Kinematics:

--- a/positronic/drivers/roboarm/kinematics.py
+++ b/positronic/drivers/roboarm/kinematics.py
@@ -5,8 +5,8 @@ from positronic.drivers import HARDWARE_EXTRA_HINT
 
 try:
     import placo
-except ImportError as e:
-    raise ImportError(f'Kinematics support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Kinematics support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class Kinematics:

--- a/positronic/drivers/roboarm/kinematics.py
+++ b/positronic/drivers/roboarm/kinematics.py
@@ -1,7 +1,12 @@
 import numpy as np
-import placo
 
 from positronic import geom
+from positronic.drivers import HARDWARE_EXTRA_HINT
+
+try:
+    import placo
+except ImportError as e:
+    raise ImportError(f'Kinematics support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class Kinematics:

--- a/positronic/drivers/sound.py
+++ b/positronic/drivers/sound.py
@@ -8,7 +8,7 @@ import numpy as np
 import pimm
 from positronic.drivers import vendor_import
 
-with vendor_import('pyaudio', 'Sound support'):
+with vendor_import('pyaudio', 'Sound support', platforms=('linux',)):
     import pyaudio
 
 

--- a/positronic/drivers/sound.py
+++ b/positronic/drivers/sound.py
@@ -4,9 +4,14 @@ import wave
 from collections.abc import Iterator
 
 import numpy as np
-import pyaudio
 
 import pimm
+from positronic.drivers import HARDWARE_EXTRA_HINT
+
+try:
+    import pyaudio
+except ImportError as e:
+    raise ImportError(f'Sound support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class SoundSystem(pimm.ControlSystem):

--- a/positronic/drivers/sound.py
+++ b/positronic/drivers/sound.py
@@ -10,8 +10,8 @@ from positronic.drivers import HARDWARE_EXTRA_HINT
 
 try:
     import pyaudio
-except ImportError as e:
-    raise ImportError(f'Sound support is not installed. {HARDWARE_EXTRA_HINT}') from e
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(f'Sound support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class SoundSystem(pimm.ControlSystem):

--- a/positronic/drivers/sound.py
+++ b/positronic/drivers/sound.py
@@ -6,12 +6,10 @@ from collections.abc import Iterator
 import numpy as np
 
 import pimm
-from positronic.drivers import HARDWARE_EXTRA_HINT
+from positronic.drivers import vendor_import
 
-try:
+with vendor_import('pyaudio', 'Sound support'):
     import pyaudio
-except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(f'Sound support is not installed. {HARDWARE_EXTRA_HINT}') from e
 
 
 class SoundSystem(pimm.ControlSystem):

--- a/positronic/tests/test_components.py
+++ b/positronic/tests/test_components.py
@@ -12,7 +12,7 @@ from pimm.core import ControlSystem
 def _optional_import(module: str, symbol: str) -> Any | None:
     try:
         return getattr(import_module(module), symbol)
-    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    except ImportError:  # pragma: no cover - optional dependency; drivers re-raise as ImportError with an install hint
         return None
 
 

--- a/positronic/tests/test_components.py
+++ b/positronic/tests/test_components.py
@@ -12,7 +12,7 @@ from pimm.core import ControlSystem
 def _optional_import(module: str, symbol: str) -> Any | None:
     try:
         return getattr(import_module(module), symbol)
-    except ImportError:  # pragma: no cover - optional dependency; drivers re-raise as ImportError with an install hint
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
         return None
 
 


### PR DESCRIPTION
Closes #525.

Eight driver modules imported their vendor package at top level with no guard, so running without the extra
gave you `ModuleNotFoundError: No module named 'pyzed'` and nothing else. `franka.py` was the only one that
told you what to do about it (#520). Now they all do.

One shared guard, `positronic.drivers.vendor_import`, carries both the install line and the rule for when to
use it — that duplication is exactly how franka drifted into recommending `pip install` while the rest of the
repo moved to uv:

```python
with vendor_import('pyzed', 'ZED camera support'):
    import pyzed.sl as sl
```

Found by walking `positronic.drivers` in a dev-only venv and importing every module; the same walk now returns
an actionable message for each:

| module | was | now |
| --- | --- | --- |
| `camera/zed.py` | `No module named 'pyzed'` | ZED camera support is not installed. … |
| `camera/linux_video.py` | `No module named 'linuxpy'` | Linux video capture is not installed. … |
| `gripper/dh.py`, `gripper/robotiq.py` | `No module named 'pymodbus'` | Gripper support is not installed. … |
| `motors/feetech.py` | `No module named 'scservo_sdk'` | Feetech motor support is not installed. … |
| `roboarm/kinematics.py` | `No module named 'placo'` | Kinematics support is not installed. … |
| `sound.py` | `No module named 'pyaudio'` | Sound support is not installed. … |

`so101/driver.py` and `motors/tools/calibrate_feetech.py` inherit feetech's message and need nothing of their
own. `roboarm/kinova` already had a good message.

## Naming the platform when the extra cannot help

Three of these packages are gated on Linux in `pyproject.toml` (`positronic-franka`, `pyaudio`, `pyzed`), so on
macOS `--extra hardware` resolves to nothing for them: running the command we suggested would install nothing
and fail identically on the next import. `vendor_import` takes the platforms whose dependency set carries the
package and says so instead:

```
ZED camera support is not available on darwin; pyzed needs linux.
```

The check runs only *after* the import has already failed, so it can never block a working setup — a package
installed by hand on an unlisted platform imports fine and the guard never speaks. Verified by stubbing
`pyaudio` on this macOS machine: `positronic.drivers.sound` imports normally.

`linuxpy` gets the same treatment, though for a different reason than #525 assumed. It has no marker and does
install on macOS — but importing it raises `OSError: dlopen(libc.so.6)`, not an import error, so the guard
correctly leaves that case alone and the real diagnostic propagates. The platform message covers the case where
it is simply absent.

`pymodbus`, `placo` and `scservo_sdk` are genuinely cross-platform and keep pointing at the extra.

## `depthai` is in no extra

`camera/luxonis.py` gets a different message, because pointing it at `--extra hardware` would be false:

```
Luxonis camera support is not installed: `depthai` is in no extra of this project.
```

`depthai` appears in neither `pyproject.toml` nor `uv.lock`, so there is no supported way to install this
driver — while `cfg/hardware/camera.py:37` still offers a `luxonis` config that constructs it. Left as a loud
`TODO` rather than resolved here, since adding the dependency is a `uv lock` change that wants its own review.

## Only a genuinely absent package is rewritten

`vendor_import` compares `e.name` against the vendor package and re-raises anything else. CPython reports the
*first* module it could not find, so an exact match separates the cases cleanly: `linuxpy` absent gives
`e.name == 'linuxpy'`, while a vendor that is installed but whose own dependency is missing gives that other
module's name.

That matters because a masked error does not just mislead — `test_components._optional_import` would read it as
an unavailable optional dependency and silently *skip* the component's tests. Only a genuinely absent vendor
does that now.

## Test plan

- `uv run --locked pytest --no-cov` -> 744 passed, 7 skipped (unchanged from `main`)
- `positronic/tests/test_components.py -rs` -> the same 4 skips as before (pyzed, linux_video, depthai, sound)
- All three vendor failure modes, by shadowing `placo` on `PYTHONPATH`: absent -> our message; present but
  raising `ImportError` on init -> propagates `cannot import name 'Nonexistent'`; present but missing its own
  dependency -> propagates `No module named 'totally_absent_dep'`. Only the first is rewritten
- Platform messages on this macOS machine: the four Linux-gated drivers name `darwin`, the three cross-platform
  ones still name the extra. With `sys.platform` patched to `linux`, the extra hint is what comes back
- Stubbed `pyaudio` on `PYTHONPATH`: `positronic.drivers.sound` imports, confirming the platform check cannot
  block a hand-installed package
- `linuxpy` installed into a throwaway venv on macOS: installs cleanly, then raises
  `OSError: dlopen(libc.so.6, 0x0006)` on import — an `OSError`, so it passes through the guard untouched
- Walked `positronic.drivers` in the dev-only venv and imported all 13 modules — every failure now names its
  extra, and no bare `ModuleNotFoundError` is left
- `uv run --locked pre-commit run --all-files basedpyright` -> passes. The baseline diff is +4 on seven
  `reportMissingImports` columns, nothing else: the same pre-existing unresolved imports, indented into a
  `try:` block
- `utilities/check_packaging.py` is unaffected — it walks `positronic.cfg`/`dataset`/`server`/`policy`/`utils`/
  `geom`, and the `cfg` hardware configs defer these driver imports into their `@cfn.config` bodies


