### PR TITLE
Record real frame timing in the video container

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -3924,56 +3924,8 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 39,
                     "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 81,
                     "lineCount": 1
                 }
             },

--- a/positronic/dataset/tests/test_episode.py
+++ b/positronic/dataset/tests/test_episode.py
@@ -388,7 +388,7 @@ def test_episode_writer_with_extra_timelines(tmp_path):
 
     # Verify video signal has extra timelines
     frames_table = pq.read_table(ep_dir / 'image.frames.parquet')
-    assert {'ts_ns', 'ts_ns.producer', 'ts_ns.consumer'} == set(frames_table.column_names)
+    assert {'ts_ns', 'ts_ns.producer', 'ts_ns.consumer'} <= set(frames_table.column_names)
     assert frames_table['ts_ns.producer'].to_pylist() == [1400, 2400]
     assert frames_table['ts_ns.consumer'].to_pylist() == [1600, 2600]
 

--- a/positronic/dataset/tests/test_remote.py
+++ b/positronic/dataset/tests/test_remote.py
@@ -40,7 +40,7 @@ def dataset_with_video(tmp_path):
                 # Video signal
                 video_path = ew.path / 'cam.mp4'
                 frames_path = ew.path / 'cam.frames.parquet'
-                with VideoSignalWriter(video_path, frames_path, fps=30) as vw:
+                with VideoSignalWriter(video_path, frames_path) as vw:
                     for i in range(3):
                         frame = np.full((64, 64, 3), (ep_idx + 1) * 50 + i * 10, dtype=np.uint8)
                         vw.append(frame, ts_ns=1000 + i * 100)

--- a/positronic/dataset/tests/test_video.py
+++ b/positronic/dataset/tests/test_video.py
@@ -1,4 +1,6 @@
+import av
 import numpy as np
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -142,7 +144,7 @@ class TestVideoSignalWriter:
 
 class TestVideoSignalStartLastTs:
     def test_video_start_last_ts_basic(self, video_paths):
-        with VideoSignalWriter(video_paths['video'], video_paths['frames'], gop_size=5, fps=30) as writer:
+        with VideoSignalWriter(video_paths['video'], video_paths['frames'], gop_size=5) as writer:
             writer.append(create_frame(10), 1000)
             writer.append(create_frame(20), 2000)
             writer.append(create_frame(30), 4000)
@@ -210,7 +212,7 @@ class TestVideoExtraTimelines:
 
         # Read the frames index directly
         table = pq.read_table(video_paths['frames'])
-        assert {'ts_ns', 'ts_ns.consumer', 'ts_ns.producer'} == set(table.column_names)
+        assert {'ts_ns', 'pts', 'ts_ns.consumer', 'ts_ns.producer'} == set(table.column_names)
 
         # Verify the data
         assert table['ts_ns'].to_pylist() == [1000, 2000, 3000]
@@ -223,7 +225,7 @@ class TestVideoExtraTimelines:
             pass
 
         table = pq.read_table(video_paths['frames'])
-        assert {'ts_ns'} == set(table.column_names)
+        assert {'ts_ns', 'pts'} == set(table.column_names)
         assert len(table) == 0
 
     def test_video_inconsistent_extra_ts_keys_raises(self, video_paths):
@@ -246,3 +248,147 @@ class TestVideoExtraTimelines:
             with VideoSignalWriter(video_paths['video'], video_paths['frames']) as w:
                 w.append(create_frame(50), 1000)
                 w.append(create_frame(100), 2000, extra_ts={'producer': 1900})
