### PR TITLE
Codify repo conventions as named rules in `CODE_RULES.md`

### DIFF
--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -68,9 +68,9 @@ the thing that went wrong.
 ## Step 4: Cold-read test
 
 The rule will be applied by readers with no access to this conversation. Test that directly with a
-subagent, which starts empty unless you fill it in. Give it the draft rule and two unlabelled snippets,
-one violating and one clean, and ask which violates it and why. Keep out which is which, the incident
-behind the rule, and what you hope it will say.
+subagent, which starts empty unless you fill it in. It needs the draft rule and two snippets, one
+violating and one clean, and must deliberately not know which is which, where they came from, or what
+you hope it will say. Ask which snippet violates the rule, and why.
 
 If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
 repeat. Do not proceed on a rule that needed the conversation to be understood.

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: add-rule
-description: Author, calibrate, or retire a rule in CODE_RULES.md. Use when a review comment or a recurring code smell should become a durable repo rule, or when an existing rule is noisy, never fires, or keeps getting waived.
+description: Author or recalibrate a rule in CODE_RULES.md. Use when a review comment or a recurring code smell should become a durable repo rule, or when an existing rule produces findings people argue with.
 ---
 
 # Add Rule
 
-Every rule in `CODE_RULES.md` spends attention on every review, so each one earns its place or comes
-out. This skill writes one, calibrates it against the repo, or retires one.
+Every rule in `CODE_RULES.md` spends attention on every review, so each one earns its place. This skill
+writes one, or recalibrates one that has gone noisy.
 
 Nothing is written to `CODE_RULES.md` without the user's explicit approval of the final wording.
 
@@ -92,24 +92,3 @@ Search the tree for what it would flag, read a sample of the hits, and judge eac
 you agree with mean the rule is right and the repo has a backlog; hits you disagree with mean it is too
 broad and needs narrowing or dropping. Say how large the sample was, so a thin one cannot read as a
 clean sweep.
-
-## Retiring a rule
-
-Rules only accumulate unless something removes them, and a stale rule dilutes attention across the
-whole file. Retire one when:
-
-- it has not fired in review for a long stretch, and a scan of the tree finds nothing it would catch;
-- its waivers are out of proportion to its compliant uses. Count the markers, but treat the count as a
-  prompt to look, never as the evidence itself:
-
-  ```bash
-  grep -rn 'rules-allow: <rule-id>' --include='*.py' .
-  ```
-
-  Five waivers against five hundred compliant sites is a healthy rule with real exceptions; five against
-  eight is a rule describing the exception as the norm. Sample both sides before concluding. If the
-  waivers win, either the rule is wrong or the exception is the real rule; say which.
-- a linter can now enforce it. Move it to `pyproject.toml` and delete it here.
-
-Deleting a rule needs the same explicit approval as adding one. Say what it was, why it is going, and
-what replaces it if anything does.

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -68,10 +68,9 @@ the thing that went wrong.
 ## Step 4: Cold-read test
 
 The rule will be applied by readers with no access to this conversation. Test that directly with a
-subagent, which starts empty unless you fill it in. Its prompt asks which snippet violates the rule and
-why, and carries exactly two pieces of context: the draft rule, and two unlabelled code snippets — one
-violating, one clean. Nothing else: not which is which, not the incident behind the rule, not what you
-hope it will say.
+subagent, which starts empty unless you fill it in. Give it the draft rule and two unlabelled snippets,
+one violating and one clean, and ask which violates it and why. Keep out which is which, the incident
+behind the rule, and what you hope it will say.
 
 If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
 repeat. Do not proceed on a rule that needed the conversation to be understood.

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: add-rule
+description: Author, calibrate, or retire a rule in CODE_RULES.md. Use when a review comment or a recurring code smell should become a durable repo rule, or when an existing rule is noisy, never fires, or keeps getting waived.
+---
+
+# Add Rule
+
+`CODE_RULES.md` is read by the Codex reviewer on every pull request, by Claude while implementing, and
+by `/check-rules`. Every rule in it spends attention on every review, so each one earns its place or
+comes out. This skill writes one, calibrates it against the repo, or retires one.
+
+Nothing is written to `CODE_RULES.md` without the user's explicit approval of the final wording.
+
+## What a rule is
+
+A judgment call no linter can make, stated as an instruction.
+
+A good rule is:
+
+- **Imperative** — "Don't X. Do Y instead." Not a description of the symptom; the reader should not have
+  to work out what to do.
+- **Explicit about the safe path**, including the exception where one exists.
+- **Checkable from a diff alone**, by someone who was not in the conversation that produced it.
+- **Durable** — describes behaviour, not the names of functions, files, or classes that exist today.
+- **Consequential** — worth someone stopping their work to fix.
+
+Not a rule:
+
+- Anything ruff or basedpyright can enforce. That belongs in `pyproject.toml`, where it runs
+  deterministically on every commit.
+- An aspiration — "keep interfaces clean", "name things well". Unfalsifiable, so it fires at random.
+- A symptom with no instruction attached.
+- Something so broad that most files violate it.
+
+## Step 1: Get the incident
+
+Ask what real code triggered this, and read it — the review comment, the commit, the function. A rule
+with no incident behind it is a preference; say so and stop.
+
+The incident is also the source of the bad/good example pair in Step 3, so capture it before it's lost.
+
+## Step 2: Rule out the cheaper homes
+
+Two checks, both of which kill the rule if they hit:
+
+```bash
+sed -n '/\[tool.ruff/,/^\[tool\.setuptools/p' pyproject.toml   # is it already a lint rule?
+grep -n '^### ' CODE_RULES.md                                  # does an existing rule cover it?
+```
+
+If ruff or basedpyright could catch it, enable the check there instead and stop. If an existing rule
+covers it, sharpen that rule rather than adding a second one — overlapping rules make findings
+ambiguous about which one was violated.
+
+## Step 3: Draft it
+
+```markdown
+### <rule-id>
+
+Don't <the thing>. <Do this instead>.
+
+Exception: <where it is legitimately fine>.
+```
+
+Then a bad/good code pair whenever the rule is about code shape rather than a naming or comment habit.
+Keep both halves to a few lines and take them from the Step 1 incident, stripped of anything
+repo-specific that will rot.
+
+`<rule-id>` is kebab-case and names the violation, not the remedy — it appears in review comments as
+`Rule <rule-id> violated:` and in waivers as `# rules-allow: <rule-id> — <reason>`, so it must read as
+the thing that went wrong.
+
+## Step 4: Cold-read test
+
+The rule will be applied by readers with no access to this conversation. Test that directly: hand a
+fresh subagent **only** the draft rule and two unlabelled code snippets — one violating, one clean —
+and ask which violates it and why.
+
+If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
+repeat. Do not proceed on a rule that needed the conversation to be understood.
+
+## Step 5: Calibrate against the repo
+
+A rule that has never fired is a guess. Scan the existing tree — not just the recent diff — for code
+the rule would flag, then **read a sample of the hits** (five, or all of them if fewer) and judge each
+one yourself.
+
+The count sizes the sample; the sample decides. Report both, and the fork they imply:
+
+- **Hits you agree with, few.** Calibrated. Land it.
+- **Hits you agree with, many.** The rule is right and the repo has a backlog. Land it, and raise
+  separately whether to clean up now or let it bite on future changes — a rule that flags a lot of
+  existing code will make the next few reviews noisy, and the user should know that going in.
+- **Hits you disagree with.** The rule is too broad. Narrow it, or drop it.
+
+Report the sample honestly, including hits that make the rule look bad.
+
+## Step 6: Approve and append
+
+Show the final wording, the id, the hit count, and the sample. On explicit approval, append the rule to
+`CODE_RULES.md` in its section, then commit following the repo's conventions.
+
+## Retiring a rule
+
+Rules only accumulate unless something removes them, and a stale rule dilutes attention across the
+whole file. Retire one when:
+
+- it has not fired in review for a long stretch, and a scan of the tree finds nothing it would catch;
+- it is waived more often than it is obeyed — count the `# rules-allow:` markers carrying its id:
+
+  ```bash
+  grep -rn 'rules-allow: <rule-id>' --include='*.py' .
+  ```
+
+  A rule with several live waivers is describing an exception as if it were the norm. Either the rule
+  is wrong or the exception is the real rule; say which.
+- a linter can now enforce it. Move it to `pyproject.toml` and delete it here.
+
+Deleting a rule needs the same explicit approval as adding one. Say what it was, why it is going, and
+what replaces it if anything does.

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -5,9 +5,8 @@ description: Author, calibrate, or retire a rule in CODE_RULES.md. Use when a re
 
 # Add Rule
 
