### PR TITLE
Say where this repository's rules and guarantees live

### DIFF
--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -40,12 +40,22 @@ The incident is also where the rule's example comes from, so capture it before i
 
 ## Step 2: Rule out the cheaper homes
 
-Two checks, both of which kill the rule if they hit: whether ruff or basedpyright already covers it
-(`pyproject.toml`), and whether an existing rule does (`CODE_RULES.md`).
+Three checks, each of which kills the rule if it hits: whether ruff or basedpyright already covers it
+(`pyproject.toml`), whether an existing rule does (`CODE_RULES.md`), and whether it is general at all.
 
 If ruff or basedpyright could catch it, enable the check there instead and stop. If an existing rule
 covers it, sharpen that rule rather than adding a second one — overlapping rules make findings
 ambiguous about which one was violated.
+
+**And if it only holds in one repository, it does not go here.** `CODE_RULES.md` is read by every
+Positronic repository, so a rule turning on one repository's architecture, layout or tooling spends
+every other repository's review attention on something that cannot apply to it — and fires there as
+a false positive, which is how a rule set stops being read. Write it in that repository's own
+architecture doc or `AGENTS.md`, where its subject lives, and say that is where it went.
+
+The test: strip the names of the modules, directories and tools it mentions. If nothing is left, the
+rule was about this repository's shape. An *example* from real code is not that — a rule stated
+generally and illustrated concretely is the shape to aim for.
 
 ## Step 3: Draft it
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,10 +1,13 @@
 # Architecture
 
 Every integration in Positronic — a simulator, a model stack, a scene catalog, a scoring method, a
-real rig — is shaped by this document. It is a derivation, not a rule list: the goals state what
-the system guarantees, the principles are the means, and the invariants and decisions that follow
-are consequences. When a new case is not settled here, decide it the same way — from the goals,
-through the principles.
+real rig — follows from what is below: the goals state what the system guarantees, the principles
+are the means, and the invariants and decisions that follow are consequences. When a new case is
+not settled here, decide it the same way — from the goals, through the principles.
+
+What code here must look like is [CLAUDE.md](CLAUDE.md) and the named rules in
+[CODE_RULES.md](CODE_RULES.md). A component with principles of its own keeps them in its
+`AGENTS.md` — [`positronic/dataset/AGENTS.md`](positronic/dataset/AGENTS.md).
 
 ## Goals
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,8 +5,8 @@ real rig — follows from what is below: the goals state what the system guarant
 are the means, and the invariants and decisions that follow are consequences. When a new case is
 not settled here, decide it the same way — from the goals, through the principles.
 
-What code here must look like is [CLAUDE.md](CLAUDE.md) and the named rules in
-[CODE_RULES.md](CODE_RULES.md). A component with principles of its own keeps them in an
+[CLAUDE.md](CLAUDE.md) is how code here is written; the named rules in
+[CODE_RULES.md](CODE_RULES.md) are what a review cites. A component with principles of its own keeps them in an
 architecture document beside its code —
 [`positronic/dataset/ARCHITECTURE.md`](positronic/dataset/ARCHITECTURE.md), which its `AGENTS.md`
 links.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,8 +6,10 @@ are the means, and the invariants and decisions that follow are consequences. Wh
 not settled here, decide it the same way — from the goals, through the principles.
 
 What code here must look like is [CLAUDE.md](CLAUDE.md) and the named rules in
-[CODE_RULES.md](CODE_RULES.md). A component with principles of its own keeps them in its
-`AGENTS.md` — [`positronic/dataset/AGENTS.md`](positronic/dataset/AGENTS.md).
+[CODE_RULES.md](CODE_RULES.md). A component with principles of its own keeps them in an
+architecture document beside its code —
+[`positronic/dataset/ARCHITECTURE.md`](positronic/dataset/ARCHITECTURE.md), which its `AGENTS.md`
+links.
 
 ## Goals
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,6 @@
 - Read `CODE_RULES.md` before writing code here — the named rules it carries govern authoring, not only
   review, and `check-rules` is how you check a change against them
 - Don't restore code that you wrote and I deleted
-- Don't hide errors with try-catch blocks; let failures surface until asked otherwise
 - Fix a defect when you find it, whether or not a current path reaches it. An unexercised wrong path
   produces no signal until something depends on it, so the failure surfaces later and further from its
   cause. Scope can justify deferring; being latent cannot
@@ -39,12 +38,6 @@
   TODO/HACK comment. Never bridge silently with an extra field, class, or indirection
 - Internal code breaks cleanly — no speculative compat shims. Before a migrate-everywhere change, grep for
   consumers that need the old form; alias or migrate only the real ones
-- A new class, file, or field must earn its place: if existing structure already encodes the distinction (the dict
-  an entry lives in, an enum, the calling context), don't reify the concept into a type. Extend an existing module
-  rather than adding a file
-- That holds for a new file of any kind — module, test, or doc. Find the existing home first; when there is
-  none, surface it rather than restructuring on your own initiative (see Testing)
-- No `X | None` for logically required values — an Optional that is never None in practice lies about the contract
 - After every fix or refactor, re-read the resulting code as a whole, not the diff: fixes create new smells (e.g.
   two classes become structurally identical only after their serializers are unified — merge them)
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -191,10 +191,8 @@ code already dispatches on the set: a `match` or an `if` ladder against literals
 closed and the type only states it, while a value this code passes through untouched is not yours to
 close. Once it is an enum, iterate it rather than restating its members.
 
-A time on the robot's timeline is `int` nanoseconds — the specific type here, not a fall back to a
-primitive. The clock is monotonic with an arbitrary epoch, so `datetime` misdescribes what the number
-is and holds only microseconds; recordings are addressed by timestamp, and `float` seconds neither
-compares nor joins exactly.
+Where a domain's own type is a primitive, that primitive is the specific one. What this names is a
+representation standing in for a domain, never the choice of a plain type over a richer-looking one.
 
 Convert once, where the value enters. A CLI token, an environment variable or a wire field arrives as
 a string: parse it at that edge and everything inside is typed. A union of a type with its own string
@@ -289,9 +287,10 @@ Don't write a document against its own past — no "previously", no "this PR", n
 no resolved-while-writing note, no struck-through section kept for context. State what holds now. The
 reader has no access to the past state, so prose written against it is noise that ages into a lie.
 
-Don't leave a worklog in the tree either. Fold a status, progress, implementation-summary or
-completed-plan file into the document that owns its subject, then delete it. A changelog is the
-exception, history being its subject.
+A worklog is not a document the tree keeps — no status, progress, implementation-summary or
+completed-plan file. Whatever such a file holds that is still true is stated as current fact in the
+document that owns the subject, and the account of how the work went goes with the file. A changelog
+is the exception, history being its subject.
 
 Where a change must be referenced, cite something durable — a ticket, a tag, a version. Two things
 that look like history and stay: a footgun the reader can still walk into, and a current limitation

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -280,7 +280,9 @@ with no enclosing condition to hold in mind.
 
 Keep the `with` where no decorator can be reached: a decorator is evaluated where the function is
 defined, so it never sees `self._lock`, and only a `ContextDecorator` works as one. Keep it too
