### PR TITLE
Leave a signal out of the plots by its width, not by its name

### DIFF
--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -138,10 +138,8 @@ def _compute_eye_controls(signals: EpisodeSignals, ep: Episode) -> rrb.EyeContro
     return rrb.EyeControls3D(position=camera_pos.tolist(), look_target=centroid.tolist())
 
 
-# One series per element stops being readable long before it stops being drawable, and a signal wide
-# enough — a full physics state runs to hundreds — takes the video panels down with it: the scalar
-# series crowd out the recording and the video sits on its loading spinner. Signals past this width
-# are left out of the plots and named in the viewer instead.
+# A per-element plot of a signal this wide is unreadable, and crowds the video panels out of the
+# recording until they never decode.
 # TODO: a view that plots a chosen few elements of a wide signal, so it stops being all-or-nothing.
 _MAX_PLOTTED_WIDTH = 32
 _UNPLOTTED_ENTITY = '/unplotted'

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -65,8 +65,8 @@ class EpisodeSignals:
     poses: list[str]
 
     @property
-    def plotted(self) -> list[str]:
-        return [name for name in self.numerics if self.dims[name] <= _MAX_PLOTTED_WIDTH]
+    def plotted(self) -> dict[str, int]:
+        return {name: self.dims[name] for name in self.numerics if self.dims[name] <= _MAX_PLOTTED_WIDTH}
 
     @property
     def unplotted(self) -> dict[str, int]:
@@ -201,7 +201,7 @@ def _build_blueprint(signals: EpisodeSignals, ep: Episode) -> rrb.Blueprint:
         return rrb.TimeSeriesView(
             name=sig,
             origin=f'/signals/{sig}',
-            plot_legend=rrb.PlotLegend(visible=signals.dims.get(sig, 1) > 1),
+            plot_legend=rrb.PlotLegend(visible=signals.plotted[sig] > 1),
             axis_y=rrb.ScalarAxis(zoom_lock=True),
         )
 
@@ -261,8 +261,7 @@ def _setup_series_names(signals: EpisodeSignals, ep: Episode) -> None:
     joint_set = _joint_signals(ep)
     joint_names = ep.static.get('joint_names')
     pose_set = set(signals.poses)
-    for key in signals.plotted:
-        dim = signals.dims.get(key, 1)
+    for key, dim in signals.plotted.items():
         is_joint_vel = key.endswith('.dq') and f'{key[: -len(".dq")]}.q' in joint_set
         if (key in joint_set or is_joint_vel) and joint_names:
             names = joint_names

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -57,6 +57,7 @@ class EpisodeSignals:
     numerics: list[str]
     dims: dict[str, int]
     poses: list[str]
+    unplotted: dict[str, int]  # name -> element count, for signals too wide to plot
 
 
 def _infer_dims(sig) -> int:
@@ -137,20 +138,28 @@ def _compute_eye_controls(signals: EpisodeSignals, ep: Episode) -> rrb.EyeContro
     return rrb.EyeControls3D(position=camera_pos.tolist(), look_target=centroid.tolist())
 
 
-# MuJoCo's privileged full-physics state is a single wide vector recorded for replay/scoring —
-# ``sim_state.mjSTATE_*`` in current recordings, bare ``mjSTATE_*`` in older datasets — not a set of
-# readable channels. Plotting it as one scalar series per channel stalls the viewer, so any signal
-# carrying it is left out of the visualization.
-# TODO: a high-dimensional signal like this has no useful scalar-series view and needs one of its own.
-_HIDDEN_SIGNAL_MARKER = 'mjSTATE'
+# One series per element stops being readable long before it stops being drawable, and a signal wide
+# enough — a full physics state runs to hundreds — takes the video panels down with it: the scalar
+# series crowd out the recording and the video sits on its loading spinner. Signals past this width
+# are left out of the plots and named in the viewer instead.
+# TODO: a view that plots a chosen few elements of a wide signal, so it stops being all-or-nothing.
+_MAX_PLOTTED_WIDTH = 32
+_UNPLOTTED_ENTITY = '/unplotted'
+
+
+def _unplotted_notice(unplotted: dict[str, int]) -> str:
+    lines = '\n'.join(f'- `{name}` — {dim} values' for name, dim in sorted(unplotted.items()))
+    return (
+        f'### Not plotted\n\n{lines}\n\n'
+        f'Wider than {_MAX_PLOTTED_WIDTH} values, so a per-element plot is unreadable and crowds out '
+        'the rest of the recording. The signals are in the episode and readable through the dataset API.'
+    )
 
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
     pose_set = set(ep.static.get('pose_signals', []))