-`CODE_RULES.md` is read by the Codex reviewer on every pull request, by Claude while implementing, and
-by `/check-rules`. Every rule in it spends attention on every review, so each one earns its place or
-comes out. This skill writes one, calibrates it against the repo, or retires one.
+Every rule in `CODE_RULES.md` spends attention on every review, so each one earns its place or comes
+out. This skill writes one, calibrates it against the repo, or retires one.
 
 Nothing is written to `CODE_RULES.md` without the user's explicit approval of the final wording.
 
@@ -95,10 +94,11 @@ The count sizes the sample; the sample decides. Report both, and the fork they i
 
 Report the sample honestly, including hits that make the rule look bad.
 
-## Step 6: Approve and append
+## Step 6: Approve and write
 
-Show the final wording, the id, the hit count, and the sample. On explicit approval, append the rule to
-`CODE_RULES.md` in its section, then commit following the repo's conventions.
+Show the final wording, the id, the hit count, and the sample. On explicit approval, write it to
+`CODE_RULES.md` — a new rule is appended, a revision of an existing id replaces that rule in place, so
+no id ever appears twice. Then commit following the repo's conventions.
 
 ## Retiring a rule
 

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -40,12 +40,8 @@ The incident is also the source of the bad/good example pair in Step 3, so captu
 
 ## Step 2: Rule out the cheaper homes
 
-Two checks, both of which kill the rule if they hit:
-
-```bash
-sed -n '/\[tool.ruff/,/^\[tool\.setuptools/p' pyproject.toml   # is it already a lint rule?
-grep -n '^### ' CODE_RULES.md                                  # does an existing rule cover it?
-```
+Two checks, both of which kill the rule if they hit: whether ruff or basedpyright already covers it
+(`pyproject.toml`), and whether an existing rule does (`CODE_RULES.md`).
 
 If ruff or basedpyright could catch it, enable the check there instead and stop. If an existing rule
 covers it, sharpen that rule rather than adding a second one — overlapping rules make findings

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -71,9 +71,10 @@ the thing that went wrong.
 
 ## Step 4: Cold-read test
 
-The rule will be applied by readers with no access to this conversation. Test that directly: hand a
-fresh subagent **only** the draft rule and two unlabelled code snippets — one violating, one clean —
-and ask which violates it and why.
+The rule will be applied by readers with no access to this conversation. Test that directly with a
+subagent, which starts empty unless you fill it in. Its prompt contains exactly two things: the draft
+rule, and two unlabelled code snippets — one violating, one clean. Not which is which, not the incident
+behind the rule, not what you hope it will say. Ask which snippet violates the rule, and why.
 
 If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
 repeat. Do not proceed on a rule that needed the conversation to be understood.

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -106,14 +106,16 @@ Rules only accumulate unless something removes them, and a stale rule dilutes at
 whole file. Retire one when:
 
 - it has not fired in review for a long stretch, and a scan of the tree finds nothing it would catch;
-- it is waived more often than it is obeyed — count the `# rules-allow:` markers carrying its id:
+- its waivers are out of proportion to its compliant uses. Count the markers, but treat the count as a
+  prompt to look, never as the evidence itself:
 
   ```bash
   grep -rn 'rules-allow: <rule-id>' --include='*.py' .
   ```
 
-  A rule with several live waivers is describing an exception as if it were the norm. Either the rule
-  is wrong or the exception is the real rule; say which.
+  Five waivers against five hundred compliant sites is a healthy rule with real exceptions; five against
+  eight is a rule describing the exception as the norm. Sample both sides before concluding. If the
+  waivers win, either the rule is wrong or the exception is the real rule; say which.
 - a linter can now enforce it. Move it to `pyproject.toml` and delete it here.
 
 Deleting a rule needs the same explicit approval as adding one. Say what it was, why it is going, and

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -79,27 +79,19 @@ behind the rule, not what you hope it will say. Ask which snippet violates the r
 If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
 repeat. Do not proceed on a rule that needed the conversation to be understood.
 
-## Step 5: Calibrate against the repo
+## Step 5: Approve and write
 
-A rule that has never fired is a guess. Scan the existing tree — not just the recent diff — for code
-the rule would flag, then **read a sample of the hits** (five, or all of them if fewer) and judge each
-one yourself.
-
-The count sizes the sample; the sample decides. Report both, and the fork they imply:
-
-- **Hits you agree with, few.** Calibrated. Land it.
-- **Hits you agree with, many.** The rule is right and the repo has a backlog. Land it, and raise
-  separately whether to clean up now or let it bite on future changes — a rule that flags a lot of
-  existing code will make the next few reviews noisy, and the user should know that going in.
-- **Hits you disagree with.** The rule is too broad. Narrow it, or drop it.
-
-Report the sample honestly, including hits that make the rule look bad.
-
-## Step 6: Approve and write
-
-Show the final wording, the id, the hit count, and the sample. On explicit approval, write it to
+Show the final wording and the id. On explicit approval, write it to
 `CODE_RULES.md` — a new rule is appended, a revision of an existing id replaces that rule in place, so
 no id ever appears twice. Then commit following the repo's conventions.
+
+## Calibrating a noisy rule
+
+Run this when a rule starts producing findings people argue with — not on every rule that lands.
+Search the tree for what it would flag, read a sample of the hits, and judge each one yourself. Hits
+you agree with mean the rule is right and the repo has a backlog; hits you disagree with mean it is too
+broad and needs narrowing or dropping. Say how large the sample was, so a thin one cannot read as a
+clean sweep.
 
 ## Retiring a rule
 

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -68,9 +68,10 @@ the thing that went wrong.
 ## Step 4: Cold-read test
 
 The rule will be applied by readers with no access to this conversation. Test that directly with a
-subagent, which starts empty unless you fill it in. Its prompt contains exactly two things: the draft
-rule, and two unlabelled code snippets — one violating, one clean. Not which is which, not the incident
-behind the rule, not what you hope it will say. Ask which snippet violates the rule, and why.
+subagent, which starts empty unless you fill it in. Its prompt asks which snippet violates the rule and
+why, and carries exactly two pieces of context: the draft rule, and two unlabelled code snippets — one
+violating, one clean. Nothing else: not which is which, not the incident behind the rule, not what you
+hope it will say.
 
 If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
 repeat. Do not proceed on a rule that needed the conversation to be understood.

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -36,7 +36,7 @@ Not a rule:
 Ask what real code triggered this, and read it — the review comment, the commit, the function. A rule
 with no incident behind it is a preference; say so and stop.
 
-The incident is also the source of the bad/good example pair in Step 3, so capture it before it's lost.
+The incident is also where the rule's example comes from, so capture it before it's lost.
 
 ## Step 2: Rule out the cheaper homes
 
@@ -49,33 +49,17 @@ ambiguous about which one was violated.
 
 ## Step 3: Draft it
 
-```markdown
-### <rule-id>
-
-Don't <the thing>. <Do this instead>.
-
-Exception: <where it is legitimately fine>.
-```
-
-Then a bad/good code pair whenever the rule is about code shape rather than a naming or comment habit.
-Keep both halves to a few lines and take them from the Step 1 incident, stripped of anything
-repo-specific that will rot.
+Read the rules already in `CODE_RULES.md` and write one like them — same shape, same length, same
+plainness. Be concise and stay on the essence of the issue.
 
 `<rule-id>` is kebab-case and names the violation, not the remedy — it appears in review comments as
 `Rule <rule-id> violated:` and in waivers as `# rules-allow: <rule-id> — <reason>`, so it must read as
 the thing that went wrong.
 
-## Step 4: Cold-read test
+The rule will be applied by people who were not in the conversation that produced it. If it only makes
+sense to someone who was, reword it.
 
-The rule will be applied by readers with no access to this conversation. Test that directly with a
-subagent, which starts empty unless you fill it in. It needs the draft rule and two snippets, one
-violating and one clean, and must deliberately not know which is which, where they came from, or what
-you hope it will say. Ask which snippet violates the rule, and why.
-
-If it picks wrong, or its reasoning is not the reasoning you intended, the rule is unclear. Reword and
-repeat. Do not proceed on a rule that needed the conversation to be understood.
-
-## Step 5: Approve and write
+## Step 4: Approve and write
 
 Show the final wording and the id. On explicit approval, write it to
 `CODE_RULES.md` — a new rule is appended, a revision of an existing id replaces that rule in place, so

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -15,7 +15,7 @@ The `push-pr` skill delegates here when review comments arrive. After each push 
 watches **both CI (GitHub Actions on the pushed commit) and the reviewer's asynchronous
 re-review** in the background, and loops itself through another pass for each new comment
 round or CI failure (Step 7) — so the user can walk away instead of babysitting the cycle,
