### PR TITLE
Read a quoted heredoc body as data, not as command words

### DIFF
--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -50,6 +50,10 @@ SUBST = '\x00subst'
 # `origin/main`, `main:other` — but not `mainline` or `feature/main2`.
 MAIN_REF_RE = re.compile(r'(^|[:/+])main(?![\w/\-])')
 
+# A heredoc opener whose delimiter is QUOTED — `<<'EOF'`, `<<"EOF"`, `<<-'EOF'`. The quoting is
+# what makes the body inert: it suppresses every expansion, so the text cannot execute.
+HEREDOC_QUOTED_RE = re.compile(r"""<<(-?)\s*(['"])(\w+)\2""")
+
 
 def repo_slug(url: str) -> str:
     """owner/repo from a remote URL, ssh or https form; empty when there is none.
@@ -137,6 +141,36 @@ def _apply_dash_c(words: list[str], base: str | None) -> str | None:
             continue
         i += 1
     return base
+
+
+def _strip_heredoc_bodies(cmd: str) -> str:
+    """`cmd` with the bodies of quoted-delimiter heredocs removed.
+
+    A heredoc body is stdin DATA, never command words — but the tokenizer reads it as words
+    anyway, so a single apostrophe in a commit message ("don't") leaves the whole command
+    unparseable and every invocation in it falls back to guarded. That refused pushes to
+    entirely different repos.
+
+    Dropping the body loses nothing analyzable, because a QUOTED delimiter suppresses every
+    expansion: the text reaches the command literally and cannot execute. Unquoted `<<EOF` is
+    deliberately left in place — its body DOES expand `$(…)`, so it keeps failing closed, and
+    `_substitution_bodies` still scans the untouched command for what such a body might run.
+    """
+    lines = cmd.split('\n')
+    kept: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        kept.append(line)
+        i += 1
+        for dash, _quote, delim in HEREDOC_QUOTED_RE.findall(line):
+            while i < len(lines):
+                # `<<-` lets the terminator be indented with tabs.
+                terminator = lines[i].lstrip('\t') if dash else lines[i]
+                i += 1
+                if terminator == delim:
+                    break
+    return '\n'.join(kept)
 
 
 def _segments(cmd: str) -> list[list[str]]:
@@ -241,6 +275,7 @@ def _parse_lossy(cmd: str) -> list[Invocation]:
 
 
 def parse_invocations(cmd: str, cwd: str, path_exists=os.path.isdir) -> list[Invocation]:
+    cmd = _strip_heredoc_bodies(cmd)
     try:
         segments = _segments(cmd)
     except ValueError:

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -215,6 +215,41 @@ def test_unbalanced_quoting_falls_back_guarded(git):
     assert verdict(git, "echo don't panic") is None
 
 
+def test_quoted_heredoc_body_does_not_guard_another_repo(git):
+    """A commit message is data, and an apostrophe in it is not a parse failure.
+
+    `<<'EOF'` bodies reach the command as literal stdin, so the apostrophe in "don't"
+    used to leave the whole command unparseable — which poisoned the `cd`, and a push
+    on a feature branch of an entirely different repo was refused as a push to main.
+    """
+    cmd = (
+        "cd /w/agent_infra && git commit -F- -- x.py <<'EOF' && git push origin HEAD\n"
+        "subject line\n\ndon't reverse this decision\nEOF"
+    )
+    assert verdict(git, cmd) is None
+
+
+def test_quoted_heredoc_body_is_text_not_commands(git):
+    """Nothing in a quoted heredoc body executes, so git-shaped prose in one is prose.
+
+    A commit message explaining a main-branch rule is the realistic case, and blocking
+    the commit that carries it is a false positive.
+    """
+    cmd = "cd /w/positronic && git commit -F- -- x.py <<'EOF'\nWhy we never git push origin main\nEOF"
+    assert verdict(git, cmd) is None
+
+
+def test_dash_quoted_heredoc_body_is_also_text(git):
+    cmd = "cd /w/agent_infra && git commit -F- -- x.py <<-'EOF' && git push origin HEAD\n\tdon't\n\tEOF"
+    assert verdict(git, cmd) is None
+
+
+def test_commands_after_a_heredoc_are_still_analyzed(git):
+    """Stripping the body must not swallow what follows the terminator."""
+    cmd = "cd /w/positronic && git commit -F- -- x.py <<'EOF'\nmessage\nEOF\ngit push origin main"
+    assert verdict(git, cmd) is not None
+
+
 def test_deny_messages_name_the_operation(git):
     assert 'amend' in verdict(git, 'git commit --amend')
     assert 'gh pr merge' in verdict(git, 'gh pr merge 5')


### PR DESCRIPTION
The guard tokenizes the entire Bash command, heredoc bodies included. A heredoc body is stdin data rather than command words, so one ASCII apostrophe in a commit message — `don't` — makes the command unparseable, every invocation in it falls back to `_parse_lossy`, and that path resolves no working directory. The result is a block whose message names a branch belonging to a repo the command never touched: committing in another repo with a message containing `don't`, chained with `git push origin HEAD` on a feature branch, is refused as `BLOCKED: pushing the current branch (main) is not allowed`.

**The fix** strips the bodies of quoted-delimiter heredocs before tokenizing. Nothing analyzable is lost: a quoted delimiter suppresses every expansion, so the body reaches the command literally and cannot execute.

**Unquoted heredocs are deliberately left alone.** Their bodies *do* expand command substitutions, so they keep failing closed, and `_substitution_bodies` still scans the untouched command for whatever such a body would run. The existing test asserting an unquoted heredoc stays guarded passes unchanged.

Four tests added, next to the existing quoting coverage: the apostrophe case; git-shaped prose in a body (a commit message explaining a main-branch rule should not be read as a push to main); the dash form with an indented terminator; and one pinning that commands *after* the terminator are still analyzed. 76 pass.

Note the stripping matches shell semantics rather than softening them — a body containing a line equal to the delimiter still ends the heredoc here exactly as bash would end it, so a command that bash would mis-parse is still analyzed as bash would run it.
