### PR TITLE
Add the `diff-comments` rule

### DIFF
--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -68,3 +68,44 @@ def __init__(self, pose_keys, command_keys): ...
 # Good — one list, handled the same way in both directions
 def __init__(self, keys): ...
 ```
+
+### diff-comments
+
+Write a comment for someone reading the file, not for someone reading the change. Read it back knowing
+nothing about why the line was touched: if it answers "why did you change this?" rather than "what must
+be true here?", delete it.
+
+Two ways it goes wrong. The comment argues for the code — names the alternative rejected, or traces the
+consequences that justify the line; that belongs in the commit message. Or it asserts how code elsewhere
+behaves — another function, another module, the layer below; nothing here keeps that claim true, so it
+rots silently.
+
+What survives is what the code cannot say: an invariant, a constraint from outside the file, a
+precondition. Write it dry — a flat statement, no intensifiers, no rhetorical build, no clause there
+only to make the point land. Usually one line, and often none.
+
+```python
+# Bad — argues the design against what it replaced, and builds to a flourish
+def _reset(self, robot, robot_state, rate_limiter, should_stop):
+    """Home the arm, yielding until it arrives. Drive with ``yield from``.
+
+    A generator rather than a blocking call because the waiting has to keep clearing robot
+    errors. `set_target_joints` returns as soon as the target is published, and the driver's
+    own loop is what notices and clears a reflex — so a wait that parks inside the library
+    stops the only thing that can end the move it is waiting for.
+    """
+
+# Good
+def _reset(self, robot, robot_state, rate_limiter, should_stop):
+    """Home the arm, yielding until it arrives. Drive with ``yield from``."""
+```
+
+```python
+# Bad — asserts what another function does; nothing here keeps it true
+if should_stop.value:
+    return  # shutting down — the caller's `finally` halts the control thread
+
+# Good
+if should_stop.value:
+    return
+```

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -76,16 +76,17 @@ nothing about why the line was touched: if it answers "why did you change this?"
 be true here?", delete it.
 
 Two ways it goes wrong. The comment narrates the change — what the code did before, what replaced it,
-the reasoning that got there; that belongs in the commit message. Or it asserts how code elsewhere
-behaves — another function, another module, the layer below; nothing here keeps that claim true, so it
-rots silently.
+the reasoning that got there. Or it describes what other code happens to do — what the caller does
+next, what a consumer waits for. Neither is anchored: the first only parses for someone who saw the
+edit, and nothing keeps the second true.
 
-What survives is what the code cannot say: an invariant, a constraint from outside the file, a
-precondition, one dry line on why the obvious alternative fails. That last one is a standing fact, not a
-story about the edit: "a `readOnce()` here would take the connection the control loop holds" stays true
-forever, where "a generator rather than a blocking call" only parses for someone who knows there was a
-blocking call. Write it flat — no intensifiers, no rhetorical build, no clause there only to make the
-point land. Usually one line, and often none.
+Each has a near neighbour that stays. A constraint the code is written against is worth one dry line,
+including one on why the obvious alternative fails. The test is whether this code would be wrong if the
+claim stopped holding: "a `readOnce()` here would take the connection the control loop holds" earns its
+place, where "the caller's `finally` halts the control thread" does not.
+
+Write it flat — no intensifiers, no rhetorical build, no clause there only to make the point land.
+Usually one line, and often none.
 
 ```python
 # Bad — narrates what it replaced, at paragraph length, and builds to a flourish
@@ -104,7 +105,7 @@ def _reset(self, robot, robot_state, rate_limiter, should_stop):
 ```
 
 ```python
-# Bad — asserts what another function does; nothing here keeps it true
+# Bad — describes what the caller happens to do; this code does not depend on it
 if should_stop.value:
     return  # shutting down — the caller's `finally` halts the control thread
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -75,17 +75,20 @@ Write a comment for someone reading the file, not for someone reading the change
 nothing about why the line was touched: if it answers "why did you change this?" rather than "what must
 be true here?", delete it.
 
-Two ways it goes wrong. The comment argues for the code — names the alternative rejected, or traces the
-consequences that justify the line; that belongs in the commit message. Or it asserts how code elsewhere
+Two ways it goes wrong. The comment narrates the change — what the code did before, what replaced it,
+the reasoning that got there; that belongs in the commit message. Or it asserts how code elsewhere
 behaves — another function, another module, the layer below; nothing here keeps that claim true, so it
 rots silently.
 
 What survives is what the code cannot say: an invariant, a constraint from outside the file, a
-precondition. Write it dry — a flat statement, no intensifiers, no rhetorical build, no clause there
-only to make the point land. Usually one line, and often none.
+precondition, one dry line on why the obvious alternative fails. That last one is a standing fact, not a
+story about the edit: "a `readOnce()` here would take the connection the control loop holds" stays true
+forever, where "a generator rather than a blocking call" only parses for someone who knows there was a
+blocking call. Write it flat — no intensifiers, no rhetorical build, no clause there only to make the
+point land. Usually one line, and often none.
 
 ```python
-# Bad — argues the design against what it replaced, and builds to a flourish
+# Bad — narrates what it replaced, at paragraph length, and builds to a flourish
 def _reset(self, robot, robot_state, rate_limiter, should_stop):
     """Home the arm, yielding until it arrives. Drive with ``yield from``.
 


### PR DESCRIPTION
Adds `diff-comments` to `CODE_RULES.md`.

## The defect

A comment that only makes sense to someone who saw the change that introduced it. Read
cold, months later, it answers a question nobody asked.

Two shapes:

- It **argues for the code** — names the alternative that was rejected, or traces the
  consequences that justify the line. That is the commit message.
- It **asserts how code elsewhere behaves** — another function, another module, the layer
  below. Nothing at the comment's own site keeps that claim true, so it rots silently.

Plus a register clause: dry, flat, no intensifiers, no rhetorical build.

## Why a rule and not prose

`CLAUDE.md` already says most of this in three places ("A docstring states what the thing
is, and nothing else", "Never write a comment justifying awkward code", "Leave a comment
only for what the code cannot say"). It has no rule id, so `check-rules` cannot check it,
and it keeps being violated.

No linter covers this — ruff selects `E/W/F/I/B/C4/UP/PLC0415/C90`, none about comment
content, and the judgement is not mechanical anyway. No existing rule overlaps:
`caller-in-name`, `hardcoded-keys` and `overspecific` are all about naming and interfaces.

## Incident

#548, which added 41 lines to `positronic/drivers/roboarm/franka.py` of which 18 were
prose, in a file running at 4% comments with no docstring longer than three lines. Both
examples in the rule are taken from it verbatim.
