### PR TITLE
Log recorder frames only on ticks that ran inference

### DIFF
--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -19,6 +19,12 @@ correlated recording::
 - the ``server`` tap (innermost, next to the remote policy) logs the observation as
   sent to the server and the chunk as received back.
 
+Both are logged once the inner call returns, so a tap above a scheduling wrapper can tell
+an inference from a control tick the wrapper skipped (``ChunkedSchedule`` returns ``None``
+for those). Frames are written only on ticks that ran inference, which ties file size to the
+inference rate; numeric entries are written on every tick, so the state trace keeps the full
+control rate.
+
 Each entity is stamped on the timelines given by ``timelines`` (a mapping of rerun
 timeline name to observation key; by default ``wall_time`` and ``obs_time``
 read from the matching ``*_ns`` observation fields). Those values are read once per
@@ -356,6 +362,7 @@ class _RecordingTapSession(DelegatingSession):
         self._name = name
         self._stream = stream
         self._step = 0
+        self._blueprint_sent = False
 
     @property
     def meta(self):
@@ -366,17 +373,22 @@ class _RecordingTapSession(DelegatingSession):
             set_timeline_time(timeline, value)
         set_timeline_sequence('step', self._step)
 
-    def _log(self, prefix: str, data: dict) -> None:
-        """Recursively log obs *data* under *prefix*, recording entity paths on the Recorder."""
+    def _log(self, prefix: str, data: dict, images: bool) -> None:
+        """Recursively log obs *data* under *prefix*, recording entity paths on the Recorder.
+
+        ``images`` False drops the frames and keeps the numeric entries.
+        """
         for key, value in data.items():
             if key.endswith('_time_ns') or isinstance(value, str):
                 continue
             path = f'{prefix}/{key}'
             if isinstance(value, dict):
-                self._log(path, value)
+                self._log(path, value, images)
             elif (img := _as_image(value)) is not None:
-                rr.log(path, rr.Image(img).compress())
-                self._rec._image_paths.append(path)
+                # Gated inside the branch: a frame that fell through would log as a numeric series.
+                if images:
+                    rr.log(path, rr.Image(img).compress())
+                    self._rec._image_paths.append(path)
             elif (num := _as_numeric(value)) is not None:
                 log_numeric_series(path, num)
                 self._rec._numeric_paths.append(path)
@@ -438,21 +450,18 @@ class _RecordingTapSession(DelegatingSession):
             rec._timeline_values = {t: obs[k] for t, k in rec._timelines.items() if k in obs}
         rec._depth += 1
         try:
-            with self._stream:
-                self._set_timelines()
-                self._log(self._name, obs)
-
             actions = self._inner(obs)
 
-            if actions is not None:
-                with self._stream:
-                    self._set_timelines()
+            with self._stream:
+                self._set_timelines()
+                self._log(self._name, obs, images=actions is not None)
+                if actions is not None:
                     self._log_action_chunk(self._name, actions, obs)
-            # Send a combined blueprint (all taps' paths) once, from the outermost
-            # tap, after inner taps have logged their first obs.
-            if outermost and self._step == 0:
-                with self._stream:
-                    self._send_blueprint()
+                    # Send a combined blueprint (all taps' paths) once, from the outermost tap: the
+                    # first tick that ran inference is the first one every inner tap logged through.
+                    if outermost and not self._blueprint_sent:
+                        self._send_blueprint()
+                        self._blueprint_sent = True
             self._step += 1
             return actions
         finally:

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -5,6 +5,7 @@ from positronic.drivers.roboarm.command import CartesianPosition
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
 from positronic.policy.recording import Recorder, _build_blueprint, _squeeze_batch, _stack_numeric
+from positronic.policy.wrappers import ChunkedSchedule
 
 
 class _TrackingSession(Session):
@@ -154,26 +155,15 @@ def test_handles_none_actions(tmp_path):
     assert session._step == 1
 
 