-where the `as` value is used, or a generator needs the context per `yield`.
+where the `as` value is used, or where the context must wrap the work rather than the call — a
+`ContextDecorator` on an `async def` opens and closes while the coroutine is merely being created,
+and on a generator it spans the call rather than the `yield`s.
 
 ```python
 # Bad

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -266,18 +266,16 @@ the first time only one of the two is set.
 Extend the module that owns the subject rather than adding a file beside it. Where nothing owns it,
 that is a finding about the layout — say so, rather than restructuring on your own initiative.
 
-### whole-body-with
+### large-indent
 
-Where a context manager can be written as a decorator, don't wrap a whole function body in a `with`.
-Decorate the function instead: that the whole call runs inside it belongs at the signature, where a
-reader meets it first, not as an indent around everything.
+Don't let a block grow into a wall of indented code. A long loop or branch body is a function
+waiting to be named and extracted, a long `try` is the same with the boundary in the wrong place,
+and a whole function body inside a `with` is a decorator. What is left then reads as what it does,
+with no enclosing condition to hold in mind.
 
-Much of the time it cannot. A decorator is evaluated where the function is defined, so a manager
-reached through the instance — `with self._lock` — is not available to one, and a manager is usable
-as a decorator at all only as a `ContextDecorator`, which `@contextlib.contextmanager` returns and an
-ordinary `__enter__`/`__exit__` class does not. Keep the `with` in those cases, and equally when code
-runs outside the block, when the `as` value is used, or when a generator or coroutine needs the
-context scoped per `yield`/`await` — a decorator scopes it per call.
+Keep the `with` where no decorator can be reached — one evaluated where the function is defined
+cannot see `self._lock`, and only a `ContextDecorator` works as one at all — or where the `as`
+value is used, or a generator needs the context per `yield`.
 
 ```python
 # Bad

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -263,8 +263,13 @@ The cost is not the lines. Every new type is another thing a reader holds, anoth
 live, and another edge to keep in sync; a field duplicating what its caller already knows goes stale
 the first time only one of the two is set.
 
-Extend the module that owns the subject rather than adding a file beside it. Where nothing owns it,
-that is a finding about the layout — say so, rather than restructuring on your own initiative.
+A genuinely new distinction still has to land somewhere, and usually the structure says where:
+beside its siblings, in the module that owns the subject — extend that rather than adding a file
+next to it. Put it there and carry on; this rule is against a concept with no work to do, not
+against growth. Only where nothing suggests a natural home is there something to say, and then it
+is a finding about the layout, for a human rather than for a restructuring of your own.
+
+A project still laying its structure out is not the subject: there is nothing yet to fit into.
 
 ### large-indent
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -176,9 +176,14 @@ if not isinstance(transform, Transform3D):
 ### primitive-type
 
 Give a value the most specific type that fits it: `Path` for a filesystem path, an enum for a bounded
-set of strings, a named struct for a multi-element return, integer nanoseconds for a time on the
-robot's timeline. A primitive stands in for all of them, so it carries none of their meaning and none
-of their operations, and every consumer re-derives what it holds.
+set of strings, a named struct for a multi-element return. A primitive stands in for all of them, so
+it carries none of their meaning and none of their operations, and every consumer re-derives what it
+holds.
+
+A time on the robot's timeline is `int` nanoseconds — the specific type here, not a fall back to a
+primitive. The clock is monotonic with an arbitrary epoch, so `datetime` misdescribes what the number
+is and holds only microseconds; recordings are addressed by timestamp, and `float` seconds neither
+compares nor joins exactly.
 
 Convert once, where the value enters. A CLI token, an environment variable or a wire field arrives as
 a string: parse it at that edge and everything inside is typed. The annotation must not lie — where a

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -1,6 +1,13 @@
 # Code Rules
 
-Judgment rules for this repository — the checks a linter cannot make.
+Judgment rules for Positronic code — the checks a linter cannot make. They hold in every Positronic
+repository, not only this one. This file is the only copy: a repository that carries no
+`CODE_RULES.md` of its own is checked against this one, read from `main`.
+
+So every rule here is general. One that turns on a single repository's architecture, layout or
+tooling is not a code rule and belongs in that repository's own docs, beside its subject. An
+*example* drawn from this repository is not that, and stays — a rule is easier to apply from real
+code than from an abstraction.
 
 Every rule has an **id** — its heading. Cite it when reporting, fixing, or waiving a violation. Add and
 recalibrate rules through the `add-rule` skill.
@@ -323,6 +330,6 @@ re-typing all of it would bury the change, so it may leave a touched file's exis
 
 A limitation outside the code takes the narrowest suppression the tool offers, at the site, with a
 reason: an import that cannot resolve gets `# pyright: ignore[reportMissingImports]`, leaving every
-other diagnostic in that file live. `.basedpyright/baseline.json` is this repository's instance. Its
-hook compares per-file counts, so re-anchoring line numbers can absorb a new finding without it
-noticing — check that yourself.
+other diagnostic in that file live. Where the gate compares per-file counts rather than entries —
+`.basedpyright/baseline.json` is one such baseline — re-anchoring line numbers can absorb a new
+finding without it noticing, so check that yourself.

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -270,13 +270,9 @@ The cost is not the lines. Every new type is another thing a reader holds, anoth
 live, and another edge to keep in sync; a field duplicating what its caller already knows goes stale
 the first time only one of the two is set.
 
-A genuinely new distinction still has to land somewhere, and usually the structure says where:
-beside its siblings, in the module that owns the subject — extend that rather than adding a file
-next to it. Put it there and carry on; this rule is against a concept with no work to do, not
-against growth. Only where nothing suggests a natural home is there something to say, and then it
-is a finding about the layout, for a human rather than for a restructuring of your own.
-
-A project still laying its structure out is not the subject: there is nothing yet to fit into.
+A new distinction lands beside its siblings, in the module that owns the subject. Put it there
+without asking. Raise it only when nothing suggests a home: that is a finding about the layout, and
+a human decides it. This rule does not apply to a repository still laying out its structure.
 
 ### large-indent
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -262,12 +262,16 @@ that is a finding about the layout — say so, rather than restructuring on your
 
 ### whole-body-with
 
-Don't wrap a whole function body in a `with`. Decorate the function with the context manager instead:
-that the whole call runs inside it belongs at the signature, where a reader meets it first, not as an
-indent around everything.
+Where a context manager can be written as a decorator, don't wrap a whole function body in a `with`.
+Decorate the function instead: that the whole call runs inside it belongs at the signature, where a
+reader meets it first, not as an indent around everything.
 
-Keep the `with` when code runs outside the block, when the `as` value is used, or when a generator or
-coroutine needs the context scoped per `yield`/`await` — a decorator scopes it per call.
+Much of the time it cannot. A decorator is evaluated where the function is defined, so a manager
+reached through the instance — `with self._lock` — is not available to one, and a manager is usable
+as a decorator at all only as a `ContextDecorator`, which `@contextlib.contextmanager` returns and an
+ordinary `__enter__`/`__exit__` class does not. Keep the `with` in those cases, and equally when code
+runs outside the block, when the `as` value is used, or when a generator or coroutine needs the
+context scoped per `yield`/`await` — a decorator scopes it per call.
 
 ```python
 # Bad

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -35,6 +35,10 @@ Two remedies, by who owns the name. When callers may legitimately use different 
 parameter with a default for the usual one. When everyone must agree on the same name, define it once
 as a named constant in a shared module.
 
+The same holds for any literal two scopes must spell identically — an environment-variable name, a
+filename two processes agree on, a wire field. Hoist it at the first duplication, into the module every
+consumer can import, usually the most constrained of them. Never a third copy neither side reaches.
+
 Exception: a name the component itself owns and defines, rather than one it reads from its input.
 
 ```python
