### PR TITLE
Correct the RoboLab frame HACK comment: tracked, not fixed

### DIFF
--- a/positronic/simulator/robolab/launcher.py
+++ b/positronic/simulator/robolab/launcher.py
@@ -95,8 +95,8 @@ def _spawn(host: str, port: int) -> subprocess.Popen:
     # filesystem, where a concurrent eval's rewrite could tear a reader mid-decode.
     # HACK: the model declares ``control_frame='end_effector'`` (the flange), but the RoboLab env reports and
     # accepts poses in DROID's eef frame (gripper base ∘ EEF_OFFSET_ROT), so episode statics mislabel the frame
-    # and offline IK over RoboLab episodes would solve the wrong target. Fixed by ``ChangeEEFrame`` + a
-    # ``droid_eef`` site: https://github.com/Positronic-Robotics/positronic/issues/483
+    # and offline IK over RoboLab episodes would solve the wrong target. Tracked in
+    # https://github.com/Positronic-Robotics/positronic/issues/483
     fd, meta_path = tempfile.mkstemp(prefix='robolab_robot_meta_', suffix='.bin')
     with os.fdopen(fd, 'wb') as meta_file:
         meta_file.write(encode(bundled_franka_model()))


### PR DESCRIPTION
The `control_frame` mismatch in the RoboLab launcher is **not** resolved on `main`: neither `ChangeEEFrame` nor a `droid_eef` site exists anywhere in the tree, and [#483](https://github.com/Positronic-Robotics/positronic/issues/483) has since ruled out that hand-wired-codec approach as the final design ("its building blocks survive as input to the design").

So the comment's "Fixed by `ChangeEEFrame` + a `droid_eef` site" is doubly stale — it claims a fix that doesn't exist and names an approach that's been superseded. Point it at the tracking issue instead.

Comment-only change; the HACK itself and the underlying mismatch are unchanged (still tracked in #483).

<!-- opened-by: posi-agent -->