### PR TITLE
Let an open review thread mean one thing: a human still owes an answer

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -298,8 +298,9 @@ When the watcher exits and you are re-invoked:
   is what ratifies a decline, for the threads it is owed to (Principles), so **resolve those
   before reporting**; what stays open is what a person has still not answered — a question they
   asked, a call escalated to them, a decline of their own comment. Give the final report and
-  **notify the user** (a push notification if available) that the review loop is done — they
-  walked away expecting to be pinged.
+  **notify the user** (a push notification if available) that the review loop is done, naming
+  what is still waiting on them — they walked away expecting to be pinged, and "done" here means
+  the agent has nothing left to do, not that the PR is clean.
 - **exit 30** — a quiet interval elapsed with no CI failure, new round, or sign-off. The PR
   isn't done, so **don't stop**: relaunch the watcher to keep waiting (reviewers and slow CI can
   take far longer than one interval). Only after several consecutive quiet cycles — i.e. a long

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -37,11 +37,15 @@ needs their call. A red build is never "done", no matter what the reviewer says.
   thread left open reads as still-broken to anyone scanning the PR; a PR whose open threads mix
   live questions with settled arguments teaches its reader that open means nothing, so the one
   thread that did need them goes unread. Never resolve a thread just to clear the queue.
-- **Ratified means the party the decline is owed to has answered it** — nobody else can.
-  A **human's** approval settles what you declined of a **bot's** findings; a human's own
-  comment is settled by that human alone. A bot's 👍 says nothing about whether a person accepted
-  your reasoning, and on a PR with two reviewers one approval says nothing about the other's
-  thread. Read a sign-off for whose it is before it settles anything.
+- **Ratified means the party the decline is owed to has answered it, after it was made** —
+  nobody else can, and nothing earlier can. A **human's** approval settles what you declined of a
+  **bot's** findings; a human's own comment is settled by that human alone. A bot's 👍 says
+  nothing about whether a person accepted your reasoning, and on a PR with two reviewers one
+  approval says nothing about the other's thread. Nor does an approval reach backwards: a round
+  that lands findings on an already-approved commit and is answered by declines produces no new
+  commit, so the old approval still stands against that SHA while postdating nothing — it was
+  given before the argument it would be settling existed. Read a sign-off for whose it is and
+  when it was given, before it settles anything.
 - **Stay scoped** to the feedback. Don't sprawl into unrelated refactors.
 - **Follow the repo's commit conventions** (see the `push-pr` skill). CRITICAL: never add
   `Co-Authored-By` or any AI / Claude / assistant attribution to commits, replies, or PRs.

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -286,12 +286,15 @@ When the watcher exits and you are re-invoked:
   your prior reasoning, then **stop and surface it for the user**; never loop into forcing a
   fix you disagree with.
 - **exit 20** — converged: CI is green on the pushed commit, a reviewer signed off (Codex 👍
-  newer than your push, or a human approval), and every comment carries your reply. The sign-off
-  is the ratification a declined or deferred thread was waiting for, so **resolve those before
-  reporting** — what stays open is only what a person has still not answered: a question they
-  asked, a call escalated to them. Give the final report and **notify the user** (a push
-  notification if available) that the review loop is done — they walked away expecting to be
-  pinged.
+  newer than your push, or a human approval), and every comment carries your reply. A sign-off
+  ratifies a decline only where it comes from the party the decline is owed to: a **human's**
+  approval settles what you declined of a **bot's** findings, and a human's own comment is
+  settled by that human alone — a bot's 👍 says nothing about whether they accepted your
+  reasoning, and neither does a second reviewer's approval about the first one's thread.
+  **Resolve what is ratified before reporting**; what stays open is what a person has still not
+  answered — a question they asked, a call escalated to them, a decline of their own comment.
+  Give the final report and **notify the user** (a push notification if available) that the
+  review loop is done — they walked away expecting to be pinged.
 - **exit 30** — a quiet interval elapsed with no CI failure, new round, or sign-off. The PR
   isn't done, so **don't stop**: relaunch the watcher to keep waiting (reviewers and slow CI can
   take far longer than one interval). Only after several consecutive quiet cycles — i.e. a long

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: address-review
-description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
+description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve every thread that is settled, leaving open only what still needs a human's answer. Use when a PR has reviewer or bot (e.g. Codex) comments to address.
 allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(awk:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*), Edit, Write
 ---
 
@@ -8,8 +8,8 @@ allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git d
 
 One full cycle of responding to review feedback on the current branch's PR: read every
 unresolved comment, decide on the merits, fix what is worth fixing, then commit, push,