+
+
+# Frames at ~15 Hz with jitter and a long gap: spacings a single frame rate could not describe.
+JITTERY_TS_NS = [
+    1_000_000_000,
+    1_066_700_000,
+    1_133_000_000,
+    1_201_400_000,
+    1_268_000_000,
+    1_600_000_000,
+    1_667_100_000,
+    1_733_000_000,
+    1_800_900_000,
+    1_866_000_000,
+    1_934_000_000,
+    2_000_000_000,
+]
+
+
+def decoded_pts(video_path):
+    """Presentation timestamps and time base a plain container reader sees, in decode order."""
+    with av.open(str(video_path)) as container:
+        stream = container.streams.video[0]
+        time_base = stream.time_base
+        assert time_base is not None
+        pts = []
+        for frame in container.decode(stream):
+            assert frame.pts is not None
+            pts.append(frame.pts)
+        return pts, time_base
+
+
+class TestVideoContainerTiming:
+    def test_container_timestamps_reproduce_recorded_span(self, video_paths):
+        sig = create_video_signal(video_paths, [(create_frame(10 + i * 20), ts) for i, ts in enumerate(JITTERY_TS_NS)])
+        assert len(sig) == len(JITTERY_TS_NS)
+
+        pts, time_base = decoded_pts(video_paths['video'])
+        assert len(pts) == len(JITTERY_TS_NS)
+        # An external player derives frame times from pts * time_base; they must match the recorded
+        # timestamps, to within the microsecond the container resolves.
+        offsets_ns = [int(p * time_base * 1_000_000_000) for p in pts]
+        expected_ns = [ts - JITTERY_TS_NS[0] for ts in JITTERY_TS_NS]
+        assert offsets_ns == pytest.approx(expected_ns, abs=1000)
+
+    def test_index_pts_are_what_the_container_carries(self, video_paths):
+        create_video_signal(video_paths, [(create_frame(10 + i * 20), ts) for i, ts in enumerate(JITTERY_TS_NS)])
+
+        indexed = pq.read_table(video_paths['frames'])['pts'].to_pylist()
+        pts, _ = decoded_pts(video_paths['video'])
+        assert indexed == pts
+
+    def test_random_access_with_jittery_timestamps(self, video_paths):
+        frames = [(create_frame(10 + i * 20), ts) for i, ts in enumerate(JITTERY_TS_NS)]
+        with VideoSignalWriter(video_paths['video'], video_paths['frames'], gop_size=3) as writer:
+            for frame, ts in frames:
+                writer.append(frame, ts)
+        sig = VideoSignal(video_paths['video'], video_paths['frames'], seek_threshold=2)
+
+        # Reverse and then scattered order, so every read has to seek rather than decode onwards.
+        for i in list(reversed(range(len(frames)))) + [0, 7, 3, 11, 5]:
+            frame, ts = sig[i]
+            assert ts == JITTERY_TS_NS[i]
+            assert_frames_equal(frame, frames[i][0], tolerance=8)
+
+    def test_search_by_time_lands_on_the_right_frame(self, video_paths):
+        sig = create_video_signal(video_paths, [(create_frame(10 + i * 20), ts) for i, ts in enumerate(JITTERY_TS_NS)])
+        # A time inside the long gap resolves to the frame that was current then, not to a frame
+        # position derived from an assumed constant rate.
+        frame, ts = sig.time[1_500_000_000]
+        assert ts == JITTERY_TS_NS[4]
+        assert_frames_equal(frame, create_frame(10 + 4 * 20), tolerance=8)
+
+
+class TestSubMicrosecondFrames:
+    def test_pts_stay_strictly_increasing_within_one_microsecond(self, video_paths):
+        # The first three land in the same microsecond once rounded; the last is well clear.
+        timestamps = [1_000_000_000, 1_000_000_100, 1_000_000_200, 1_000_500_000]
+        frames = [(create_frame(10 + i * 40), ts) for i, ts in enumerate(timestamps)]
+        sig = create_video_signal(video_paths, frames)
+
+        indexed = pq.read_table(video_paths['frames'])['pts'].to_pylist()
+        assert indexed == [0, 1, 2, 500]
+        assert np.all(np.diff(indexed) > 0)
+
+        pts, _ = decoded_pts(video_paths['video'])
+        assert pts == indexed
+        for i, (frame, ts) in enumerate(frames):
+            got_frame, got_ts = sig[i]
+            assert got_ts == ts
+            assert_frames_equal(got_frame, frame, tolerance=8)
+
+
+def write_legacy_video(video_paths, frames_with_timestamps, declared_fps=100, gop_size=30):
+    """Write a video the way it was written before the frames index carried presentation timestamps.
+
+    Presentation timestamps are the ordinal frame number against a fixed declared rate, and the index
+    holds timestamps only. Written out explicitly so the fallback is tested against the real old format
+    rather than against whatever the current writer produces.
+    """
+    container = av.open(str(video_paths['video']), mode='w')
+    stream = container.add_stream('h264', rate=declared_fps)
+    first_frame = frames_with_timestamps[0][0]
+    stream.height, stream.width = first_frame.shape[:2]
+    stream.pix_fmt = 'yuv420p'
+    stream.gop_size = gop_size
+
+    for i, (data, _ts) in enumerate(frames_with_timestamps):
+        frame = av.VideoFrame.from_ndarray(data, format='rgb24')
+        frame.pts = i
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+    timestamps = [ts for _data, ts in frames_with_timestamps]
+    pq.write_table(pa.table({'ts_ns': timestamps}, schema=pa.schema([('ts_ns', pa.int64())])), video_paths['frames'])
+    return VideoSignal(video_paths['video'], video_paths['frames'])
+
+
+class TestIndexWithoutPtsColumn:
+    def test_legacy_video_reads_through_declared_rate(self, video_paths):
+        frames = [(create_frame(10 + i * 20), ts) for i, ts in enumerate(JITTERY_TS_NS)]
+        sig = write_legacy_video(video_paths, frames, gop_size=3)
+
+        assert 'pts' not in pq.read_table(video_paths['frames']).column_names
+        assert len(sig) == len(frames)
+        assert sig.start_ts == JITTERY_TS_NS[0]
+        assert sig.last_ts == JITTERY_TS_NS[-1]
+
+        for i in list(range(len(frames))) + list(reversed(range(len(frames)))) + [0, 7, 3]:
+            frame, ts = sig[i]
+            assert ts == JITTERY_TS_NS[i]
+            assert_frames_equal(frame, frames[i][0], tolerance=8)
+
+    def test_legacy_video_ordinal_pts_are_left_alone(self, video_paths):
+        frames = [(create_frame(10 + i * 20), ts) for i, ts in enumerate(JITTERY_TS_NS)]
+        write_legacy_video(video_paths, frames)
+
+        # The fallback reads the file as written; it does not rewrite or reinterpret its timing.
+        pts, time_base = decoded_pts(video_paths['video'])
+        ticks_per_frame = round(1 / (100 * time_base))
+        assert pts == [i * ticks_per_frame for i in range(len(frames))]