-    signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[])
+    signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[], unplotted={})
     for name, sig in ep.signals.items():
-        if _HIDDEN_SIGNAL_MARKER in name:
-            continue
         if sig.kind == Kind.IMAGE:
             try:
                 sig[0]
@@ -159,11 +168,16 @@ def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
                 pass
             continue
 
-        signals.numerics.append(name)
         try:
-            signals.dims[name] = _infer_dims(sig)
+            dim = _infer_dims(sig)
         except Exception:
-            signals.dims[name] = 1
+            dim = 1
+        if dim > _MAX_PLOTTED_WIDTH:
+            signals.unplotted[name] = dim
+            continue
+
+        signals.numerics.append(name)
+        signals.dims[name] = dim
         if name in pose_set:
             signals.poses.append(name)
     return signals
@@ -196,6 +210,8 @@ def _build_blueprint(signals: EpisodeSignals, ep: Episode) -> rrb.Blueprint:
         else:
             view = rrb.Tabs(*[_ts_view(sig) for sig in sigs], name=group_name)
         series_views.append(view)
+    if signals.unplotted:
+        series_views.append(rrb.TextDocumentView(name='Not plotted', origin=_UNPLOTTED_ENTITY))
 
     # Top row: images (big) + optional 3D (smaller)
     top_items = []
@@ -526,6 +542,10 @@ def stream_episode_rrd(ds: Dataset, episode_id: int) -> Iterator[bytes]:
     with rec:
         signals = _collect_signal_groups(ep)
         rr.send_blueprint(_build_blueprint(signals, ep))