@@ -169,3 +173,124 @@ def _as_transform(value):
 if not isinstance(transform, Transform3D):
     transform = Transform3D.from_vector(np.asarray(transform), QUAT)
 ```
+### primitive-type
+
+Give a value the most specific type that fits it: `Path` for a filesystem path, an enum for a bounded
+set of strings, a named struct for a multi-element return, integer nanoseconds for a time on the
+robot's timeline. A primitive stands in for all of them, so it carries none of their meaning and none
+of their operations, and every consumer re-derives what it holds.
+
+Convert once, where the value enters. A CLI token, an environment variable or a wire field arrives as
+a string: parse it at that edge and everything inside is typed. The annotation must not lie — where a
+framework hands the value through uncoerced, keep the honest `str` on the parameter it lands on and
+convert immediately inside, or fix the framework.
+
+Two tells. A literal meeting a `match` or an `if` ladder is a bounded set that wants an enum, and once
+it is one, iterate it rather than restating its members. A union of a type with its own string form
+pushes the conversion onto every consumer instead of doing it once.
+
+```python
+# Bad
+def record(recording_dir: str | Path): ...
+
+if state == 'OPEN': ...
+elif state == 'CLOSED': ...
+
+# Good
+def record(recording_dir: Path): ...
+
+if state is GripperState.OPEN: ...
+```
+
+### optional-lie
+
+Don't type a value `X | None` when it is never `None`. The annotation says `None` is a case this code
+handles, so every consumer writes the guard — and the guard that matters is then indistinguishable
+from the ones that are dead.
+
+Where the value is genuinely absent sometimes, say when: a default in the signature, or a distinct
+state. `None` standing for both "not supplied" and "not applicable" is the same lie one level down.
+
+### swallowed-error
+
+Let a failure surface. Don't wrap a call in `try`/`except` to keep going, and don't fall back to a
+second path when the first comes back empty. A pipeline that silently yields nothing is harder to
+diagnose than one that raises, and the fallback becomes the path everything quietly runs through.
+
+Where a failure genuinely must not stop the caller — one malformed file in a scan, an optional
+feature, a cleanup — catch that specific exception, log it at ERROR with what failed, and say in one
+line why continuing is correct. `except Exception: pass` says none of it.
+
+```python
+# Bad
+try:
+    meta = _read_meta(path)
+except Exception:
+    continue
+
+# Good
+try:
+    meta = _read_meta(path)
+except json.JSONDecodeError:
+    logger.error('Skipping %s: malformed episode meta', path)
+    continue
+```
+
+### earn-its-place
+
+A new class, file, field or parameter must carry a distinction the code does not already encode. The
+dict an entry lives in, an enum member, the calling context, a module that already owns the subject —
+check each before adding a name for it.
+
+The cost is not the lines. Every new type is another thing a reader holds, another place a value can
+live, and another edge to keep in sync; a field duplicating what its caller already knows goes stale
+the first time only one of the two is set.
+
+Extend the module that owns the subject rather than adding a file beside it. Where nothing owns it,
+that is a finding about the layout — say so, rather than restructuring on your own initiative.
+
+### whole-body-with
+
+When the entire body of a function is one `with` block, make the context manager a decorator. That the
+whole call runs inside it belongs at the signature, where a reader meets it first, not as an indent
+wrapped around everything.
+
+Keep the `with` when code runs outside the block, when the `as` value is used, or when a generator or
+coroutine needs the context scoped per `yield`/`await` — a decorator scopes it per call.
+
+```python
+# Bad
+def step(self, action):
+    with telemetry.span('env.step'):
+        ...
+
+# Good
+@telemetry.traced('env.step')
+def step(self, action):
+    ...
+```
+
+### stale-doc
+
+A document states the system as it is now. Not how it got here: no "previously", no "this PR", no "as
+of this writing", no resolved-while-writing note, no struck-through section kept for context. The
+reader has no access to the past state, so prose written against it is noise that ages into a lie.
+
+Nothing in the tree is a worklog. A status, progress, implementation-summary or completed-plan file is
+folded into the document that owns its subject and then deleted. A changelog is the exception, history
+being its subject.
+
+Where a change must be referenced, cite something durable — a ticket, a tag, a version. Two things
+that look like history and stay: a footgun the reader can still walk into, and a current limitation
+with its workaround.
+
+### baseline-grandfather
+
+Never add an entry to `.basedpyright/baseline.json` for code in your own change. The baseline holds the
+debt that existed when the ratchet landed: a file you write or touch lands clean, and typing an old
+file removes its entries.
+
+The hook compares per-file counts, so it cannot see one diagnostic swapped for another under the same
+code, and re-anchoring line numbers absorbs new findings silently. That part is yours to hold. An
+import that genuinely cannot resolve takes a narrow `# pyright: ignore[reportMissingImports]` with a
+reason, so every other diagnostic in the file stays live.

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -180,9 +180,11 @@ if not isinstance(transform, Transform3D):
 ### primitive-type
 
 Don't leave a value typed by its representation when its domain has a type of its own. A filesystem
-path is a `Path`, a bounded set of strings is an enum, a multi-element return is a named struct. The
-primitive carries none of the domain's meaning and none of its operations, so every consumer
-re-derives what the value holds.
+path is a `Path`, a bounded set of strings is an enum, a return whose elements a caller can tell
+apart only by position is a named struct. The primitive carries none of the domain's meaning and
+none of its operations, so every consumer re-derives what the value holds. A pair whose elements are
+typed and unpacked where it is called — `(emitter, receiver)` — is not that: nothing is re-derived,
+and a struct over it would restate the call site (`earn-its-place`).
 
 This governs what a value **is**; what an interface may assume about its **use** is `overspecific`,
 and the two never trade against each other. A truer type refuses nothing a caller could legitimately
@@ -227,6 +229,10 @@ state. `None` standing for both "not supplied" and "not applicable" is the same 
 Don't catch an exception so the code can carry on, and don't fall back to a second path when the first
 comes back empty. Let the failure surface: a pipeline that silently yields nothing is harder to
 diagnose than one that raises, and a fallback becomes the path everything quietly runs through.
+
+An exception is not always a failure. Where an API reports an expected state by raising — `Empty`
+from a non-blocking `get`, `StopIteration` — catching it is how that state is read, and none of this
+applies.
 
 Where a failure genuinely must not stop the caller — one malformed file in a scan, an optional
 feature, a cleanup — catch that specific exception, log it at ERROR with what failed, and say in one

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -295,10 +295,9 @@ Don't write a document against its own past — no "previously", no "this PR", n
 no resolved-while-writing note, no struck-through section kept for context. State what holds now. The
 reader has no access to the past state, so prose written against it is noise that ages into a lie.
 
-A worklog is not a document the tree keeps — no status, progress, implementation-summary or
-completed-plan file. Whatever such a file holds that is still true is stated as current fact in the
-document that owns the subject, and the account of how the work went goes with the file. A changelog
-is the exception, history being its subject.
+Don't keep worklogs — status, progress or implementation-summary files. Move what is still true
+into the document that owns the subject, and delete the rest. A changelog is the exception: history
+is its subject.
 
 Where a change must be referenced, cite something durable — a ticket, a tag, a version. Two things
 that look like history and stay: a footgun the reader can still walk into, and a current limitation

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -37,7 +37,7 @@ as a named constant in a shared module.
 
 The same holds for any literal two scopes must spell identically — an environment-variable name, a
 filename two processes agree on, a wire field. Hoist it at the first duplication, into the module every
-consumer can import, usually the most constrained of them. Never a third copy neither side reaches.
+consumer can import, usually the most constrained of them. Not a third copy neither side imports.
 
 Exception: a name the component itself owns and defines, rather than one it reads from its input.
 
