### PR TITLE
Add a Franka Desk operations library and CLI

### DIFF
--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -67,6 +67,8 @@ uv run positronic-data-collection real \
 
 Requires Franka Panda with FCI, gripper, cameras. Install extras: `uv sync --locked --extra hardware` (Linux only). Configure network connection and udev rules (see [Drivers](../positronic/drivers/)).
 
+The run opens the brakes and activates FCI itself, given `FRANKA_DESK_USER` and `FRANKA_DESK_PASSWORD`. When the control box needs attention between runs, `positronic-franka-desk` reaches the same Desk API from the shell: `state --host=<desk-host>` prints brakes, FCI and control-token state as JSON without taking control, `reboot` recovers a control token stranded by a crashed session or a `SafetyError`, and `ack_errors` clears recoverable safety errors by running the TD2 self-test.
+
 ### Other Platforms
 - **Kinova Gen3**: Add `--robot_arm=@positronic.cfg.hardware.roboarm.kinova`
 - **SO101**: Use `positronic-data-collection so101` (bimanual setup)

--- a/positronic/drivers/roboarm/franka_desk.py
+++ b/positronic/drivers/roboarm/franka_desk.py
@@ -1,0 +1,214 @@
+"""Franka Desk operations: read the control box's state, reboot it, clear recoverable safety errors.
+
+Desk's web API is the only way to reach the brakes, FCI, the robot control token and the TD2 safety
+self-test; `positronic_franka.desk.Desk` speaks that API, and the arm driver (`franka.py`) drives it
+inline for the duration of a run. The three operations here are the out-of-band half — the ones an
+operator or a tool runs on its own, when the control box needs attention rather than the arm needs
+driving:
+
+- `read_state` is passive. It authenticates and reads. It never takes the control token, so it is
+  safe to call while another process is driving the arm.
+- `reboot` restarts the control box. The reboot deactivates FCI, locks the brakes and drops the
+  control token, which is what makes it the recovery path for a token stranded by a crashed session
+  and for a `SafetyError` Desk refuses to clear any other way. It commands no arm motion.
+- `acknowledge_errors` takes the control token, acknowledges the recoverable safety errors Desk
+  reports and runs the TD2 self-test, then releases the token on the way out — including when the
+  self-test fails. It needs the token, so nothing else may be holding control while it runs.
+
+Credentials reach this module only as arguments or through the environment (`desk_from_env`), and
+never appear in a returned value, a log line or an exception message.
+
+From the shell::
+
+    positronic-franka-desk state --host=<desk-host>       # JSON snapshot on stdout
+    positronic-franka-desk reboot --host=<desk-host>
+    positronic-franka-desk ack_errors --host=<desk-host>
+
+`FRANKA_DESK_USER` and `FRANKA_DESK_PASSWORD` carry the Desk login for all three.
+"""
+
+import dataclasses
+import json
+import os
+from types import TracebackType
+from typing import Protocol
+
+import configuronic as cfn
+import pos3
+
+from positronic.drivers import vendor_import
+from positronic.utils.logging import init_logging
+
+# Brake state Desk reports per joint, and the number of joints a Franka arm has. `parked` requires a
+# reading of exactly that length: `all()` over an empty or truncated read is vacuously true, which
+# would report a moving arm as mechanically held.
+_BRAKE_LOCKED = 'Locked'
+_JOINT_COUNT = 7
+
+
+class DeskClient(Protocol):
+    """The `positronic_franka.desk.Desk` surface these operations drive.
+
+    Typed structurally rather than against the class itself so this module — and its tests — import
+    without `positronic-franka`, which ships only in the Linux-only `hardware` extra.
+
+    `_authenticate` and `_token_state` are private API of that pinned dependency, declared here and
+    called in `read_state` alone, so a version bump that renames them breaks in one obvious place.
+    Desk exposes no public equivalent: authentication is otherwise done only by the context manager,
+    which also takes the control token, and the token state is where FCI and the active token live.
+    """
+
+    def safety_status(self) -> dict: ...
+
+    def reboot(self, wait: bool = False) -> None: ...
+
+    def run_self_test(self) -> None: ...
+
+    def _authenticate(self) -> None: ...
+
+    def _token_state(self) -> dict: ...
+
+    def __enter__(self) -> 'DeskClient': ...
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+    ) -> None: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class DeskState:
+    """What the control box reports about itself at one moment.
+
+    :param brakes: Per-joint brake state, in the order Desk reports it (`'Locked'` / `'Unlocked'`).
+    :param safety_status: Safety controller state, e.g. `'Work'`, `'Recovery'`, `'SafetyError'`.
+    :param control_held: Whether a session holds the robot control token. While it is held, taking
+        control elsewhere is refused, so `acknowledge_errors` cannot run.
+    :param fci_active: Whether FCI is up, i.e. whether libfranka can connect and drive the arm.
+    :param recoverable_errors: Errors Desk flags as recoverable, which `acknowledge_errors` clears.
+        An unrecoverable fault shows up as a `safety_status` of `'SafetyError'` instead, and needs a
+        reboot.
+    """
+
+    brakes: tuple[str, ...]
+    safety_status: str
+    control_held: bool
+    fci_active: bool
+    recoverable_errors: tuple[str, ...]
+
+    @property
+    def parked(self) -> bool:
+        """Whether every joint brake is locked, so the arm is mechanically held and cannot move.
+
+        False for a reading that does not cover the whole arm: a truncated or empty brake list is
+        an incomplete answer, not evidence that the arm is safe.
+        """
+        return len(self.brakes) == _JOINT_COUNT and all(brake == _BRAKE_LOCKED for brake in self.brakes)
+
+
+def read_state(desk: DeskClient) -> DeskState:
+    """Read the control box's state, without taking the robot control token.
+
+    Passive: it authenticates and reads, and commands nothing. Safe to call while another session
+    holds control and drives the arm — that session shows up as `control_held`.
+
+    :param desk: Desk client for the control box to read.
+    """
+    # `_authenticate` and `_token_state` are private API of positronic-franka; see `DeskClient`.
+    # Authenticating here, rather than through the context manager, is what keeps this read passive:
+    # entering the context manager would also take the control token away from whoever holds it.
+    desk._authenticate()
+    status = desk.safety_status()
+    token = desk._token_state()
+    return DeskState(
+        brakes=tuple(status['brakeState']),
+        safety_status=status['safetyControllerStatus'],
+        control_held=token['activeToken'] is not None,
+        fci_active=bool(token['fciActive']),
+        recoverable_errors=tuple(sorted(flag for flag, active in status['recoverableErrors'].items() if active)),
+    )
+
+
+def reboot(desk: DeskClient) -> None:
+    """Reboot the control box and block until it is back and its safety controller has settled.
+
+    The reboot deactivates FCI, locks the brakes and drops the control token, which recovers a token
+    stranded by a crashed session and a `SafetyError` Desk refuses to clear while it stands. It
+    commands no arm motion. The box is unreachable for roughly 40 seconds in the middle; this raises
+    `TimeoutError` if it never goes down or never settles afterwards.
+
+    :param desk: Desk client for the control box to reboot.
+    """
+    desk.reboot(wait=True)
+
+
+def acknowledge_errors(desk: DeskClient) -> None:
+    """Acknowledge the recoverable safety errors Desk reports and run the TD2 safety self-test.
+
+    Takes the robot control token for the duration and releases it on the way out, including when
+    the self-test fails, so a failure never strands control. Nothing else may be holding control:
+    Desk grants the token to one session at a time and refuses to hand it over while it is held.
+
+    :param desk: Desk client for the control box to clear.
+    """
+    with desk:
+        desk.run_self_test()
+
+
+def desk_from_env(
+    host: str, user_env: str = 'FRANKA_DESK_USER', password_env: str = 'FRANKA_DESK_PASSWORD'
+) -> DeskClient:
+    """Build a Desk client for `host`, reading the login and password from the environment.
+
+    Credentials stay in the environment so they never reach a command line, which processes on the
+    same machine can read and which tooling tends to record verbatim.
+
+    :param host: Hostname or address of the control box's Desk web interface.
+    :param user_env: Environment variable holding the Desk login.
+    :param password_env: Environment variable holding the Desk password.
+    """
+    login, password = os.environ.get(user_env), os.environ.get(password_env)
+    if not (login and password):
+        missing = ' and '.join(name for name, value in ((user_env, login), (password_env, password)) if not value)
+        raise RuntimeError(f'{missing} not set in the environment; Desk operations need Desk credentials.')
+    # Deferred: positronic-franka lives in the Linux-only `hardware` extra and only this constructor
+    # needs the concrete class, everything else being typed against `DeskClient`. Importing it at
+    # module level would make the module, and its tests, unimportable without that extra.
+    with vendor_import('positronic_franka', 'Franka support', platforms=('linux',)):
+        from positronic_franka.desk import Desk  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+    return Desk(host, login, password)
+
+
+def state_as_json(state: DeskState) -> str:
+    """Render a `DeskState` as JSON, with `parked` alongside the fields it is derived from."""
+    return json.dumps({**dataclasses.asdict(state), 'parked': state.parked}, indent=2, sort_keys=True)
+
+
+def print_state(host: str) -> None:
+    """Print the control box's state as JSON on stdout. Takes no control, so it is safe during a run."""
+    print(state_as_json(read_state(desk_from_env(host))))
+
+
+def reboot_control_box(host: str) -> None:
+    """Reboot the control box, waiting for it to come back. Locks the brakes; commands no arm motion."""
+    reboot(desk_from_env(host))
+
+
+def acknowledge_safety_errors(host: str) -> None:
+    """Clear recoverable safety errors by running the TD2 self-test. Nothing else may hold control."""
+    acknowledge_errors(desk_from_env(host))
+
+
+# Console entry point for [project.scripts]. Every command fails loudly, so a failed operation
+# leaves a non-zero exit status behind.
+@pos3.with_mirror()
+def _internal_main():
+    init_logging()
+    cfn.cli({
+        'state': cfn.Config(print_state),
+        'reboot': cfn.Config(reboot_control_box),
+        'ack_errors': cfn.Config(acknowledge_safety_errors),
+    })
+
+
+if __name__ == '__main__':
+    _internal_main()

