### PR TITLE
Give the inference handshake field names one home in `positronic.keys`

### DIFF
--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -45,17 +45,17 @@ def _model_label_from_path(model_type: str, checkpoint_path: str) -> str | None:
 
 
 def model(ep: Episode) -> str:
-    policy_type = ep.get('inference.policy.type', '')
+    policy_type = ep.get(f'{keys.POLICY_META}.{keys.TYPE}', '')
 
     if policy_type == 'remote':
-        server_type = ep.get('inference.policy.server.type', '')
-        path_label = _model_label_from_path(server_type, ep.get('inference.policy.server.checkpoint_path', ''))
+        server_type = ep.get(f'{keys.SERVER_META}.{keys.TYPE}', '')
+        path_label = _model_label_from_path(server_type, ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_PATH}', ''))
         if path_label:
             return path_label
         return server_type or ''
 
     if policy_type:
-        path_label = _model_label_from_path(policy_type, ep.get('inference.policy.checkpoint_path', ''))
+        path_label = _model_label_from_path(policy_type, ep.get(f'{keys.POLICY_META}.{keys.CHECKPOINT_PATH}', ''))
         if path_label:
             return path_label
         return policy_type
@@ -68,7 +68,7 @@ def _split_path(path: str) -> list[str]:
 
 
 def _ckpt_act(ep: Episode) -> str:
-    raw_path = ep['inference.policy.checkpoint_path']
+    raw_path = ep[f'{keys.POLICY_META}.{keys.CHECKPOINT_PATH}']
     parts = _split_path(raw_path)
     chkpt_idxs = [i for i, p in enumerate(parts) if p == 'checkpoints']
     if chkpt_idxs:
@@ -79,10 +79,10 @@ def _ckpt_act(ep: Episode) -> str:
 
 
 def _ckpt_remote(ep: Episode) -> str:
-    checkpoint_id = ep.get('inference.policy.server.checkpoint_id', '')
+    checkpoint_id = ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}', '')
     if checkpoint_id:
         return str(checkpoint_id)
-    raw_path = ep.get('inference.policy.server.checkpoint_path', '')
+    raw_path = ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_PATH}', '')
     if raw_path:
         parts = _split_path(raw_path)
         if parts[-1] == 'pretrained_model' and len(parts) >= 2:
@@ -93,7 +93,7 @@ def _ckpt_remote(ep: Episode) -> str:
 
 def ckpt(ep: Episode) -> str | None:
     try:
-        match ep.get('inference.policy.type', ''):
+        match ep.get(f'{keys.POLICY_META}.{keys.TYPE}', ''):
             case 'act':
                 return _ckpt_act(ep)
             case 'remote':
@@ -572,7 +572,7 @@ PHAIL_OUTCOME_BADGE = RendererConfig(
 
 
 def phail_model(ep: Episode) -> str:
-    return PHAIL_MODEL_DISPLAY.get(ep.get('inference.policy.server.type', ''), '')
+    return PHAIL_MODEL_DISPLAY.get(ep.get(f'{keys.SERVER_META}.{keys.TYPE}', ''), '')
 
 
 def phail_status(ep: Episode) -> str:
@@ -605,8 +605,8 @@ def phail_uph(ep: Episode) -> float | None:
 
 
 def phail_variant(ep: Episode) -> str:
-    exp = ep.get('inference.policy.server.experiment_name', '')
-    ckpt = ep.get('inference.policy.server.checkpoint_id', '')
+    exp = ep.get(f'{keys.SERVER_META}.{keys.EXPERIMENT_NAME}', '')
+    ckpt = ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}', '')
     if exp and ckpt:
         return f'{exp}:{ckpt}'
     if exp:
@@ -639,13 +639,13 @@ phail_inference = base_cfg.transform.override(
                     'robot_commands.reset',
                     'robot_command.reset',
                     'eval.object',
-                    'inference.policy.port',
-                    'inference.policy.host',
-                    'inference.policy.server.checkpoint_id',
-                    'inference.policy.server.config_name',
-                    'inference.policy.server.experiment_name',
-                    'inference.policy.server.type',
-                    'inference.policy.type',
+                    f'{keys.POLICY_META}.port',
+                    f'{keys.POLICY_META}.host',
+                    f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}',
+                    f'{keys.SERVER_META}.{keys.CONFIG_NAME}',
+                    f'{keys.SERVER_META}.{keys.EXPERIMENT_NAME}',
+                    f'{keys.SERVER_META}.{keys.TYPE}',
+                    f'{keys.POLICY_META}.{keys.TYPE}',
                 ]
             ),
             # NOTE: _phail_derives reads inference.policy.server.type from the original episode,
@@ -728,7 +728,7 @@ phail_episodes = base_cfg.concat_ds.override(datasets=[phail_inference, phail_hu
 
 
 def _raw_model(ep: Episode) -> str:
-    return ep.get('inference.policy.server.type', '')
+    return ep.get(f'{keys.SERVER_META}.{keys.TYPE}', '')
 
 
 phail_inference_release = base_cfg.transform.override(
@@ -744,9 +744,9 @@ phail_inference_release = base_cfg.transform.override(
                 remove=[
                     'robot_commands.reset',
                     'robot_command.reset',
-                    'inference.policy.port',
-                    'inference.policy.host',
-                    'inference.policy.type',
+                    f'{keys.POLICY_META}.port',
+                    f'{keys.POLICY_META}.host',
+                    f'{keys.POLICY_META}.{keys.TYPE}',
                 ]
             ),
             Derive(model=_raw_model, variant=phail_variant),

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -639,8 +639,8 @@ phail_inference = base_cfg.transform.override(
                     'robot_commands.reset',
                     'robot_command.reset',
                     'eval.object',
-                    f'{keys.POLICY_META}.port',
-                    f'{keys.POLICY_META}.host',
+                    f'{keys.POLICY_META}.{keys.PORT}',
+                    f'{keys.POLICY_META}.{keys.HOST}',
                     f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}',
                     f'{keys.SERVER_META}.{keys.CONFIG_NAME}',
                     f'{keys.SERVER_META}.{keys.EXPERIMENT_NAME}',
@@ -744,8 +744,8 @@ phail_inference_release = base_cfg.transform.override(
                 remove=[
                     'robot_commands.reset',
                     'robot_command.reset',
-                    f'{keys.POLICY_META}.port',
-                    f'{keys.POLICY_META}.host',
+                    f'{keys.POLICY_META}.{keys.PORT}',
+                    f'{keys.POLICY_META}.{keys.HOST}',
                     f'{keys.POLICY_META}.{keys.TYPE}',
                 ]
             ),

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -38,7 +38,9 @@ def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None
     if n_action_steps is not None:
         policy.config.n_action_steps = n_action_steps
 
-    return LerobotPolicy(policy, device, extra_meta={'type': 'act', 'checkpoint_path': fully_specified_checkpoint_dir})
+    return LerobotPolicy(
+        policy, device, extra_meta={keys.TYPE: 'act', keys.CHECKPOINT_PATH: fully_specified_checkpoint_dir}
+    )
 
 
 @cfn.config(

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -42,6 +42,8 @@ CHECKPOINT_ID = 'checkpoint_id'
 CHECKPOINT_PATH = 'checkpoint_path'
 EXPERIMENT_NAME = 'experiment_name'
 CONFIG_NAME = 'config_name'
+HOST = 'host'
+PORT = 'port'
 SERVER = 'server'
 
 POLICY_META = 'inference.policy'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -1,6 +1,7 @@
-"""Canonical raw observation-signal keys of the positronic embodiment/inference wire.
+"""Canonical names on the positronic embodiment/inference wire.
 
-Every sim adapter and embodiment produces these keys and every vendor codec consumes them. They
+Every sim adapter and embodiment produces the signal keys and every vendor codec consumes them;
+every policy reports the handshake fields and the analysis configs read them back off an episode. They
 are defined here once, in a leaf module with no positronic imports, so a rename is a single-site
 change the type checker propagates instead of a string literal duplicated across codecs, evals,
 configs, adapters and datasets.
@@ -31,3 +32,17 @@ JOINT_NAMES = 'joint_names'
 # Where the episode's poses sit relative to ``models.DEFAULT_FRAME``, as a ``[tx,ty,tz,qw,qx,qy,qz]``
 # transform. Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.
 EE_FRAME = 'ee_frame'
+
+# The inference handshake: a policy reports these through its ``meta``, a remote policy nests the serving
+# half under ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy
+# at the top level and the vendor under ``SERVER``, so a reader composes a prefix with a field:
+# f'{SERVER_META}.{TYPE}'.
+TYPE = 'type'
+CHECKPOINT_ID = 'checkpoint_id'
+CHECKPOINT_PATH = 'checkpoint_path'
+EXPERIMENT_NAME = 'experiment_name'
+CONFIG_NAME = 'config_name'
+SERVER = 'server'
+
+POLICY_META = 'inference.policy'
+SERVER_META = f'{POLICY_META}.{SERVER}'

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -15,6 +15,7 @@ import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from starlette.datastructures import QueryParams
 
+from positronic import keys
 from positronic.policy import Codec, Policy, Recorder
 from positronic.policy.spec import SEQ, ModelSource, Pipeline, split
 from positronic.utils.serialization import deserialise, serialise
@@ -274,7 +275,7 @@ class PolicyServer:
             meta = {
                 **self.metadata,
                 **self._source.meta(rid),
-                'checkpoint_id': rid,
+                keys.CHECKPOINT_ID: rid,
                 **served.meta,
                 **session.meta,
                 'local_stack': local_spec,

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -191,7 +191,7 @@ class PolicyServer:
         self._manager = PolicyManager(self._source)
         self.host = host
         self.port = port
-        self.metadata: dict[str, Any] = {'host': host, 'port': port}
+        self.metadata: dict[str, Any] = {keys.HOST: host, keys.PORT: port}
         # Synced once; each session builds its own ``Recorder`` so concurrent streams never mix.
         self._recording_dir = pos3.sync(recording_dir) if recording_dir else None
 

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -241,7 +241,7 @@ class Harness(pimm.ControlSystem):
         # sub-policy) and wins on conflict.
         session_meta = self.policy.meta | (self._policy_session.meta if self._policy_session else {})
         for k, v in flatten_dict(session_meta).items():
-            meta[f'inference.policy.{k}'] = v
+            meta[f'{keys.POLICY_META}.{k}'] = v
         meta.update(context)
         return meta
 

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -6,7 +6,7 @@ from typing import Any
 import numpy as np
 import pos3
 
-from positronic import telemetry, telemetry_keys
+from positronic import keys, telemetry, telemetry_keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
@@ -101,7 +101,7 @@ class RemoteSession(Session):
 
     @property
     def meta(self) -> dict[str, Any]:
-        return flatten_dict({'type': 'remote', 'server': self._session.metadata})
+        return flatten_dict({keys.TYPE: 'remote', keys.SERVER: self._session.metadata})
 
     def close(self):
         self._session.close()
@@ -147,7 +147,7 @@ class _Endpoint(Policy):
 
     @property
     def meta(self) -> dict[str, Any]:
-        return flatten_dict({'type': 'remote', 'server': self.server_meta()})
+        return flatten_dict({keys.TYPE: 'remote', keys.SERVER: self.server_meta()})
 
     def close(self):
         self._client = None

--- a/positronic/policy/sampler.py
+++ b/positronic/policy/sampler.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from collections.abc import Hashable, Sequence
 from typing import Any
 
+from positronic import keys
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,7 +46,7 @@ class EpisodeCounter:
         group = self._counts[self._group(context)]
         return {k: group[k] for k in keys}
 
-    def seed_from(self, dataset: Any, meta_prefix: str = 'inference.policy.') -> int:
+    def seed_from(self, dataset: Any, meta_prefix: str = f'{keys.POLICY_META}.') -> int:
         """Rebuild tallies from recorded episodes in ``dataset``. Returns the number counted.
 
         The episode static stores the key under ``{meta_prefix}{key_field}`` and the

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -16,6 +16,7 @@ import websockets.sync.client
 from huggingface_hub import snapshot_download
 from websockets.exceptions import ConnectionClosed
 
+from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Codec, Policy, PolicyWrapper, Session
@@ -308,11 +309,11 @@ class DreamZeroSource(ModelSource):
     def meta(self, model_id: str) -> dict[str, Any]:
         checkpoint_path = self._checkpoint_path(model_id)
         return {
-            'type': 'dreamzero',
+            keys.TYPE: 'dreamzero',
             'backbone': self._backbone,
             'num_gpus': self._num_gpus,
-            'checkpoint_path': checkpoint_path,
-            'experiment_name': _experiment_name(checkpoint_path),
+            keys.CHECKPOINT_PATH: checkpoint_path,
+            keys.EXPERIMENT_NAME: _experiment_name(checkpoint_path),
         }
 
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -12,6 +12,7 @@ import numpy as np
 import pos3
 import zmq
 
+from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Policy, Session
@@ -220,7 +221,7 @@ class Gr00tPolicy(Policy):
 
     @property
     def meta(self):
-        return {'checkpoint_path': self._checkpoint_path}
+        return {keys.CHECKPOINT_PATH: self._checkpoint_path}
 
     def close(self):
         self._groot.stop()
@@ -303,9 +304,9 @@ class Gr00tSource(ModelSource):
 
     def meta(self, model_id: str) -> dict[str, Any]:
         return {
-            'type': 'groot',
+            keys.TYPE: 'groot',
             'modality_config': self.modality_config,
-            'experiment_name': self.checkpoints_dir.split('/')[-1] or '',
+            keys.EXPERIMENT_NAME: self.checkpoints_dir.split('/')[-1] or '',
         }
 
 

--- a/positronic/vendors/lerobot/policy.py
+++ b/positronic/vendors/lerobot/policy.py
@@ -5,6 +5,7 @@ import torch
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.policies.factory import get_policy_class, make_pre_post_processors
 
+from positronic import keys
 from positronic.policy import Policy, Session
 
 
@@ -74,7 +75,7 @@ class LerobotPolicy(Policy):
         policy_cls = get_policy_class(config.type)
         self._policy = policy_cls.from_pretrained(checkpoint_path).to(self._device)
         self._preprocessor, self._postprocessor = make_pre_post_processors(config, pretrained_path=checkpoint_path)
-        self._meta = {**(extra_meta or {}), 'type': config.type}
+        self._meta = {**(extra_meta or {}), keys.TYPE: config.type}
 
     def new_session(self, context=None, now=None):
         self._policy.reset()

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -6,6 +6,7 @@ from typing import Any
 import configuronic as cfn
 import pos3
 
+from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress
 from positronic.policy import Codec, Policy
@@ -45,10 +46,10 @@ class LerobotSource(ModelSource):
         local = run_with_progress(
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress
         )
-        return LerobotPolicy(str(local), self.device, extra_meta={'checkpoint_path': checkpoint_path})
+        return LerobotPolicy(str(local), self.device, extra_meta={keys.CHECKPOINT_PATH: checkpoint_path})
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'device': self.device, 'experiment_name': self.experiment_name}
+        return {'device': self.device, keys.EXPERIMENT_NAME: self.experiment_name}
 
 
 lerobot_source = cfn.Config(LerobotSource, checkpoint=None, device=None)

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -8,6 +8,7 @@ import pos3
 from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.pretrained import PreTrainedPolicy
 
+from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress
 from positronic.policy import Codec, Policy
@@ -66,11 +67,11 @@ class LerobotSource(ModelSource):
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress
         )
         policy = self._policy_factory(str(local))
-        meta = {'type': self._model_type, 'checkpoint_path': checkpoint_path}
+        meta = {keys.TYPE: self._model_type, keys.CHECKPOINT_PATH: checkpoint_path}
         return LerobotPolicy(policy, self._device, extra_meta=meta)
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'device': self._device, 'experiment_name': self._experiment_name}
+        return {'device': self._device, keys.EXPERIMENT_NAME: self._experiment_name}
 
 
 lerobot_source = cfn.Config(LerobotSource, policy_factory=act)

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 from transformers import AutoModelForImageTextToText, AutoProcessor
 
+from positronic import keys
 from positronic.policy import Policy, Session
 
 
@@ -47,7 +48,7 @@ class MolmoAct2Policy(Policy):
         ).eval()
         self._norm_tag = norm_tag
         self._num_steps = num_steps
-        self._meta = {'type': 'molmoact2', 'norm_tag': norm_tag}
+        self._meta = {keys.TYPE: 'molmoact2', 'norm_tag': norm_tag}
 
     def new_session(self, context=None, now=None) -> Session:
         return _MolmoAct2Session(self._model, self._processor, self._norm_tag, self._num_steps, self._meta)

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -10,7 +10,7 @@ import configuronic as cfn
 import pos3
 from openpi_client.websocket_client_policy import WebsocketClientPolicy
 
-from positronic import geom
+from positronic import geom, keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Codec, Policy, Session
@@ -223,10 +223,10 @@ class OpenpiSource(ModelSource):
 
     def meta(self, model_id: str) -> dict[str, Any]:
         return {
-            'type': 'openpi',
-            'config_name': self.config_name,
-            'checkpoint_path': self.checkpoints_dir if self._passthrough else f'{self.checkpoints_dir}/{model_id}',
-            'experiment_name': self.checkpoints_dir.rsplit('/', 1)[-1],
+            keys.TYPE: 'openpi',
+            keys.CONFIG_NAME: self.config_name,
+            keys.CHECKPOINT_PATH: self.checkpoints_dir if self._passthrough else f'{self.checkpoints_dir}/{model_id}',
+            keys.EXPERIMENT_NAME: self.checkpoints_dir.rsplit('/', 1)[-1],
         }
 
 


### PR DESCRIPTION
**Stacked on #560** — merge that first. Until it does, this PR's diff carries #560's three commits as well; the change under review here is the last commit, `02b6fe24`.

`checkpoint_path`, `experiment_name`, `type` and `checkpoint_id` are a contract between six vendor servers, `RemotePolicy`, the harness and the analysis configs, and every participant spelled the name out as a literal. The `inference.policy.` prefix the harness composes appeared twenty times in `analysis.py` alone. Codex flagged this on #560 against DreamZero; the rule cannot be satisfied for one vendor while the same string lives in five others, so this does the whole set.

**Home: `positronic/keys.py`.** It is already the canonical module for wire names, already a leaf with no positronic imports — which matters, because both a vendor server in a heavy image and `cfg/analysis.py` have to import it — and both sides already import it for `keys.TASK`. The module docstring now covers the two vocabularies it carries, under section headers.

`TYPE` is deliberately one constant, not two: the same wire word names the policy at the top level (`remote`, `act`) and the vendor under `server` (`openpi`, `dreamzero`). Readers disambiguate by prefix, exactly as the wire does — `f'{keys.SERVER_META}.{keys.TYPE}'`.

Only names used in more than one place moved. `modality_config`, `device`, `norm_tag` and `backbone` are written by one vendor and read by nobody else, so they stay literals where they are. `config_name` moved because `analysis.py` reads it. The `type` keys in `positronic/simulator/**` and the server UI are a different vocabulary that happens to reuse the word, and are untouched.

Test assertions keep their literals on purpose: spelling the expected mapping out is what makes them a check on the contract rather than a restatement of it — importing the same constants the code under test uses would make them pass whatever those constants held.

Full suite green (843 passed, 7 skipped). No behaviour change: every constant holds the string that was there before, which the analysis and offboard tests assert on directly.