@@ -179,28 +179,25 @@ if not isinstance(transform, Transform3D):
 ```
 ### primitive-type
 
-Don't leave a value typed by its representation when its domain has a type of its own. A filesystem
-path is a `Path`, a bounded set of strings is an enum, a return whose elements a caller can tell
-apart only by position is a named struct. The primitive carries none of the domain's meaning and
-none of its operations, so every consumer re-derives what the value holds. A pair whose elements are
-typed and unpacked where it is called — `(emitter, receiver)` — is not that: nothing is re-derived,
-and a struct over it would restate the call site (`earn-its-place`).
+Don't leave a value typed by its representation when its domain has a type of its own: a filesystem
+path is a `Path`, a bounded set of strings is an enum, a return a caller can only read by position is
+a named struct. The primitive carries none of the domain's meaning or operations, so every consumer
+re-derives what the value holds.
 
-This governs what a value **is**; what an interface may assume about its **use** is `overspecific`,
-and the two never trade against each other. A truer type refuses nothing a caller could legitimately
-have passed — every path is a `Path`. The enum is the case that can go either way, so ask whether this
-code already dispatches on the set: a `match` or an `if` ladder against literals means the set is
-closed and the type only states it, while a value this code passes through untouched is not yours to
-close. Once it is an enum, iterate it rather than restating its members.
+Some domains own a primitive, and then the primitive is the specific type. This is about a
+representation standing in for a domain, not about preferring the richer-looking type. A pair
+unpacked where it is called, each element typed, re-derives nothing either: a struct over
+`(emitter, receiver)` would restate the call site (`earn-its-place`).
 
-Where a domain's own type is a primitive, that primitive is the specific one. What this names is a
-representation standing in for a domain, never the choice of a plain type over a richer-looking one.
+An enum is the case that can go either way. If this code dispatches on the set — a `match`, an `if`
+ladder against literals — the set is closed and the type only says so; a value this code passes
+through untouched is not yours to close. Once it is an enum, iterate it rather than restating its
+members.
 
-Convert once, where the value enters. A CLI token, an environment variable or a wire field arrives as
-a string: parse it at that edge and everything inside is typed. A union of a type with its own string
-form is that conversion left undone, pushing it onto every consumer. The annotation must not lie —
-where a framework hands the value through uncoerced, keep the honest `str` on the parameter it lands
-on and convert immediately inside, or fix the framework.
+Convert once, where the value enters: a CLI token, an environment variable, a wire field. A union of
+a type with its own string form is that conversion left undone, pushed onto every consumer. Don't
+let the annotation lie — where a framework hands the value through uncoerced, keep the honest `str`
+and convert immediately inside, or fix the framework.
 
 ```python
 # Bad
@@ -221,8 +218,9 @@ Don't type a value `X | None` when it is never `None`. The annotation says `None
 handles, so every consumer writes the guard — and the guard that matters is then indistinguishable
 from the ones that are dead.
 
-Where the value is genuinely absent sometimes, say when: a default in the signature, or a distinct
-state. `None` standing for both "not supplied" and "not applicable" is the same lie one level down.
+Where the value really is sometimes absent, say when it is: a default in the signature, or a
+distinct state. `None` meaning both "not supplied" and "not applicable" is the same lie one level
+down.
 
 ### swallowed-error
 
@@ -273,9 +271,9 @@ waiting to be named and extracted, a long `try` is the same with the boundary in
 and a whole function body inside a `with` is a decorator. What is left then reads as what it does,
 with no enclosing condition to hold in mind.
 
-Keep the `with` where no decorator can be reached — one evaluated where the function is defined
-cannot see `self._lock`, and only a `ContextDecorator` works as one at all — or where the `as`
-value is used, or a generator needs the context per `yield`.
+Keep the `with` where no decorator can be reached: a decorator is evaluated where the function is
+defined, so it never sees `self._lock`, and only a `ContextDecorator` works as one. Keep it too
+where the `as` value is used, or a generator needs the context per `yield`.
 
 ```python
 # Bad
@@ -305,17 +303,17 @@ with its workaround.
 
 ### grandfathered-violation
 
-Don't silence a violation in code you write or touch — fix it. An exception list, whether a
-type-check baseline, a lint allowlist or a suppression file, is for one thing: a gate introduced
-over a codebase that already breaks it, where fixing everything first is impractical. It records
-the debt standing at that moment, and shrinks from there.
+Don't silence a violation in code you write or touch — fix it. An exception list — a type-check
+baseline, a lint allowlist, a suppression file — is for one case: a gate landing on a codebase that
+already breaks it, where fixing everything first is impractical. It records the debt standing that
+day, and shrinks from there.
 
 So a change may only remove entries. A file you add lands clean, and a file you touch loses the
 entries your change covers. The exception is a large refactor, which moves code it did not write:
 re-typing all of it would bury the change, so it may leave a touched file's existing entries alone.
 
 A limitation outside the code takes the narrowest suppression the tool offers, at the site, with a
-reason — an import that cannot resolve gets `# pyright: ignore[reportMissingImports]`, so every
-other diagnostic in that file stays live. `.basedpyright/baseline.json` is this repository's
-instance, and its hook compares per-file counts, so re-anchoring line numbers can absorb a new
-finding silently. That part is yours to hold.
+reason: an import that cannot resolve gets `# pyright: ignore[reportMissingImports]`, leaving every
+other diagnostic in that file live. `.basedpyright/baseline.json` is this repository's instance. Its
+hook compares per-file counts, so re-anchoring line numbers can absorb a new finding without it
+noticing — check that yourself.

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -239,7 +239,8 @@ diagnose than one that raises, and a fallback becomes the path everything quietl
 
 This is about hiding a failure, and neither an exception nor an absence is always one. Where a
 contract says the value may not be there — `Empty` from a non-blocking `get`, a cache the format
-declares optional — reading that and going on is how the contract is used, not a fallback.
+declares optional — reading that and going on is how the contract is used, not a fallback. A retry
+that re-raises when it gives up hides nothing either: the failure still reaches the caller.
 
 Where a failure genuinely must not stop the caller — one malformed file in a scan, an optional
 feature, a cleanup — catch that specific exception, log it at ERROR with what failed, and say in one

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -37,7 +37,9 @@ as a named constant in a shared module.
 
 The same holds for any literal two pieces of code must spell identically — an environment-variable
 name, a filename two processes agree on, a wire field. Hoist it at the first duplication, into the module every
-consumer can import, usually the most constrained of them. Not a third copy neither side imports.
+consumer can import, usually the most constrained of them. Not a third copy neither side imports —
+and where there is no shared module at all, as across languages, name it once on each side, beside
+the code that parses it.
 
 Exception: a name the component itself owns and defines, rather than one it reads from its input.
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -35,8 +35,8 @@ Two remedies, by who owns the name. When callers may legitimately use different 
 parameter with a default for the usual one. When everyone must agree on the same name, define it once
 as a named constant in a shared module.
 
-The same holds for any literal two scopes must spell identically — an environment-variable name, a
-filename two processes agree on, a wire field. Hoist it at the first duplication, into the module every
+The same holds for any literal two pieces of code must spell identically — an environment-variable
+name, a filename two processes agree on, a wire field. Hoist it at the first duplication, into the module every
 consumer can import, usually the most constrained of them. Not a third copy neither side imports.
 
 Exception: a name the component itself owns and defines, rather than one it reads from its input.

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -65,6 +65,10 @@ and the caller must read the implementation to know what to pass — the same mi
 way. This is a matter of taste and does not reduce to a measurement: judge the result as a reader, not
 by counting.
 
+Widening what a component accepts is not the same as weakening how its values are typed. Sharpening a
+type is `primitive-type` and is never overspecification: it constrains what a value may be, not what
+the component may be asked to do.
+
 ```python
 # Bad — assumes every key belongs to exactly one category, and that the categories need different handling
 def __init__(self, pose_keys, command_keys): ...
@@ -175,10 +179,17 @@ if not isinstance(transform, Transform3D):
 ```
 ### primitive-type
 
-Give a value the most specific type that fits it: `Path` for a filesystem path, an enum for a bounded
-set of strings, a named struct for a multi-element return. A primitive stands in for all of them, so
-it carries none of their meaning and none of their operations, and every consumer re-derives what it
-holds.
+Don't leave a value typed by its representation when its domain has a type of its own. A filesystem
+path is a `Path`, a bounded set of strings is an enum, a multi-element return is a named struct. The
+primitive carries none of the domain's meaning and none of its operations, so every consumer
+re-derives what the value holds.
+
+This governs what a value **is**; what an interface may assume about its **use** is `overspecific`,
+and the two never trade against each other. A truer type refuses nothing a caller could legitimately
+have passed — every path is a `Path`. The enum is the case that can go either way, so ask whether this
+code already dispatches on the set: a `match` or an `if` ladder against literals means the set is
+closed and the type only states it, while a value this code passes through untouched is not yours to
+close. Once it is an enum, iterate it rather than restating its members.
 
 A time on the robot's timeline is `int` nanoseconds — the specific type here, not a fall back to a
 primitive. The clock is monotonic with an arbitrary epoch, so `datetime` misdescribes what the number