--- a/positronic/drivers/roboarm/tests/test_franka_desk.py
+++ b/positronic/drivers/roboarm/tests/test_franka_desk.py
@@ -1,0 +1,187 @@
+import json
+from types import TracebackType
+
+import pytest
+
+from positronic.drivers.roboarm.franka_desk import (
+    DeskState,
+    acknowledge_errors,
+    desk_from_env,
+    read_state,
+    reboot,
+    state_as_json,
+)
+
+LOCKED = ('Locked',) * 7
+UNLOCKED = ('Unlocked',) * 7
+
+
+def safety_status(
+    brakes: tuple[str, ...] = LOCKED, status: str = 'Work', recoverable: dict[str, bool] | None = None
+) -> dict:
+    """A `Desk.safety_status()` reading, shaped as the Desk web API returns it."""
+    return {
+        'brakeState': list(brakes),
+        'safetyControllerStatus': status,
+        'recoverableErrors': {'td2Timeout': False, 'genericJointError': False, **(recoverable or {})},
+    }
+
+
+class FakeDesk:
+    """A Desk that answers from canned readings and records what was asked of it.
+
+    Entering it stands for taking the robot control token, as the real context manager does, so a
+    test can assert an operation left control alone.
+    """
+
+    def __init__(self, status: dict | None = None, active_token: dict | None = None, fci_active: bool = False):
+        self._status = status if status is not None else safety_status()
+        self._token = {'activeToken': active_token, 'fciActive': fci_active}
+        self.calls: list[str] = []
+        self.self_test_error: Exception | None = None
+        self.control_held = False
+
+    def safety_status(self) -> dict:
+        self.calls.append('safety_status')
+        return self._status
+
+    def reboot(self, wait: bool = False) -> None:
+        self.calls.append(f'reboot(wait={wait})')
+
+    def run_self_test(self) -> None:
+        self.calls.append('run_self_test')
+        if self.self_test_error is not None:
+            raise self.self_test_error
+
+    def _authenticate(self) -> None:
+        self.calls.append('_authenticate')
+
+    def _token_state(self) -> dict:
+        self.calls.append('_token_state')
+        return self._token
+
+    def __enter__(self) -> 'FakeDesk':
+        self.calls.append('take_control')
+        self.control_held = True
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+    ) -> None:
+        self.calls.append('release_control')
+        self.control_held = False
+
+
+def test_read_state_maps_a_full_reading():
+    desk = FakeDesk(
+        status=safety_status(brakes=UNLOCKED, status='Recovery', recoverable={'td2Timeout': True}),
+        active_token={'id': 7},
+        fci_active=True,
+    )
+
+    state = read_state(desk)
+
+    assert state == DeskState(
+        brakes=UNLOCKED,
+        safety_status='Recovery',
+        control_held=True,
+        fci_active=True,
+        recoverable_errors=('td2Timeout',),
+    )
+    assert not state.parked
+
+
+def test_read_state_reports_an_idle_box():
+    state = read_state(FakeDesk())
+
+    assert state == DeskState(
+        brakes=LOCKED, safety_status='Work', control_held=False, fci_active=False, recoverable_errors=()
+    )
+    assert state.parked
+
+
+def test_read_state_never_takes_control():
+    desk = FakeDesk(active_token={'id': 3})
+
+    read_state(desk)
+
+    assert 'take_control' not in desk.calls
+    assert 'release_control' not in desk.calls
+    assert desk.control_held is False
+
+
+@pytest.mark.parametrize('brakes', [(), ('Locked',), ('Locked',) * 6, ('Locked',) * 8])
+def test_parked_is_false_on_a_partial_reading(brakes: tuple[str, ...]):
+    """An `all()` over an empty or truncated brake list is vacuously true; `parked` must not be."""
+    assert not read_state(FakeDesk(safety_status(brakes=brakes))).parked
+
+
+@pytest.mark.parametrize('unlocked_joint', [0, 3, 6])
+def test_parked_is_false_when_a_joint_is_unlocked(unlocked_joint: int):
+    brakes: list[str] = list(LOCKED)
+    brakes[unlocked_joint] = 'Unlocked'
+
+    assert not read_state(FakeDesk(safety_status(brakes=tuple(brakes)))).parked
+
+
+def test_recoverable_errors_lists_only_the_flagged_ones():
+    desk = FakeDesk(safety_status(recoverable={'td2Timeout': True, 'genericJointError': False, 'other': True}))
+
+    assert read_state(desk).recoverable_errors == ('other', 'td2Timeout')
+
+
+def test_acknowledge_errors_runs_the_self_test_under_control():
+    desk = FakeDesk()
+
+    acknowledge_errors(desk)
+
+    assert desk.calls == ['take_control', 'run_self_test', 'release_control']
+    assert desk.control_held is False
+
+
+def test_acknowledge_errors_releases_control_when_the_self_test_fails():
+    desk = FakeDesk()
+    desk.self_test_error = TimeoutError('TD2 self-test did not complete')
+
+    with pytest.raises(TimeoutError):
+        acknowledge_errors(desk)
+
+    assert desk.calls == ['take_control', 'run_self_test', 'release_control']
+    assert desk.control_held is False
+
+
+def test_reboot_waits_for_the_box_to_come_back():
+    desk = FakeDesk()
+
+    reboot(desk)
+
+    assert desk.calls == ['reboot(wait=True)']
+
+
+def test_state_as_json_carries_parked_alongside_the_fields():
+    payload = json.loads(state_as_json(read_state(FakeDesk())))
+
+    assert payload == {
+        'brakes': list(LOCKED),
+        'safety_status': 'Work',
+        'control_held': False,
+        'fci_active': False,
+        'recoverable_errors': [],
+        'parked': True,
+    }
+
+
+@pytest.mark.parametrize(
+    ('user', 'password', 'missing'),
+    [(None, 'pw', 'DESK_USER'), ('user', None, 'DESK_PASSWORD'), (None, None, 'DESK_USER and DESK_PASSWORD')],
+)
+def test_desk_from_env_names_the_missing_variables(
+    monkeypatch: pytest.MonkeyPatch, user: str | None, password: str | None, missing: str
+):
+    for name, value in (('DESK_USER', user), ('DESK_PASSWORD', password)):
+        monkeypatch.delenv(name, raising=False)
+        if value is not None:
+            monkeypatch.setenv(name, value)
+
+    with pytest.raises(RuntimeError, match=missing):
+        desk_from_env('desk.invalid', user_env='DESK_USER', password_env='DESK_PASSWORD')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ positronic-server="positronic.server.positronic_server:_internal_main"
 positronic-inference="positronic.inference:_internal_main"
 positronic-probe="positronic.probe:_internal_main"
 positronic-data-collection="positronic.data_collection:_internal_main"
