### PR TITLE
Let the served pipeline declare where the rig records

### DIFF
--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -141,12 +141,11 @@ Which command type your model produces is decided by its codec.
 
 ## Debugging with recordings
 
-When a run doesn't produce the result you expected, it helps to record exactly what crossed the boundaries between the robot, the codec, and the model. Recording is itself a policy wrapper — `Recorder` in [`positronic/policy/recording.py`](../positronic/policy/recording.py) — that taps into any client pipeline; the built-in servers expose it via `--recording_dir`. It writes one [rerun](https://rerun.io) file per episode with two layers:
+When a run doesn't produce the result you expected, it helps to record exactly what crossed the boundaries between the robot, the codec, and the model. Recording writes one [rerun](https://rerun.io) file per episode; where the recording is taken is a property of the pipeline, not of whoever runs it.
 
-- **`raw`** — the observation and action as they appear on the wire.
-- **`inference`** — the same episode *after* the codec: the encoded observation the model received and the raw actions it produced.
+A `Tap` ([`positronic/policy/recording.py`](../positronic/policy/recording.py)) names a seam worth recording and goes in the pipeline like any other entry — `... | Tap('wire') | remote | codec | source`. The server publishes it with the rest of the rig-side stack, and a rig given `--policy.recording_dir` logs, under that name, the observation passing down through the seam and the action chunk coming back up. Every built-in pipeline names its wire seam, so a recorded episode shows what was sent and what came back for each inference — and nothing on the ticks in between, since a seam below the scheduling wrapper only sees the ticks that ran one.
 