+        if signals.unplotted:
+            logging.warning(f'Episode {episode_id}: not plotting {signals.unplotted}')
+            notice = _unplotted_notice(signals.unplotted)
+            rr.log(_UNPLOTTED_ENTITY, rr.TextDocument(notice, media_type=rr.MediaType.MARKDOWN), static=True)
         yield from drainer.drain()
 
         _setup_series_names(signals, ep)

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -352,6 +352,15 @@ def _log_video_signals(ep: Episode, signals: EpisodeSignals, drainer: _BinaryStr
         yield from drainer.drain()
 
 
+def _send_scalar_columns(key: str, ts_arr: np.ndarray, vals: np.ndarray) -> None:
+    time_idx = [rr.TimeColumn('time', timestamp=ts_arr)]
+    if vals.shape[1] == 1:
+        rr.send_columns(f'/signals/{key}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals.ravel()))
+        return
+    for i in range(vals.shape[1]):
+        rr.send_columns(f'/signals/{key}/{i}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals[:, i]))
+
+
 def _log_numeric_signals(
     ep: Episode, signals: EpisodeSignals, drainer: _BinaryStreamDrainer
 ) -> Generator[bytes, None, dict[str, tuple[np.ndarray, np.ndarray]]]:
@@ -369,6 +378,8 @@ def _log_numeric_signals(
     unplotted = signals.unplotted
 
     for key in signals.numerics:
+        if key in unplotted and key not in stash_keys:  # nothing would read the values
+            continue
         sig = ep.signals[key]
         if len(sig) == 0:
             continue
@@ -379,17 +390,9 @@ def _log_numeric_signals(
             continue
         if vals.ndim == 1:
             vals = vals.reshape(-1, 1)
-        dim = vals.shape[1]
 
         if key not in unplotted:
-            time_idx = [rr.TimeColumn('time', timestamp=ts_arr)]
-            if dim == 1:
-                rr.send_columns(f'/signals/{key}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals.ravel()))
-            else:
-                for i in range(dim):
-                    rr.send_columns(
-                        f'/signals/{key}/{i}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals[:, i])
-                    )
+            _send_scalar_columns(key, ts_arr, vals)
 
         if key in stash_keys:
             pose_data[key] = (ts_arr, vals)

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -51,17 +51,26 @@ def _pose_color(name: str) -> list[int]:
     return _POSE_COLORS['default']
 
 
+# A per-element plot of a signal this wide is unreadable, and crowds the video panels out of the
+# recording until they never decode.
+# TODO: a view that plots a chosen few elements of a wide signal, so it stops being all-or-nothing.
+_MAX_PLOTTED_WIDTH = 32
+
+
 @dataclass
 class EpisodeSignals:
     videos: list[str]
     numerics: list[str]
     dims: dict[str, int]
     poses: list[str]
-    unplotted: dict[str, int]  # name -> element count, for signals too wide to plot
 
     @property
     def plotted(self) -> list[str]:
-        return [name for name in self.numerics if name not in self.unplotted]
+        return [name for name in self.numerics if self.dims[name] <= _MAX_PLOTTED_WIDTH]
+
+    @property
+    def unplotted(self) -> dict[str, int]:
+        return {name: dim for name, dim in self.dims.items() if dim > _MAX_PLOTTED_WIDTH}
 
 
 def _infer_dims(sig) -> int:
@@ -142,10 +151,6 @@ def _compute_eye_controls(signals: EpisodeSignals, ep: Episode) -> rrb.EyeContro
     return rrb.EyeControls3D(position=camera_pos.tolist(), look_target=centroid.tolist())
 
 
-# A per-element plot of a signal this wide is unreadable, and crowds the video panels out of the
-# recording until they never decode.
-# TODO: a view that plots a chosen few elements of a wide signal, so it stops being all-or-nothing.
-_MAX_PLOTTED_WIDTH = 32
 _UNPLOTTED_ENTITY = '/unplotted'
 
 
@@ -160,7 +165,7 @@ def _unplotted_notice(unplotted: dict[str, int]) -> str:
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
     pose_set = set(ep.static.get('pose_signals', []))
-    signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[], unplotted={})
+    signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[])
     for name, sig in ep.signals.items():
         if sig.kind == Kind.IMAGE:
             try:
@@ -174,9 +179,6 @@ def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
             dim = _infer_dims(sig)
         except Exception:
             dim = 1
-        if dim > _MAX_PLOTTED_WIDTH:
-            signals.unplotted[name] = dim
-
         signals.numerics.append(name)
         signals.dims[name] = dim
         if name in pose_set:
@@ -364,6 +366,7 @@ def _log_numeric_signals(
     if gripper:
         stash_keys.add(gripper['signal'])
     pose_data = {}
+    unplotted = signals.unplotted
 
     for key in signals.numerics:
         sig = ep.signals[key]
@@ -378,7 +381,7 @@ def _log_numeric_signals(
             vals = vals.reshape(-1, 1)
         dim = vals.shape[1]
 
-        if key not in signals.unplotted:
+        if key not in unplotted:
             time_idx = [rr.TimeColumn('time', timestamp=ts_arr)]
             if dim == 1:
                 rr.send_columns(f'/signals/{key}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals.ravel()))

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -59,6 +59,10 @@ class EpisodeSignals:
     poses: list[str]
     unplotted: dict[str, int]  # name -> element count, for signals too wide to plot
 
+    @property
+    def plotted(self) -> list[str]:
+        return [name for name in self.numerics if name not in self.unplotted]
+
 
 def _infer_dims(sig) -> int:
     if len(sig) == 0:
@@ -172,7 +176,6 @@ def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
             dim = 1
         if dim > _MAX_PLOTTED_WIDTH:
             signals.unplotted[name] = dim
-            continue
 
         signals.numerics.append(name)
         signals.dims[name] = dim
@@ -182,9 +185,9 @@ def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
 
 
 def _group_signals_by_prefix(signals: EpisodeSignals) -> list[tuple[str, list[str]]]:
-    """Group numeric signals by prefix before the first '.'. Preserves insertion order."""
+    """Group plotted signals by prefix before the first '.'. Preserves insertion order."""
     groups: defaultdict[str, list[str]] = defaultdict(list)
-    for sig in signals.numerics:
+    for sig in signals.plotted:
         groups[sig.split('.')[0] if '.' in sig else sig].append(sig)
     return list(groups.items())
 
@@ -256,7 +259,7 @@ def _setup_series_names(signals: EpisodeSignals, ep: Episode) -> None:
     joint_set = _joint_signals(ep)
     joint_names = ep.static.get('joint_names')
     pose_set = set(signals.poses)
-    for key in signals.numerics:
+    for key in signals.plotted:
         dim = signals.dims.get(key, 1)
         is_joint_vel = key.endswith('.dq') and f'{key[: -len(".dq")]}.q' in joint_set
         if (key in joint_set or is_joint_vel) and joint_names:
@@ -350,7 +353,11 @@ def _log_video_signals(ep: Episode, signals: EpisodeSignals, drainer: _BinaryStr
 def _log_numeric_signals(
     ep: Episode, signals: EpisodeSignals, drainer: _BinaryStreamDrainer
 ) -> Generator[bytes, None, dict[str, tuple[np.ndarray, np.ndarray]]]:
-    """Log numeric time-series via send_columns. Returns pose/joint data for 3D logging."""
+    """Log numeric time-series via send_columns. Returns pose/joint data for 3D logging.
+
+    A signal too wide to plot is still read, so that a joint or pose vector of any width reaches the
+    3D view.
+    """
     pose_set = set(signals.poses)
     gripper = ep.static.get('gripper')
     stash_keys = pose_set | _joint_signals(ep)
@@ -371,12 +378,15 @@ def _log_numeric_signals(
             vals = vals.reshape(-1, 1)
         dim = vals.shape[1]
 
-        time_idx = [rr.TimeColumn('time', timestamp=ts_arr)]
-        if dim == 1:
-            rr.send_columns(f'/signals/{key}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals.ravel()))
-        else:
-            for i in range(dim):
-                rr.send_columns(f'/signals/{key}/{i}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals[:, i]))
+        if key not in signals.unplotted:
+            time_idx = [rr.TimeColumn('time', timestamp=ts_arr)]
+            if dim == 1:
+                rr.send_columns(f'/signals/{key}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals.ravel()))
+            else:
+                for i in range(dim):
+                    rr.send_columns(
+                        f'/signals/{key}/{i}', indexes=time_idx, columns=rr.Scalars.columns(scalars=vals[:, i])
+                    )
 
         if key in stash_keys:
             pose_data[key] = (ts_arr, vals)

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from positronic import keys
 from positronic.dataset.local_dataset import DiskEpisode, DiskEpisodeWriter
 from positronic.server.dataset_utils import _MAX_PLOTTED_WIDTH, _collect_signal_groups, _unplotted_notice
 
@@ -13,18 +14,18 @@ def _episode(ep_dir, widths: dict[str, int]) -> DiskEpisode:
 
 
 def test_narrow_signals_are_plotted(tmp_path):
-    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {'robot_state.q': 7, 'grip': 1}))
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, keys.GRIP: 1}))
 
-    assert set(signals.numerics) == {'robot_state.q', 'grip'}
+    assert set(signals.numerics) == {keys.JOINTS, keys.GRIP}
     assert signals.unplotted == {}
 
 
 def test_wide_signal_is_named_instead_of_plotted(tmp_path):
     width = _MAX_PLOTTED_WIDTH + 1
-    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {'robot_state.q': 7, 'sim_state': width}))
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, 'sim_state': width}))
 
-    assert signals.numerics == ['robot_state.q']
-    assert signals.dims == {'robot_state.q': 7}
+    assert signals.numerics == [keys.JOINTS]
+    assert signals.dims == {keys.JOINTS: 7}
     assert signals.unplotted == {'sim_state': width}
 
 

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -16,7 +16,7 @@ def _episode(ep_dir, widths: dict[str, int]) -> DiskEpisode:
 def test_narrow_signals_are_plotted(tmp_path):
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, keys.GRIP: 1}))
 