+positronic-franka-desk="positronic.drivers.roboarm.franka_desk:_internal_main"
 
 
 [project.optional-dependencies]


### PR DESCRIPTION
Desk's web API is the only way to reach the brakes, FCI, the robot control token and the TD2 safety self-test. The arm driver (`franka.py`) already drives it inline for the duration of a run; this adds the out-of-band half — the operations an operator or a tool runs on its own when the control box needs attention rather than the arm needs driving.

## Library — `positronic/drivers/roboarm/franka_desk.py`

```python
read_state(desk: DeskClient) -> DeskState
reboot(desk: DeskClient) -> None
acknowledge_errors(desk: DeskClient) -> None
desk_from_env(host: str, user_env='FRANKA_DESK_USER', password_env='FRANKA_DESK_PASSWORD') -> DeskClient
```

- `read_state` is **passive**: it authenticates and reads, and never takes the control token, so it is safe to call while another session is driving the arm (that session shows up as `control_held`).
- `reboot` restarts the control box and blocks until it has settled. The reboot deactivates FCI, locks the brakes and drops the control token, which is what recovers a token stranded by a crashed session and a `SafetyError` Desk refuses to clear while it stands. It commands no arm motion.
- `acknowledge_errors` takes the control token, runs the TD2 self-test (which acknowledges the recoverable safety errors Desk reports), and releases the token on the way out — including when the self-test fails.