-Comparing the two localizes the fault: if `raw` looks right but `inference` looks wrong, the codec is at fault; if the `inference` input looks right but the output is bad, it is the model.
+The server records its own side separately, via `--recording_dir` on the server: `raw` is the observation as it arrived on the wire, `inference` the same observation *after* the codec — what the model consumed — and the raw actions it produced. Comparing those localizes the fault: if `raw` looks right but `inference` looks wrong, the codec is at fault; if the `inference` input looks right but the output is bad, it is the model.
 
 The client side can record too: `--output_dir` saves the full episode as a Positronic dataset, browsable with `positronic-server`.
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -65,7 +65,7 @@ The model source (`checkpoints_dir`, `checkpoint`, device...) is fixed at server
 
 `--policy.local=@...` and `--policy.compress_images` are deprecated stand-ins for a server too old to declare either; against a server that does declare, they raise rather than quietly winning. A server that declares no stack at all but still reports `image_sizes` gets a third stand-in: the client bounds frames to those sizes, logging what it did. All three go away once every server declares (see [#514](https://github.com/Positronic-Robotics/positronic/issues/514)).
 
-> **Recording inference I/O:** Pass `--policy.recording_dir=s3://bucket/path` to write a rerun `.rrd` file per episode capturing the raw and server-side observation/action boundaries. Useful for debugging codec behavior and visualizing what the policy actually received.
+> **Recording inference I/O:** Pass `--policy.recording_dir=s3://bucket/path` to write a rerun `.rrd` file per episode. Which points of the rig-side stack it captures is the server's call too: each `Tap` the declared stack names becomes one layer of the recording, under that tap's name. Useful for debugging codec behavior and visualizing what the policy actually received.
 
 ## Local Inference
 

--- a/positronic/offboard/README.md
+++ b/positronic/offboard/README.md
@@ -84,7 +84,8 @@ Upon connection, the server sends a ready packet with metadata:
     "action_horizon_sec": 1.0,
     "local_stack": {"seq": [
       {"name": "chunked_schedule"},
-      {"name": "restrict_image_size", "args": {"width": 224, "height": 224}}
+      {"name": "restrict_image_size", "args": {"width": 224, "height": 224}},
+      {"name": "tap", "args": {"name": "wire"}}
     ]},
     "compress_images": false,
     "positronic_version": "0.2.1"
@@ -104,6 +105,9 @@ This metadata tells the client:
   `positronic.policy.spec.WIRE_WRAPPERS` — an unknown entry fails at connect, before the robot moves.
   An empty declaration (`{"seq": []}`) means the policy needs no rig-side glue; when the key is
   absent the server declares nothing and the client falls back to the standard `ChunkedSchedule`.
+  A `tap` entry names a seam worth recording rather than a transform: a rig given a `recording_dir`
+  logs the observation and action chunk crossing that point under the tap's name, and a rig that
+  records nowhere passes straight through it.
 - `compress_images` — the `remote` marker's own wire setting: whether the rig JPEG-encodes frames before
   sending, for an endpoint behind a proxy with a message-size cap
 - `positronic_version` — the server's positronic version, for diagnosing declaration mismatches
@@ -182,7 +186,7 @@ uv run positronic-inference sim \
 
 **Status Streaming:** Long model loads are handled gracefully with progress updates.
 
-**Server-side recording:** Servers accept an optional `recording_dir`. When set, each WebSocket session writes a rerun `.rrd` file that taps both sides of the codec: `raw` captures the obs/action at the wire boundary, and `inference` captures the encoded observation and raw model output.
+**Recording:** A `Tap` in the pipeline names a seam worth recording; every built-in pipeline names the one at the wire, and a rig given `--policy.recording_dir` writes a rerun `.rrd` per episode holding the observation and action chunk crossing each named seam. Servers additionally accept their own `recording_dir`, writing a separate file that taps both sides of the codec: `raw` captures the obs/action at the wire boundary, and `inference` captures the encoded observation and raw model output.
 
 **Python Client:** We provide a Python client (`positronic.offboard.client.InferenceClient`) that handles the WebSocket protocol automatically. While the API is currently in alpha and may change, we'll do our best to maintain backward compatibility for the inference client.
 
@@ -200,7 +204,7 @@ pipeline = ChunkedSchedule() | remote | PolicySource(my_policy)
 PolicyServer(pipeline, host='0.0.0.0', port=8000).serve()
 ```
 
-`PolicySource` serves one ready in-process policy; vendors instead define a `ModelSource` over a checkpoint directory. Passing a `cfn.Config` that builds the pipeline — as the vendor servers do with their named pipelines — enables [session parameters](#session-parameters); an instantiated pipeline serves exactly as launched. `recording_dir` enables the per-session recording taps described above, and `idle_timeout_min` shuts the server down after that many minutes without activity.
+`PolicySource` serves one ready in-process policy; vendors instead define a `ModelSource` over a checkpoint directory. Passing a `cfn.Config` that builds the pipeline — as the vendor servers do with their named pipelines — enables [session parameters](#session-parameters); an instantiated pipeline serves exactly as launched. `recording_dir` enables the server-side recording described above, and `idle_timeout_min` shuts the server down after that many minutes without activity.
 
 ### `server.serve`
 The CLI entry point every vendor server exposes. A vendor binds `pipeline` to each of its named pipelines and lists the results as subcommands, so `<vendor>-server <pipeline>` launches one. Only `--host`, `--port`, `--recording_dir` and `--idle_timeout_min` are flags of `serve` itself; everything the served model is — codec, source, checkpoint directory — is reached through the pipeline (`--pipeline.source.checkpoints_dir=...`), which is also where a deployment preset binds it.

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -255,6 +255,10 @@ class PolicyServer:
             assert rid is not None
             policy = await self._manager.get_policy(rid, websocket)
             if self._recording_dir is not None:
+                # TODO(#534): these seams are hardcoded here while the rig's are declared by the pipeline
+                # (``Tap``), and they land in a file on the server's disk and clock that nobody fetches. Both
+                # go once the serving half can report into the rig's recording: a ``Tap`` in the remote half
+                # of the pipeline, shipped back on the inference response.
                 # Tap both sides: 'raw' is the wire boundary, 'inference' the encoded obs and model output.
                 rec = Recorder(self._recording_dir)
                 if remote_half is not None:

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -3,12 +3,14 @@ import time
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pos3
 import pytest
 
 from positronic import keys, telemetry, telemetry_keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient
-from positronic.policy import RemotePolicy
+from positronic.policy import DelegatingSession, RemotePolicy, Session
 from positronic.policy.codec import ActionHorizon
+from positronic.policy.recording import _RecordingTapSession
 from positronic.policy.remote import RemoteSession
 from positronic.policy.wrappers import ChunkedSchedule
 
@@ -327,6 +329,66 @@ def test_unknown_declared_entry_fails_before_motion():
     policy, _ = _mock_remote_policy({'local_stack': {'name': 'run_arbitrary_code'}, 'positronic_version': '9.9.9'})
     with pytest.raises(ValueError, match='9.9.9'):
         policy.new_session()
+
+
+WIRE_TAP_STACK = {'local_stack': {'seq': [{'name': 'chunked_schedule'}, {'name': 'tap', 'args': {'name': 'wire'}}]}}
+
+
+def _recording_policy(metadata, tmp_path, **kwargs):
+    """A mocked-wire ``RemotePolicy`` recording into ``tmp_path``."""
+    with pos3.mirror():
+        return _mock_remote_policy(metadata, recording_dir=str(tmp_path), **kwargs)
+
+
+def _tap_session(session: Session) -> _RecordingTapSession:
+    """The tap the declared stack built, under the scheduling wrapper that gates it."""
+    assert isinstance(session, DelegatingSession)
+    tap = session._inner
+    assert isinstance(tap, _RecordingTapSession)
+    return tap
+
+
+def test_declared_tap_records_under_the_seam_it_names(tmp_path):
+    policy, _ = _recording_policy(WIRE_TAP_STACK, tmp_path, infer_return=[{'a': 1, 'timestamp': 0.0}])
+    session = policy.new_session(now=lambda: 0.0)
+    session({'obs_time_ns': 0, 'cam': _make_image(48, 64)})
+
+    assert _tap_session(session)._rec._image_paths == ['wire/cam']
+    assert len(list(tmp_path.glob('*.rrd'))) == 1
+
+
+def test_declared_tap_logs_once_per_inference_not_once_per_tick(tmp_path):
+    """A seam inside the declared stack sits below ``ChunkedSchedule``, so a tick that runs no inference
+    has nothing to log."""
+    policy, _ = _recording_policy(WIRE_TAP_STACK, tmp_path, infer_return=[{'a': 1, 'timestamp': 0.5}])
+    clock = [0.0]
+    session = policy.new_session(now=lambda: clock[0])
+    for t in (0.0, 0.1, 0.2):
+        clock[0] = t
+        session({'obs_time_ns': 0, 'cam': _make_image(48, 64)})
+
+    assert _tap_session(session)._step == 1
+
+
+def test_recording_dir_against_a_server_that_names_no_seam(tmp_path, caplog):
+    """The seams are the served pipeline's to name, so a rig told to record can end up with nothing —
+    say so rather than leaving an empty directory."""
+    policy, _ = _recording_policy(EMPTY_STACK, tmp_path, infer_return=[{'a': 1, 'timestamp': 0.0}])
+    with caplog.at_level(logging.WARNING, logger='positronic.policy.remote'):
+        session = policy.new_session(now=lambda: 0.0)
+    session({'obs_time_ns': 0, 'cam': _make_image(48, 64)})
+
+    assert 'no tap' in caplog.text
+    assert not list(tmp_path.glob('*.rrd'))
+
+
+def test_legacy_server_records_at_the_wire(tmp_path):
+    """A server that declares no stack gets the rig's stand-in, seam included."""
+    policy, _ = _recording_policy({}, tmp_path, infer_return=[{'a': 1, 'timestamp': 0.0}])
+    session = policy.new_session(now=lambda: 0.0)
+    session({'obs_time_ns': 0, 'cam': _make_image(48, 64)})
+
+    assert _tap_session(session)._rec._image_paths == ['wire/cam']
 
 
 def test_operator_local_drives_a_server_that_declares_nothing():

--- a/positronic/policy/__init__.py
+++ b/positronic/policy/__init__.py
@@ -1,6 +1,6 @@
 from .base import DelegatingPolicy, DelegatingSession, Policy, PolicyWrapper, SampledPolicy, Session
 from .codec import ActionHorizon, ActionTimestamp, ActionTiming, Codec, is_action
-from .recording import Recorder
+from .recording import Recorder, Tap
 from .remote import RemotePolicy
 from .sampler import BalancedSampler, Sampler, UniformSampler
 
@@ -18,6 +18,7 @@ __all__ = [
     'ActionTiming',
     'is_action',
     'Recorder',
+    'Tap',
     'Sampler',
     'UniformSampler',
     'BalancedSampler',

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -4,20 +4,17 @@ Recordings are written with `rerun <https://rerun.io>`_, a logging/visualization
 tool. Each episode becomes one ``.rrd`` file in the recording directory; open it in
 the rerun viewer to inspect what flowed through the policy.
 
-A :class:`Recorder` hands out lightweight ``tap(name)`` wrappers. A tap inserted
-into a policy pipeline logs the observation passing *down* through it and the action
-chunk coming back *up*, under entity paths prefixed by its ``name``. Placing two
-taps at different points captures both ends of a remote inference round-trip in one
-correlated recording::
+A :class:`Tap` names a seam in a policy pipeline — a point worth recording. It logs
+the observation passing *down* through it and the action chunk coming back *up*,
+under entity paths prefixed by its ``name``, once a :class:`Recorder` binds it::
+
+    pipeline = ChunkedSchedule() | Tap('wire') | remote | codec | source
 
     rec = Recorder(recording_dir)
-    pipeline = rec.tap('raw') | codec | rec.tap('server')
-    policy = pipeline.wrap(remote_policy)
+    stack = from_spec(declared_local_stack, tap=rec.tap)
 
-- the ``raw`` tap (outermost) logs the observation as received and the final action
-  chunk;
-- the ``server`` tap (innermost, next to the remote policy) logs the observation as
-  sent to the server and the chunk as received back.
+Several taps bound to one recorder write to the same file, so seams on either side
+of a transform read as one correlated recording.
 
 Each entity is stamped on the timelines given by ``timelines`` (a mapping of rerun
 timeline name to observation key; by default ``wall_time`` and ``obs_time``
@@ -279,8 +276,26 @@ def _log_ee_pose_chunk(
     return np.concatenate([translations, quats_wxyz], axis=1)
 
 
+class Tap(PolicyWrapper):
+    """A named seam in a policy pipeline: the point whose observations and actions are worth recording.
+
+    A tap names the seam and nothing else; where its entries land is the builder's call
+    (``from_spec(..., tap=...)``). ``Recorder.tap`` returns one bound to a recording; unbound, a tap
+    passes the policy through untouched.
+    """
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def wrap_session(self, inner: Session, context, now) -> Session:
+        return inner
+
+    def to_spec(self) -> dict[str, Any]:
+        return {'name': 'tap', 'args': {'name': self._name}}
+
+
 class Recorder:
-    """Writes one rerun ``.rrd`` file per episode and hands out ``tap(name)`` wrappers.
+    """Writes one rerun ``.rrd`` file per episode, and builds the taps that log into it.
 
     Taps share the recorder's current episode stream, so taps placed at different
     points in one pipeline write to the same recording. The episode boundary is
@@ -335,12 +350,12 @@ class Recorder:
         self._live -= 1
 
 
-class _RecordingTap(PolicyWrapper):
-    """A named tap. Wraps a single session to log its observations and actions."""
+class _RecordingTap(Tap):
+    """A tap bound to a ``Recorder``. Wraps a single session to log its observations and actions."""
 
     def __init__(self, rec: Recorder, name: str):
+        super().__init__(name)
         self._rec = rec
-        self._name = name
 
     def wrap_session(self, inner: Session, context, now) -> Session:
         stream = self._rec._open_stream()

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -13,7 +13,7 @@ from positronic.utils.serialization import encode_jpeg
 
 from .base import Policy, PolicyWrapper, Session
 from .codec import RestrictImageSize
-from .recording import Recorder
+from .recording import Recorder, Tap
 from .spec import from_spec
 from .wrappers import ChunkedSchedule
 
@@ -167,7 +167,8 @@ class RemotePolicy(Policy):
     ``local`` — with the ``image_sizes`` such a server reports bounding the wire either way.
 
     ``local`` and ``compress_images`` stand in for a server that declares neither — see
-    ``_operator_override``. ``recording_dir`` taps the raw and wire boundaries around the stack.
+    ``_operator_override``. ``recording_dir`` is where the recording goes; which seams it holds is
+    the declaration's call, one ``.rrd`` entry per ``Tap`` the stack names.
     """
 
     def __init__(
@@ -190,35 +191,42 @@ class RemotePolicy(Policy):
         declared = meta.get('local_stack')
         # Settles the operator's stack against the declaration before either is built.
         _operator_override('local', self._local, declared)
+        rec = Recorder(self._recording_dir) if self._recording_dir is not None else None
+        seams: list[str] = []
+
+        def tap(name: str) -> PolicyWrapper:
+            seams.append(name)
+            return rec.tap(name) if rec is not None else Tap(name)
+
         if declared is not None:
             try:
-                return from_spec(declared)
+                stack = from_spec(declared, tap)
             except Exception as e:
                 version = meta.get('positronic_version', 'unknown')
                 raise ValueError(f'Cannot build the server-declared local stack (server positronic {version})') from e
+            if rec is not None and not seams:
+                logger.warning(
+                    'recording_dir is set but the declared stack names no tap, so nothing is recorded; a seam '
+                    'is named by the pipeline the server serves'
+                )
+            return stack
         # The bound is a wire setting rather than part of the stack, so it outlives whichever stack runs.
         stack = ChunkedSchedule() if self._local is None else self._local
         bound = _legacy_bound(meta['image_sizes']) if 'image_sizes' in meta else None
         if bound is None:
             logger.info('Server declares no local stack and names no image geometry; frames go out unbounded')
-            return stack
-        logger.warning(
-            'Server declares no local stack; bounding frames to %r from the image_sizes %r it reports',
-            bound.to_spec()['args'],
-            meta['image_sizes'],
-        )
-        return stack | bound
+        else:
+            logger.warning(
+                'Server declares no local stack; bounding frames to %r from the image_sizes %r it reports',
+                bound.to_spec()['args'],
+                meta['image_sizes'],
+            )
+            stack = stack | bound
+        return stack | tap('wire')
 
     def _policy(self) -> Policy:
         if self._stacked is None:
             stack = self._resolve_stack()
-            if self._recording_dir is not None:
-                rec = Recorder(self._recording_dir)
-                if stack is None:
-                    # With no stack the raw and wire boundaries coincide, so a single tap.
-                    stack = rec.tap('raw')
-                else:
-                    stack = rec.tap('raw') | stack | rec.tap('server')
             self._stacked = stack.wrap(self._endpoint) if stack is not None else self._endpoint
         return self._stacked
 

--- a/positronic/policy/spec.py
+++ b/positronic/policy/spec.py
@@ -46,6 +46,7 @@ from positronic.policy.codec import (
     RestrictImageSize,
 )
 from positronic.policy.observation import ObservationCodec
+from positronic.policy.recording import Tap
 from positronic.policy.wrappers import ChunkedSchedule, TemporalStack
 
 
@@ -159,6 +160,7 @@ WIRE_WRAPPERS: dict[str, type[PolicyWrapper]] = {
     'restrict_image_size': RestrictImageSize,
     'change_ee_frame': ChangeEEFrame,
     'observation_codec': ObservationCodec,
+    'tap': Tap,
     'absolute_position_action': AbsolutePositionAction,
     'absolute_joints_action': AbsoluteJointsAction,
     'relative_position_action': RelativePositionAction,
@@ -192,18 +194,23 @@ def inline(pipeline: Pipeline) -> Policy:
     return joined.wrap(policy) if joined is not None else policy
 
 
-def from_spec(node: dict[str, Any]) -> PolicyWrapper | None:
+def from_spec(node: dict[str, Any], tap: Callable[..., PolicyWrapper] = Tap) -> PolicyWrapper | None:
     """Rebuild a declared local stack from its wire spec; ``None`` for an empty declaration.
+
+    ``tap`` builds each declared seam, so where a recording lands is the builder's call rather than
+    the declaration's: a rig that records passes ``Recorder.tap``, and the default records nothing.
 
     Unknown entry names raise ``ValueError`` and unknown arguments ``TypeError`` — a declaration
     this build cannot honor fails before anything moves.
     """
     if SEQ in node:
-        parts = tuple(part for part in (from_spec(child) for child in node[SEQ]) if part is not None)
+        parts = tuple(part for part in (from_spec(child, tap) for child in node[SEQ]) if part is not None)
         return _join(parts)
     if PAR in node:
-        return functools.reduce(operator.and_, (from_spec(child) for child in node[PAR]))
+        return functools.reduce(operator.and_, (from_spec(child, tap) for child in node[PAR]))
     name = node.get('name')
     if name not in WIRE_WRAPPERS:
         raise ValueError(f'Unknown local-stack entry {name!r}; this build knows {sorted(WIRE_WRAPPERS)}')
-    return WIRE_WRAPPERS[name](**node.get('args', {}))
+    cls = WIRE_WRAPPERS[name]
+    args = node.get('args', {})
+    return tap(**args) if cls is Tap else cls(**args)

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -4,7 +4,7 @@ from positronic import keys
 from positronic.drivers.roboarm.command import CartesianPosition
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
-from positronic.policy.recording import Recorder, _build_blueprint, _squeeze_batch, _stack_numeric
+from positronic.policy.recording import Recorder, Tap, _build_blueprint, _squeeze_batch, _stack_numeric
 
 
 class _TrackingSession(Session):
@@ -97,6 +97,16 @@ def test_tap_delegates_inner_call(tmp_path):
     session = policy.new_session()
     result = session({'x': 1.0, 'wall_time_ns': 1_000_000})
     assert result == actions
+
+
+def test_unbound_tap_leaves_the_policy_alone():
+    """A seam nothing is bound to — an in-process pipeline, or a rig that records nowhere."""
+    actions = [{'v': 1, 'timestamp': 0.0}]
+    inner = _TrackingPolicy(actions)
+    session = Tap('wire').wrap(inner).new_session()
+
+    assert session({'x': 1.0, 'wall_time_ns': 1}) == actions
+    assert session.meta == inner.meta
 
 
 def test_tap_meta_passthrough(tmp_path):

--- a/positronic/policy/tests/test_wrappers.py
+++ b/positronic/policy/tests/test_wrappers.py
@@ -27,6 +27,7 @@ from positronic.policy.codec import (
     RestrictImageSize,
 )
 from positronic.policy.observation import ObservationCodec
+from positronic.policy.recording import Tap
 from positronic.policy.wrappers import ChunkedSchedule, TemporalStack
 
 
@@ -319,6 +320,20 @@ class TestPipelineSpec:
         rebuilt = spec.from_spec(stack.to_spec())
         assert rebuilt is not None and rebuilt.to_spec() == stack.to_spec()
 
+    def test_declared_seam_is_built_by_the_caller(self):
+        """A tap names a seam; what records there comes from the builder, not the declaration."""
+        seams: list[str] = []
+
+        def tap(name: str) -> PolicyWrapper:
+            seams.append(name)
+            return Tap(name)
+
+        stack = ChunkedSchedule() | Tap('wire')
+        rebuilt = spec.from_spec(stack.to_spec(), tap)
+
+        assert seams == ['wire']
+        assert rebuilt is not None and rebuilt.to_spec() == stack.to_spec()
+
     def test_codec_spec_round_trip(self):
         obs = ObservationCodec(
             state={'observation.state': {'grip': 1}}, images={'left': (keys.WRIST_IMAGE, (224, 224))}
@@ -379,6 +394,7 @@ class TestPipelineSpec:
             'flip_grip': FlipGrip(),
             'restrict_image_size': RestrictImageSize(),
             'observation_codec': ObservationCodec(state={}, images={}),
+            'tap': Tap('wire'),
             'absolute_position_action': AbsolutePositionAction(keys.TARGET_EE_POSE, 'target_grip'),
             'absolute_joints_action': AbsoluteJointsAction(keys.TARGET_JOINTS, 'target_grip'),
             'relative_position_action': RelativePositionAction(),

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -21,6 +21,7 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Codec, Policy, PolicyWrapper, Session
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.recording import Tap
 from positronic.policy.spec import ModelSource, remote
 from positronic.utils.checkpoints import list_checkpoints
 from positronic.utils.logging import init_logging
@@ -326,7 +327,7 @@ def pipeline(local: PolicyWrapper, codec: Codec, source: ModelSource, width: int
 
     ``width``/``height`` bound frames on the rig and follow the codec's own geometry.
     """
-    return local | RestrictImageSize(width, height) | remote | codec | source
+    return local | RestrictImageSize(width, height) | Tap('wire') | remote | codec | source
 
 
 joints = pipeline

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -17,6 +17,7 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Policy, Session
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.recording import Tap
 from positronic.policy.spec import ModelSource, remote
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils.checkpoints import list_checkpoints
@@ -320,7 +321,7 @@ gr00t_source = cfn.Config(Gr00tSource)
 
 @cfn.config(codec=codecs.ee_quat, source=gr00t_source)
 def pipeline(codec, source):
-    return ChunkedSchedule() | RestrictImageSize(224, 224) | remote | codec | source
+    return ChunkedSchedule() | RestrictImageSize(224, 224) | Tap('wire') | remote | codec | source
 
 
 # Each entry pairs the codec with the matching GR00T modality config; they must agree with training.

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -11,6 +11,7 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress
 from positronic.policy import Codec, Policy
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.recording import Tap
 from positronic.policy.spec import ModelSource, Pipeline, remote
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils.checkpoints import list_checkpoints, resolve_checkpoint
@@ -57,7 +58,7 @@ lerobot_source = cfn.Config(LerobotSource, checkpoint=None, device=None)
 
 @cfn.config(codec=lerobot_codecs.ee, source=lerobot_source)
 def pipeline(codec: Codec, source: ModelSource) -> Pipeline:
-    return ChunkedSchedule() | RestrictImageSize(512, 512) | remote | codec | source
+    return ChunkedSchedule() | RestrictImageSize(512, 512) | Tap('wire') | remote | codec | source
 
 
 ee = pipeline

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -13,6 +13,7 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress
 from positronic.policy import Codec, Policy
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.recording import Tap
 from positronic.policy.spec import ModelSource, remote
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils.checkpoints import list_checkpoints, resolve_checkpoint
@@ -79,7 +80,7 @@ lerobot_source = cfn.Config(LerobotSource, policy_factory=act)
 
 @cfn.config(codec=lerobot_codecs.ee, source=lerobot_source)
 def pipeline(codec: Codec, source: ModelSource):
-    return ChunkedSchedule() | RestrictImageSize(224, 224) | remote | codec | source
+    return ChunkedSchedule() | RestrictImageSize(224, 224) | Tap('wire') | remote | codec | source
 
 
 ee = pipeline

--- a/positronic/vendors/molmoact2/server.py
+++ b/positronic/vendors/molmoact2/server.py
@@ -7,6 +7,7 @@ import configuronic as cfn
 from positronic.offboard.server import serve
 from positronic.policy import Codec, Policy
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.recording import Tap
 from positronic.policy.spec import ModelSource, remote
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils.logging import init_logging
@@ -57,7 +58,7 @@ molmoact2_source = cfn.Config(MolmoAct2Source)
 
 @cfn.config(codec=molmoact2_codecs.droid, source=molmoact2_source)
 def pipeline(codec: Codec, source: ModelSource):
-    return ChunkedSchedule() | RestrictImageSize() | remote | codec | source
+    return ChunkedSchedule() | RestrictImageSize() | Tap('wire') | remote | codec | source
 
 
 droid = pipeline

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -15,6 +15,7 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Codec, Policy, Session
 from positronic.policy.codec import ChangeEEFrame, RestrictImageSize
+from positronic.policy.recording import Tap
 from positronic.policy.spec import ModelSource, remote
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils.checkpoints import get_latest_checkpoint, list_checkpoints
@@ -249,7 +250,7 @@ def pipeline(codec: Codec, source: ModelSource, ee_frame: geom.Transform3D | Non
     if ee_frame is not None:
         # Outermost, so everything downstream — the wire, the server's codec — sees poses already in ``ee_frame``.
         local = ChangeEEFrame(ee_frame) | local
-    return local | remote | codec | source
+    return local | Tap('wire') | remote | codec | source
 
 
 ee = pipeline


### PR DESCRIPTION
Step 1 of #534: the client half. The server shipping its own entries into the rig's stream is a
follow-up, tracked by a `TODO(#534)` on the code it replaces.

## Summary

`RemotePolicy` bracketed the server-declared stack with taps it authored itself —
`rec.tap('raw') | stack | rec.tap('server')`. The outer one sat *above* `ChunkedSchedule`, which
returns `None` on ticks that run no inference, so it logged every control tick: ~13 observations per
inference. Two runs of the same rig, same episode length, same cameras: 52 frames per camera before
#497, **687** after; ~4 MB per episode became **227 MB**.

- A `Tap(name)` names a seam in the pipeline itself — `... | Tap('wire') | remote | codec | source` —
  and travels to the rig inside the `local_stack` declaration, joining `WIRE_WRAPPERS` like any other
  entry.
- `from_spec(node, tap=...)` builds each declared seam through a factory, so where a recording lands
  is the builder's call rather than the declaration's: the rig points it at its `Recorder`, and a rig
  that records nowhere passes straight through. The tap is the only entry whose behaviour is not
  fully described by its args, so it is the only one routed this way; the vocabulary table stays
  closed.
- The client stops authoring taps. `recording_dir` still says *where* the file goes; *what* goes into
  it is the served pipeline's call. `raw` is gone — the dataset writer already records the rig's
  cameras and state at control rate.
- The volume problem stops existing rather than being suppressed: a seam below the scheduler only
  sees the ticks that ran an inference. No gate, no frame-rate cap.
- All six vendor pipelines name their wire seam. A rig given `recording_dir` against a server that
  names none records nothing and says so at connect.
- The legacy stand-in for a server that declares no stack at all (`TODO(#514)`) keeps a wire seam, so
  `--policy.recording_dir` does not silently stop working against those servers.

Left alone deliberately: the server's own `recording_dir` and its hardcoded `raw`/`inference` taps.
Those go once a `Tap` in the remote half can report into the rig's stream, which needs the wire
protocol change this PR does not make.

## Test plan

- `uv run --locked --extra dev pytest --no-cov` — 950 passed.
- New tests: the declared seam records under the name it was given; a declared seam logs once per
  inference across three gated ticks (the regression); `recording_dir` against a declaration with no
  tap warns and writes nothing; the legacy path still records; an unbound `Tap` leaves the policy
  untouched; `from_spec` routes the seam through the caller's factory; `tap` joins the wire-name
  table check.
- End to end over a real websocket (`PolicyServer` declaring `chunked_schedule | tap`, a real
  `RemotePolicy` recording), 20 control ticks / 4 inferences:

  | recording shape | image logs | `.rrd` bytes |
  |---|---|---|
  | declared tap, at the wire | 4 (`wire/image.exterior`) | 46,560 |
  | tap wrapped around the stack (this PR removes) | 20 (`raw/image.exterior`) | 110,152 |

- Not verified: a full eval against a real vendor server with a loaded checkpoint.