### PR TITLE
Wire the DreamZero PhAIL fine-tune into the eval

### DIFF
--- a/docker/docker-compose.phail.dreamzero.yml
+++ b/docker/docker-compose.phail.dreamzero.yml
@@ -1,0 +1,13 @@
+# DreamZero on vm-train2 (H100 80GB — wan2.2 5B needs ~26GB)
+#
+# docker --context vm-train2 compose -f docker-compose.phail.dreamzero.yml up
+services:
+  phail-dreamzero-server:
+    extends:
+      file: docker-compose.yml
+      service: dreamzero-server
+    container_name: phail-dreamzero-server
+    pull_policy: always
+    command: ["phail"]
+    ports: !override
+      - "8000:8000"

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -555,6 +555,7 @@ PHAIL_MODEL_DISPLAY = {
     'groot': 'NVIDIA GR00T N1.6',
     'act': 'Action Chunking Transformer',
     'smolvla': 'Hugging Face SmolVLA',
+    'dreamzero': 'NVIDIA DreamZero',
     'human': HUMAN_MODEL,
     'teleop': TELEOP_MODEL,
 }

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -103,7 +103,14 @@ def phail_single(hostname, w_openpi=1.0, w_groot=1.0, w_act=1.0):
 
 
 phail_multiple = production.override(
-    endpoints={'smolvla': 'notebook:8000', 'act': 'notebook:8001', 'groot': 'desktop:8000', 'openpi': 'vm-openpi:8000'},
+    endpoints={
+        'smolvla': 'notebook:8000',
+        'act': 'notebook:8001',
+        'groot': 'desktop:8000',
+        'openpi': 'vm-openpi:8000',
+        # DreamZero's 5B wan2.2 needs an H100, so it cannot share the consumer boxes above.
+        'dreamzero': 'vm-train2:8000',
+    },
     sampler=balanced,
     group_fields=[keys.TASK, 'eval.object', 'eval.tote_placement', 'eval.external_camera'],
 )

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -57,7 +57,7 @@ def sample(origins: list[cfn.Config], weights: list[float] | None):
     return SampledPolicy(*origins, weights=weights)
 
 
-remote = cfn.Config(RemotePolicy, url='localhost:8000')
+remote = cfn.Config(RemotePolicy, url='ws://localhost:8000')
 
 
 @cfn.config(balance=2)
@@ -77,12 +77,12 @@ def production(
 ):
     """Routes each episode to one of several remote endpoints, each named for CLI overrides.
 
-    An endpoint is one URL, so `--policy.endpoints.groot=desktop:8000` adds or repoints one without
+    An endpoint is one URL, so `--policy.endpoints.groot=ws://desktop:8000` adds or repoints one without
     restating the others. `weights` name the same endpoints and set their sampling odds; endpoints left
     out of it weigh 1.0.
     """
     if not endpoints:
-        raise ValueError('At least one endpoint must be given, e.g. --policy.endpoints.groot=desktop:8000')
+        raise ValueError('At least one endpoint must be given, e.g. --policy.endpoints.groot=ws://desktop:8000')
     if unknown := weights.keys() - endpoints.keys():
         raise ValueError(f'weights name unknown endpoints: {sorted(unknown)}; known are {sorted(endpoints)}')
     # Every Sampler but the default uniform one picks by episode counts alone, so weights would be dropped.