`DeskState` is a frozen snapshot of `brakes`, `safety_status`, `control_held`, `fci_active` and `recoverable_errors`, with a `parked` property. `parked` requires a brake reading covering all seven joints: `all()` over an empty or truncated list is vacuously true, which would report a moving arm as mechanically held.

## CLI — `positronic-franka-desk`

```bash
positronic-franka-desk state --host=<desk-host>       # JSON snapshot on stdout, takes no control
positronic-franka-desk reboot --host=<desk-host>
positronic-franka-desk ack_errors --host=<desk-host>
```

The host is always a parameter. Credentials come from `FRANKA_DESK_USER` / `FRANKA_DESK_PASSWORD` and never reach a command line, a log line or a returned value. Failures propagate, so a failed operation leaves a non-zero exit status.

## Two things worth a reviewer's eye

**Typed against a `DeskClient` protocol, not the concrete `Desk`.** `positronic-franka` ships only in the Linux-only `hardware` extra, which CI does not install — a module-level vendor import would make this module, and its tests, uncollectable there. The protocol is the surface these operations actually drive, so the module imports anywhere, the tests run in CI against a structurally-checked fake, and only `desk_from_env` needs the concrete class (deferred import, `vendor_import`-wrapped exactly as `franka.py` does it).

**The two private-API calls are declared and called in one place each.** `read_state` needs `Desk._authenticate` and `Desk._token_state`: Desk authenticates publicly only via its context manager, which would also take the control token away from whoever holds it, and the token state is where FCI and the active token live. Both are named on `DeskClient` as private API of a pinned dependency, so a version bump that renames them breaks in one obvious place.

## Tests

`positronic/drivers/roboarm/tests/test_franka_desk.py`, 18 cases against a fake Desk — no hardware. They cover the full-reading mapping, `parked` on empty/truncated/unlocked readings, that `read_state` never asks for control, that `acknowledge_errors` releases control even when the self-test raises, that `recoverable_errors` lists only flagged errors, and that `desk_from_env` names the missing environment variables.

<!-- opened-by: posi-agent -->