-reply, and resolve **only the threads you fixed**. Declines, defers, and discussion /
-question comments get a reasoned reply and stay **open** — closing them is the human's call.
+reply, and resolve every thread that is **settled**. What stays **open** is what a human still
+owes an answer on — a decline they have not ratified, a question they asked.
 
 The `push-pr` skill delegates here when review comments arrive. After each push this skill
 watches **both CI (GitHub Actions on the pushed commit) and the reviewer's asynchronous
@@ -29,16 +29,14 @@ needs their call. A red build is never "done", no matter what the reviewer says.
   intentional.
 - **Fix → push → reply → resolve, in that order.** Reply text references the commit that
   fixed it, so the fix must land first.
-- **Every thread you fixed MUST be resolved — and only those.** Once a bot comment's fix is
-  pushed and you have replied referencing the commit, resolve its thread: a fixed Codex
-  thread left open reads as still-broken to anyone scanning the PR and leaves the conversation
-  cluttered with items already handled. The two directions are symmetric and both mandatory:
-  **fixed → resolve**, and **declines,
-  defers, and discussion / question comments stay OPEN** — those get a reasoned reply, but
-  resolving them closes a conversation that is the human's to close (especially a reviewer's
-  "why…?" or "should we…?", which is an invitation to discuss, not a change request). Never
-  resolve a thread just to clear the queue, and never leave a thread you fixed unresolved.
-  When a comment is on the fence, leave it open.
+- **An OPEN thread means a human still owes an answer here — nothing else.** So the question
+  per thread is not "was this a fix or a decline" but "is a person's answer still outstanding".
+  **Settled → resolve**: a fix you pushed, a decline or deferral the human has ratified. **Not
+  settled → open**: a decline or defer on your own judgement that they have not seen yet, a
+  question they asked, a design call you escalated. Both directions are mandatory. A fixed
+  thread left open reads as still-broken to anyone scanning the PR; a PR whose open threads mix
+  live questions with settled arguments teaches its reader that open means nothing, so the one
+  thread that did need them goes unread. Never resolve a thread just to clear the queue.
 - **Stay scoped** to the feedback. Don't sprawl into unrelated refactors.
 - **Follow the repo's commit conventions** (see the `push-pr` skill). CRITICAL: never add
   `Co-Authored-By` or any AI / Claude / assistant attribution to commits, replies, or PRs.
