### PR TITLE
Say what the no-new-test-files rule is for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,8 @@
 - Comments wrap at 120 columns, same as code
 
 # Testing
-- A new test goes in the file that already covers its subject — a bug fix's regression test beside the other
-  tests of what broke, in the existing package `tests/`
+- A test goes in the file that already covers its subject. A test written for a bug is an ordinary test of the
+  thing that broke — it belongs beside the others and needs neither a file of its own nor "regression" framing
 - Look for that home by subject rather than by filename, and conclude there is none only after looking. A new
   test file claims the subject has no home yet, and that claim is usually wrong
 - When a test genuinely has nowhere to go, the file organization is what needs adjusting — that is a finding,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@
   TODO/HACK comment. Never bridge silently with an extra field, class, or indirection
 - Internal code breaks cleanly — no speculative compat shims. Before a migrate-everywhere change, grep for
   consumers that need the old form; alias or migrate only the real ones
+- The same holds for a new file of any kind — module, test, or doc: find the existing home first, and when
+  there is none, surface that rather than restructuring on your own initiative (see Testing)
 - A new class, file, or field must earn its place: if existing structure already encodes the distinction (the dict
   an entry lives in, an enum, the calling context), don't reify the concept into a type. Extend an existing module
   rather than adding a file
@@ -65,7 +67,13 @@
 - Comments wrap at 120 columns, same as code
 
 # Testing
-- A bug fix may add a focused regression test to the existing package `tests/`; beyond that, don't add new test files or suites unless explicitly asked
+- Tests are welcome — new test *files* are what to avoid. Add to the file that already covers the subject; a
+  bug fix's regression test belongs in the existing package `tests/`, beside the other tests of what broke
+- Search for that home by subject, not by filename, and only conclude there is none after looking. A new file
+  claims the subject has no home yet, and that claim is usually wrong
+- When a test genuinely has nowhere to go, the file organization is what needs adjusting — that is a finding,
+  not a licence to invent a home. Don't restructure on your own initiative: put the test in the least-wrong
+  existing home and say plainly that nothing fit, so the gap reaches a human instead of being absorbed
 
 # Commit messages
 - Short, imperative sentences (e.g., "Fix wrong type", not "Fixed wrong type")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,11 @@
   TODO/HACK comment. Never bridge silently with an extra field, class, or indirection
 - Internal code breaks cleanly — no speculative compat shims. Before a migrate-everywhere change, grep for
   consumers that need the old form; alias or migrate only the real ones
-- The same holds for a new file of any kind — module, test, or doc: find the existing home first, and when
-  there is none, surface that rather than restructuring on your own initiative (see Testing)
 - A new class, file, or field must earn its place: if existing structure already encodes the distinction (the dict
   an entry lives in, an enum, the calling context), don't reify the concept into a type. Extend an existing module
   rather than adding a file
+- That holds for a new file of any kind — module, test, or doc. Find the existing home first; when there is
+  genuinely none, surface it rather than restructuring on your own initiative (see Testing)
 - No `X | None` for logically required values — an Optional that is never None in practice lies about the contract
 - After every fix or refactor, re-read the resulting code as a whole, not the diff: fixes create new smells (e.g.
   two classes become structurally identical only after their serializers are unified — merge them)
@@ -67,10 +67,10 @@
 - Comments wrap at 120 columns, same as code
 
 # Testing
-- Tests are welcome — new test *files* are what to avoid. Add to the file that already covers the subject; a
-  bug fix's regression test belongs in the existing package `tests/`, beside the other tests of what broke
-- Search for that home by subject, not by filename, and only conclude there is none after looking. A new file
-  claims the subject has no home yet, and that claim is usually wrong
+- A new test goes in the file that already covers its subject — a bug fix's regression test beside the other
+  tests of what broke, in the existing package `tests/`
+- Look for that home by subject rather than by filename, and conclude there is none only after looking. A new
+  test file claims the subject has no home yet, and that claim is usually wrong
 - When a test genuinely has nowhere to go, the file organization is what needs adjusting — that is a finding,
   not a licence to invent a home. Don't restructure on your own initiative: put the test in the least-wrong
   existing home and say plainly that nothing fit, so the gap reaches a human instead of being absorbed


### PR DESCRIPTION
The Testing rule read as a cap on testing — *don't add new test files or suites* — when the intent is narrower: **find the existing home before creating any file**, tests included. Adding tests is not the thing being discouraged, and reading it that way costs coverage.

## The regression carve-out goes rather than getting restated

The line said a bug fix *may add a focused regression test to the existing package `tests/`*. That clause arrived in #498 to reconcile the older blanket *don't add new test files* against the standing rule that every bug leaves a test behind.

Those two never actually conflicted. One is about **files**, the other about **tests**, and the bug's test goes in the file that already covers what broke. The reconciliation read the file rule as a rule about tests, and licensed a *category of test* instead — which invites a file per regression, and names a test after the incident that prompted it rather than the behaviour it pins.

So the carve-out is dropped, not reworded. A test written for a bug is an ordinary test of the thing that broke.

## The case the rule was missing

**A test with nowhere to go is a fact about the code's layout**, not a paperwork problem — and an agent that quietly opens a new file absorbs exactly the signal worth having. The rule now says: put it in the least-wrong existing home, and state plainly that nothing fit, so a human rules on whether the organization changes.

One sentence is added to Design discipline, after the class/file/field bullet it generalizes, so the two do not drift.