@@ -186,13 +197,10 @@ is and holds only microseconds; recordings are addressed by timestamp, and `floa
 compares nor joins exactly.
 
 Convert once, where the value enters. A CLI token, an environment variable or a wire field arrives as
-a string: parse it at that edge and everything inside is typed. The annotation must not lie — where a
-framework hands the value through uncoerced, keep the honest `str` on the parameter it lands on and
-convert immediately inside, or fix the framework.
-
-Two tells. A literal meeting a `match` or an `if` ladder is a bounded set that wants an enum, and once
-it is one, iterate it rather than restating its members. A union of a type with its own string form
-pushes the conversion onto every consumer instead of doing it once.
+a string: parse it at that edge and everything inside is typed. A union of a type with its own string
+form is that conversion left undone, pushing it onto every consumer. The annotation must not lie —
+where a framework hands the value through uncoerced, keep the honest `str` on the parameter it lands
+on and convert immediately inside, or fix the framework.
 
 ```python
 # Bad
@@ -218,9 +226,9 @@ state. `None` standing for both "not supplied" and "not applicable" is the same 
 
 ### swallowed-error
 
-Let a failure surface. Don't wrap a call in `try`/`except` to keep going, and don't fall back to a
-second path when the first comes back empty. A pipeline that silently yields nothing is harder to
-diagnose than one that raises, and the fallback becomes the path everything quietly runs through.
+Don't catch an exception so the code can carry on, and don't fall back to a second path when the first
+comes back empty. Let the failure surface: a pipeline that silently yields nothing is harder to
+diagnose than one that raises, and a fallback becomes the path everything quietly runs through.
 
 Where a failure genuinely must not stop the caller — one malformed file in a scan, an optional
 feature, a cleanup — catch that specific exception, log it at ERROR with what failed, and say in one
@@ -243,9 +251,9 @@ except json.JSONDecodeError:
 
 ### earn-its-place
 
-A new class, file, field or parameter must carry a distinction the code does not already encode. The
-dict an entry lives in, an enum member, the calling context, a module that already owns the subject —
-check each before adding a name for it.
+Don't add a class, file, field or parameter for a distinction the code already encodes. Check each of
+the places one can already live — the dict an entry sits in, an enum member, the calling context, a
+module that owns the subject — and use that instead.
 
 The cost is not the lines. Every new type is another thing a reader holds, another place a value can
 live, and another edge to keep in sync; a field duplicating what its caller already knows goes stale
@@ -256,9 +264,9 @@ that is a finding about the layout — say so, rather than restructuring on your
 
 ### whole-body-with
 
-When the entire body of a function is one `with` block, make the context manager a decorator. That the
-whole call runs inside it belongs at the signature, where a reader meets it first, not as an indent
-wrapped around everything.
+Don't wrap a whole function body in a `with`. Decorate the function with the context manager instead:
+that the whole call runs inside it belongs at the signature, where a reader meets it first, not as an
+indent around everything.
 
 Keep the `with` when code runs outside the block, when the `as` value is used, or when a generator or
 coroutine needs the context scoped per `yield`/`await` — a decorator scopes it per call.
@@ -277,13 +285,13 @@ def step(self, action):
 
 ### stale-doc
 
-A document states the system as it is now. Not how it got here: no "previously", no "this PR", no "as
-of this writing", no resolved-while-writing note, no struck-through section kept for context. The
+Don't write a document against its own past — no "previously", no "this PR", no "as of this writing",
+no resolved-while-writing note, no struck-through section kept for context. State what holds now. The
 reader has no access to the past state, so prose written against it is noise that ages into a lie.
 
-Nothing in the tree is a worklog. A status, progress, implementation-summary or completed-plan file is
-folded into the document that owns its subject and then deleted. A changelog is the exception, history
-being its subject.
+Don't leave a worklog in the tree either. Fold a status, progress, implementation-summary or
+completed-plan file into the document that owns its subject, then delete it. A changelog is the
+exception, history being its subject.
 
 Where a change must be referenced, cite something durable — a ticket, a tag, a version. Two things
 that look like history and stay: a footgun the reader can still walk into, and a current limitation
@@ -291,9 +299,9 @@ with its workaround.
 
 ### baseline-grandfather
 
-Never add an entry to `.basedpyright/baseline.json` for code in your own change. The baseline holds the
-debt that existed when the ratchet landed: a file you write or touch lands clean, and typing an old
-file removes its entries.
+Never add an entry to `.basedpyright/baseline.json` for code in your own change — fix the diagnostic
+instead. The baseline holds the debt that existed when the ratchet landed: a file you write or touch
+lands clean, and typing an old file removes its entries.
 
 The hook compares per-file counts, so it cannot see one diagnostic swapped for another under the same
 code, and re-anchoring line numbers absorbs new findings silently. That part is yours to hold. An

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -228,9 +228,9 @@ Don't catch an exception so the code can carry on, and don't fall back to a seco
 comes back empty. Let the failure surface: a pipeline that silently yields nothing is harder to
 diagnose than one that raises, and a fallback becomes the path everything quietly runs through.
 
-An exception is not always a failure. Where an API reports an expected state by raising — `Empty`
-from a non-blocking `get`, `StopIteration` — catching it is how that state is read, and none of this
-applies.
+This is about hiding a failure, and neither an exception nor an absence is always one. Where a
+contract says the value may not be there — `Empty` from a non-blocking `get`, a cache the format
+declares optional — reading that and going on is how the contract is used, not a fallback.
 
 Where a failure genuinely must not stop the caller — one malformed file in a scan, an optional
 feature, a cleanup — catch that specific exception, log it at ERROR with what failed, and say in one

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -296,13 +296,19 @@ Where a change must be referenced, cite something durable — a ticket, a tag, a
 that look like history and stay: a footgun the reader can still walk into, and a current limitation
 with its workaround.
 
-### baseline-grandfather
+### grandfathered-violation
 
-Never add an entry to `.basedpyright/baseline.json` for code in your own change — fix the diagnostic
-instead. The baseline holds the debt that existed when the ratchet landed: a file you write or touch
-lands clean, and typing an old file removes its entries.
+Don't silence a violation in code you write or touch — fix it. An exception list, whether a
+type-check baseline, a lint allowlist or a suppression file, is for one thing: a gate introduced
+over a codebase that already breaks it, where fixing everything first is impractical. It records
+the debt standing at that moment, and shrinks from there.
 
-The hook compares per-file counts, so it cannot see one diagnostic swapped for another under the same
-code, and re-anchoring line numbers absorbs new findings silently. That part is yours to hold. An
-import that genuinely cannot resolve takes a narrow `# pyright: ignore[reportMissingImports]` with a
-reason, so every other diagnostic in the file stays live.
+So a change may only remove entries. A file you add lands clean, and a file you touch loses the
+entries your change covers. The exception is a large refactor, which moves code it did not write:
+re-typing all of it would bury the change, so it may leave a touched file's existing entries alone.
+
+A limitation outside the code takes the narrowest suppression the tool offers, at the site, with a
+reason — an import that cannot resolve gets `# pyright: ignore[reportMissingImports]`, so every
+other diagnostic in that file stays live. `.basedpyright/baseline.json` is this repository's
+instance, and its hook compares per-file counts, so re-anchoring line numbers can absorb a new
+finding silently. That part is yours to hold.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -121,10 +121,9 @@ uv run ruff format .         # Format code
 
 ## Code Rules
 