@@ -102,9 +100,9 @@ For each open comment, decide and note severity if the bot tagged one (e.g. Code
 - **Partial / alternative** — valid concern, but a different fix than suggested → explain;
   resolve only if you land a concrete change, else leave open.
 - **Decline** — wrong, not applicable, or contradicts a deliberate decision → reasoned
-  reply, **leave open**.
-- **Defer** — valid but out of scope for this PR → reply (note where it's tracked),
-  **leave open**.
+  reply; **leave open** until the human ratifies it, **resolve** once they have.
+- **Defer** — valid but out of scope for this PR → reply naming where it is tracked; same
+  rule — **open** until they agree the deferral is right, **resolved** after.
 - **Discuss** — the reviewer is asking a question or opening a design discussion, not
   requesting a change → answer it, **leave open** for them to respond.
 
@@ -213,17 +211,17 @@ query($owner:String!,$repo:String!,$num:Int!,$after:String){
 gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread { isResolved } } }' -f id=<thread_node_id>
 ```
 
-**Leave declined, deferred, and discussion threads OPEN** — each carries a reasoned reply,
-but closing the conversation is the human's call (resolving a "why…?"/"should we…?" thread
-preempts a discussion they opened on purpose). The reply records your reasoning either way,
-and the human resolves when satisfied.
+**Resolve a settled thread whichever way it settled** — a landed fix, or a decline/deferral
+the human has ratified (the reply records the reasoning either way). **Leave open** only what
+still needs them: a decline they have not seen, a "why…?"/"should we…?" they opened on purpose,
+a design call you escalated.
 
 ## Step 6: Report
 
 Summarize:
 - a table of comment → verdict → fix (with commit SHA),
 - what was pushed,
-- which threads you resolved (fixes only) vs left open (declines / defers / discussion),
+- which threads you resolved (settled) vs left open, each with what the human owes on it,
 - any follow-ups the user should track.
 
 A bot will re-review on push and may add comments. **Don't hand the watch back to the

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -286,10 +286,12 @@ When the watcher exits and you are re-invoked:
   your prior reasoning, then **stop and surface it for the user**; never loop into forcing a
   fix you disagree with.
 - **exit 20** — converged: CI is green on the pushed commit, a reviewer signed off (Codex 👍
-  newer than your push, or a human approval), and every comment carries your reply (open
-  declines / defers / discussions are fine). Give the final report and **notify the user** (a
-  push notification if available) that the review loop is done — they walked away expecting to
-  be pinged.
+  newer than your push, or a human approval), and every comment carries your reply. The sign-off
+  is the ratification a declined or deferred thread was waiting for, so **resolve those before
+  reporting** — what stays open is only what a person has still not answered: a question they
+  asked, a call escalated to them. Give the final report and **notify the user** (a push
+  notification if available) that the review loop is done — they walked away expecting to be
+  pinged.
 - **exit 30** — a quiet interval elapsed with no CI failure, new round, or sign-off. The PR
   isn't done, so **don't stop**: relaunch the watcher to keep waiting (reviewers and slow CI can
   take far longer than one interval). Only after several consecutive quiet cycles — i.e. a long

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -221,7 +221,7 @@ gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:
 ```
 
 **Resolve a settled thread whichever way it settled** — a landed fix, or a ratified decline/deferral (the reply records the reasoning either way). **Leave open** only what
-still needs them: a decline they have not seen, a "why…?"/"should we…?" they opened on purpose,
+still needs them: a decline they have not answered, a "why…?"/"should we…?" they opened on purpose,
 a design call you escalated.
 
 ## Step 6: Report

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -31,12 +31,17 @@ needs their call. A red build is never "done", no matter what the reviewer says.
   fixed it, so the fix must land first.
 - **An OPEN thread means a human still owes an answer here — nothing else.** So the question
   per thread is not "was this a fix or a decline" but "is a person's answer still outstanding".
-  **Settled → resolve**: a fix you pushed, a decline or deferral the human has ratified. **Not
-  settled → open**: a decline or defer on your own judgement that they have not seen yet, a
+  **Settled → resolve**: a fix you pushed, a decline or deferral that has been ratified. **Not
+  settled → open**: a decline or defer on your own judgement nobody has answered yet, a
   question they asked, a design call you escalated. Both directions are mandatory. A fixed
   thread left open reads as still-broken to anyone scanning the PR; a PR whose open threads mix
   live questions with settled arguments teaches its reader that open means nothing, so the one
   thread that did need them goes unread. Never resolve a thread just to clear the queue.
+- **Ratified means the party the decline is owed to has answered it** — nobody else can.
+  A **human's** approval settles what you declined of a **bot's** findings; a human's own
+  comment is settled by that human alone. A bot's 👍 says nothing about whether a person accepted
+  your reasoning, and on a PR with two reviewers one approval says nothing about the other's
+  thread. Read a sign-off for whose it is before it settles anything.
 - **Stay scoped** to the feedback. Don't sprawl into unrelated refactors.
 - **Follow the repo's commit conventions** (see the `push-pr` skill). CRITICAL: never add
   `Co-Authored-By` or any AI / Claude / assistant attribution to commits, replies, or PRs.
@@ -100,9 +105,9 @@ For each open comment, decide and note severity if the bot tagged one (e.g. Code
 - **Partial / alternative** — valid concern, but a different fix than suggested → explain;
   resolve only if you land a concrete change, else leave open.
 - **Decline** — wrong, not applicable, or contradicts a deliberate decision → reasoned
-  reply; **leave open** until the human ratifies it, **resolve** once they have.
+  reply; **leave open** until it is ratified, **resolve** once it is.
 - **Defer** — valid but out of scope for this PR → reply naming where it is tracked; same
-  rule — **open** until they agree the deferral is right, **resolved** after.
+  rule — **open** until the deferral is ratified, **resolved** after.
 - **Discuss** — the reviewer is asking a question or opening a design discussion, not
   requesting a change → answer it, **leave open** for them to respond.
 
@@ -211,8 +216,7 @@ query($owner:String!,$repo:String!,$num:Int!,$after:String){
 gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread { isResolved } } }' -f id=<thread_node_id>
 ```
 
-**Resolve a settled thread whichever way it settled** — a landed fix, or a decline/deferral
-the human has ratified (the reply records the reasoning either way). **Leave open** only what
+**Resolve a settled thread whichever way it settled** — a landed fix, or a ratified decline/deferral (the reply records the reasoning either way). **Leave open** only what
 still needs them: a decline they have not seen, a "why…?"/"should we…?" they opened on purpose,
 a design call you escalated.
 
@@ -287,14 +291,11 @@ When the watcher exits and you are re-invoked:
   fix you disagree with.
 - **exit 20** — converged: CI is green on the pushed commit, a reviewer signed off (Codex 👍
   newer than your push, or a human approval), and every comment carries your reply. A sign-off
-  ratifies a decline only where it comes from the party the decline is owed to: a **human's**
-  approval settles what you declined of a **bot's** findings, and a human's own comment is
-  settled by that human alone — a bot's 👍 says nothing about whether they accepted your
-  reasoning, and neither does a second reviewer's approval about the first one's thread.
-  **Resolve what is ratified before reporting**; what stays open is what a person has still not
-  answered — a question they asked, a call escalated to them, a decline of their own comment.
-  Give the final report and **notify the user** (a push notification if available) that the
-  review loop is done — they walked away expecting to be pinged.
+  is what ratifies a decline, for the threads it is owed to (Principles), so **resolve those
+  before reporting**; what stays open is what a person has still not answered — a question they
+  asked, a call escalated to them, a decline of their own comment. Give the final report and
+  **notify the user** (a push notification if available) that the review loop is done — they
+  walked away expecting to be pinged.
 - **exit 30** — a quiet interval elapsed with no CI failure, new round, or sign-off. The PR
   isn't done, so **don't stop**: relaunch the watcher to keep waiting (reviewers and slow CI can
   take far longer than one interval). Only after several consecutive quiet cycles — i.e. a long

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -105,7 +105,11 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     echo "WATCH 10: new reviewer round — run another address-review pass (Steps 1-6)"; exit 10
   fi
   # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off. A human
-  # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA). Codex signs off
+  # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA). SHA-pinned is
+  # not time-ordered: a round that lands findings on an already-approved commit makes no new
+  # commit, so this approval keeps matching while predating the argument. It is a wake signal,
+  # never per-thread evidence — whether it ratifies a given decline is the resolve-time judgment
+  # the skill makes (Principles), which reads when the sign-off was given. Codex signs off
   # with a 👍 (+1) reaction, which carries no commit id and so can't be SHA-pinned like a review.
   # Anchor it on the PUSH: pushed_at = the earliest check-SUITE created_at on this SHA. GitHub
   # creates the suite the moment it receives the push, before any runner queues — so this tracks

--- a/.claude/skills/address-review/watch.sh
+++ b/.claude/skills/address-review/watch.sh
@@ -107,9 +107,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   # --- convergence: CI green (all checks done, none failing) AND a reviewer sign-off. A human
   # signs off via an APPROVED review pinned to the exact SHA (commit_id == $SHA). SHA-pinned is
   # not time-ordered: a round that lands findings on an already-approved commit makes no new
-  # commit, so this approval keeps matching while predating the argument. It is a wake signal,
-  # never per-thread evidence — whether it ratifies a given decline is the resolve-time judgment
-  # the skill makes (Principles), which reads when the sign-off was given. Codex signs off
+  # commit, so this approval keeps matching while predating the argument. Codex signs off
   # with a 👍 (+1) reaction, which carries no commit id and so can't be SHA-pinned like a review.
   # Anchor it on the PUSH: pushed_at = the earliest check-SUITE created_at on this SHA. GitHub
   # creates the suite the moment it receives the push, before any runner queues — so this tracks


### PR DESCRIPTION
The `address-review` skill resolves a thread when it is settled, whichever way it settled, and leaves open only what a person still owes an answer on.

## Why

The skill told every self-decline and every deferral to stay open, on the reasoning that closing someone else's disagreement is their call. Carried far enough that produces a pull request whose open threads contain no unfixed defect at all — a mix of declines already answered in-thread and comments on prose since rewritten — and an open count that says "outstanding" about nothing. A reader who learns that open means nothing stops reading open threads, and the one that did need them goes unread. positronic#504 reached eleven such threads.

The rule the skill now states is the one that makes the state readable: settled resolves — a landed fix, or a ratified decline, with the reply carrying the reasoning either way. Open is for a decline nobody has answered, a question they asked, or a call escalated to them.

Ratification is scoped to the party the decline is owed to, because "a reviewer signed off" otherwise collapses three different parties into one: a bot's pass says nothing about whether a human accepted the reasoning declining their own comment, and on a PR with two reviewers one approval says nothing about the other's thread. That criterion sits in Principles, beside the open/settled distinction it qualifies, since every step that resolves a thread turns on it.

The alternative worth naming is keeping declines open permanently and letting the human resolve them at merge. That is what the skill said, and it fails for the reason above: it makes the count meaningless well before merge, and it puts a clerical step on the person the discipline exists to serve.

## Verification

Docs only — `check-rules` clean over all six rules; no code path touched.

<!-- opened-by: posi-agent -->