--- a/positronic/dataset/video.py
+++ b/positronic/dataset/video.py
@@ -1,3 +1,4 @@
+import fractions
 import queue
 import struct
 import threading
@@ -13,12 +14,26 @@ import pyarrow.parquet as pq
 
 from .signal import IndicesLike, Kind, RealNumericArrayLike, Signal, SignalMeta, SignalWriter, is_realnum_dtype
 
+# Presentation timestamps are muxed in microseconds since the first frame. Microseconds rather than
+# nanoseconds because some MP4 boxes carry a 32-bit timescale and duration.
+_TIME_BASE = fractions.Fraction(1, 1_000_000)
+_NS_PER_TICK = 1_000_000_000 // _TIME_BASE.denominator
+
+# Frames arrive at whatever rate the producer runs at, so the stream has no single rate. This one is
+# only the nominal figure encoders want for their bitrate and GOP heuristics; frame timing comes from
+# the per-frame presentation timestamps, never from here.
+_NOMINAL_ENCODER_RATE = 30
+
 
 class VideoSignalWriter(SignalWriter[np.ndarray]):
     """Writer for video signals.
 
     Stores video frames in a video file (e.g., MP4/MKV) with a Parquet index
     containing frame timestamps for fast random access.
+
+    Each frame is muxed with a presentation timestamp derived from its ``ts_ns``, so the container plays
+    back at the rate the frames were recorded at. The index records those presentation timestamps in a
+    ``pts`` column, which is what the reader maps back to frame indices.
     """
 
     def __init__(
@@ -27,7 +42,6 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
         frames_index_path: Path,
         codec: str = 'h264',
         gop_size: int = 30,
-        fps: int = 100,
         codec_options: dict[str, str] | None = None,
     ):
         """Initialize VideoSignalWriter.
@@ -37,19 +51,16 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
             frames_index_path: Path to frames.parquet index file
             codec: Video codec to use (default: 'h264')
             gop_size: Group of Pictures size - distance between keyframes (default: 30)
-            fps: Frame rate for encoding (default: 30)
             codec_options: Encoder options (e.g. x264 ``preset``/``tune``); None keeps the codec defaults.
         """
         self.video_path = video_path
         self.frames_index_path = frames_index_path
         self.codec = codec
         self.gop_size = gop_size