-and gets pinged only when it truly converges (CI green **and** the reviewer signs off) or
+and gets pinged only when it converges (CI green **and** the reviewer signs off) or
 needs their call. A red build is never "done", no matter what the reviewer says.
 
 ## Principles
@@ -35,7 +35,7 @@ needs their call. A red build is never "done", no matter what the reviewer says.
   resolving them closes a conversation that is the human's to close (especially a reviewer's
   "why…?" or "should we…?", which is an invitation to discuss, not a change request). Never
   resolve a thread just to clear the queue, and never leave a thread you fixed unresolved.
-  When a comment is genuinely on the fence, leave it open.
+  When a comment is on the fence, leave it open.
 - **Stay scoped** to the feedback. Don't sprawl into unrelated refactors.
 - **Follow the repo's commit conventions** (see the `push-pr` skill). CRITICAL: never add
   `Co-Authored-By` or any AI / Claude / assistant attribution to commits, replies, or PRs.
@@ -100,7 +100,7 @@ Present the triage as a short numbered list: comment → verdict → planned fix
 
 **Autonomy:** invoking this skill authorizes the cycle. Act on clear-cut fixes and clear
 declines without prompting. Pause and confirm only when a fix is risky, large, or whether
-to agree is genuinely unclear. The user may drop or override any item.
+to agree is unclear. The user may drop or override any item.
 
 ## Step 3: Fix
 
@@ -222,7 +222,7 @@ blocks until something actionable happens, then loop on how it exits:
 
 - exit **10** → a new round of reviewer comments landed (Codex or a human) → run another full
   pass (Steps 1–6), which ends right back here and relaunches the watcher;
