### PR TITLE
Run basedpyright in CI, not only pre-commit

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -52,6 +52,11 @@ jobs:
         if [ -n "$CHANGED_PY_FILES" ]; then
           echo "$CHANGED_PY_FILES" | xargs python3 utilities/check_tests_location.py
         fi
+    - name: Run basedpyright type check
+      # Whole-project type-check ratchet: fails on any error not grandfathered in
+      # .basedpyright/baseline.json. The fresh dev-only venv above is the canonical
+      # env the baseline is generated against, so no `--exact` is needed here.
+      run: uv run --locked --extra dev basedpyright
     - name: Check basedpyright baseline ratchet
       # Runs unconditionally: cheap, and fast-passes when no baseline file grew. RATCHET_BASE is the
       # PR base sha ($BASE_SHA); the script diffs against its merge-base with HEAD, since origin/main


### PR DESCRIPTION
Completes the last P1 item of the typing-ratchet plan (Positronic-Robotics/internal#52): enforce the basedpyright type-check ratchet in CI, not only in the local pre-commit hook.

Before this, `basedpyright` ran only in pre-commit, so a contributor who skips hooks could land a new type error — CI checked ruff, tests-location, and the baseline-monotonicity ratchet guard (#510), but never ran the checker itself.

This adds a `Run basedpyright type check` step to the existing `code-style` job, which already builds the canonical dev-only venv (`uv sync --locked --extra dev`) that `.basedpyright/baseline.json` is generated against — so it's the DRY home for the step rather than a separate workflow.

Verified green against current `main`'s baseline in that exact env (`uv run --locked --exact --extra dev basedpyright` → 0 errors), so this does not turn CI red on merge.

<!-- opened-by: posi-agent -->