-        self.fps = fps
         self.codec_options = codec_options
 
         self._finished = False
         self._aborted = False
-        self._frame_count = 0
         self._last_ts = None
 
         self._container: av.container.OutputContainer | None = None
@@ -57,6 +68,7 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
         self._width: int | None = None
         self._height: int | None = None
         self._frame_timestamps: list[int] = []
+        self._frame_pts: list[int] = []
         self._extra_timelines: dict[str, list[int]] = defaultdict(list)
 
         # Encoding runs on a per-writer thread (libav releases the GIL), so several writers — e.g. one per
@@ -77,11 +89,14 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
         self._height, self._width = first_frame.shape[:2]
 
         self._container = av.open(str(self.video_path), mode='w')
-        self._stream = self._container.add_stream(self.codec, rate=self.fps, options=self.codec_options)
+        self._stream = self._container.add_stream(self.codec, rate=_NOMINAL_ENCODER_RATE, options=self.codec_options)
+        assert self._stream is not None
         self._stream.width = self._width
         self._stream.height = self._height
         self._stream.pix_fmt = 'yuv420p'
         self._stream.gop_size = self.gop_size
+        self._stream.time_base = _TIME_BASE
+        self._stream.codec_context.time_base = _TIME_BASE
 
     def append(self, data: np.ndarray, ts_ns: int, extra_ts: dict[str, int] | None = None) -> None:  # noqa: C901
         """Append a video frame with timestamp.
@@ -127,6 +142,13 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
             raise RuntimeError('Video encoding failed') from self._encoder_error
 
         self._frame_timestamps.append(ts_ns)
+        # Presentation timestamps run from the first frame, rounded to the nearest tick, and are kept
+        # strictly increasing: two frames less than a tick apart round to the same value, which the
+        # muxer would reject.
+        pts = (ts_ns - self._frame_timestamps[0] + _NS_PER_TICK // 2) // _NS_PER_TICK
+        if self._frame_pts and pts <= self._frame_pts[-1]:
+            pts = self._frame_pts[-1] + 1
+        self._frame_pts.append(pts)
 
         # Handle extra timelines using defaultdict
         for timeline_name, timeline_ts in extra_ts.items():
@@ -139,9 +161,8 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
             self._encoder_thread.start()
         # Copy before enqueueing: callers routinely pass views into shared memory that the producer
         # overwrites with the next frame.
-        self._frames.put((data.copy(), self._frame_count))
+        self._frames.put((data.copy(), pts))
 
-        self._frame_count += 1
         self._last_ts = ts_ns
 
     def _encode_loop(self) -> None:
@@ -184,9 +205,9 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
                 self._container.mux(packet)
             self._container.close()
 
-        # Write frame index with primary timestamp and extra timelines
-        data_dict = {'ts_ns': self._frame_timestamps if self._frame_timestamps else []}
-        fields = [('ts_ns', pa.int64())]
+        # Write frame index with primary timestamp, muxed presentation timestamps and extra timelines
+        data_dict = {'ts_ns': self._frame_timestamps, 'pts': self._frame_pts}
+        fields = [('ts_ns', pa.int64()), ('pts', pa.int64())]
 
         # Add extra timeline columns
         for timeline_name in sorted(self._extra_timelines.keys()):
@@ -222,15 +243,25 @@ class VideoSignalWriter(SignalWriter[np.ndarray]):
 
 
 class _VideoNavigator:
-    """Efficiently navigates video frames using buffering and smart seeking."""
+    """Efficiently navigates video frames using buffering and smart seeking.
 