-- exit **20** → truly converged: **CI green on the pushed commit AND** a reviewer sign-off
+- exit **20** → converged: **CI green on the pushed commit AND** a reviewer sign-off
   (Codex 👍 newer than the push, or a human approval) → give the final report, **notify the
   user**, and **stop**;
 - exit **30** → a quiet interval elapsed → **relaunch the watcher and keep waiting** (don't

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -65,7 +65,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   # objects, so the runs are at `.[].check_runs[]`. ghr surfaces an unreadable API as exit 50
   # rather than a fake "no checks" reading (total=0 would block both exit 40 and ci_green, so the
   # persisting loop would spin forever); a readable-but-empty response is still valid JSON, so a
-  # commit with genuinely no checks yet stays in the loop.
+  # commit with no checks yet stays in the loop.
   cr=$(ghr api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate --slurp) || fail50 "cannot read check runs for $SHA"
   # Any completed check whose conclusion is outside the passing set counts as failed — this
   # covers failure/timed_out plus cancelled/action_required/stale/startup_failure, so a

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -33,13 +33,11 @@ Say which scope you used. A clean report over the wrong scope is worse than no r
 grep -n '^### ' CODE_RULES.md
 ```
 
-Spawn one agent per rule, in parallel. Each needs its rule and a way to tell which code changed, and
-must deliberately not know how that code came to be: it is a cold-headed reviewer answering one
-question, not a colleague who sat through the reasoning.
-
-One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
-checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not
-nine rules half-checked.
+Spawn them in parallel, one rule each rather than one agent holding all of them — an agent given nine
+rules skims for nine and checks none, and reporting nothing then means nine rules half-checked instead
+of one cleanly checked. Each needs its rule and a way to tell which code changed, and must deliberately
+not know how that code came to be: a cold-headed reviewer answering one question, not a colleague who
+sat through the reasoning.
 
 Each agent returns two sections, either of which may be empty:
 

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -33,10 +33,9 @@ Say which scope you used. A clean report over the wrong scope is worse than no r
 grep -n '^### ' CODE_RULES.md
 ```
 
-Spawn one agent per rule, in parallel. Give it the job, that one rule, and the change.
-
-Keep out anything that would tell it the answer: the other rules, what the change was for, why the code
-looks the way it does, what you expect it to find. It reads the repository itself for the rest.
+Spawn one agent per rule, in parallel. Each needs its rule and a way to tell which code changed, and
+must deliberately not know how that code came to be: it is a cold-headed reviewer answering one
+question, not a colleague who sat through the reasoning.
 
 One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
 checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -77,6 +77,6 @@ Report only. Fixing is a separate decision and the user makes it.
 
 ## When a finding is wrong
 
-A false positive is information about the rule, not just about the code. If a rule produces findings
-you disagree with, take it to the `add-rule` skill and recalibrate or reword it there. Arguing with the
-same rule twice means the rule is broken.
+A false positive is information about the rule, not just about the code. Say so in the report and stop
+there: only a human changes `CODE_RULES.md`, through the `add-rule` skill and with their explicit
+approval. This skill never edits a rule, however wrong the rule looks from here.

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -16,17 +16,18 @@ what stops it from seeing a violation.
 
 ```bash
 BASE=$(git merge-base HEAD main)
-git diff $BASE --stat                                      # base -> worktree
-git diff --cached $BASE --stat                             # base -> index, what a plain commit records
-git status --porcelain --untracked-files=all | grep '^??'  # untracked files, which no diff shows
+git diff $BASE HEAD --stat                                 # committed — what a push sends
+git diff $BASE --cached --stat                             # index — what a plain commit records
+git diff $BASE --stat                                      # worktree — what you see in the files
+git status --porcelain --untracked-files=all | grep '^??'  # untracked — what no diff shows
 ```
 
-Everything not yet on `main` is in scope: committed, staged, unstaged, and untracked. Pass the untracked
-files' contents alongside the diff — a brand-new file is where rules bite hardest and is the one thing
-`git diff` cannot show.
+Git keeps three snapshots — HEAD, the index, the worktree — and a violation can sit in any one of them
+while the others look clean: staged and then reverted, or committed and then fixed only in the index.
+Check all three, plus untracked files. That set is closed; there is no fourth place for code to hide.
 
-The two diffs are identical unless a file was staged and then edited again. When they differ, both are
-in scope: content can sit in the index, never appear in the worktree, and still be committed.
+In the ordinary case the three agree and it is one diff. Pass the untracked files' contents alongside
+it — a brand-new file is where rules bite hardest and is the one thing no diff shows.
 
 Narrow to the files the user named if they named any, and say which scope you used. A clean report over
 the wrong scope is worse than no report.

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -8,9 +8,14 @@ description: Check the current changes against CODE_RULES.md and report violatio
 Checks a diff against `CODE_RULES.md`. Nothing else — not a code review, not a style pass, not a bug
 hunt. A finding that does not name a rule is out of scope, however good it is.
 
-The check runs in fresh subagents with no access to this conversation. That isolation is the point: the
-session that wrote the code knows why every line looks the way it does, and that knowledge is exactly
-what stops it from seeing a violation.
+Each rule is checked by a subagent that starts empty — no conversation history, no files this session
+has read, no other rule. That much the platform guarantees; the one thing that would undo it is a fork,
+which inherits the parent conversation, so never use one here.
+
+What the platform cannot guarantee is the prompt you write, and that is the only channel into the agent.
+You are the worst possible author for it: you know why every line looks the way it does, and that
+knowledge is precisely what stops you seeing the violation. Whatever of it you write into the prompt,
+the agent inherits.
 
 ## Step 1: Scope the diff
 
@@ -51,9 +56,13 @@ the wrong scope is worse than no report.
 grep -n '^### ' CODE_RULES.md
 ```
 
-Spawn one agent per rule, in parallel. Each gets exactly: the full text of **its own rule and no
-other**, the diff, and the repository to read around the change. Don't tell it what the other rules
-say, what the change was for, or what you expect it to find.
+Spawn one agent per rule, in parallel. Its prompt contains exactly two things:
+
+1. the full text of that one rule, verbatim from `CODE_RULES.md`;
+2. the Step 1 patches, plus the contents of any untracked files.
+
+Nothing else goes in: not the other rules, not what the change was for, not what you expect it to find,
+not why the code looks the way it does. The agent reads the repository itself for anything more.
 
 One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
 checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -16,9 +16,9 @@ what stops it from seeing a violation.
 
 ```bash
 BASE=$(git merge-base HEAD main)
-git diff $BASE HEAD --stat                                 # committed — what a push sends
-git diff $BASE --cached --stat                             # index — what a plain commit records
-git diff $BASE --stat                                      # worktree — what you see in the files
+git diff $BASE HEAD                                        # committed — what a push sends
+git diff $BASE --cached                                    # index — what a plain commit records
+git diff $BASE                                             # worktree — what you see in the files
 git status --porcelain --untracked-files=all | grep '^??'  # untracked — what no diff shows
 ```
 
@@ -26,7 +26,12 @@ Git keeps three snapshots — HEAD, the index, the worktree — and a violation 
 while the others look clean: staged and then reverted, or committed and then fixed only in the index.
 Check all three, plus untracked files. That set is closed; there is no fourth place for code to hide.
 
-In the ordinary case the three agree and it is one diff. Pass the untracked files' contents alongside
+These commands produce patches, not summaries. The agents need the patch text: when the snapshots
+disagree, the violating lines exist in one of them and nowhere in the files on disk, so an agent that
+only reads the repository cannot see them. Add `--stat` separately if you want a file list for your own
+report.
+
+In the ordinary case the three agree and it is one patch. Pass the untracked files' contents alongside
 it — a brand-new file is where rules bite hardest and is the one thing no diff shows.
 
 Narrow to the files the user named if they named any, and say which scope you used. A clean report over

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -29,10 +29,12 @@ grep -n '^### ' CODE_RULES.md
 ```
 
 Spawn one agent per rule, in parallel. Each gets exactly: the full text of **its own rule and no
-other**, the diff, and the repository to read around the change.
+other**, the diff, and the repository to read around the change. Don't tell it what the other rules
+say, what the change was for, or what you expect it to find.
 
 One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
-checks none. Per-rule agents also stay honest as the file grows.
+checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not
+nine rules half-checked.
 
 Each agent returns either the single word `none`, or findings in this form:
 
@@ -52,9 +54,10 @@ Instruct every agent to:
 
 ## Step 3: Report
 
-Group findings by rule, in the agents' own format so local output matches what Codex posts on the pull
-request. State the scope, the rules checked, and every waiver that was honoured — a rule silenced by a
-waiver must never look the same as a rule that passed.
+Aggregate every agent's findings into **one list**, ordered by file and line, each entry naming its own
+rule and keeping the agents' format so local output matches what Codex posts on the pull request. State
+the scope, the rules checked, and every waiver that was honoured — a rule silenced by a waiver must
+never look the same as a rule that passed.
 
 Report only. Fixing is a separate decision and the user makes it.
 

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -19,17 +19,13 @@ the agent inherits.
 
 ## Step 1: Scope the diff
 
-Collect the patches for everything not yet on the mainline: HEAD, the index, the worktree, and the
-contents of untracked files. A violation can sit in any one of them while the others look clean —
-staged and then reverted, or committed and then fixed only in the index — and that set is closed, so
-there is no fifth place for code to hide.
+The caller owns the scope. Check whatever they name — a branch, a commit range, a set of files — and
+nothing else.
 
-Take the base from a merge base against a remote-tracking ref, never local `main`, which goes stale the
-moment someone merges upstream. Stop if there is no merge base rather than falling back to a comparison
-against HEAD, which reports clean while checking nothing.
+With nothing named, check the whole change as it would land if merged as it stands. Work out what that
+means here; it is a judgement about this checkout, not a fixed recipe.
 
-Narrow to the files the user named if they named any, and say which scope you used. A clean report over
-the wrong scope is worse than no report.
+Say which scope you used. A clean report over the wrong scope is worse than no report.
 
 ## Step 2: One agent per rule
 
@@ -40,7 +36,7 @@ grep -n '^### ' CODE_RULES.md
 Spawn one agent per rule, in parallel. Its prompt contains exactly two things:
 
 1. the full text of that one rule, verbatim from `CODE_RULES.md`;
-2. the Step 1 patches, plus the contents of any untracked files.
+2. the Step 1 change, as patch text.
 
 Nothing else goes in: not the other rules, not what the change was for, not what you expect it to find,
 not why the code looks the way it does. The agent reads the repository itself for anything more.
@@ -54,16 +50,12 @@ Each agent returns two sections, either of which may be empty:
 ```
 FINDINGS
 Rule <rule-id> violated:
-<snapshot> <file>:<line>
+<file>:<line>
 <what the code does, and the safe path>
 
 WAIVERS
-<snapshot> <file>:<line> — <the reason the waiver gives>
+<file>:<line> — <the reason the waiver gives>
 ```
-
-`<snapshot>` is `HEAD`, `index`, `worktree`, or `untracked` — which of the four the violating text lives
-in. Without it a finding against HEAD points at a line the reader opens and finds already clean, with
-nothing to say where the fix is owed.
 
 Instruct every agent to:
 
@@ -79,7 +71,7 @@ Instruct every agent to:
 ## Step 3: Report
 
 Aggregate every agent's `FINDINGS` into **one list**, ordered by file and line, each entry keeping its
-own rule and snapshot and the agents' format, so local output matches what Codex posts on the PR. State
+own rule and the agents' format, so local output matches what Codex posts on the PR. State
 the scope and the rules checked, then list the collected `WAIVERS` separately — a rule silenced by a
 waiver must never look the same as a rule that passed.
 

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -15,12 +15,12 @@ what stops it from seeing a violation.
 ## Step 1: Scope the diff
 
 ```bash
-BASE_REF=$(git rev-parse --verify --quiet upstream/main || git rev-parse --verify --quiet origin/main)
-[ -n "$BASE_REF" ] || { echo 'no upstream/main or origin/main — name the base explicitly'; exit 1; }
-BASE=$(git merge-base HEAD "$BASE_REF")
-git diff $BASE HEAD                                        # committed — what a push sends
-git diff $BASE --cached                                    # index — what a plain commit records
-git diff $BASE                                             # worktree — what you see in the files
+BASE=$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null)
+[ -n "$BASE" ] || { echo 'no merge base — fetch, deepen a shallow clone, or name the base commit'; exit 1; }
+
+git diff "$BASE" HEAD                                      # committed — what a push sends
+git diff "$BASE" --cached                                  # index — what a plain commit records
+git diff "$BASE"                                           # worktree — what you see in the files
 git status --porcelain --untracked-files=all | grep '^??'  # untracked — what no diff shows
 ```
 
@@ -36,9 +36,11 @@ report.
 In the ordinary case the three agree and it is one patch. Pass the untracked files' contents alongside
 it — a brand-new file is where rules bite hardest and is the one thing no diff shows.
 
-The base comes from a remote-tracking ref, not from local `main`, which goes stale the moment someone
-merges upstream and would silently widen the scope to changes already on the mainline. Fetch first if
-the remote ref itself may be behind, and stop rather than guess when neither ref exists.
+The base is a merge base against a remote-tracking ref, never local `main` — that one goes stale the
+moment someone merges upstream and would quietly widen the scope to changes already on the mainline.
+One emptiness check covers every way this can fail: ref missing, ancestry not fetched, shallow clone.
+`BASE` comes out empty and the run stops, rather than the expansion vanishing and each command
+degrading into a diff against HEAD that reports clean.
 
 Narrow to the files the user named if they named any, and say which scope you used. A clean report over
 the wrong scope is worse than no report.

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -63,8 +63,6 @@ Instruct every agent to:
 - honour `# rules-allow: <its-rule-id> — <reason>` on the line or its enclosing block, and list every
   waiver it honoured. A rule whose every match is waived returns an empty `FINDINGS` and a populated
   `WAIVERS`, which is not the same as passing;
-- report the violation anyway when the waiver's reason does not say why that instance is correct.
-  `# rules-allow: hardcoded-keys — temporary` explains nothing and would silence a real finding;
 - leave `FINDINGS` empty rather than reach for a marginal one. A checker that always finds something
   gets ignored, which costs more than the violation it caught.
 

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -19,33 +19,14 @@ the agent inherits.
 
 ## Step 1: Scope the diff
 
-```bash
-BASE=$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null)
-[ -n "$BASE" ] || { echo 'no merge base — fetch, deepen a shallow clone, or name the base commit'; exit 1; }
+Collect the patches for everything not yet on the mainline: HEAD, the index, the worktree, and the
+contents of untracked files. A violation can sit in any one of them while the others look clean —
+staged and then reverted, or committed and then fixed only in the index — and that set is closed, so
+there is no fifth place for code to hide.
 
-git diff "$BASE" HEAD                                      # committed — what a push sends
-git diff "$BASE" --cached                                  # index — what a plain commit records
-git diff "$BASE"                                           # worktree — what you see in the files
-git status --porcelain --untracked-files=all | grep '^??' || true  # untracked — what no diff shows
-```
-
-Git keeps three snapshots — HEAD, the index, the worktree — and a violation can sit in any one of them
-while the others look clean: staged and then reverted, or committed and then fixed only in the index.
-Check all three, plus untracked files. That set is closed; there is no fourth place for code to hide.
-
-These commands produce patches, not summaries. The agents need the patch text: when the snapshots
-disagree, the violating lines exist in one of them and nowhere in the files on disk, so an agent that
-only reads the repository cannot see them. Add `--stat` separately if you want a file list for your own
-report.
-
-In the ordinary case the three agree and it is one patch. Pass the untracked files' contents alongside
-it — a brand-new file is where rules bite hardest and is the one thing no diff shows.
-
-The base is a merge base against a remote-tracking ref, never local `main` — that one goes stale the
-moment someone merges upstream and would quietly widen the scope to changes already on the mainline.
-One emptiness check covers every way this can fail: ref missing, ancestry not fetched, shallow clone.
-`BASE` comes out empty and the run stops, rather than the expansion vanishing and each command
-degrading into a diff against HEAD that reports clean.
+Take the base from a merge base against a remote-tracking ref, never local `main`, which goes stale the
+moment someone merges upstream. Stop if there is no merge base rather than falling back to a comparison
+against HEAD, which reports clean while checking nothing.
 
 Narrow to the files the user named if they named any, and say which scope you used. A clean report over
 the wrong scope is worse than no report.

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -14,7 +14,7 @@ which inherits the parent conversation, so never use one here.
 
 What the platform cannot guarantee is the prompt you write, and that is the only channel into the agent.
 You are the worst possible author for it: you know why every line looks the way it does, and that
-knowledge is precisely what stops you seeing the violation. Whatever of it you write into the prompt,
+knowledge is what stops you seeing the violation. Whatever of it you write into the prompt,
 the agent inherits.
 
 ## Step 1: Scope the diff

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -21,7 +21,7 @@ BASE=$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD orig
 git diff "$BASE" HEAD                                      # committed — what a push sends
 git diff "$BASE" --cached                                  # index — what a plain commit records
 git diff "$BASE"                                           # worktree — what you see in the files
-git status --porcelain --untracked-files=all | grep '^??'  # untracked — what no diff shows
+git status --porcelain --untracked-files=all | grep '^??' || true  # untracked — what no diff shows
 ```
 
 Git keeps three snapshots — HEAD, the index, the worktree — and a violation can sit in any one of them

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -33,14 +33,10 @@ Say which scope you used. A clean report over the wrong scope is worse than no r
 grep -n '^### ' CODE_RULES.md
 ```
 
-Spawn one agent per rule, in parallel. Its prompt carries the task and the response format below, plus
-exactly two pieces of context:
+Spawn one agent per rule, in parallel. Give it the job, that one rule, and the change.
 
-1. the full text of that one rule, verbatim from `CODE_RULES.md`;
-2. the change from Step 1, as patch text.
-
-No other context goes in: not the other rules, not what the change was for, not what you expect it to
-find, not why the code looks the way it does. The agent reads the repository itself for anything more.
+Keep out anything that would tell it the answer: the other rules, what the change was for, why the code
+looks the way it does, what you expect it to find. It reads the repository itself for the rest.
 
 One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
 checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -59,7 +59,7 @@ WAIVERS
 
 Instruct every agent to:
 
-- report only what it can point at — a file, a line, and the text that breaks the rule;
+- give every violation a file and a line, best effort — a finding with nowhere to point is not a finding;
 - honour `# rules-allow: <its-rule-id> — <reason>` on the line or its enclosing block, and list every
   waiver it honoured. A rule whose every match is waived returns an empty `FINDINGS` and a populated
   `WAIVERS`, which is not the same as passing;

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -33,13 +33,14 @@ Say which scope you used. A clean report over the wrong scope is worse than no r
 grep -n '^### ' CODE_RULES.md
 ```
 
-Spawn one agent per rule, in parallel. Its prompt contains exactly two things:
+Spawn one agent per rule, in parallel. Its prompt carries the task and the response format below, plus
+exactly two pieces of context:
 
 1. the full text of that one rule, verbatim from `CODE_RULES.md`;
-2. the Step 1 change, as patch text.
+2. the change from Step 1, as patch text.
 
-Nothing else goes in: not the other rules, not what the change was for, not what you expect it to find,
-not why the code looks the way it does. The agent reads the repository itself for anything more.
+No other context goes in: not the other rules, not what the change was for, not what you expect it to
+find, not why the code looks the way it does. The agent reads the repository itself for anything more.
 
 One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
 checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -15,12 +15,17 @@ what stops it from seeing a violation.
 ## Step 1: Scope the diff
 
 ```bash
-git diff --stat                                   # uncommitted work
-git diff $(git merge-base HEAD main)... --stat    # the whole branch
+BASE=$(git merge-base HEAD main)
+git diff $BASE --stat                # committed, staged and unstaged, against main
+git status --porcelain | grep '^??'  # untracked files, which no diff shows
 ```
 
-Use the uncommitted changes if there are any, the branch diff otherwise, or the files the user named.
-Say which scope you used — a clean report over the wrong scope is worse than no report.
+Everything not yet on `main` is in scope: committed, staged, unstaged, and untracked. Pass the untracked
+files' contents alongside the diff — a brand-new file is where rules bite hardest and is the one thing
+`git diff` cannot show.
+
+Narrow to the files the user named if they named any, and say which scope you used. A clean report over
+the wrong scope is worse than no report.
 
 ## Step 2: One agent per rule
 
@@ -36,28 +41,35 @@ One agent per rule, not one agent holding all of them — an agent given nine ru
 checks none. A narrow agent also fails visibly: reporting nothing is one rule cleanly checked, not
 nine rules half-checked.
 
-Each agent returns either the single word `none`, or findings in this form:
+Each agent returns two sections, either of which may be empty:
 
 ```
+FINDINGS
 Rule <rule-id> violated:
 <file>:<line>
 <what the code does, and the safe path>
+
+WAIVERS
+<file>:<line> — <the reason the waiver gives>
 ```
 
 Instruct every agent to:
 
 - report only what it can point at — a file, a line, and the text that breaks the rule;
-- skip code carrying `# rules-allow: <its-rule-id> — <reason>` on the line or its enclosing block, and
-  list what it skipped;
-- answer `none` plainly rather than reach for a marginal finding. A checker that always finds something
+- honour `# rules-allow: <its-rule-id> — <reason>` on the line or its enclosing block, and list every
+  waiver it honoured. A rule whose every match is waived returns an empty `FINDINGS` and a populated
+  `WAIVERS`, which is not the same as passing;
+- report the violation anyway when the waiver's reason does not say why that instance is correct.
+  `# rules-allow: hardcoded-keys — temporary` explains nothing and would silence a real finding;
+- leave `FINDINGS` empty rather than reach for a marginal one. A checker that always finds something
   gets ignored, which costs more than the violation it caught.
 
 ## Step 3: Report
 
-Aggregate every agent's findings into **one list**, ordered by file and line, each entry naming its own
+Aggregate every agent's `FINDINGS` into **one list**, ordered by file and line, each entry naming its own
 rule and keeping the agents' format so local output matches what Codex posts on the pull request. State
-the scope, the rules checked, and every waiver that was honoured — a rule silenced by a waiver must
-never look the same as a rule that passed.
+the scope and the rules checked, then list the collected `WAIVERS` separately — a rule silenced by a
+waiver must never look the same as a rule that passed.
 
 Report only. Fixing is a separate decision and the user makes it.
 

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: check-rules
+description: Check the current changes against CODE_RULES.md and report violations. Use before pushing, or when asked whether a change breaks the repo's rules. Each rule is checked by an isolated agent with no session context.
+---
+
+# Check Rules
+
+Checks a diff against `CODE_RULES.md`. Nothing else — not a code review, not a style pass, not a bug
+hunt. A finding that does not name a rule is out of scope, however good it is.
+
+The check runs in fresh subagents with no access to this conversation. That isolation is the point: the
+session that wrote the code knows why every line looks the way it does, and that knowledge is exactly
+what stops it from seeing a violation.
+
+## Step 1: Scope the diff
+
+```bash
+git diff --stat                                   # uncommitted work
+git diff $(git merge-base HEAD main)... --stat    # the whole branch
+```
+
+Use the uncommitted changes if there are any, the branch diff otherwise, or the files the user named.
+Say which scope you used — a clean report over the wrong scope is worse than no report.
+
+## Step 2: One agent per rule
+
+```bash
+grep -n '^### ' CODE_RULES.md
+```
+
+Spawn one agent per rule, in parallel. Each gets exactly: the full text of **its own rule and no
+other**, the diff, and the repository to read around the change.
+
+One agent per rule, not one agent holding all of them — an agent given nine rules skims for nine and
+checks none. Per-rule agents also stay honest as the file grows.
+
+Each agent returns either the single word `none`, or findings in this form:
+
+```
+Rule <rule-id> violated:
+<file>:<line>
+<what the code does, and the safe path>
+```
+
+Instruct every agent to:
+
+- report only what it can point at — a file, a line, and the text that breaks the rule;
+- skip code carrying `# rules-allow: <its-rule-id> — <reason>` on the line or its enclosing block, and
+  list what it skipped;
+- answer `none` plainly rather than reach for a marginal finding. A checker that always finds something
+  gets ignored, which costs more than the violation it caught.
+
+## Step 3: Report
+
+Group findings by rule, in the agents' own format so local output matches what Codex posts on the pull
+request. State the scope, the rules checked, and every waiver that was honoured — a rule silenced by a
+waiver must never look the same as a rule that passed.
+
+Report only. Fixing is a separate decision and the user makes it.
+
+## When a finding is wrong
+
+A false positive is information about the rule, not just about the code. If a rule produces findings
+you disagree with, take it to the `add-rule` skill and recalibrate or reword it there. Arguing with the
+same rule twice means the rule is broken.

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -16,13 +16,17 @@ what stops it from seeing a violation.
 
 ```bash
 BASE=$(git merge-base HEAD main)
-git diff $BASE --stat                                      # committed, staged and unstaged
+git diff $BASE --stat                                      # base -> worktree
+git diff --cached $BASE --stat                             # base -> index, what a plain commit records
 git status --porcelain --untracked-files=all | grep '^??'  # untracked files, which no diff shows
 ```
 
 Everything not yet on `main` is in scope: committed, staged, unstaged, and untracked. Pass the untracked
 files' contents alongside the diff — a brand-new file is where rules bite hardest and is the one thing
 `git diff` cannot show.
+
+The two diffs are identical unless a file was staged and then edited again. When they differ, both are
+in scope: content can sit in the index, never appear in the worktree, and still be committed.
 
 Narrow to the files the user named if they named any, and say which scope you used. A clean report over
 the wrong scope is worse than no report.

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -16,8 +16,8 @@ what stops it from seeing a violation.
 
 ```bash
 BASE=$(git merge-base HEAD main)
-git diff $BASE --stat                # committed, staged and unstaged, against main
-git status --porcelain | grep '^??'  # untracked files, which no diff shows
+git diff $BASE --stat                                      # committed, staged and unstaged
+git status --porcelain --untracked-files=all | grep '^??'  # untracked files, which no diff shows
 ```
 
 Everything not yet on `main` is in scope: committed, staged, unstaged, and untracked. Pass the untracked

--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -15,7 +15,9 @@ what stops it from seeing a violation.
 ## Step 1: Scope the diff
 
 ```bash
-BASE=$(git merge-base HEAD main)
+BASE_REF=$(git rev-parse --verify --quiet upstream/main || git rev-parse --verify --quiet origin/main)
+[ -n "$BASE_REF" ] || { echo 'no upstream/main or origin/main — name the base explicitly'; exit 1; }
+BASE=$(git merge-base HEAD "$BASE_REF")
 git diff $BASE HEAD                                        # committed — what a push sends
 git diff $BASE --cached                                    # index — what a plain commit records
 git diff $BASE                                             # worktree — what you see in the files
@@ -33,6 +35,10 @@ report.
 
 In the ordinary case the three agree and it is one patch. Pass the untracked files' contents alongside
 it — a brand-new file is where rules bite hardest and is the one thing no diff shows.
+
+The base comes from a remote-tracking ref, not from local `main`, which goes stale the moment someone
+merges upstream and would silently widen the scope to changes already on the mainline. Fetch first if
+the remote ref itself may be behind, and stop rather than guess when neither ref exists.
 
 Narrow to the files the user named if they named any, and say which scope you used. A clean report over
 the wrong scope is worse than no report.
@@ -56,12 +62,16 @@ Each agent returns two sections, either of which may be empty:
 ```
 FINDINGS
 Rule <rule-id> violated:
-<file>:<line>
+<snapshot> <file>:<line>
 <what the code does, and the safe path>
 
 WAIVERS
-<file>:<line> — <the reason the waiver gives>
+<snapshot> <file>:<line> — <the reason the waiver gives>
 ```
+
+`<snapshot>` is `HEAD`, `index`, `worktree`, or `untracked` — which of the four the violating text lives
+in. Without it a finding against HEAD points at a line the reader opens and finds already clean, with
+nothing to say where the fix is owed.
 
 Instruct every agent to:
 
@@ -76,8 +86,8 @@ Instruct every agent to:
 
 ## Step 3: Report
 
-Aggregate every agent's `FINDINGS` into **one list**, ordered by file and line, each entry naming its own
-rule and keeping the agents' format so local output matches what Codex posts on the pull request. State
+Aggregate every agent's `FINDINGS` into **one list**, ordered by file and line, each entry keeping its
+own rule and snapshot and the agents' format, so local output matches what Codex posts on the PR. State
 the scope and the rules checked, then list the collected `WAIVERS` separately — a rule silenced by a
 waiver must never look the same as a rule that passed.
 

--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -15,7 +15,7 @@ questions.
   classes, moving ownership, renaming + migrating). Do NOT present findings and wait.
 - **Ask only when** (a) an action is irreversible beyond the working tree — dataset/data
   migrations, deleting files you didn't create whose purpose is unclear, anything touching
-  remote state; or (b) two designs are genuinely defensible and externally visible — then ask
+  remote state; or (b) two designs are defensible and externally visible — then ask
   with a recommendation. Everything else: decide, fix, report.
 - **Review code as a whole, never as a diff.** The diff only tells you *which* files to look
   at. Read each touched file (and the immediate neighbors it interacts with) in its entirety
@@ -142,7 +142,7 @@ For **every** comment and docstring in the touched files (not just new ones in t
 ## Step 5: Iterate to a fixed point
 
 Re-run Steps 2–4 on the **resulting state** of the touched code. Repeat until a full round
-produces no findings. In practice 2–3 rounds; the second round exists precisely to catch
+produces no findings. In practice 2–3 rounds; the second round exists to catch
 what the first round's fixes created (structural twins, dead parameters, orphaned helpers,
 stale comments describing the pre-fix code).
 
@@ -400,7 +400,7 @@ comment, rewrite the code instead.
 - **No `**kwargs` propagation** — name every parameter explicitly.
 - **The constructor defines the initialization contract** — if a value is part of what the
   object *is* (configuration, identity), it belongs in the constructor, not set afterwards.
-  Reserve direct attribute mutation for truly dynamic state. Knowing the concrete type
+  Reserve direct attribute mutation for dynamic state. Knowing the concrete type
   doesn't justify bypassing the constructor:
   ```python
   # BAD — known at construction, but set after

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,4 @@ Rule {name} violated:
 the safe path out of it.
 
 Do not raise a violation when the offending line or its enclosing block carries a
-`# rules-allow: <rule-id> — <reason>` comment for that rule and the reason says why that instance is
-correct. Report the violation anyway when the reason does not: `# rules-allow: hardcoded-keys —
-temporary` explains nothing.
+`# rules-allow: <rule-id> — <reason>` comment for that rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Positronic
 
-Python-native stack for real-life ML robotics: recording, datasets, policy training and on-robot inference.
+Python-native stack for real-life ML robotics.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,4 +18,6 @@ Rule {name} violated:
 the safe path out of it.
 
 Do not raise a violation when the offending line or its enclosing block carries a
-`# rules-allow: <rule-id> — <reason>` comment for that rule.
+`# rules-allow: <rule-id> — <reason>` comment for that rule and the reason says why that instance is
+correct. Report the violation anyway when the reason does not: `# rules-allow: hardcoded-keys —
+temporary` explains nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@ Python-native stack for real-life ML robotics.
 Apart from your normal review, read `CODE_RULES.md` in the repository root and check the diff against
 every rule in it. The rules are not repeated here — that file is the whole set.
 
+They govern authoring as much as review: follow them when writing code here, not only when reviewing
+someone else's. The heading is named for the review case because that is the section name Codex looks
+for.
+
 Report each violation as a comment in exactly this form:
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Positronic
+
+Python-native stack for real-life ML robotics: recording, datasets, policy training and on-robot inference.
+
+## Code Review Rules
+
+Apart from your normal review, read `CODE_RULES.md` in the repository root and check the diff against
+every rule in it. The rules are not repeated here — that file is the whole set.
+
+Report each violation as a comment in exactly this form:
+
+```
+Rule {name} violated:
+{details}
+```
+
+`{name}` is the rule's id — its heading in `CODE_RULES.md`. `{details}` names the offending code and
+the safe path out of it.
+
+Do not raise a violation when the offending line or its enclosing block carries a
+`# rules-allow: <rule-id> — <reason>` comment for that rule.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,18 @@
   suppress an error that actually fires — no blanket or speculative suppressions
 
 # Comments & docstrings
-- Write for a fresh reader: no references to past or future state ("no longer", "previously", "step N", "today").
-  Future work is a TODO, nothing else
+- Write for a colleague who knows this codebase but not the thing you are documenting: don't explain the domain,
+  the neighbouring modules, or vocabulary the repo already uses
+- No references to past or future state ("no longer", "previously", "step N", "today"). Future work is a TODO,
+  nothing else
 - Never write a comment justifying awkward code — the urge to justify is the signal to fix the design or mark it
   HACK/TODO
-- Don't restate the code; if there is nothing to say beyond it, stay silent. Docstrings are plain statements of
-  what the thing is
+- A docstring states what the thing is, and nothing else. Behaviour worth pinning down belongs in a test name,
+  a design decision in a TODO or a commit message, a usage example once in the module docstring
+- Leave a comment only for what the code cannot say: an invariant, a constraint from outside the file, a reason
+  the obvious alternative fails. Dry and factual. If it restates the code, delete it
+- Be economical: a class docstring runs a few lines, a method's one, and most methods need none. Past that it is
+  teaching rather than stating — cut it, or move the content to the home named above
 - Comments wrap at 120 columns, same as code
 - No empty intensifiers, in comments or in docs — "honestly", "load-bearing", "genuinely", "truly", "precisely".
   Delete the word; if the sentence still means the same thing, it was never doing any work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@
 - Don't restate the code; if there is nothing to say beyond it, stay silent. Docstrings are plain statements of
   what the thing is
 - Comments wrap at 120 columns, same as code
+- No empty intensifiers, in comments or in docs — "honestly", "load-bearing", "genuinely", "truly", "precisely".
+  Delete the word; if the sentence still means the same thing, it was never doing any work
 
 # Testing
 - A test goes in the file that already covers its subject. A test written for a bug is an ordinary test of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # Contributor behavior
+- Read `CODE_RULES.md` before writing code here — the named rules it carries govern authoring, not only
+  review, and `check-rules` is how you check a change against them
 - Don't restore code that you wrote and I deleted
 - Don't hide errors with try-catch blocks; let failures surface until asked otherwise
 - Stay scoped: no features beyond the request. Structure of the code you touch is governed by Design
   discipline below — bringing it to the end state is in scope, refactoring unrelated code is not
 - Don't add comments, docstrings, or type annotations to code you didn't change
-- Ask clarifying questions only when requirements are genuinely ambiguous and investigation can't resolve them
+- Ask clarifying questions only when requirements are ambiguous and investigation can't resolve them
 
 # Commands
 - Every Python execution goes through `uv run --locked --extra dev` — bare `python`/`pytest` bypasses the locked
@@ -38,14 +40,14 @@
   an entry lives in, an enum, the calling context), don't reify the concept into a type. Extend an existing module
   rather than adding a file
 - That holds for a new file of any kind — module, test, or doc. Find the existing home first; when there is