@@ -95,21 +95,21 @@ def production(
 
 @cfn.config()
 def phail_single(hostname, w_openpi=1.0, w_groot=1.0, w_act=1.0):
-    openpi = RemotePolicy(f'{hostname}:8000')
-    groot = RemotePolicy(f'{hostname}:8001')
-    act = RemotePolicy(f'{hostname}:8002')
+    openpi = RemotePolicy(f'ws://{hostname}:8000')
+    groot = RemotePolicy(f'ws://{hostname}:8001')
+    act = RemotePolicy(f'ws://{hostname}:8002')
 
     return SampledPolicy(openpi, groot, act, weights=[w_openpi, w_groot, w_act])
 
 
 phail_multiple = production.override(
     endpoints={
-        'smolvla': 'notebook:8000',
-        'act': 'notebook:8001',
-        'groot': 'desktop:8000',
-        'openpi': 'vm-openpi:8000',
+        'smolvla': 'ws://notebook:8000',
+        'act': 'ws://notebook:8001',
+        'groot': 'ws://desktop:8000',
+        'openpi': 'ws://vm-openpi:8000',
         # DreamZero's 5B wan2.2 needs an H100, so it cannot share the consumer boxes above.
-        'dreamzero': 'vm-train2:8000',
+        'dreamzero': 'ws://vm-train2:8000',
     },
     sampler=balanced,
     group_fields=[keys.TASK, 'eval.object', 'eval.tote_placement', 'eval.external_camera'],

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -343,11 +343,12 @@ COMMANDS = {
     # TODO: publish this checkpoint to positronic-public and point here, as the other PhAIL models are
     # (`utilities/release_phail.py`, `positronic.cfg.phail.v1_0.models`). Reading it needs credentials until then.
     'phail': serve.override(
-        pipeline=joints.override(**{
-            'source.model_path': 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/',
-            'source.backbone': 'wan2.2',
-        }),
+        pipeline=joints,
         recording_dir='s3://inference/phail_unified/server_recordings/dreamzero/w22f1_100k_200626/',
+        **{
+            'pipeline.source.model_path': 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/',
+            'pipeline.source.backbone': 'wan2.2',
+        },
     ),
     # Public pretrained DROID checkpoint: wan2.1 backbone (the base default) paired with the DROID
     # pipeline whose codec feeds its required 320x180 frames.

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -41,11 +41,20 @@ def _download_checkpoint(model_path: str) -> Path:
     return Path(snapshot_download(model_path))
 
 
+def _is_run_directory(model_path: str) -> bool:
+    """Whether ``model_path`` holds ``checkpoint-N`` children rather than being one checkpoint itself.
+
+    Decided by shape, not by name: a run directory may be called anything, including the step number of
+    the checkpoint inside it.
+    """
+    last = model_path.rstrip('/').split('/')[-1]
+    return model_path.startswith('s3://') and not last.startswith('checkpoint-')
+
+
 def _resolve_checkpoint_path(model_path: str) -> str:
     """Latest ``checkpoint-N`` under an ``s3://`` run directory; a pinned checkpoint dir, a HuggingFace repo,
     or a local path is returned unchanged."""
-    last = model_path.rstrip('/').split('/')[-1]
-    if not model_path.startswith('s3://') or last.startswith('checkpoint-'):
+    if not _is_run_directory(model_path):
         return model_path
     return f'{model_path.rstrip("/")}/{get_latest_checkpoint(model_path, "checkpoint-")}'
 
@@ -272,7 +281,7 @@ class DreamZeroSource(ModelSource):
         Composed rather than looked up: a session handshake reaches here, and must not need the
         checkpoint bucket to describe weights that are already loaded.
         """
-        if _checkpoint_id(self._model_path) == model_id:
+        if not _is_run_directory(self._model_path):
             return self._model_path
         return f'{self._model_path.rstrip("/")}/checkpoint-{model_id}'
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -50,6 +50,22 @@ def _resolve_checkpoint_path(model_path: str) -> str:
     return f'{model_path.rstrip("/")}/{get_latest_checkpoint(model_path, "checkpoint-")}'
 
 
+def _checkpoint_id(checkpoint_path: str) -> str:
+    """The public id for a resolved checkpoint: its step number, free of any zero-padding.
+
+    A HuggingFace repo or a bare local path names no step, so its trailing segment stands in.
+    """
+    last = checkpoint_path.rstrip('/').split('/')[-1]
+    step = last.removeprefix('checkpoint-')
+    return str(int(step)) if step.isdigit() else last
+
+
+def _experiment_name(checkpoint_path: str) -> str:
+    """The training run a resolved checkpoint belongs to."""
+    parts = checkpoint_path.rstrip('/').split('/')
+    return parts[-2] if len(parts) >= 2 and parts[-1].startswith('checkpoint-') else parts[-1]
+
+
 # TODO: Extract RoboarenaClient to positronic/offboard/ — roboarena is a cross-vendor
 # standard (used by DreamZero, potentially GR00T N2, etc.) and other vendors may need it.
 class RoboarenaClient:
@@ -215,13 +231,18 @@ class _DreamZeroSession(Session):
 class DreamZeroPolicy(Policy):
     """Owns the DreamZero subprocess; every session talks to it over its own roboarena connection."""
 
-    def __init__(self, sp: DreamZeroSubprocess):
+    def __init__(self, sp: DreamZeroSubprocess, checkpoint_path: str):
         self._subprocess = sp
+        self._checkpoint_path = checkpoint_path
 
     def new_session(self, context=None, now=None):
         client = RoboarenaClient(port=self._subprocess.roboarena_port)
         client.connect()
         return _DreamZeroSession(client, str(uuid.uuid4()))
+
+    @property
+    def meta(self):
+        return {'checkpoint_path': self._checkpoint_path}
 
     def close(self):
         self._subprocess.stop()
@@ -231,7 +252,8 @@ class DreamZeroSource(ModelSource):
     """DreamZero checkpoints served through a torchrun subprocess speaking the roboarena protocol.
 
     ``model_path`` is an ``s3://`` run directory (served at its latest ``checkpoint-N``), a pinned
-    checkpoint dir, a HuggingFace repo, or a local path.
+    checkpoint dir, a HuggingFace repo, or a local path. Model ids are checkpoint step numbers
+    (``'100000'`` for ``checkpoint-100000``).
     """
 
     def __init__(
@@ -251,11 +273,12 @@ class DreamZeroSource(ModelSource):
         self._enable_dit_cache = enable_dit_cache
 
     def get_models(self) -> list[str]:
-        return [_resolve_checkpoint_path(self._model_path)]
+        return [_checkpoint_id(_resolve_checkpoint_path(self._model_path))]
 
     def load(self, model_id: str, on_progress: Callable[[str], None] | None = None) -> Policy:
+        checkpoint_path = _resolve_checkpoint_path(self._model_path)
         local_path = run_with_progress(
-            lambda: _download_checkpoint(model_id), 'Downloading DreamZero checkpoint', on_progress
+            lambda: _download_checkpoint(checkpoint_path), 'Downloading DreamZero checkpoint', on_progress
         )
         logger.info(f'Starting DreamZero subprocess with {self._num_gpus} GPUs')
         sp = DreamZeroSubprocess(
@@ -271,10 +294,15 @@ class DreamZeroSource(ModelSource):
         except Exception:
             sp.stop()
             raise
-        return DreamZeroPolicy(sp)
+        return DreamZeroPolicy(sp, checkpoint_path)
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'type': 'dreamzero', 'backbone': self._backbone, 'model_path': model_id, 'num_gpus': self._num_gpus}
+        return {
+            'type': 'dreamzero',
+            'backbone': self._backbone,
+            'num_gpus': self._num_gpus,
+            'experiment_name': _experiment_name(_resolve_checkpoint_path(self._model_path)),
+        }
 
 
 dreamzero_source = cfn.Config(DreamZeroSource)
@@ -304,6 +332,15 @@ COMMANDS = {
     'joints_traj': serve.override(pipeline=joints_traj),
     'joints_ik': serve.override(pipeline=joints_ik),
     'joints_ik_sim': serve.override(pipeline=joints_ik_sim),
+    # The PhAIL fine-tune. Trained with the joints_ik codec, whose inference decode is the shared joints
+    # one, so the joints pipeline serves it; the backbone must be the one the run was trained on.
+    'phail': serve.override(
+        pipeline=joints.override(**{
+            'source.model_path': 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/',
+            'source.backbone': 'wan2.2',
+        }),
+        recording_dir='s3://inference/phail_unified/server_recordings/dreamzero/w22f1_100k_200626/',
+    ),
     # Public pretrained DROID checkpoint: wan2.1 backbone (the base default) paired with the DROID
     # pipeline whose codec feeds its required 320x180 frames.
     'droid': serve.override(pipeline=droid.override(**{'source.model_path': 'GEAR-Dreams/DreamZero-DROID'})),

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -52,12 +52,14 @@ def _is_run_directory(model_path: str) -> bool:
 
 
 def _checkpoint_id(checkpoint_path: str) -> str:
-    """The public id for a resolved checkpoint: the step its directory names.
+    """The public id for a checkpoint: the step a ``checkpoint-N`` directory names, else the path itself.
 
-    Kept as the directory writes it, zero-padding and all, so the id maps back to a directory that
-    exists. A HuggingFace repo or a bare local path names no step, so its trailing segment stands in.
+    The step is kept as the directory writes it, zero-padding and all, so the id maps back to a directory
+    that exists. Anything else — a HuggingFace repo, a local path — names no step and stays whole, since
+    that whole string is the id a client addresses it by.
     """
-    return checkpoint_path.rstrip('/').split('/')[-1].removeprefix('checkpoint-')
+    last = checkpoint_path.rstrip('/').split('/')[-1]
+    return last.removeprefix('checkpoint-') if last.startswith('checkpoint-') else checkpoint_path
 
 
 def _experiment_name(checkpoint_path: str) -> str:

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -21,7 +21,7 @@ from positronic.offboard.server_utils import run_with_progress, wait_for_subproc
 from positronic.policy import Codec, Policy, PolicyWrapper, Session
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.spec import ModelSource, remote
-from positronic.utils.checkpoints import get_latest_checkpoint
+from positronic.utils.checkpoints import list_checkpoints
 from positronic.utils.logging import init_logging
 from positronic.utils.serialization import deserialize, serialize
 from positronic.vendors.dreamzero import codecs
@@ -49,14 +49,6 @@ def _is_run_directory(model_path: str) -> bool:
     """
     last = model_path.rstrip('/').split('/')[-1]
     return model_path.startswith('s3://') and not last.startswith('checkpoint-')
-
-
-def _resolve_checkpoint_path(model_path: str) -> str:
-    """Latest ``checkpoint-N`` under an ``s3://`` run directory; a pinned checkpoint dir, a HuggingFace repo,
-    or a local path is returned unchanged."""
-    if not _is_run_directory(model_path):
-        return model_path
-    return f'{model_path.rstrip("/")}/{get_latest_checkpoint(model_path, "checkpoint-")}'
 
 
 def _checkpoint_id(checkpoint_path: str) -> str:
@@ -286,7 +278,9 @@ class DreamZeroSource(ModelSource):
         return f'{self._model_path.rstrip("/")}/checkpoint-{model_id}'
 
     def get_models(self) -> list[str]:
-        return [_checkpoint_id(_resolve_checkpoint_path(self._model_path))]
+        if not _is_run_directory(self._model_path):
+            return [_checkpoint_id(self._model_path)]
+        return [_checkpoint_id(c) for c in list_checkpoints(self._model_path, prefix='checkpoint-')]
 
     def load(self, model_id: str, on_progress: Callable[[str], None] | None = None) -> Policy:
         checkpoint_path = self._checkpoint_path(model_id)

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -230,18 +230,13 @@ class _DreamZeroSession(Session):
 class DreamZeroPolicy(Policy):
     """Owns the DreamZero subprocess; every session talks to it over its own roboarena connection."""
 
-    def __init__(self, sp: DreamZeroSubprocess, checkpoint_path: str):
+    def __init__(self, sp: DreamZeroSubprocess):
         self._subprocess = sp
-        self._checkpoint_path = checkpoint_path
 
     def new_session(self, context=None, now=None):
         client = RoboarenaClient(port=self._subprocess.roboarena_port)
         client.connect()
         return _DreamZeroSession(client, str(uuid.uuid4()))
-
-    @property
-    def meta(self):
-        return {'checkpoint_path': self._checkpoint_path}
 
     def close(self):
         self._subprocess.stop()
@@ -272,10 +267,13 @@ class DreamZeroSource(ModelSource):
         self._enable_dit_cache = enable_dit_cache
 
     def _checkpoint_path(self, model_id: str) -> str:
-        """The checkpoint directory whose public id is ``model_id``."""
-        resolved = _resolve_checkpoint_path(self._model_path)
-        if _checkpoint_id(resolved) == model_id:
-            return resolved
+        """The checkpoint directory whose public id is ``model_id``.
+
+        Composed rather than looked up: a session handshake reaches here, and must not need the
+        checkpoint bucket to describe weights that are already loaded.
+        """
+        if _checkpoint_id(self._model_path) == model_id:
+            return self._model_path
         return f'{self._model_path.rstrip("/")}/checkpoint-{model_id}'
 
     def get_models(self) -> list[str]:
@@ -300,16 +298,16 @@ class DreamZeroSource(ModelSource):
         except Exception:
             sp.stop()
             raise
-        return DreamZeroPolicy(sp, checkpoint_path)
+        return DreamZeroPolicy(sp)
 
     def meta(self, model_id: str) -> dict[str, Any]:
+        checkpoint_path = self._checkpoint_path(model_id)
         return {
             'type': 'dreamzero',
             'backbone': self._backbone,
             'num_gpus': self._num_gpus,
-            # Read off the configured path: a handshake must not depend on the checkpoint bucket
-            # being reachable, since the weights it describes are already in GPU memory.
-            'experiment_name': _experiment_name(self._model_path),
+            'checkpoint_path': checkpoint_path,
+            'experiment_name': _experiment_name(checkpoint_path),
         }
 
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -272,11 +272,18 @@ class DreamZeroSource(ModelSource):
         self._roboarena_port = roboarena_port
         self._enable_dit_cache = enable_dit_cache
 
+    def _checkpoint_path(self, model_id: str) -> str:
+        """The checkpoint directory whose public id is ``model_id``."""
+        resolved = _resolve_checkpoint_path(self._model_path)
+        if _checkpoint_id(resolved) == model_id:
+            return resolved
+        return f'{self._model_path.rstrip("/")}/checkpoint-{model_id}'
+
     def get_models(self) -> list[str]:
         return [_checkpoint_id(_resolve_checkpoint_path(self._model_path))]
 
     def load(self, model_id: str, on_progress: Callable[[str], None] | None = None) -> Policy:
-        checkpoint_path = _resolve_checkpoint_path(self._model_path)
+        checkpoint_path = self._checkpoint_path(model_id)
         local_path = run_with_progress(
             lambda: _download_checkpoint(checkpoint_path), 'Downloading DreamZero checkpoint', on_progress
         )
@@ -301,7 +308,7 @@ class DreamZeroSource(ModelSource):
             'type': 'dreamzero',
             'backbone': self._backbone,
             'num_gpus': self._num_gpus,
-            'experiment_name': _experiment_name(_resolve_checkpoint_path(self._model_path)),
+            'experiment_name': _experiment_name(self._checkpoint_path(model_id)),
         }
 
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -340,6 +340,8 @@ COMMANDS = {
     'joints_ik_sim': serve.override(pipeline=joints_ik_sim),
     # The PhAIL fine-tune. Trained with the joints_ik codec, whose inference decode is the shared joints
     # one, so the joints pipeline serves it; the backbone must be the one the run was trained on.
+    # TODO: publish this checkpoint to positronic-public and point here, as the other PhAIL models are
+    # (`utilities/release_phail.py`, `positronic.cfg.phail.v1_0.models`). Reading it needs credentials until then.
     'phail': serve.override(
         pipeline=joints.override(**{
             'source.model_path': 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/',

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -51,13 +51,12 @@ def _resolve_checkpoint_path(model_path: str) -> str:
 
 
 def _checkpoint_id(checkpoint_path: str) -> str:
-    """The public id for a resolved checkpoint: its step number, free of any zero-padding.
+    """The public id for a resolved checkpoint: the step its directory names.
 
-    A HuggingFace repo or a bare local path names no step, so its trailing segment stands in.
+    Kept as the directory writes it, zero-padding and all, so the id maps back to a directory that
+    exists. A HuggingFace repo or a bare local path names no step, so its trailing segment stands in.
     """
-    last = checkpoint_path.rstrip('/').split('/')[-1]
-    step = last.removeprefix('checkpoint-')
-    return str(int(step)) if step.isdigit() else last
+    return checkpoint_path.rstrip('/').split('/')[-1].removeprefix('checkpoint-')
 
 
 def _experiment_name(checkpoint_path: str) -> str:
@@ -308,7 +307,9 @@ class DreamZeroSource(ModelSource):
             'type': 'dreamzero',
             'backbone': self._backbone,
             'num_gpus': self._num_gpus,
-            'experiment_name': _experiment_name(self._checkpoint_path(model_id)),
+            # Read off the configured path: a handshake must not depend on the checkpoint bucket
+            # being reachable, since the weights it describes are already in GPU memory.
+            'experiment_name': _experiment_name(self._model_path),
         }
 
 

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -60,6 +60,15 @@ def test_a_newer_checkpoint_does_not_displace_the_id_being_loaded(latest):
     assert source.meta('100000')['checkpoint_path'] == RUN_DIR + 'checkpoint-100000'
 
 
+def test_a_run_directory_named_like_a_step_still_serves_its_checkpoint(latest):
+    downloaded = latest('100000')
+    source = DreamZeroSource(model_path='s3://bucket/100000/', backbone='wan2.2')
+
+    source.load(source.get_models()[0])
+
+    assert downloaded == ['s3://bucket/100000/checkpoint-100000']
+
+
 def test_a_huggingface_repo_is_itself_the_checkpoint():
     assert _checkpoint_id('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
     assert _experiment_name('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -23,24 +23,35 @@ class _FakeSubprocess:
 
 
 @pytest.fixture
-def latest(monkeypatch):
-    """Pin what the run directory's newest checkpoint is, and record what ``load`` downloads."""
+def holding(monkeypatch):
+    """Pin the checkpoints the run directory holds, oldest first, and record what ``load`` downloads."""
     downloaded = []
     monkeypatch.setattr(server, 'DreamZeroSubprocess', _FakeSubprocess)
     monkeypatch.setattr(server, '_download_checkpoint', lambda path: downloaded.append(path) or Path('/nonexistent'))
 
-    def _set(step: str) -> list[str]:
-        monkeypatch.setattr(server, 'get_latest_checkpoint', lambda _path, _prefix: f'checkpoint-{step}')
+    def _set(*steps: str) -> list[str]:
+        names = [f'checkpoint-{s}' for s in steps]
+        monkeypatch.setattr(server, 'list_checkpoints', lambda _path, prefix='': list(names))
         return downloaded
 
     return _set
 
 
-def test_run_directory_is_served_at_its_latest_step(latest):
-    latest('100000')
+def test_a_run_directory_advertises_every_checkpoint_it_holds(holding):
+    holding('95000', '100000')
+    source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
+
+    assert source.get_models() == ['95000', '100000']
+    assert source.resolve(None) == '100000'
+
+
+def test_run_directory_is_served_at_its_latest_step(holding):
+    holding('100000')
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
 
     assert source.get_models() == ['100000']
+    # rules-allow: hardcoded-keys — the wire spelling is what this asserts; reading it from the same
+    # constants the code writes with would pass whatever those constants held.
     assert source.meta('100000') == {
         'type': 'dreamzero',
         'backbone': 'wan2.2',
@@ -50,21 +61,22 @@ def test_run_directory_is_served_at_its_latest_step(latest):
     }
 
 
-def test_a_newer_checkpoint_does_not_displace_the_id_being_loaded(latest):
-    downloaded = latest('105000')
+def test_a_newer_checkpoint_does_not_displace_the_id_being_loaded(holding):
+    downloaded = holding('100000', '105000')
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
 
     source.load('100000')
 
     assert downloaded == [RUN_DIR + 'checkpoint-100000']
+    # rules-allow: hardcoded-keys — as above, the spelling is the assertion.
     assert source.meta('100000')['checkpoint_path'] == RUN_DIR + 'checkpoint-100000'
 
 
-def test_a_run_directory_named_like_a_step_still_serves_its_checkpoint(latest):
-    downloaded = latest('100000')
+def test_a_run_directory_named_like_a_step_still_serves_its_checkpoint(holding):
+    downloaded = holding('100000')
     source = DreamZeroSource(model_path='s3://bucket/100000/', backbone='wan2.2')
 
-    source.load(source.get_models()[0])
+    source.load(source.resolve(None))
 
     assert downloaded == ['s3://bucket/100000/checkpoint-100000']
 
@@ -74,19 +86,20 @@ def test_a_huggingface_repo_is_itself_the_checkpoint():
     assert _experiment_name('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
 
 
-def test_a_zero_padded_step_is_reached_by_the_name_its_directory_carries(latest):
-    latest('005000')
+def test_a_zero_padded_step_is_reached_by_the_name_its_directory_carries(holding):
+    holding('005000')
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
-    pinned = source.get_models()[0]
+    pinned = source.resolve(None)
 
-    downloaded = latest('010000')
+    downloaded = holding('005000', '010000')
     source.load(pinned)
 
     assert downloaded == [RUN_DIR + 'checkpoint-005000']
 
 
 def test_meta_does_not_relist_the_bucket(monkeypatch):
-    monkeypatch.setattr(server, 'get_latest_checkpoint', lambda _path, _prefix: pytest.fail('meta must not reach S3'))
+    monkeypatch.setattr(server, 'list_checkpoints', lambda _path, prefix='': pytest.fail('meta must not reach S3'))
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
 
+    # rules-allow: hardcoded-keys — as above, the spelling is the assertion.
     assert source.meta('100000')['experiment_name'] == 'w22f1_100k_200626'

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -45,6 +45,7 @@ def test_run_directory_is_served_at_its_latest_step(latest):
         'type': 'dreamzero',
         'backbone': 'wan2.2',
         'num_gpus': 1,
+        'checkpoint_path': RUN_DIR + 'checkpoint-100000',
         'experiment_name': 'w22f1_100k_200626',
     }
 
@@ -53,10 +54,10 @@ def test_a_newer_checkpoint_does_not_displace_the_id_being_loaded(latest):
     downloaded = latest('105000')
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
 
-    policy = source.load('100000')
+    source.load('100000')
 
     assert downloaded == [RUN_DIR + 'checkpoint-100000']
-    assert policy.meta == {'checkpoint_path': RUN_DIR + 'checkpoint-100000'}
+    assert source.meta('100000')['checkpoint_path'] == RUN_DIR + 'checkpoint-100000'
 
 
 def test_a_huggingface_repo_is_itself_the_checkpoint():
@@ -75,7 +76,7 @@ def test_a_zero_padded_step_is_reached_by_the_name_its_directory_carries(latest)
     assert downloaded == [RUN_DIR + 'checkpoint-005000']
 
 
-def test_the_experiment_name_does_not_relist_the_bucket(monkeypatch):
+def test_meta_does_not_relist_the_bucket(monkeypatch):
     monkeypatch.setattr(server, 'get_latest_checkpoint', lambda _path, _prefix: pytest.fail('meta must not reach S3'))
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
 

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -1,0 +1,46 @@
+import pytest
+
+pytest.importorskip('huggingface_hub')
+
+from positronic.vendors.dreamzero.server import (  # noqa: E402
+    DreamZeroSource,
+    _checkpoint_id,
+    _experiment_name,
+)
+
+RUN_DIR = 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/'
+CHECKPOINT = RUN_DIR + 'checkpoint-100000'
+
+
+@pytest.mark.parametrize(
+    ('path', 'expected'),
+    [
+        (CHECKPOINT, '100000'),
+        ('s3://bucket/exp/checkpoint-005000', '5000'),
+        ('GEAR-Dreams/DreamZero-DROID', 'DreamZero-DROID'),
+    ],
+)
+def test_checkpoint_id(path, expected):
+    assert _checkpoint_id(path) == expected
+
+
+@pytest.mark.parametrize(
+    ('path', 'expected'), [(CHECKPOINT, 'w22f1_100k_200626'), ('GEAR-Dreams/DreamZero-DROID', 'DreamZero-DROID')]
+)
+def test_experiment_name(path, expected):
+    assert _experiment_name(path) == expected
+
+
+def test_run_directory_is_served_at_its_latest_step(monkeypatch):
+    monkeypatch.setattr(
+        'positronic.vendors.dreamzero.server.get_latest_checkpoint', lambda _path, _prefix: 'checkpoint-100000'
+    )
+    source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
+
+    assert source.get_models() == ['100000']
+    assert source.meta('100000') == {
+        'type': 'dreamzero',
+        'backbone': 'wan2.2',
+        'num_gpus': 1,
+        'experiment_name': 'w22f1_100k_200626',
+    }

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -1,40 +1,42 @@
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip('huggingface_hub')
 
-from positronic.vendors.dreamzero.server import (  # noqa: E402
-    DreamZeroSource,
-    _checkpoint_id,
-    _experiment_name,
-)
+from positronic.vendors.dreamzero import server  # noqa: E402
+from positronic.vendors.dreamzero.server import DreamZeroSource, _checkpoint_id, _experiment_name  # noqa: E402
 
 RUN_DIR = 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/'
-CHECKPOINT = RUN_DIR + 'checkpoint-100000'
 
 
-@pytest.mark.parametrize(
-    ('path', 'expected'),
-    [
-        (CHECKPOINT, '100000'),
-        ('s3://bucket/exp/checkpoint-005000', '5000'),
-        ('GEAR-Dreams/DreamZero-DROID', 'DreamZero-DROID'),
-    ],
-)
-def test_checkpoint_id(path, expected):
-    assert _checkpoint_id(path) == expected
+class _FakeSubprocess:
+    def __init__(self, **kwargs):
+        self.roboarena_port = kwargs['roboarena_port']
+
+    def start(self, on_progress=None):
+        pass
+
+    def stop(self):
+        pass
 
 
-@pytest.mark.parametrize(
-    ('path', 'expected'), [(CHECKPOINT, 'w22f1_100k_200626'), ('GEAR-Dreams/DreamZero-DROID', 'DreamZero-DROID')]
-)
-def test_experiment_name(path, expected):
-    assert _experiment_name(path) == expected
+@pytest.fixture
+def latest(monkeypatch):
+    """Pin what the run directory's newest checkpoint is, and record what ``load`` downloads."""
+    downloaded = []
+    monkeypatch.setattr(server, 'DreamZeroSubprocess', _FakeSubprocess)
+    monkeypatch.setattr(server, '_download_checkpoint', lambda path: downloaded.append(path) or Path('/nonexistent'))
+
+    def _set(step: str) -> list[str]:
+        monkeypatch.setattr(server, 'get_latest_checkpoint', lambda _path, _prefix: f'checkpoint-{step}')
+        return downloaded
+
+    return _set
 
 
-def test_run_directory_is_served_at_its_latest_step(monkeypatch):
-    monkeypatch.setattr(
-        'positronic.vendors.dreamzero.server.get_latest_checkpoint', lambda _path, _prefix: 'checkpoint-100000'
-    )
+def test_run_directory_is_served_at_its_latest_step(latest):
+    latest('100000')
     source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
 
     assert source.get_models() == ['100000']
@@ -44,3 +46,22 @@ def test_run_directory_is_served_at_its_latest_step(monkeypatch):
         'num_gpus': 1,
         'experiment_name': 'w22f1_100k_200626',
     }
+
+
+def test_a_newer_checkpoint_does_not_displace_the_id_being_loaded(latest):
+    downloaded = latest('105000')
+    source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
+
+    policy = source.load('100000')
+
+    assert downloaded == [RUN_DIR + 'checkpoint-100000']
+    assert policy.meta == {'checkpoint_path': RUN_DIR + 'checkpoint-100000'}
+
+
+def test_a_huggingface_repo_is_itself_the_checkpoint():
+    assert _checkpoint_id('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
+    assert _experiment_name('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
+
+
+def test_a_zero_padded_step_keeps_its_number_as_the_id():
+    assert _checkpoint_id('s3://bucket/exp/checkpoint-005000') == '5000'

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -11,8 +11,9 @@ RUN_DIR = 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/'
 
 
 class _FakeSubprocess:
-    def __init__(self, **kwargs):
-        self.roboarena_port = kwargs['roboarena_port']
+    def __init__(self, model_path, roboarena_port, **kwargs):
+        self.model_path = model_path
+        self.roboarena_port = roboarena_port
 
     def start(self, on_progress=None):
         pass
@@ -63,5 +64,19 @@ def test_a_huggingface_repo_is_itself_the_checkpoint():
     assert _experiment_name('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
 
 
-def test_a_zero_padded_step_keeps_its_number_as_the_id():
-    assert _checkpoint_id('s3://bucket/exp/checkpoint-005000') == '5000'
+def test_a_zero_padded_step_is_reached_by_the_name_its_directory_carries(latest):
+    latest('005000')
+    source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
+    pinned = source.get_models()[0]
+
+    downloaded = latest('010000')
+    source.load(pinned)
+
+    assert downloaded == [RUN_DIR + 'checkpoint-005000']
+
+
+def test_the_experiment_name_does_not_relist_the_bucket(monkeypatch):
+    monkeypatch.setattr(server, 'get_latest_checkpoint', lambda _path, _prefix: pytest.fail('meta must not reach S3'))
+    source = DreamZeroSource(model_path=RUN_DIR, backbone='wan2.2')
+
+    assert source.meta('100000')['experiment_name'] == 'w22f1_100k_200626'

--- a/positronic/vendors/dreamzero/tests/test_server.py
+++ b/positronic/vendors/dreamzero/tests/test_server.py
@@ -81,9 +81,20 @@ def test_a_run_directory_named_like_a_step_still_serves_its_checkpoint(holding):
     assert downloaded == ['s3://bucket/100000/checkpoint-100000']
 
 
-def test_a_huggingface_repo_is_itself_the_checkpoint():
-    assert _checkpoint_id('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
+def test_a_huggingface_repo_is_addressed_by_its_whole_name():
+    """The id a client puts in /api/v1/session/<id>, which for a repo keeps its own slash."""
+    source = DreamZeroSource(model_path='GEAR-Dreams/DreamZero-DROID')
+
+    assert source.get_models() == ['GEAR-Dreams/DreamZero-DROID']
+    assert source.resolve('GEAR-Dreams/DreamZero-DROID') == 'GEAR-Dreams/DreamZero-DROID'
     assert _experiment_name('GEAR-Dreams/DreamZero-DROID') == 'DreamZero-DROID'
+
+
+def test_a_pinned_checkpoint_directory_is_addressed_by_its_step():
+    source = DreamZeroSource(model_path='s3://bucket/exp/checkpoint-40000')
+
+    assert source.get_models() == ['40000']
+    assert _checkpoint_id('checkpoint-005000') == '005000'
 
 
 def test_a_zero_padded_step_is_reached_by_the_name_its_directory_carries(holding):


### PR DESCRIPTION
The DreamZero fine-tune on the PhAIL teleop data (`s3://checkpoints/phail/dreamzero/w22f1_100k_200626/`, wan2.2 full FT, 100k steps, trained on `phail.v1_0.teleop_unified` with the `joints_ik` codec) finished but had no route to the rig. Three things were missing.

**A `phail` deployment.** `dreamzero/server.py` stopped at the bare pipelines, so the run could only be served by spelling out `model_path` and `backbone` by hand. The preset binds both, alongside a `server_recordings` dir matching the other vendors. The `joints` pipeline serves it: all four `joints*` codecs share one inference decode.

**An endpoint in `phail_multiple`.** Added on `vm-train2` — wan2.2 5B wants an H100 and cannot share the desktop/notebook GPUs the other four use. `docker-compose.phail.dreamzero.yml` mirrors the existing per-host PhAIL compose files.

**Checkpoint identity in the handshake.** `DreamZeroSource` advertised the full checkpoint path as its model id and reported no `experiment_name`, so `phail_variant` in `positronic/cfg/analysis.py` came back empty and rollouts could not be attributed to a run or a step. Model ids are now step numbers, `meta()` carries `experiment_name`, and the policy reports its `checkpoint_path` the way `Gr00tPolicy` does. A rollout of this checkpoint now labels as `variant=w22f1_100k_200626:100000`, `ckpt=100000`.

Verified against real S3: the preset resolves to `checkpoint-100000`, `get_models()` returns `['100000']`, and `phail_multiple` instantiates with five policies. Not served on hardware — that needs the H100.

Note `model()` in `analysis.py` now labels these `dreamzero:dreamzero`, because `_model_label_from_path` reads the vendor segment out of the path. That is the same shape it already produces for GR00T (`groot:groot`) and is untouched here; the PhAIL analysis path uses `_raw_model` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