-    def __init__(self, video_path: Path, seek_threshold: int):
+    ``frame_pts`` is the presentation timestamp of every frame, in stream time base units, taken from the
+    frames index — the index owns the mapping between frame position and container time. Videos written
+    before the index carried that column pass None, and the mapping is re-derived from the declared frame
+    rate, which is the convention they were written with.
+    """
+
+    def __init__(self, video_path: Path, seek_threshold: int, frame_pts: np.ndarray | None):
         self._container = av.open(str(video_path))
         self._stream = self._container.streams.video[0]
 
-        rate = self._stream.average_rate or self._stream.rate
-        ticks_per_frame = round(1.0 / (float(rate) * float(self._stream.time_base)))
-        self._ticks_per_frame = max(1, int(ticks_per_frame))
+        self._frame_pts = frame_pts
+        if frame_pts is None:
+            rate = self._stream.average_rate or self._stream.rate
+            time_base = self._stream.time_base
+            assert rate is not None and time_base is not None
+            ticks_per_frame = round(1.0 / (float(rate) * float(time_base)))
+            self._ticks_per_frame = max(1, int(ticks_per_frame))
         self._seek_threshold = seek_threshold
 
         self._frame_buffer: deque[tuple[int, av.VideoFrame]] = deque()
@@ -243,33 +274,62 @@ class _VideoNavigator:
         """Returns the index of the last decoded frame."""
         return self._last_idx
 
+    def _pts_of(self, frame_index: int) -> int:
+        if self._frame_pts is None:
+            return frame_index * self._ticks_per_frame
+        return int(self._frame_pts[frame_index])
+
+    def _index_of(self, pts: int) -> int:
+        """Frame index of a decoded frame. Decode order can't be counted: a seek restarts decoding at the
+        preceding keyframe, so the position is recovered from the timestamp the frame carries."""
+        if self._frame_pts is None:
+            return int(pts // self._ticks_per_frame)
+        return int(np.searchsorted(self._frame_pts, pts, side='right')) - 1
+
     def seek_if_needed(self, target_frame_index: int):
         """Seeks to target frame if distance exceeds threshold."""
-        target_pts = target_frame_index * self._ticks_per_frame
-
         if self._last_idx != -1 and 0 < target_frame_index - self._last_idx <= self._seek_threshold:
             return
 
-        self._container.seek(target_pts, stream=self._stream)
+        # Seeking is decode-timestamp based while the target is a presentation timestamp, so where a
+        # stream reorders frames a keyframe's decode timestamp can precede the target while its own
+        # presentation timestamp follows it — leaving the stream past the frame we asked for. Step the
+        # seek back a frame at a time until decoding actually resumes at or before the target.
+        seek_from = target_frame_index
+        while True:
+            self._restart_at(self._pts_of(seek_from))
+            if seek_from == 0:
+                return
+            try:
+                self._fill_buffer()
+            except StopIteration:
+                return
+            if self._frame_buffer[0][0] <= target_frame_index:
+                return
+            seek_from -= 1
+
+    def _restart_at(self, pts: int) -> None:
+        self._container.seek(pts, stream=self._stream)
         self._demux_iter = iter(self._container.demux(self._stream))
         self._frame_buffer.clear()
         self._last_idx = -1
+
+    def _fill_buffer(self) -> None:
+        """Decodes packets until at least one frame is buffered. Raises StopIteration at end of stream."""
+        while not self._frame_buffer:
+            packet = next(self._demux_iter)
+            for frame in packet.decode():
+                assert frame.pts is not None
+                self._last_idx = self._index_of(frame.pts)
+                self._frame_buffer.append((self._last_idx, frame))
 
     def __iter__(self) -> Iterator[tuple[int, av.VideoFrame]]:
         return self
 
     def __next__(self) -> tuple[int, av.VideoFrame]:
         """Returns next frame from buffer or decodes new packets."""
-        while self._frame_buffer:
-            return self._frame_buffer.popleft()
-
-        while not self._frame_buffer:
-            packet = next(self._demux_iter)
-            for frame in packet.decode():
-                assert frame.pts is not None
-                self._last_idx = int(frame.pts // self._ticks_per_frame)
-                self._frame_buffer.append((self._last_idx, frame))
-
+        if not self._frame_buffer:
+            self._fill_buffer()
         return self._frame_buffer.popleft()
 
 
@@ -278,6 +338,10 @@ class VideoSignal(Signal[np.ndarray]):
 
     Reads video frames from a video file (e.g., MP4/MKV) with a Parquet index
     containing frame timestamps for fast random access.
+
+    Random access maps a frame index to the presentation timestamp the index records for it. Videos
+    written before the index carried a ``pts`` column fall back to deriving that mapping from the
+    stream's declared frame rate, which is the convention they were written with.
     """
 
     def __init__(self, video_path: Path, frames_index_path: Path, seek_threshold: int | None = None):
@@ -296,6 +360,7 @@ class VideoSignal(Signal[np.ndarray]):
         self._seek_threshold = seek_threshold or 30
 
         self._timestamps = None
+        self._frame_pts = None
         self._navigator: _VideoNavigator | None = None
 
     def _load_timestamps(self):