-  genuinely none, surface it rather than restructuring on your own initiative (see Testing)
+  none, surface it rather than restructuring on your own initiative (see Testing)
 - No `X | None` for logically required values — an Optional that is never None in practice lies about the contract
 - After every fix or refactor, re-read the resulting code as a whole, not the diff: fixes create new smells (e.g.
   two classes become structurally identical only after their serializers are unified — merge them)
 
 # Code style
 - No imports inside functions/methods; always place imports at the top of the file
-- Exception: circular dependencies or truly unavoidable cases
+- Exception: circular dependencies or cases with no other resolution
 - No `hasattr`/`getattr` hacks for type dispatch; use `isinstance` with proper base classes or protocols
 - Judge names at the call site (`ds`, `teleop` — not `dataset`, `teleoperation`) and against the roadmap
   (`mujoco_franka`, not `sim` — more sims will exist)
@@ -73,7 +75,7 @@
   thing that broke — it belongs beside the others and needs neither a file of its own nor "regression" framing
 - Look for that home by subject rather than by filename, and conclude there is none only after looking. A new
   test file claims the subject has no home yet, and that claim is usually wrong
-- When a test genuinely has nowhere to go, the file organization is what needs adjusting — that is a finding,
+- When a test has nowhere to go, the file organization is what needs adjusting — that is a finding,
   not a licence to invent a home. Don't restructure on your own initiative: put the test in the least-wrong
   existing home and say plainly that nothing fit, so the gap reaches a human instead of being absorbed
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -1,10 +1,6 @@
 # Code Rules
 
