### PR TITLE
Enforce the complexity limit that was configured and never running

### DIFF
--- a/pimm/world.py
+++ b/pimm/world.py
@@ -685,7 +685,7 @@ class World:
             return emitter
         raise ValueError(f'Unsupported connector type: {type(connector)}.')
 
-    def start(
+    def start(  # noqa: C901
         self,
         main_process: ControlSystem | list[ControlSystem | None],
         background: ControlSystem | list[ControlSystem | None] | None = None,

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -485,7 +485,7 @@ def sim_checkpoint_table():
 FIXED_ITEM_COUNTS = {tasks.SCISSORS_TASK: 10, tasks.BATTERIES_TASK: 8}
 
 
-def calculate_units(episode: Episode) -> int:
+def calculate_units(episode: Episode) -> int:  # noqa: C901
     """Estimates the number of pick-and-place operations. Vibe-coded heuristic."""
     if episode[keys.TASK] in FIXED_ITEM_COUNTS:
         return FIXED_ITEM_COUNTS[episode[keys.TASK]]

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -183,7 +183,7 @@ class DsWriterAgent(pimm.ControlSystem):
     def inputs(self) -> dict[str, pimm.ControlSystemReceiver[Any]]:
         return frozen_keys_dict(self._inputs)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):  # noqa: C901
         """Main loop: process commands and append updated inputs to the episode."""
         limiter = pimm.utils.RateLimiter(clock, hz=self._poll_hz)
         pace = (lambda: pimm.Yield()) if self._virtual_time else limiter.wait
@@ -253,7 +253,7 @@ class DsWriterAgent(pimm.ControlSystem):
                     ep_writer.__exit__(None, None, None)
                     logger.info(f'DsWriterAgent: [ABORT] Episode {ep_counter}')
 
-    def _handle_command(
+    def _handle_command(  # noqa: C901
         self, cmd: DsWriterCommand, ep_writer: EpisodeWriter | None, ep_counter: int, now_ns: int | None = None
     ):
         match cmd.type:

--- a/positronic/dataset/signal.py
+++ b/positronic/dataset/signal.py
@@ -214,7 +214,7 @@ class Signal(Sequence[tuple[T, int]], ABC, Generic[T]):
         return self._ts_at(slice(None))
 
     @final
-    def __getitem__(self, index_or_slice: int | IndicesLike) -> Union[tuple[T, int], 'Signal[T]']:
+    def __getitem__(self, index_or_slice: int | IndicesLike) -> Union[tuple[T, int], 'Signal[T]']:  # noqa: C901
         match index_or_slice:
             case int() | np.integer() as idx:
                 if idx < 0:
@@ -246,7 +246,7 @@ class _SignalViewTime(TimeIndexerLike[T], Generic[T]):
     def __init__(self, signal: Signal[T]):
         self._signal = signal
 
-    def __getitem__(self, ts_or_array: int | IndicesLike) -> Union[tuple[T, int], 'Signal[T]']:
+    def __getitem__(self, ts_or_array: int | IndicesLike) -> Union[tuple[T, int], 'Signal[T]']:  # noqa: C901
         match ts_or_array:
             case int() | float() | np.floating() as ts:
                 idx = int(self._signal._search_ts([ts])[0])

--- a/positronic/dataset/video.py
+++ b/positronic/dataset/video.py
@@ -83,7 +83,7 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
         self._stream.pix_fmt = 'yuv420p'
         self._stream.gop_size = self.gop_size
 
-    def append(self, data: np.ndarray, ts_ns: int, extra_ts: dict[str, int] | None = None) -> None:
+    def append(self, data: np.ndarray, ts_ns: int, extra_ts: dict[str, int] | None = None) -> None:  # noqa: C901
         """Append a video frame with timestamp.
 
         Args:

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -21,7 +21,7 @@ class LinuxVideo(pimm.ControlSystem):
         self.fps_counter = pimm.utils.RateCounter(f'LinuxVideo {device_path}')
         self.frame: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         codec_mapping = {
             PixelFormat.H264: 'h264',
             PixelFormat.HEVC: 'hevc',

--- a/positronic/drivers/camera/zed.py
+++ b/positronic/drivers/camera/zed.py
@@ -71,7 +71,7 @@ class SLCamera(pimm.ControlSystem):
         self.depth_mask: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)
         self._depth_mask_adapter = None  # Lazy init
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         SUCCESS = sl.ERROR_CODE.SUCCESS
         TIME_REF_IMAGE = sl.TIME_REFERENCE.IMAGE
         fps_counter = pimm.utils.RateCounter('Camera')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -253,7 +253,7 @@ class Robot(pimm.ControlSystem):
                     yield desk
                     return
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         with self._desk_session():
             robot = self._ensure_robot()
             try:

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -189,7 +189,7 @@ class Robot(pimm.ControlSystem):
         self.grip = pimm.ControlSystemEmitter[float](self)
         self.robot_meta = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:  # noqa: C901
         arm = self._connect(self._channel, self._sim)
         try:
             kin = _Kinematics()

--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -662,7 +662,7 @@ class EvalUI(pimm.ControlSystem):
 
     # --- Control System Run Loop ---
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         self.clock = clock
         # Initialize DPG Context
         dpg.create_context()

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -217,7 +217,7 @@ class WebEvalUI(pimm.ControlSystem):
         self.directive = pimm.ControlSystemEmitter(self)
         self.manual_command = pimm.ControlSystemEmitter(self)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         templates = Jinja2Templates(directory=_pkg_path('templates'))
         names = list(self.cameras)
         stream = _CameraStream(self.fps, self.keyframe_interval, self.bitrate)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -363,7 +363,7 @@ class Harness(pimm.ControlSystem):
             return {'eval.terminated': False}
         return None
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:  # noqa: C901
         # Home the embodiment before the first episode; each ``_end_episode`` re-homes for the next one, so
         # every episode begins from the home pose (a real arm gets the inter-episode gap to reach it).
         self._home(clock)

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -381,7 +381,7 @@ class _RecordingTapSession(DelegatingSession):
                 log_numeric_series(path, num)
                 self._rec._numeric_paths.append(path)
 
-    def _log_action_chunk(self, prefix: str, actions: list[dict], obs: dict) -> None:
+    def _log_action_chunk(self, prefix: str, actions: list[dict], obs: dict) -> None:  # noqa: C901
         """Log the action chunk as an enriched 3D trajectory + ``action_time`` time series."""
         # Skip validity sentinels: they carry no command to plot and would flip the ``all(... in a)`` checks below.
         actions = [a for a in actions if is_action(a)]

--- a/positronic/policy/tests/test_sampled_e2e.py
+++ b/positronic/policy/tests/test_sampled_e2e.py
@@ -109,7 +109,7 @@ def _episode_metas(p):
 
 
 @pytest.mark.timeout(5.0)
-def test_sampled_policy_e2e():
+def test_sampled_policy_e2e():  # noqa: C901
     """Full harness e2e with SampledPolicy: 4 episodes, 2 policies, balanced sampling."""
     random.seed(0)
     robot_state = FakeRobotState()

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -363,7 +363,7 @@ def _group_id(episode: Episode, group_keys: tuple[str, ...]) -> tuple[Any, ...]:
 
 @app.get('/api/groups/{suffix}')
 @require_dataset
-async def api_groups(request: Request, suffix: str):
+async def api_groups(request: Request, suffix: str):  # noqa: C901
     cache_key = ('groups', suffix, tuple(sorted(request.query_params.items())))
     if cache_key in _api_cache:
         return _api_cache[cache_key]

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -179,7 +179,7 @@ class LiberoEnv(EnvProtocol):
         raw, _reward, done, _info = self._env.step(np.concatenate([arm, [grip]]).tolist())
         return {'obs': self._observe(raw), 'done': bool(done), 'control_dt': self._control_dt}
 
-    def _arm_action(self, command: dict[str, Any]) -> np.ndarray:
+    def _arm_action(self, command: dict[str, Any]) -> np.ndarray:  # noqa: C901
         # All-to-all: each command becomes the physical pre-scale quantity the active controller's set_goal adds to
         # the current setpoint, then ``_normalize`` inverts the controller's scaling. The pose<->joint cells use
         # FK/IK on the site Jacobian. ``dq`` is a per-step joint delta (positronic applies ``JointDelta`` as

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -162,7 +162,7 @@ class MujocoSim(pimm.ControlSystem):
         # replays these states through it (``mj_setState`` + ``mj_forward``).
         self.sim_state: pimm.SignalEmitter[dict[str, np.ndarray]] = pimm.ControlSystemEmitter(self)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         self._emit_robot_meta()
         state_due = _Cadence(self._state_fps)
         grip_due = _Cadence(self._grip_fps)

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -26,7 +26,7 @@ from positronic.utils import package_assets_path
 
 # This integration test exercises the unified `main` end-to-end on the sim embodiment.
 @pytest.mark.timeout(30.0)
-def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):
+def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa: C901
     class DummyTqdm:
         def __init__(self, *args, **kwargs):
             self.n = 0.0

--- a/positronic/utils/__init__.py
+++ b/positronic/utils/__init__.py
@@ -95,7 +95,7 @@ def find_uv_lock(start_dir: Path) -> Path | None:
     return None
 
 
-def get_docker_info() -> dict | None:
+def get_docker_info() -> dict | None:  # noqa: C901
     """Detect if running inside Docker and gather container metadata.
 
     Returns:
@@ -147,7 +147,7 @@ def get_docker_info() -> dict | None:
     return None
 
 
-def run_metadata(patterns: list[str] | None = None, add_git_diff: bool = True, add_uv_lock: bool = True) -> dict:
+def run_metadata(patterns: list[str] | None = None, add_git_diff: bool = True, add_uv_lock: bool = True) -> dict:  # noqa: C901
     """Capture script run metadata for maximum reproducibility.
 
     This function collects comprehensive information about the current script execution,

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -8,7 +8,7 @@ from positronic.eval import ROBOT_STATIC_META, Embodiment, Observation
 __all__ = ['ROBOT_STATIC_META', 'wire', 'wire_embodiment']
 
 
-def wire(
+def wire(  # noqa: C901
     world: pimm.World,
     harness: pimm.ControlSystem,
     dataset_writer: DatasetWriter | None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ select = [
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
     "PLC0415",  # imports belong at the top of the file
+    "C90", # mccabe cyclomatic complexity (threshold below)
 ]
 ignore = [
     "E203",  # whitespace before ':'

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -172,7 +172,7 @@ def _segments(cmd: str) -> list[list[str]]:
     return [s for s in segments if s]
 
 
-def _substitution_bodies(cmd: str) -> list[str]:
+def _substitution_bodies(cmd: str) -> list[str]:  # noqa: C901
     """Bodies of the command substitutions in `cmd` — backtick `` `…` `` and `$(…)`.
 
     Bash runs these in a subshell (same cwd) BEFORE the outer command, so an embedded
@@ -310,7 +310,7 @@ def _is_gh_pr_merge(words: list[str]) -> bool:
     return False
 
 
-def _push_dest_slug(inv_dir: str | None, rest: list[str], git: GitInfo) -> str:
+def _push_dest_slug(inv_dir: str | None, rest: list[str], git: GitInfo) -> str:  # noqa: C901
     """Destination slug of one push invocation, resolved from the repo it runs in.
 
     The `<repository>` positional (or `--repo=`) may be a URL (slugged directly), a local path
@@ -362,7 +362,7 @@ def _push_dest_slug(inv_dir: str | None, rest: list[str], git: GitInfo) -> str:
     return repo_slug(git.remote_url(inv_dir, remote))
 
 
-def analyze(cmd: str, cwd: str, guarded_slug: str, git: GitInfo, path_exists=os.path.isdir, _depth=0) -> str | None:
+def analyze(cmd: str, cwd: str, guarded_slug: str, git: GitInfo, path_exists=os.path.isdir, _depth=0) -> str | None:  # noqa: C901
     """The deny message for `cmd`, or None to allow it."""
     guarded_slug = guarded_slug.casefold()
     # A command substitution runs its own command (same cwd) before the outer command, so a git

--- a/utilities/plot_eval.py
+++ b/utilities/plot_eval.py
@@ -19,7 +19,7 @@ from positronic.dataset import Dataset
 
 
 @cfn.config(dataset=positronic.cfg.analysis.sim_episodes, output='eval_plots.html')
-def main(dataset: Dataset, output: str):
+def main(dataset: Dataset, output: str):  # noqa: C901
     """
     Generate evaluation plots for a given dataset.
 

--- a/utilities/release_phail.py
+++ b/utilities/release_phail.py
@@ -94,7 +94,7 @@ def _check_dest_empty(dest: str, profile=None):
 
 
 @cfn.config(dataset=analysis_cfg.phail_inference_prod_v1_0, force=False)
-def verify_inference(dataset: Dataset, force: bool):
+def verify_inference(dataset: Dataset, force: bool):  # noqa: C901
     """Verify inference episodes for consistency. Raises SystemExit on failure unless force=False."""
     issues = []
 


### PR DESCRIPTION
`[tool.ruff.lint.mccabe] max-complexity = 10` has been set for as long as the config has existed, and `C90` was never in `select` — so mccabe never ran. The limit was stated in two places and checked in none.

Selecting `C90` surfaces **28 pre-existing functions** over the limit, across 23 files, with a long tail — 5 are still over 16 and one is over 25. Raising the threshold until the tree passes would need ~26: a number nobody chose, holding nothing.

So the limit stays at **10**, and each of the 28 carries a narrow per-line `# noqa: C901` (added by `ruff check --add-noqa`, scoped to the one rule). Those markers are **debt, not exemption** — the initial capture of what was already there, so new code is held at the real bar from here, and the list only shrinks as functions are refactored under it.

`ruff check .` is green.

The alternative shape — a loose passing threshold ratcheted down later — is a one-line change if that is preferred; it just does not gate anything today.