-[CODE_RULES.md](../CODE_RULES.md) carries the judgment rules Ruff cannot check — how things are
-named, where a shared name lives, what a comment may say. Each rule has an id, and a review cites
-that id, so read it before your first pull request. Where a rule is genuinely wrong for one line,
-waive it at that line:
+[CODE_RULES.md](../CODE_RULES.md) carries the judgment rules Ruff cannot check. Each rule has an id,
+and a review cites that id, so read it before your first pull request. Where a rule is genuinely
+wrong for one line, waive it at that line:
 
 ```python
 # rules-allow: <rule-id> — <why this instance is correct>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -122,8 +122,8 @@ uv run ruff format .         # Format code
 ## Code Rules
 
 [CODE_RULES.md](../CODE_RULES.md) carries the judgment rules Ruff cannot check. Each rule has an id,
-and a review cites that id. Read it before your first pull request, and read what has changed in it
-since your last one. Where a rule is genuinely wrong for one line, waive it at that line:
+and a review cites that id. The file gains rules, and a review cites it as it stands. Where a rule
+is genuinely wrong for one line, waive it at that line:
 
 ```python
 # rules-allow: <rule-id> — <why this instance is correct>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -119,6 +119,20 @@ uv run ruff check --fix .   # Auto-fix linting issues
 uv run ruff format .         # Format code
 ```
 
+## Code Rules
+
+[CODE_RULES.md](../CODE_RULES.md) carries the judgment rules Ruff cannot check — how things are
+named, where a shared name lives, what a comment may say. Each rule has an id, and a review cites
+that id, so read it before your first pull request. Where a rule is genuinely wrong for one line,
+waive it at that line:
+
+```python
+# rules-allow: <rule-id> — <why this instance is correct>
+```
+
+What the system as a whole guarantees, and the principles an integration follows from, are in
+[ARCHITECTURE.md](../ARCHITECTURE.md).
+
 ## Testing
 
 All new features should include tests. Run the test suite with:
@@ -140,7 +154,7 @@ uv run pytest --cov=positronic --cov=pimm --cov-report=term-missing
 - Include tests for new functionality
 - Update documentation as needed
 - All CI checks must pass
-- Follow the existing code style
+- Follow the code style above and the named rules in [CODE_RULES.md](../CODE_RULES.md)
 
 ## Questions?
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -122,8 +122,8 @@ uv run ruff format .         # Format code
 ## Code Rules
 
 [CODE_RULES.md](../CODE_RULES.md) carries the judgment rules Ruff cannot check. Each rule has an id,
-and a review cites that id, so read it before your first pull request. Where a rule is genuinely
-wrong for one line, waive it at that line:
+and a review cites that id. Read it before your first pull request, and read what has changed in it
+since your last one. Where a rule is genuinely wrong for one line, waive it at that line:
 
 ```python
 # rules-allow: <rule-id> — <why this instance is correct>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -129,8 +129,8 @@ wrong for one line, waive it at that line:
 # rules-allow: <rule-id> — <why this instance is correct>
 ```
 
-What the system as a whole guarantees, and the principles an integration follows from, are in
-[ARCHITECTURE.md](../ARCHITECTURE.md).
+[ARCHITECTURE.md](../ARCHITECTURE.md) says what a policy, a driver, a simulator and a recording may
+assume about each other. Read it before adding one of them.
 
 ## Testing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -122,8 +122,8 @@ uv run ruff format .         # Format code
 ## Code Rules
 
 [CODE_RULES.md](../CODE_RULES.md) carries the judgment rules Ruff cannot check. Each rule has an id,
-and a review cites that id. The file gains rules, and a review cites it as it stands. Where a rule
-is genuinely wrong for one line, waive it at that line:
+and a review cites that id, applying the rules in force on the day. Where a rule is genuinely wrong
+for one line, waive it at that line:
 
 ```python
 # rules-allow: <rule-id> — <why this instance is correct>

--- a/docs/GEMINI.md
+++ b/docs/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -2,5 +2,6 @@
 
 The design principles this library maintains — one interface over many backends, the
 backend → edits → transforms → consumer layering, the episode data model, identity, edits,
-laziness, transforms — are in [ARCHITECTURE.md](ARCHITECTURE.md). Read it before changing
-anything here. The user-facing guide is [README.md](README.md).
+laziness, transforms — are in [ARCHITECTURE.md](ARCHITECTURE.md). Read it before changing or
+reviewing anything here; they are what a review of this package cites. The user-facing guide is
+[README.md](README.md).

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -1,8 +1,10 @@
 # Dataset Library — Design Principles
 
+Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Only the recording is irreplaceable, and everything else stays re-derivable from it.
+
 ## One API, many backends
 
-The library covers the data path of the robot-learning loop — record → curate/annotate → convert → train → eval → re-score — through a single interface: `Signal`/`Episode`/`Dataset` and the layers composed over them. Storage formats are backends behind that interface (`LocalDataset` is the native one, `RemoteDataset` serves it over HTTP, and foreign formats plug in as read adapters). Never push a capability into a storage format when it can live in a layer above it.
+Raw recordings and the views over them, through a single interface: `Signal`/`Episode`/`Dataset` and the layers composed over them. Storage formats are backends behind that interface (`LocalDataset` is the native one, `RemoteDataset` serves it over HTTP, and foreign formats plug in as read adapters). A foreign format is wrapped into the interface, never the reverse. Never push a capability into a storage format when it can live in a layer above it.
 
 ## Layering: backend → edits → transforms → consumer
 
@@ -13,7 +15,7 @@ Every dataset read composes in this order:
 - **Transforms** compute lazy views over the curated episode. Transforms never persist.
 - **Consumers** (codecs, viewers, converters) see one `Dataset` interface and don't know which layers are present.
 
-The shape mirrors the systems that got this right — Lightroom catalogs over raw photos, video EDLs, git, Delta Lake logs over parquet: identity-keyed (uid, never path or position), time-addressed (absolute ns timestamps, never indices), append-only, dumb plain data with versioned records so a log replays forever.
+The shape is that of Lightroom catalogs over raw photos and Delta Lake logs over parquet: identity-keyed (uid, never path or position), time-addressed (absolute ns timestamps, never indices), append-only, dumb plain data with versioned records so a log replays forever.
 
 ## Episode data model
 
@@ -29,7 +31,7 @@ Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — 
 
 ## Edits
 
-Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. `EditedDataset(base, edits_dir)` is both that view and the handle that amends it: curated reads (drops hidden, static edits overlaid) plus `set_static`/`drop`/`undrop` methods that append a record and return a fresh view over the same recordings — so a held reference never changes shape underneath a consumer. `load_dataset`/`load_all_datasets` compose it over a `LocalDataset`, while `LocalDataset` itself reads raw recordings. The static overlay primitive (`EditedEpisode`) is backend-agnostic; the edit layer reads a local `edits_dir` for now — when a second edit-storage format appears, `edits_dir` is where the seam reopens.
+Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. `EditedDataset(base, edits_dir)` is both that view and the handle that amends it: curated reads (drops hidden, static edits overlaid) plus `set_static`/`drop`/`undrop` methods that append a record and return a fresh view over the same recordings — so a held reference never changes shape underneath a consumer. `load_dataset`/`load_all_datasets` compose it over a `LocalDataset`, while `LocalDataset` itself reads raw recordings. The static overlay primitive (`EditedEpisode`) is backend-agnostic; the edit layer reads a local `edits_dir`, the seam to reopen when a second edit-storage format appears.
 
 - One JSON record per line, each carrying its op and version so a log stays replayable forever. `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}` merges static items over the recorded ones (log order, last write per key wins); `{"op": "drop", "v": 1, "ep": "<uid>"}` removes the episode from the loaded view while the recording stays on disk, and `{"op": "undrop", ...}` restores it — the last drop/undrop per episode wins.
 - The format stays dumb plain data — smarts live in the library — so external editors can write it. The dataset directory assumes a single writer; readers fail loudly on corrupt or unrecognized records.