-Judgment rules for this repository — the checks a linter cannot make. Read by the Codex reviewer on
-pull requests, by Claude while implementing, and by the `check-rules` skill.
-
-Mechanical checks live in `pyproject.toml` (ruff, basedpyright), never here. A rule a linter could
-enforce is a rule that would be applied inconsistently.
+Judgment rules for this repository — the checks a linter cannot make.
 
 Every rule has an **id** — its heading. Cite it when reporting, fixing, or waiving a violation. Add,
 calibrate, and retire rules through the `add-rule` skill.
@@ -17,9 +13,7 @@ A violation is waived when the offending line or its enclosing block carries:
 # rules-allow: <rule-id> — <reason>
 ```
 
-The reason is required, and must say why this instance is correct — not that the rule is inconvenient.
-A waiver is as narrow as a `noqa`: one rule id, at the site. To retire a rule everywhere, delete it
-from this file.
+The reason must say why this instance is correct. One rule id, at the site — as narrow as a `noqa`.
 
 ## Rules
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -39,19 +39,9 @@ paths. Take them as parameters instead, with a default for the usual name.
 Exception: a name the component itself owns and defines, rather than one it reads from its input.
 
 ```python
-# Bad — only works on data that spells these three names exactly this way
-class ChangeEEFrame:
-    def encode(self, data):
-        transform = frame_transform(data['urdf'], data['control_frame'], self._to)
-        return {**data, 'robot_state.ee_pose': change_frame(data['robot_state.ee_pose'], transform)}
+# Bad
+return {**data, 'ee_pose': change_frame(data['ee_pose'])}
 