@@ -303,11 +368,14 @@ class VideoSignal(Signal[np.ndarray]):
         if self._timestamps is None:
             frames_table = pq.read_table(self.frames_index_path)
             self._timestamps = frames_table['ts_ns'].to_numpy()
+            if 'pts' in frames_table.column_names:
+                self._frame_pts = frames_table['pts'].to_numpy()
 
     @property
     def _nav(self) -> _VideoNavigator:
         if self._navigator is None:
-            self._navigator = _VideoNavigator(self.video_path, self._seek_threshold)
+            self._load_timestamps()
+            self._navigator = _VideoNavigator(self.video_path, self._seek_threshold, self._frame_pts)
         return self._navigator
 
     def __len__(self) -> int:


### PR DESCRIPTION
`VideoSignalWriter` stored an ordinal frame index in `pts` — a field that means time — against a fixed declared rate (`fps=100`). Reader and writer agreed through that rate, so reads inside the library were correct. Everything outside reads `pts` as time: a player, a browser, ffmpeg, the viewer — so the defect was invisible from here. On a pre-existing recording (`sweep_jp` episode 5, 159 frames) the frames arrive 66 ms apart (15.15 fps) spanning 10.428 s, while the container declares 100 fps and 1.590 s — 6.56x too fast, over a sixth of the real duration. True timing lived only in `frames.parquet`.

## What it stores now

Each frame is muxed with a microsecond presentation timestamp taken from its `ts_ns`, relative to the first frame, on a `1/1000000` time base — microseconds, not nanoseconds, because some MP4 boxes carry a 32-bit timescale and duration.

The frames index gains a `pts` column, making the index the single owner of the mapping between frame position and container time: the reader looks it up instead of re-deriving it from a rate convention both sides assume. Random access seeks to a frame's recorded `pts` and recovers a decoded frame's index by bisecting that array — decode order cannot be counted, since a seek restarts at the preceding keyframe.

Two consequences:

- `fps` leaves `VideoSignalWriter` — it declared a fact the writer is not given and cannot source, while the writer already receives the truth on every frame. The `rate=` passed to `add_stream` survives only as a nominal encoder hint for bitrate and GOP heuristics, named and commented as such.
- Presentation timestamps are guarded monotonic: `append` enforces strictly-increasing `ts_ns`, but two frames inside one microsecond round to the same tick, which the muxer rejects. Such a frame is bumped to `previous + 1`, and the index records what was actually muxed.

Seeking needed a related correction: seeks are decode-timestamp based while these targets are presentation timestamps, so with B-frames a keyframe's decode timestamp can precede the target while its presentation timestamp follows it, leaving the stream past the wanted frame. The seek now steps back until decoding resumes at or before the target — latent before, and it applies on both paths.

This changes the on-disk container for newly written data: new `.mp4` files carry a microsecond time base and real timestamps instead of a `1/12800` base and ordinal ticks, and their `frames.parquet` carries the extra `pts` column. Existing recordings are untouched.

## Pre-existing exports stay readable

An index with no `pts` column falls back to exactly the previous behaviour — `ticks_per_frame` from the declared stream rate, `index = pts // ticks_per_frame` — the convention those files were written with. Checked against the recordings the live viewer serves: old and new readers return bit-identical frames and timestamps across 8 pre-existing videos, read sequentially, in reverse and in random order — 0 mismatches. A test writes a legacy-format fixture explicitly rather than via the current writer, pinning the fallback against the real old format.

## Measured

Re-recording that episode's frames through `LocalDatasetWriter`:

| | declared rate | container duration | vs recorded span |
|---|---|---|---|
| before | 100.00 fps | 1.590 s | 6.56x too fast |
| after | 15.20 fps | 10.461 s | 1.00x |

Recorded span is 10.428 s over 159 frames. Per-frame timing error after the change is 0 ns, max and mean, and index `pts` equal container `pts` exactly; the residual 33 ms is the final frame's own duration, not drift.

Tests in `positronic/dataset/tests/test_video.py` cover the container span under jittery, non-uniform spacing including a gap no single rate could describe; index `pts` against what the container carries; random access with a seek forced on every read; time search inside the gap; the sub-microsecond collision; and the legacy fixture. The `basedpyright` baseline shrinks by 6 entries; no file grows.

<!-- opened-by: posi-agent -->