-    assert set(signals.plotted) == {keys.JOINTS, keys.GRIP}
+    assert signals.plotted == {keys.JOINTS: 7, keys.GRIP: 1}
     assert signals.unplotted == {}
 
 
@@ -24,7 +24,7 @@ def test_wide_signal_is_named_instead_of_plotted(tmp_path):
     width = _MAX_PLOTTED_WIDTH + 1
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, 'wide_signal': width}))
 
-    assert signals.plotted == [keys.JOINTS]
+    assert signals.plotted == {keys.JOINTS: 7}
     assert signals.unplotted == {'wide_signal': width}
 
 

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from positronic.dataset.local_dataset import DiskEpisode, DiskEpisodeWriter
+from positronic.server.dataset_utils import _MAX_PLOTTED_WIDTH, _collect_signal_groups, _unplotted_notice
+
+
+def _episode(ep_dir, widths: dict[str, int]) -> DiskEpisode:
+    with DiskEpisodeWriter(ep_dir) as writer:
+        for name, width in widths.items():
+            writer.append(name, np.zeros(width, dtype=np.float32), 1000)
+            writer.append(name, np.ones(width, dtype=np.float32), 2000)
+    return DiskEpisode(ep_dir)
+
+
+def test_narrow_signals_are_plotted(tmp_path):
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {'robot_state.q': 7, 'grip': 1}))
+
+    assert set(signals.numerics) == {'robot_state.q', 'grip'}
+    assert signals.unplotted == {}
+
+
+def test_wide_signal_is_named_instead_of_plotted(tmp_path):
+    width = _MAX_PLOTTED_WIDTH + 1
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {'robot_state.q': 7, 'sim_state': width}))
+
+    assert signals.numerics == ['robot_state.q']
+    assert signals.dims == {'robot_state.q': 7}
+    assert signals.unplotted == {'sim_state': width}
+
+
+def test_notice_names_every_unplotted_signal_and_its_width():
+    notice = _unplotted_notice({'sim_state': 866, 'contacts': 120})
+
+    assert '`sim_state` — 866 values' in notice
+    assert '`contacts` — 120 values' in notice

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -22,10 +22,10 @@ def test_narrow_signals_are_plotted(tmp_path):
 
 def test_wide_signal_is_named_instead_of_plotted(tmp_path):
     width = _MAX_PLOTTED_WIDTH + 1