-
-# Good — a second dataset passes urdf_key='robot/urdf' and reuses the class
-class ChangeEEFrame:
-    def __init__(self, to, pose_key='robot_state.ee_pose', urdf_key='urdf', control_frame_key='control_frame'):
-        ...
-
-    def encode(self, data):
-        transform = frame_transform(data[self._urdf_key], data[self._control_frame_key], self._to)
-        return {**data, self._pose_key: change_frame(data[self._pose_key], transform)}
+# Good — pose_key is a constructor parameter defaulting to 'ee_pose'
+return {**data, self._pose_key: change_frame(data[self._pose_key])}
 ```

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -27,8 +27,13 @@ has never heard of a policy.
 
 ### hardcoded-keys
 
-Don't write the names of data fields as literals inside your code — dict keys, signal names, field
-paths. Take them as parameters instead, with a default for the usual name.
+Don't write the names of shared data as bare literals — dict keys, signal names, field paths. The name
+is a contract between whoever writes the data and whoever reads it, and a literal leaves that contract
+invisible and repeated.
+
+Two remedies, by who owns the name. When callers may legitimately use different names, take it as a
+parameter with a default for the usual one. When everyone must agree on the same name, define it once
+as a named constant in a shared module.
 
 Exception: a name the component itself owns and defines, rather than one it reads from its input.
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -39,3 +39,21 @@ return {**data, 'ee_pose': change_frame(data['ee_pose'])}
 # Good — pose_key is a constructor parameter defaulting to 'ee_pose'
 return {**data, self._pose_key: change_frame(data[self._pose_key])}
 ```
+
+### overspecific
+
+Don't bake assumptions about how a component will be used into its interface. Before adding a
+parameter, a branch, or a category to a signature, ask what else the component could legitimately be
+asked to do — many keys instead of one, several value types instead of one, the same operation in
+reverse. Where handling those uniformly makes the code **shorter**, the specific version is wrong.
+
+Generalise until it simplifies, and stop there. A parameter, flag, or strategy object added for a case
+nobody has is the same mistake pointed the other way.
+
+```python
+# Bad — assumes every key belongs to exactly one category, and that the categories need different handling
+def __init__(self, pose_keys, command_keys): ...
+
+# Good — one list, handled the same way in both directions
+def __init__(self, keys): ...
+```

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -2,8 +2,8 @@
 
 Judgment rules for this repository — the checks a linter cannot make.
 