-def test_skipped_tick_logs_state_without_frames(tmp_path):
-    """A tick the inner scheduling wrapper skipped keeps the numeric trace but writes no frame."""
-
-    class _FirstTickSession(Session):
-        def __init__(self):
-            self._calls = 0
-
-        def __call__(self, obs):
-            self._calls += 1
-            return [{'v': 1.0, 'timestamp': 0.0}] if self._calls == 1 else None
-
-    class _FirstTickPolicy(Policy):
-        def new_session(self, context=None, now=None):
-            return _FirstTickSession()
-
+def test_frames_follow_inference_not_control_ticks(tmp_path):
+    """A tap above `ChunkedSchedule` writes a frame per inference; numeric entries stay per tick."""
     rec = Recorder(tmp_path)
-    session = rec.tap('raw').wrap(_FirstTickPolicy()).new_session()
+    policy = (rec.tap('raw') | ChunkedSchedule()).wrap(_TrackingPolicy([{'v': 1.0, 'timestamp': 0.5}]))
+    session = policy.new_session(None, lambda: 0.0)
     obs = {'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.GRIP: 0.5, 'wall_time_ns': 1}
-    session(obs)
-    session(obs)
+
+    assert session(obs) is not None
+    assert session(obs) is None  # the 0.5 s chunk is still playing
 
     assert rec._image_paths == ['raw/camera']
     assert rec._numeric_paths == ['raw/grip', 'raw/grip']

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -154,6 +154,31 @@ def test_handles_none_actions(tmp_path):
     assert session._step == 1
 
 
+def test_skipped_tick_logs_state_without_frames(tmp_path):
+    """A tick the inner scheduling wrapper skipped keeps the numeric trace but writes no frame."""
+
+    class _FirstTickSession(Session):
+        def __init__(self):
+            self._calls = 0
+
+        def __call__(self, obs):
+            self._calls += 1
+            return [{'v': 1.0, 'timestamp': 0.0}] if self._calls == 1 else None
+
+    class _FirstTickPolicy(Policy):
+        def new_session(self, context=None, now=None):
+            return _FirstTickSession()
+
+    rec = Recorder(tmp_path)
+    session = rec.tap('raw').wrap(_FirstTickPolicy()).new_session()
+    obs = {'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.GRIP: 0.5, 'wall_time_ns': 1}
+    session(obs)
+    session(obs)
+
+    assert rec._image_paths == ['raw/camera']
+    assert rec._numeric_paths == ['raw/grip', 'raw/grip']
+
+
 def test_two_taps_share_one_file_per_episode(tmp_path):
     rec = Recorder(tmp_path)
     policy = (rec.tap('raw') | rec.tap('server')).wrap(_TrackingPolicy())


### PR DESCRIPTION
## Summary

Fixes part 1 of #534: the `raw` tap sits above `ChunkedSchedule`, so it saw every control
tick (~14 Hz) instead of one observation per inference, and inference `.rrd` files grew ~50x
(4 MB -> 227 MB per episode; full-resolution JPEG frames were ~98% of the bytes).

- `_RecordingTapSession.__call__` logs *after* the inner call returns, so a tap can tell an
  inference from a tick the scheduler skipped (`ChunkedSchedule` returns `None` for those).
- Frames are gated on that; numeric entries still log every tick, so the state trace
  (`robot_state.q`, `ee_pose`, `grip`) keeps full control rate at kilobyte cost.
- The blueprint now goes out on the first tick that ran inference rather than at step 0 —
  that is the first tick every inner tap logged through, and the only one with image paths
  registered.
- Nothing moves in the pipeline, so file content is otherwise unchanged: inner taps just log
  before the outer one within a tick, and everything is timestamped.

Part 2 of the issue (server-side entries reported into the client's tap) is not touched.

No frame-rate cap is added: volume is tied to the inference rate, which is what "restore the
default" means, but it does not bound anything — a server inferring at 5 Hz brings the growth
back.

## Test plan

- `positronic/policy/tests/test_recording.py::test_frames_follow_inference_not_control_ticks`
  ticks a `rec.tap('raw') | ChunkedSchedule()` pipeline twice inside one chunk and asserts one
  frame, two numeric entries. Verified it fails without the gate.
- Full suite: 945 passed, 7 skipped. Not verified on a real rig.