@@ -42,12 +44,14 @@ Implementations may cache these values internally (e.g. `DiskEpisode` reads a ca
 
 ## Laziness
 
-Nothing expensive should happen until needed. The library is designed around lazy evaluation:
+Nothing expensive happens until needed:
 - Listing episodes should not touch signal data
 - Accessing `duration_ns` should not load signal values
 - Accessing one signal should not load other signals
 
 `SimpleSignal` reads parquet row-group statistics (file footer) for `start_ts`/`last_ts`/`len` without touching actual data. Full timestamps and values are loaded only when indexed or searched.
+
+Laziness is what keeps the layering honest: if reading through the abstraction were expensive, a consumer would reach around it for the backend.
 
 ## Transforms
 

--- a/positronic/dataset/AGENTS.md
+++ b/positronic/dataset/AGENTS.md
@@ -1,58 +1,6 @@
-# Dataset Library — Design Principles
+# Dataset Library
 
-Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Only the recording is irreplaceable, and everything else stays re-derivable from it.
-
-## One API, many backends
-
-Raw recordings and the views over them, through a single interface: `Signal`/`Episode`/`Dataset` and the layers composed over them. Storage formats are backends behind that interface (`LocalDataset` is the native one, `RemoteDataset` serves it over HTTP, and foreign formats plug in as read adapters). A foreign format is wrapped into the interface, never the reverse. Never push a capability into a storage format when it can live in a layer above it.
-
-## Layering: backend → edits → transforms → consumer
-
-Every dataset read composes in this order:
-
-- **Backend** reads immutable recordings (`LocalDataset`, `RemoteDataset`).
-- **Edits** (`edits.py`) persist post-hoc facts as a declarative log applied as a view. Edits bind to recorded keys and never compute.
-- **Transforms** compute lazy views over the curated episode. Transforms never persist.
-- **Consumers** (codecs, viewers, converters) see one `Dataset` interface and don't know which layers are present.
-
-The shape is that of Lightroom catalogs over raw photos and Delta Lake logs over parquet: identity-keyed (uid, never path or position), time-addressed (absolute ns timestamps, never indices), append-only, dumb plain data with versioned records so a log replays forever.
-
-## Episode data model
-
-An Episode has three kinds of data with distinct roles:
-
-- **Signals** and **static** are episode *content*. They appear in `episode.keys()`, are accessed via `episode[name]`, and transforms can add, remove, or modify them. Signals are time-series; static values are constants.
-
-- **Meta** (`episode.meta`) is *about* the episode — recording facts like `created_ts_ns`, `schema_version`, `writer`. Meta is not part of episode content, not in `keys()`, and transforms pass it through unchanged. Meta keys are optional and may vary by implementation (e.g. `size_mb` exists for disk episodes, may not for others).
-
-## Identity
-
-Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — the identity contract. Episodes lacking a stamped uid derive a stable `ts-<created_ts_ns>` one from their recording timestamp, which is equally immutable and travels with the episode. Position in a `Dataset` is *access*, not identity: `FilterDataset`/`ConcatDataset` renumber episodes freely. The uid is *reference* — stable across views, processes, copies, and exports. Because transforms pass meta through unchanged, a transformed episode keeps its recording's uid: it is a view of the same recording event.
-
-## Edits
-
-Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. `EditedDataset(base, edits_dir)` is both that view and the handle that amends it: curated reads (drops hidden, static edits overlaid) plus `set_static`/`drop`/`undrop` methods that append a record and return a fresh view over the same recordings — so a held reference never changes shape underneath a consumer. `load_dataset`/`load_all_datasets` compose it over a `LocalDataset`, while `LocalDataset` itself reads raw recordings. The static overlay primitive (`EditedEpisode`) is backend-agnostic; the edit layer reads a local `edits_dir`, the seam to reopen when a second edit-storage format appears.
-
-- One JSON record per line, each carrying its op and version so a log stays replayable forever. `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}` merges static items over the recorded ones (log order, last write per key wins); `{"op": "drop", "v": 1, "ep": "<uid>"}` removes the episode from the loaded view while the recording stays on disk, and `{"op": "undrop", ...}` restores it — the last drop/undrop per episode wins.
-- The format stays dumb plain data — smarts live in the library — so external editors can write it. The dataset directory assumes a single writer; readers fail loudly on corrupt or unrecognized records.
-
-## Episode properties
-
-`duration_ns`, `start_ts`, `last_ts` are **first-class properties on Episode**, always derived from signals. They are never stored in meta. If a transform changes signals, these properties reflect the change.
-
-Implementations may cache these values internally (e.g. `DiskEpisode` reads a cached `duration_ns` from `meta.json`), but this is a private optimization — `episode.meta` must not expose `duration_ns`.
-
-## Laziness
-
-Nothing expensive happens until needed:
-- Listing episodes should not touch signal data
-- Accessing `duration_ns` should not load signal values
-- Accessing one signal should not load other signals
-
-`SimpleSignal` reads parquet row-group statistics (file footer) for `start_ts`/`last_ts`/`len` without touching actual data. Full timestamps and values are loaded only when indexed or searched.
-
-Laziness is what keeps the layering honest: if reading through the abstraction were expensive, a consumer would reach around it for the backend.
-
-## Transforms
-
-`TransformedEpisode` wraps any `Episode` — it must not assume the underlying type or bypass the standard Episode interface. Correctness comes from the abstraction; performance comes from caching at the signal and dataset levels.
+The design principles this library maintains — one interface over many backends, the
+backend → edits → transforms → consumer layering, the episode data model, identity, edits,
+laziness, transforms — are in [ARCHITECTURE.md](ARCHITECTURE.md). Read it before changing
+anything here. The user-facing guide is [README.md](README.md).

--- a/positronic/dataset/ARCHITECTURE.md
+++ b/positronic/dataset/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dataset Library — Design Principles
 
-Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). The recording is irreplaceable, and so is the edit log — a human's verdict on an episode cannot be recomputed. Everything else stays re-derivable from the two.
+Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Of what this library holds, the recording and the edit log are irreplaceable — a human's verdict on an episode cannot be recomputed — and every view over them is re-derivable.
 
 ## One API, many backends
 