-    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, 'sim_state': width}))
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, 'wide_signal': width}))
 
     assert signals.plotted == [keys.JOINTS]
-    assert signals.unplotted == {'sim_state': width}
+    assert signals.unplotted == {'wide_signal': width}
 
 
 def test_wide_signal_still_reaches_the_3d_view(tmp_path):
@@ -37,7 +37,7 @@ def test_wide_signal_still_reaches_the_3d_view(tmp_path):
 
 
 def test_notice_names_every_unplotted_signal_and_its_width():
-    notice = _unplotted_notice({'sim_state': 866, 'contacts': 120})
+    notice = _unplotted_notice({'wide_signal': 866, 'wider_signal': 120})
 
-    assert '`sim_state` — 866 values' in notice
-    assert '`contacts` — 120 values' in notice
+    assert '`wide_signal` — 866 values' in notice
+    assert '`wider_signal` — 120 values' in notice

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -16,7 +16,7 @@ def _episode(ep_dir, widths: dict[str, int]) -> DiskEpisode:
 def test_narrow_signals_are_plotted(tmp_path):
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, keys.GRIP: 1}))
 
-    assert set(signals.numerics) == {keys.JOINTS, keys.GRIP}
+    assert set(signals.plotted) == {keys.JOINTS, keys.GRIP}
     assert signals.unplotted == {}
 
 
@@ -24,9 +24,16 @@ def test_wide_signal_is_named_instead_of_plotted(tmp_path):
     width = _MAX_PLOTTED_WIDTH + 1
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7, 'sim_state': width}))
 
-    assert signals.numerics == [keys.JOINTS]
-    assert signals.dims == {keys.JOINTS: 7}
+    assert signals.plotted == [keys.JOINTS]
     assert signals.unplotted == {'sim_state': width}
+
+
+def test_wide_signal_still_reaches_the_3d_view(tmp_path):
+    width = _MAX_PLOTTED_WIDTH + 1
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: width}))
+
+    assert signals.numerics == [keys.JOINTS]
+    assert signals.dims == {keys.JOINTS: width}
 
 
 def test_notice_names_every_unplotted_signal_and_its_width():


### PR DESCRIPTION
Video panels in the dataset viewer never render for MolmoSpaces episodes: both cameras sit on the loading spinner for the whole episode, then show the final frame at the end. The cause is `sim_state`, a MuJoCo physics state of a thousand-odd elements — its width varies with the scene's object count, 866 on episode 5 — which the viewer logs as one scalar series per element. The recording goes from 0.90 MB to 6.57 MB and the video starves.

The viewer already guarded against wide signals, by matching `mjSTATE` in the signal name. The in-process MuJoCo sim's channels carry that name; MolmoSpaces reaches the recorder through the env-server and writes one flat `sim_state`, so the guard missed it. Keeping the guard on names and adding `sim_state` to the list fails the same way again — a name match fails open, so the next unrecognised wide signal still draws all its series. So the guard keys on width: `_MAX_PLOTTED_WIDTH = 32`, and anything wider is left out of the plots whatever it is called.

Width decides only what is plotted and what is sent as scalar columns, not what the episode's numeric signals are. `signals.numerics` also feeds the stash that animates the URDF robot, so excluding a wide signal there would cost a robot with more than 32 joints its model, with no error — the same silent failure the name guard had.

Nothing is dropped silently: the signals it catches are named with their element counts in a "Not plotted" panel in the viewer, and logged as a server-side warning. All-or-nothing is still the wrong end state for a debug viewer — seeing that one object moved is useful — so the TODO left in the code is a view that plots a chosen few elements of a wide signal.

Verified against episode 5 of the battle sweep in a headless browser: both cameras render, the robot and its trajectory render, and the panel reads `sim_state — 866 values`. `positronic/server/` had no tests, so this adds the conventional per-package `tests/` directory, with four covering the split, the notice, and a wide signal still reaching the 3D view.

Closes Positronic-Robotics/internal#128.

<!-- opened-by: posi-agent -->