-Every rule has an **id** — its heading. Cite it when reporting, fixing, or waiving a violation. Add,
-calibrate, and retire rules through the `add-rule` skill.
+Every rule has an **id** — its heading. Cite it when reporting, fixing, or waiving a violation. Add and
+recalibrate rules through the `add-rule` skill.
 
 ## Waiving a rule
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -1,0 +1,57 @@
+# Code Rules
+
+Judgment rules for this repository — the checks a linter cannot make. Read by the Codex reviewer on
+pull requests, by Claude while implementing, and by the `check-rules` skill.
+
+Mechanical checks live in `pyproject.toml` (ruff, basedpyright), never here. A rule a linter could
+enforce is a rule that would be applied inconsistently.
+
+Every rule has an **id** — its heading. Cite it when reporting, fixing, or waiving a violation. Add,
+calibrate, and retire rules through the `add-rule` skill.
+
+## Waiving a rule
+
+A violation is waived when the offending line or its enclosing block carries:
+
+```python
+# rules-allow: <rule-id> — <reason>
+```
+
+The reason is required, and must say why this instance is correct — not that the rule is inconvenient.
+A waiver is as narrow as a `noqa`: one rule id, at the site. To retire a rule everywhere, delete it
+from this file.
+
+## Rules
+
+### caller-in-name
+
+Don't name anything — function, class, module, variable — after where it is used. Name it after what it
+does. Information about the callers must not leak into the name.
+
+A helper that recomposes a pose through a fixed transform is `change_frame`, not `to_policy_frame`: it
+has never heard of a policy.
+
+### hardcoded-keys
+
+Don't write the names of data fields as literals inside your code — dict keys, signal names, field
+paths. Take them as parameters instead, with a default for the usual name.
+
+Exception: a name the component itself owns and defines, rather than one it reads from its input.
+
+```python
+# Bad — only works on data that spells these three names exactly this way
+class ChangeEEFrame:
+    def encode(self, data):
+        transform = frame_transform(data['urdf'], data['control_frame'], self._to)
+        return {**data, 'robot_state.ee_pose': change_frame(data['robot_state.ee_pose'], transform)}
+
+
+# Good — a second dataset passes urdf_key='robot/urdf' and reuses the class
+class ChangeEEFrame:
+    def __init__(self, to, pose_key='robot_state.ee_pose', urdf_key='urdf', control_frame_key='control_frame'):
+        ...
+
+    def encode(self, data):
+        transform = frame_transform(data[self._urdf_key], data[self._control_frame_key], self._to)
+        return {**data, self._pose_key: change_frame(data[self._pose_key], transform)}
+```

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -50,10 +50,16 @@ return {**data, self._pose_key: change_frame(data[self._pose_key])}
 Don't bake assumptions about how a component will be used into its interface. Before adding a
 parameter, a branch, or a category to a signature, ask what else the component could legitimately be
 asked to do — many keys instead of one, several value types instead of one, the same operation in
-reverse. Where handling those uniformly makes the code **shorter**, the specific version is wrong.
+reverse.
 
-Generalise until it simplifies, and stop there. A parameter, flag, or strategy object added for a case
-nobody has is the same mistake pointed the other way.
+Handling those uniformly usually comes out simpler and easier for a human to read: fewer branches,
+often fewer lines, and every use falling into place without deliberation. When it does, the specific
+version was wrong.
+
+Generalise until it simplifies, and stop there. Past that point the signature stops having an opinion
+and the caller must read the implementation to know what to pass — the same mistake pointed the other
+way. This is a matter of taste and does not reduce to a measurement: judge the result as a reader, not
+by counting.
 
 ```python
 # Bad — assumes every key belongs to exactly one category, and that the categories need different handling

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,7 @@ both invariants — the run produces no dataset, and execution is scheduled by c
 
 ## Derived decisions
 
-The load-bearing consequences of the goals and principles. Each is stated with what forces it —
+What the goals and principles force. Each is stated with what forces it —
 revisit a decision only by revisiting its premises.
 
 **Time is an observation.** A policy that cannot tell sim from real cannot be allowed to read the

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 # Only the checkpoint pinned at server startup is pre-warmed; a session that requests any other model loads it
 # cold, so its first ``infer`` can include the backend's JAX compilation. Bound each ``recv`` generously enough to
-# outlast that compile (still surfacing a truly stalled/half-open connection), and let callers override per use.
+# outlast that compile (still surfacing a stalled/half-open connection), and let callers override per use.
 DEFAULT_INFER_TIMEOUT = 180.0
 
 

--- a/positronic/simulator/libero/validate.py
+++ b/positronic/simulator/libero/validate.py
@@ -150,7 +150,7 @@ def _check_obs_encoding(env: LiberoEnv, token: dict) -> None:
 
     # Gripper: drive to both stops to read the finger qpos endpoints, then the codec's linear reconstruction
     # CLOSED + (1 - grip) * (OPEN - CLOSED) recovers the true qpos from the closure scalar (q_open/q_closed are
-    # the load-bearing, non-circular measurement; the sweep checks the linear model holds).
+    # the non-circular measurement; the sweep checks the linear model holds).
     env.reset(token)
     for _ in range(40):
         wire = env.step({'command': {'type': 'hold'}, 'grip': 0.0})['obs']

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -85,7 +85,7 @@ def _parse_renames(out: str | None) -> dict[str, str]:
 
     Only `R` (rename) is mapped, never `C` (copy): a rename moves a file's entries to a new key, so
     the new path must inherit the base counts; a copy leaves the source in place and duplicates its
-    diagnostics into a genuinely new file, which must face the new-file check, not reuse the source's
+    diagnostics into a new file, which must face the new-file check, not reuse the source's
     grandfathered allowances.
     """
     renames: dict[str, str] = {}

--- a/utilities/tests/test_check_basedpyright_baseline_ratchet.py
+++ b/utilities/tests/test_check_basedpyright_baseline_ratchet.py
@@ -90,7 +90,7 @@ def test_build_rename_map_includes_staged_rename(tmp_path, monkeypatch):
 
 def test_parse_renames_maps_renames_not_copies():
     # A rename (R) moves entries to a new key and must map back; a copy (C) leaves the source in
-    # place and duplicates its diagnostics into a genuinely new file, which must face the new-file
+    # place and duplicates its diagnostics into a new file, which must face the new-file
     # check rather than reuse the source's grandfathered allowances — so C must NOT be mapped.
     out = 'R100\told.py\tmoved.py\nC100\tkept.py\tcopy.py\n'
     assert ratchet._parse_renames(out) == {'moved.py': 'old.py'}


### PR DESCRIPTION
## Summary

Codifies repo conventions as named rules, read from one place by the Codex reviewer, by agents, and by
humans.

- **`CODE_RULES.md`** — judgment rules a linter cannot make, each with an id, an imperative statement,
  and the safe path. Three to start, all three from review comments on #485:
  - `caller-in-name` — don't name things after where they are used
  - `hardcoded-keys` — don't write data field names as literals inside the code
  - `overspecific` — don't bake assumptions about the caller into an interface; generalise until it
    simplifies, and stop there
- **`AGENTS.md`** — points the Codex reviewer at `CODE_RULES.md` and fixes the report format
  (`Rule {name} violated:`). Deliberately contains no rule text.
- **`CLAUDE.md`** — points at `CODE_RULES.md` too, so the rules reach Claude while it writes code, not
  only when it reviews. Sessions load `CLAUDE.md`, not `AGENTS.md`, so without this the rules would have
  been review-only.
- **`/add-rule`** — authors and recalibrates rules. A rule needs a real incident behind it, must not
  duplicate ruff or basedpyright, and has to survive a cold read by someone who was not in the
  conversation that produced it.
- **`/check-rules`** — checks a diff against the rules, one isolated agent per rule, no session context.
  Reports only; fixing stays a human decision.

Rules are waived at the site with `# rules-allow: <rule-id> — <reason>`, narrow like a `noqa`.

Also adds one `CLAUDE.md` rule that the rulebook's own prose failed: no empty intensifiers ("genuinely",
"truly", "load-bearing"). The offending words are removed from `CLAUDE.md` and `docs/architecture.md`.

## Open question this PR tests

Codex's documentation describes rules living under a `## Code Review Rules` heading in `AGENTS.md`, and
says nothing about following links to other files. This PR deliberately keeps `AGENTS.md` rule-free to
find out whether the link is followed. Partial evidence so far: Codex cited `CODE_RULES.md` by line
number while reviewing this branch — but that file was in the diff, so it is not yet proof. If Codex
never cites a rule id on a code diff, the fallback is a pre-commit hook that mirrors `CODE_RULES.md`
into `AGENTS.md`, with everything else unchanged.

## Not in this PR

- Seven further rule candidates: `optional-lies`, `silent-bridge`, `structural-twins`,
  `type-dispatch-hacks`, `impl-owns-default`, `comment-narrates-diff`, `speculative-shim`.
- Calibrating `overspecific` against the existing tree — it is the rule most likely to over-fire, and it
  has not been sampled yet.
- Resolving the overlap between `CODE_RULES.md` and the design-discipline section `CLAUDE.md` still
  carries; the two coexist for now.

## Test plan

Not verified — the mechanism can only be tested once Codex reviews a code diff with these files on the
branch. Markdown only; no code paths touched.