--- a/positronic/dataset/ARCHITECTURE.md
+++ b/positronic/dataset/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Dataset Library — Design Principles
+
+Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Only the recording is irreplaceable, and everything else stays re-derivable from it.
+
+## One API, many backends
+
+Raw recordings and the views over them, through a single interface: `Signal`/`Episode`/`Dataset` and the layers composed over them. Storage formats are backends behind that interface (`LocalDataset` is the native one, `RemoteDataset` serves it over HTTP, and foreign formats plug in as read adapters). A foreign format is wrapped into the interface, never the reverse. Never push a capability into a storage format when it can live in a layer above it.
+
+## Layering: backend → edits → transforms → consumer
+
+Every dataset read composes in this order:
+
+- **Backend** reads immutable recordings (`LocalDataset`, `RemoteDataset`).
+- **Edits** (`edits.py`) persist post-hoc facts as a declarative log applied as a view. Edits bind to recorded keys and never compute.
+- **Transforms** compute lazy views over the curated episode. Transforms never persist.
+- **Consumers** (codecs, viewers, converters) see one `Dataset` interface and don't know which layers are present.
+
+The shape is that of Lightroom catalogs over raw photos and Delta Lake logs over parquet: identity-keyed (uid, never path or position), time-addressed (absolute ns timestamps, never indices), append-only, dumb plain data with versioned records so a log replays forever.
+
+## Episode data model
+
+An Episode has three kinds of data with distinct roles:
+
+- **Signals** and **static** are episode *content*. They appear in `episode.keys()`, are accessed via `episode[name]`, and transforms can add, remove, or modify them. Signals are time-series; static values are constants.
+
+- **Meta** (`episode.meta`) is *about* the episode — recording facts like `created_ts_ns`, `schema_version`, `writer`. Meta is not part of episode content, not in `keys()`, and transforms pass it through unchanged. Meta keys are optional and may vary by implementation (e.g. `size_mb` exists for disk episodes, may not for others).
+
+## Identity
+
+Every episode is stamped with `meta['uid']` (a uuid4 hex) at recording time — the identity contract. Episodes lacking a stamped uid derive a stable `ts-<created_ts_ns>` one from their recording timestamp, which is equally immutable and travels with the episode. Position in a `Dataset` is *access*, not identity: `FilterDataset`/`ConcatDataset` renumber episodes freely. The uid is *reference* — stable across views, processes, copies, and exports. Because transforms pass meta through unchanged, a transformed episode keeps its recording's uid: it is a view of the same recording event.
+
+## Edits
+
+Recordings are immutable. All post-hoc modification goes through one mechanism: an append-only edit log (`edits.jsonl` in the dataset directory) of uid-keyed declarative records, applied as a view on read. `EditedDataset(base, edits_dir)` is both that view and the handle that amends it: curated reads (drops hidden, static edits overlaid) plus `set_static`/`drop`/`undrop` methods that append a record and return a fresh view over the same recordings — so a held reference never changes shape underneath a consumer. `load_dataset`/`load_all_datasets` compose it over a `LocalDataset`, while `LocalDataset` itself reads raw recordings. The static overlay primitive (`EditedEpisode`) is backend-agnostic; the edit layer reads a local `edits_dir`, the seam to reopen when a second edit-storage format appears.
+
+- One JSON record per line, each carrying its op and version so a log stays replayable forever. `{"op": "set_static", "v": 1, "ep": "<uid>", "data": {...}}` merges static items over the recorded ones (log order, last write per key wins); `{"op": "drop", "v": 1, "ep": "<uid>"}` removes the episode from the loaded view while the recording stays on disk, and `{"op": "undrop", ...}` restores it — the last drop/undrop per episode wins.
+- The format stays dumb plain data — smarts live in the library — so external editors can write it. The dataset directory assumes a single writer; readers fail loudly on corrupt or unrecognized records.
+
+## Episode properties
+
+`duration_ns`, `start_ts`, `last_ts` are **first-class properties on Episode**, always derived from signals. They are never stored in meta. If a transform changes signals, these properties reflect the change.
+
+Implementations may cache these values internally (e.g. `DiskEpisode` reads a cached `duration_ns` from `meta.json`), but this is a private optimization — `episode.meta` must not expose `duration_ns`.
+
+## Laziness
+
+Nothing expensive happens until needed:
+- Listing episodes should not touch signal data
+- Accessing `duration_ns` should not load signal values
+- Accessing one signal should not load other signals
+
+`SimpleSignal` reads parquet row-group statistics (file footer) for `start_ts`/`last_ts`/`len` without touching actual data. Full timestamps and values are loaded only when indexed or searched.
+
+Laziness is what keeps the layering honest: if reading through the abstraction were expensive, a consumer would reach around it for the backend.
+
+## Transforms
+
+`TransformedEpisode` wraps any `Episode` — it must not assume the underlying type or bypass the standard Episode interface. Correctness comes from the abstraction; performance comes from caching at the signal and dataset levels.

--- a/positronic/dataset/ARCHITECTURE.md
+++ b/positronic/dataset/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dataset Library — Design Principles
 
-Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Only the recording is irreplaceable, and everything else stays re-derivable from it.
+Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). The recording is irreplaceable, and so is the edit log — a human's verdict on an episode cannot be recomputed. Everything else stays re-derivable from the two.
 
 ## One API, many backends
 

--- a/positronic/dataset/ARCHITECTURE.md
+++ b/positronic/dataset/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dataset Library — Design Principles
 
-Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Of what this library holds, the recording and the edit log are irreplaceable — a human's verdict on an episode cannot be recomputed — and every view over them is re-derivable.
+Repository-wide goals and principles are in [ARCHITECTURE.md](../../ARCHITECTURE.md); the user-facing guide is [README.md](README.md). Only the recording is irreplaceable, and everything else stays re-derivable from it.
 
 ## One API, many backends
 

--- a/utilities/check_basedpyright_baseline_ratchet.py
+++ b/utilities/check_basedpyright_baseline_ratchet.py
@@ -175,7 +175,7 @@ def main(argv: list[str]) -> int:
 
     print('basedpyright baseline is a one-way ratchet — a file may shrink, never grow per code.', file=sys.stderr)
     print('These files gained baseline diagnostics; fix the new issue instead of grandfathering it', file=sys.stderr)
-    print('(see the no_grandfather_new_code discipline):', file=sys.stderr)
+    print('(CODE_RULES.md, grandfathered-violation):', file=sys.stderr)
     for path, code, base_n, cur_n in grown:
         print(f'  {path}: {code} {base_n} -> {cur_n}', file=sys.stderr)
     return 1


### PR DESCRIPTION
Where this repository's rules and guarantees live, and the documents that point at them.

`CODE_RULES.md` gains seven named rules, promoted from the engineering contract that positronic#541
originally carried as a separate `ENGINEERING.md`: `primitive-type`, `optional-lie`, `swallowed-error`,
`earn-its-place`, `large-indent`, `stale-doc`, `grandfathered-violation`. `hardcoded-keys` widens to
cover any literal two scopes must spell identically. The three `CLAUDE.md` bullets that now have ids a
review can cite are removed, so each requirement has one home.

The cut: a requirement becomes a rule when it is a judgment call, checkable from a diff by a reviewer
who was not in the conversation that produced the change. What needs the change's intent — implement
the end state, one owner per value, stay scoped — stays authoring guidance in `CLAUDE.md`. What a
linter already enforces gets no rule, and what is about running a review rather than reading a diff
belongs in `docs/CONTRIBUTING.md`. The full triage is on internal#173.

Each rule states the judgment, not the case that produced it and not the argument for its own
calibration. `primitive-type` says a primitive can be a domain's own type without arguing it through
one timeline's units, and holds a struct to returns a caller can only read by position.
`grandfathered-violation` is about exception lists as such — a baseline, a lint allowlist, a
suppression file. `large-indent` is about a wall of indented code wherever it comes from.
`swallowed-error` says that an exception is not always a failure.

They are also stated as every Positronic repository's, which is what they have become: a repository
carrying no `CODE_RULES.md` of its own is checked against this file, read from `main` (internal#153).
Generality is therefore a property the file must hold, so the header says so and `add-rule` gains it
as a third cheaper home — a rule turning on one repository's architecture, layout or tooling goes to
that repository's own docs. Examples from real code stay. `grandfathered-violation` was the one rule
failing the new test, naming this repository's basedpyright baseline as *the* instance; the footgun —
a gate comparing per-file counts, where re-anchoring line numbers absorbs a finding silently — holds
for any such baseline, and now says so with the file as an example.

The ratchet's failure message named a rule file that lives in the agent fleet's configuration rather
than in this repository, so a contributor was pointed at something they cannot open; it names
`grandfathered-violation` now.

The documents that read `ARCHITECTURE.md` follow it to the root:

- `ARCHITECTURE.md` — the opening sentence's subject was the document itself; it now names what the
  goals govern, and points at `CLAUDE.md` as how code here is written and `CODE_RULES.md` as what a
  review cites, plus the component that carries principles of its own.
- `docs/CONTRIBUTING.md` — a Code Rules section: where the rules live, that a review cites them by id,
  and the `# rules-allow:` waiver. They were cited only from agent- and design-facing files, so a human
  contributor met Ruff and nothing else.
- `positronic/dataset/ARCHITECTURE.md` — the dataset library's design principles, which used to live in
  that package's `AGENTS.md`, which now links them and asks to be read before reviewing as well as
  before changing. Design principles are a document a contributor reads, the arrangement the repository
  root already has. The prose edits that come with them: the opening no longer enumerates the learning
  loop; `for now` dated a seam; the layering analogy listed four systems for one point; laziness states
  why it is load-bearing.
- the dead `docs/GEMINI.md` symlink is dropped — it pointed at `docs/AGENTS.md`, deleted in
  positronic#427.

<!-- opened-by: posi-agent -->