### PR TITLE
Show the rollout batch assignment in the eval console

### DIFF
--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -106,7 +106,7 @@ class EvalUI(pimm.ControlSystem):
 
         # Handover state. `_batch_base_count` is the episode count when the current assignment was picked up,
         # so progress against the target counts this batch's recordings rather than the whole output directory.
-        self._assignment: handover.Assignment | None = None
+        self._assignment: handover.Assignment | handover.UnsupportedSchema | None = None
         self._batch_base_count = 0
 
     def size(self, v: int) -> int:
@@ -497,12 +497,12 @@ class EvalUI(pimm.ControlSystem):
 
     def _update_assignment_ui(self):
         assignment = self._assignment
-        dpg.configure_item('hv_body', show=assignment is not None and assignment.supported)
+        dpg.configure_item('hv_body', show=isinstance(assignment, handover.Assignment))
         if assignment is None:
             dpg.set_value('hv_status', 'No active assignment')
             dpg.configure_item('hv_status', color=(140, 140, 140))
             return
-        if not assignment.supported:
+        if isinstance(assignment, handover.UnsupportedSchema):
             dpg.set_value(
                 'hv_status',
                 f'Assignment written for schema_version {assignment.schema_version}; '
@@ -523,17 +523,18 @@ class EvalUI(pimm.ControlSystem):
         self._set_enabled('hv_note', not done)
 
     def _update_assignment_progress(self):
-        if self._assignment is None or not self._assignment.supported:
+        assignment = self._assignment
+        if not isinstance(assignment, handover.Assignment):
             return
         recorded = self._count - self._batch_base_count
-        target = self._assignment.episode_target
+        target = assignment.episode_target
         dpg.set_value('hv_progress', f'Episodes recorded: {recorded} / {target}')
         dpg.configure_item('hv_progress', color=(0, 200, 0) if recorded >= target else (255, 255, 255))
 
     def hand_back(self, sender=None, app_data=None):
         """Write the completion marker for the current assignment."""
         assignment = self._assignment
-        assert assignment is not None, 'the hand-back button is shown only while an assignment is active'
+        assert isinstance(assignment, handover.Assignment), 'the hand-back button shows only for a readable assignment'
         handover.write_completion(self.handover_dir, assignment.batch_id, dpg.get_value('hv_note'))
         self._set_handed_back(True)
 

--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -13,6 +13,7 @@ from positronic import keys
 from positronic.cfg.eval.real.tasks import SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
 from positronic.dataset.edits import EditedDataset
 from positronic.dataset.local_dataset import LocalDataset
+from positronic.gui import handover
 from positronic.policy.harness import Directive
 
 
@@ -46,7 +47,11 @@ EDITOR_POLL_SEC = 0.5
 # the positronic server grows into it — and owning `output_dir` there frees the driver from the factory closure.
 # The editable static fields differ per eval, so the form must become data-driven (declared by the Task/Eval).
 class EvalUI(pimm.ControlSystem):
-    """Operator console for attended evals: trial control plus an episode editor.
+    """Operator console for attended evals: the batch assignment, trial control, and an episode editor.
+
+    The assignment panel shows the batch handed over through `handover_dir` — its task, its episode target,
+    how many episodes this session has recorded against it — and hands the batch back with a completion
+    marker. It sits outside the tabs so neither half of the console can hide it.
 
     Trial control drives the lifecycle (RUN/FINISH/HOME directives) and shows the remaining time budget.
     The editor is a non-modal view over the recorded dataset: the operator navigates episodes and corrects
@@ -57,10 +62,15 @@ class EvalUI(pimm.ControlSystem):
     """
 
     def __init__(
-        self, output_dir: Path | None = None, max_im_size: tuple[int, int] = (320, 240), ui_scale: float = 1.0
+        self,
+        output_dir: Path | None = None,
+        max_im_size: tuple[int, int] = (320, 240),
+        ui_scale: float = 1.0,
+        handover_dir: Path = handover.DEFAULT_DIR,
     ):
         self.state = State.WAITING
         self.output_dir = output_dir
+        self.handover_dir = handover_dir
         self.ui_scale = ui_scale
         self.max_im_size = (self.size(max_im_size[0]), self.size(max_im_size[1]))
 
@@ -93,6 +103,11 @@ class EvalUI(pimm.ControlSystem):
         # The selected episode's video signal under the review scrubber.
         self._rv_signal = None
         self.rv_texture = np.zeros((240, 320, 4), dtype=np.float32)
+
+        # Handover state. `_batch_base_count` is the episode count when the current assignment was picked up,
+        # so progress against the target counts this batch's recordings rather than the whole output directory.
+        self._assignment: handover.Assignment | None = None
+        self._batch_base_count = 0
 
     def size(self, v: int) -> int:
         """Scale a value by ui_scale."""
@@ -167,6 +182,28 @@ class EvalUI(pimm.ControlSystem):
             dpg.add_spacer(width=self.size(25))
             with dpg.drawlist(width=self.size(160), height=self.size(46)):
                 dpg.draw_text((0, 0), '0:00', size=self.size(40), tag='time_text')
+
+    def _build_assignment(self):
+        dpg.add_separator()
+        dpg.add_text('', tag='hv_status')
+        # dearpygui's stubs type the container helpers as their tag, not as context managers.
+        with dpg.group(show=False, tag='hv_body'):  # pyright: ignore[reportGeneralTypeIssues]
+            dpg.add_text('', tag='hv_task', wrap=self.size(660))
+            dpg.add_text('', tag='hv_notes', wrap=self.size(660), color=(160, 160, 160))
+            dpg.add_text('', tag='hv_progress')
+            with dpg.group(horizontal=True):  # pyright: ignore[reportGeneralTypeIssues]
+                dpg.add_input_text(hint='note for the batch (optional)', width=self.size(320), tag='hv_note')
+                dpg.add_spacer(width=self.size(10))
+                dpg.add_button(
+                    label='Batch done',
+                    tag='hv_done',
+                    callback=self.hand_back,
+                    width=self.size(110),
+                    height=self.size(28),
+                )
+                dpg.add_spacer(width=self.size(10))
+                dpg.add_text('', tag='hv_confirm', color=(0, 200, 0))
+        dpg.add_separator()
 
     def _build_configuration(self):
         dpg.add_text('Configuration')
@@ -447,6 +484,59 @@ class EvalUI(pimm.ControlSystem):
         self.update_ui()
         self.directive.emit(Directive.ABORT())
 
+    # --- Batch handover ---
+
+    def _poll_assignment(self):
+        """Pick up the assignment in the handover directory, including one that lands after start-up."""
+        assignment = handover.read_assignment(self.handover_dir)
+        if assignment != self._assignment:
+            self._assignment = assignment
+            self._batch_base_count = self._count
+            self._update_assignment_ui()
+        self._update_assignment_progress()
+
+    def _update_assignment_ui(self):
+        assignment = self._assignment
+        dpg.configure_item('hv_body', show=assignment is not None and assignment.supported)
+        if assignment is None:
+            dpg.set_value('hv_status', 'No active assignment')
+            dpg.configure_item('hv_status', color=(140, 140, 140))
+            return
+        if not assignment.supported:
+            dpg.set_value(
+                'hv_status',
+                f'Assignment written for schema_version {assignment.schema_version}; '
+                f'this console reads {handover.SCHEMA_VERSION}. Not showing it.',
+            )
+            dpg.configure_item('hv_status', color=(230, 170, 60))
+            return
+        dpg.set_value('hv_status', f'ASSIGNMENT — batch {assignment.batch_id}')
+        dpg.configure_item('hv_status', color=(120, 180, 255))
+        dpg.set_value('hv_task', assignment.task)
+        dpg.set_value('hv_notes', assignment.notes)
+        dpg.configure_item('hv_notes', show=bool(assignment.notes))
+        self._set_handed_back(handover.completion_path(self.handover_dir, assignment.batch_id).exists())
+
+    def _set_handed_back(self, done: bool):
+        dpg.set_value('hv_confirm', 'Handed back' if done else '')
+        self._set_enabled('hv_done', not done)
+        self._set_enabled('hv_note', not done)
+
+    def _update_assignment_progress(self):
+        if self._assignment is None or not self._assignment.supported:
+            return
+        recorded = self._count - self._batch_base_count
+        target = self._assignment.episode_target
+        dpg.set_value('hv_progress', f'Episodes recorded: {recorded} / {target}')
+        dpg.configure_item('hv_progress', color=(0, 200, 0) if recorded >= target else (255, 255, 255))
+
+    def hand_back(self, sender=None, app_data=None):
+        """Write the completion marker for the current assignment."""
+        assignment = self._assignment
+        assert assignment is not None, 'the hand-back button is shown only while an assignment is active'
+        handover.write_completion(self.handover_dir, assignment.batch_id, dpg.get_value('hv_note'))
+        self._set_handed_back(True)
+
     # --- Episode editor ---
 
     def _refresh_view(self):
@@ -688,6 +778,9 @@ class EvalUI(pimm.ControlSystem):
                     self._build_controls()
 
                     dpg.add_spacer(height=self.size(10))
+                    self._build_assignment()
+
+                    dpg.add_spacer(height=self.size(10))
                     with dpg.tab_bar(tag='mode_tabs'):
                         with dpg.tab(label='Trial', tag='tab_trial'):
                             dpg.add_spacer(height=self.size(10))
@@ -709,6 +802,7 @@ class EvalUI(pimm.ControlSystem):
 
         # Initialize UI state; open the editor on the newest episode of an existing dataset
         self.update_ui()
+        self._update_assignment_ui()
         if self.output_dir is not None:
             self._refresh_view()
         self._select(self._count - 1)
@@ -718,6 +812,7 @@ class EvalUI(pimm.ControlSystem):
             if now - self._last_scan >= EDITOR_POLL_SEC:
                 self._last_scan = now
                 self._poll_episodes()
+                self._poll_assignment()
 
             # Count down the remaining time budget; the run stops when it is exhausted
             if self.state == State.RUNNING and self.run_start_time:

--- a/positronic/gui/handover.py
+++ b/positronic/gui/handover.py
@@ -1,0 +1,84 @@
+"""The file contract between the tooling that assigns a rollout batch and the operator console.
+
+The launcher writes ``assignment.yaml`` into a handover directory before starting a run; the console
+writes ``done-<batch_id>.yaml`` back into the same directory when the operator hands the batch in. Both
+are YAML mappings, versioned by ``schema_version`` on the assignment::
+
+    # assignment.yaml
+    schema_version: 1
+    batch_id: 2026-08-05-a
+    task: Pick up objects from the red tote and place them in the green tote.
+    episode_target: 20
+    notes: tote on the left                 # optional
+    created_at: 2026-08-05T09:14:03+00:00
+
+    # done-2026-08-05-a.yaml
+    batch_id: 2026-08-05-a
+    finished_at: 2026-08-05T11:02:41+00:00
+    operator_note: gripper slipped twice    # optional
+
+An assignment names neither endpoint nor policy: the operator records and scores the batch without
+knowing what is under test.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+SCHEMA_VERSION = 1
+DEFAULT_DIR = Path('/home/rollout/handover')
+ASSIGNMENT_NAME = 'assignment.yaml'
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """A batch of episodes to record, as the launcher described it.
+
+    A ``schema_version`` other than ``SCHEMA_VERSION`` leaves every other field empty: the file follows a
+    contract this console does not know, and the version is all it can report about it.
+    """
+
+    schema_version: int
+    batch_id: str = ''
+    task: str = ''
+    episode_target: int = 0
+    notes: str = ''
+    created_at: str = ''
+
+    @property
+    def supported(self) -> bool:
+        return self.schema_version == SCHEMA_VERSION
+
+
+def read_assignment(handover_dir: Path) -> Assignment | None:
+    """The assignment in ``handover_dir``, or None when it holds none."""
+    path = handover_dir / ASSIGNMENT_NAME
+    if not path.exists():
+        return None
+    raw = yaml.safe_load(path.read_text())
+    if raw['schema_version'] != SCHEMA_VERSION:
+        return Assignment(schema_version=raw['schema_version'])
+    return Assignment(
+        schema_version=SCHEMA_VERSION,
+        batch_id=raw['batch_id'],
+        task=raw['task'],
+        episode_target=raw['episode_target'],
+        notes=raw.get('notes', ''),
+        created_at=raw['created_at'],
+    )
+
+
+def completion_path(handover_dir: Path, batch_id: str) -> Path:
+    return handover_dir / f'done-{batch_id}.yaml'
+
+
+def write_completion(handover_dir: Path, batch_id: str, operator_note: str = '') -> Path:
+    """Mark the batch handed back, returning the marker path."""
+    payload = {'batch_id': batch_id, 'finished_at': datetime.now(UTC).isoformat()}
+    if operator_note:
+        payload['operator_note'] = operator_note
+    path = completion_path(handover_dir, batch_id)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False))
+    return path

--- a/positronic/gui/handover.py
+++ b/positronic/gui/handover.py
@@ -34,34 +34,35 @@ ASSIGNMENT_NAME = 'assignment.yaml'
 
 @dataclass(frozen=True)
 class Assignment:
-    """A batch of episodes to record, as the launcher described it.
+    """A batch of episodes to record, as the launcher described it."""
 
-    A ``schema_version`` other than ``SCHEMA_VERSION`` leaves every other field empty: the file follows a
-    contract this console does not know, and the version is all it can report about it.
+    batch_id: str
+    task: str
+    episode_target: int
+    notes: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class UnsupportedSchema:
+    """An assignment written against a ``schema_version`` this module does not implement.
+
+    Its version is the whole of what can be said about such a file: the rest of it follows a contract
+    that is not this one, so reading further would be guesswork.
     """
 
     schema_version: int
-    batch_id: str = ''
-    task: str = ''
-    episode_target: int = 0
-    notes: str = ''
-    created_at: str = ''
-
-    @property
-    def supported(self) -> bool:
-        return self.schema_version == SCHEMA_VERSION
 
 
-def read_assignment(handover_dir: Path) -> Assignment | None:
+def read_assignment(handover_dir: Path) -> Assignment | UnsupportedSchema | None:
     """The assignment in ``handover_dir``, or None when it holds none."""
     path = handover_dir / ASSIGNMENT_NAME
     if not path.exists():
         return None
     raw = yaml.safe_load(path.read_text())
     if raw['schema_version'] != SCHEMA_VERSION:
-        return Assignment(schema_version=raw['schema_version'])
+        return UnsupportedSchema(raw['schema_version'])
     return Assignment(
-        schema_version=SCHEMA_VERSION,
         batch_id=raw['batch_id'],
         task=raw['task'],
         episode_target=raw['episode_target'],

--- a/positronic/gui/handover.py
+++ b/positronic/gui/handover.py
@@ -45,11 +45,7 @@ class Assignment:
 
 @dataclass(frozen=True)
 class UnsupportedSchema:
-    """An assignment written against a ``schema_version`` this module does not implement.
-
-    Its version is the whole of what can be said about such a file: the rest of it follows a contract
-    that is not this one, so reading further would be guesswork.
-    """
+    """An assignment written against a ``schema_version`` this module does not implement."""
 
     schema_version: int
 

--- a/positronic/gui/tests/test_handover.py
+++ b/positronic/gui/tests/test_handover.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timedelta
+
+import pytest
+import yaml
+
+from positronic.gui import handover
+
+
+def write_assignment(directory, **fields):
+    payload = {
+        'schema_version': handover.SCHEMA_VERSION,
+        'batch_id': '2026-08-05-a',
+        'task': 'Pick up objects from the red tote and place them in the green tote.',
+        'episode_target': 20,
+        'created_at': '2026-08-05T09:14:03+00:00',
+        **fields,
+    }
+    (directory / handover.ASSIGNMENT_NAME).write_text(yaml.safe_dump(payload))
+    return payload
+
+
+def test_read_assignment_is_none_without_a_file(tmp_path):
+    assert handover.read_assignment(tmp_path) is None
+
+
+def test_read_assignment_is_none_when_the_directory_is_absent(tmp_path):
+    assert handover.read_assignment(tmp_path / 'nowhere') is None
+
+
+def test_read_assignment_reads_every_field(tmp_path):
+    write_assignment(tmp_path, notes='tote on the left')
+
+    assignment = handover.read_assignment(tmp_path)
+    assert assignment is not None
+
+    assert assignment == handover.Assignment(
+        schema_version=1,
+        batch_id='2026-08-05-a',
+        task='Pick up objects from the red tote and place them in the green tote.',
+        episode_target=20,
+        notes='tote on the left',
+        created_at='2026-08-05T09:14:03+00:00',
+    )
+    assert assignment.supported
+
+
+def test_notes_are_optional(tmp_path):
+    write_assignment(tmp_path)
+
+    assignment = handover.read_assignment(tmp_path)
+    assert assignment is not None
+
+    assert assignment.notes == ''
+
+
+def test_a_newer_schema_version_reports_only_its_version(tmp_path):
+    write_assignment(tmp_path, schema_version=handover.SCHEMA_VERSION + 1)
+
+    assignment = handover.read_assignment(tmp_path)
+    assert assignment is not None
+
+    assert not assignment.supported
+    assert assignment.schema_version == handover.SCHEMA_VERSION + 1
+    assert assignment.task == ''
+
+
+def test_a_missing_required_field_surfaces(tmp_path):
+    payload = write_assignment(tmp_path)
+    del payload['episode_target']
+    (tmp_path / handover.ASSIGNMENT_NAME).write_text(yaml.safe_dump(payload))
+
+    with pytest.raises(KeyError):
+        handover.read_assignment(tmp_path)
+
+
+def test_an_existing_marker_marks_the_batch_handed_back(tmp_path):
+    assert not handover.completion_path(tmp_path, '2026-08-05-a').exists()
+
+    handover.write_completion(tmp_path, '2026-08-05-a')
+
+    assert handover.completion_path(tmp_path, '2026-08-05-a').exists()
+
+
+def test_write_completion_names_the_marker_after_the_batch(tmp_path):
+    path = handover.write_completion(tmp_path, '2026-08-05-a')
+
+    assert path == tmp_path / 'done-2026-08-05-a.yaml'
+    assert path == handover.completion_path(tmp_path, '2026-08-05-a')
+
+
+def test_completion_marker_carries_the_batch_and_a_utc_timestamp(tmp_path):
+    written = yaml.safe_load(handover.write_completion(tmp_path, '2026-08-05-a').read_text())
+
+    assert written['batch_id'] == '2026-08-05-a'
+    assert datetime.fromisoformat(written['finished_at']).utcoffset() == timedelta(0)
+    assert 'operator_note' not in written
+
+
+def test_an_operator_note_is_recorded_when_given(tmp_path):
+    written = yaml.safe_load(handover.write_completion(tmp_path, 'b', 'gripper slipped twice').read_text())
+
+    assert written['operator_note'] == 'gripper slipped twice'

--- a/positronic/gui/tests/test_handover.py
+++ b/positronic/gui/tests/test_handover.py
@@ -31,24 +31,21 @@ def test_read_assignment_reads_every_field(tmp_path):
     write_assignment(tmp_path, notes='tote on the left')
 
     assignment = handover.read_assignment(tmp_path)
-    assert assignment is not None
 
     assert assignment == handover.Assignment(
-        schema_version=1,
         batch_id='2026-08-05-a',
         task='Pick up objects from the red tote and place them in the green tote.',
         episode_target=20,
         notes='tote on the left',
         created_at='2026-08-05T09:14:03+00:00',
     )
-    assert assignment.supported
 
 
 def test_notes_are_optional(tmp_path):
     write_assignment(tmp_path)
 
     assignment = handover.read_assignment(tmp_path)
-    assert assignment is not None
+    assert isinstance(assignment, handover.Assignment)
 
     assert assignment.notes == ''
 
@@ -56,12 +53,7 @@ def test_notes_are_optional(tmp_path):
 def test_a_newer_schema_version_reports_only_its_version(tmp_path):
     write_assignment(tmp_path, schema_version=handover.SCHEMA_VERSION + 1)
 
-    assignment = handover.read_assignment(tmp_path)
-    assert assignment is not None
-
-    assert not assignment.supported
-    assert assignment.schema_version == handover.SCHEMA_VERSION + 1
-    assert assignment.task == ''
+    assert handover.read_assignment(tmp_path) == handover.UnsupportedSchema(handover.SCHEMA_VERSION + 1)
 
 
 def test_a_missing_required_field_surfaces(tmp_path):

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -12,7 +12,7 @@ import positronic.cfg.policy as policy_cfg
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.cli.eval.run import Driver, main, run
 from positronic.dataset.local_dataset import load_all_datasets
-from positronic.gui import dpg_ui
+from positronic.gui import dpg_ui, handover
 from positronic.gui.keyboard import KeyboardControl
 from positronic.gui.web import WebEvalUI
 from positronic.policy.harness import Directive
@@ -34,12 +34,12 @@ class KeyboardHandler:
         return None
 
 
-@cfn.config(ui_scale=1)
-def eval_ui(ui_scale):
+@cfn.config(ui_scale=1, handover_dir=handover.DEFAULT_DIR)
+def eval_ui(ui_scale, handover_dir):
     def make(output_dir: Path | None) -> Driver:
         from positronic.gui.eval import EvalUI  # noqa: PLC0415
 
-        gui = EvalUI(output_dir, ui_scale=ui_scale)
+        gui = EvalUI(output_dir, ui_scale=ui_scale, handover_dir=Path(handover_dir))
         return Driver(gui, gui.directive, pimm.utils.identity, [])
 
     return make


### PR DESCRIPTION
The operator runs a rollout batch from the local dearpygui console (`positronic-inference phail`, no `--driver` → `EvalUI`). The batch reaches her out of band today, and there is no way to say from the console that it is finished. This adds both ends of that handover.

## The contract

`positronic/gui/handover.py` — dearpygui-free, so it is testable on its own. The launcher writes `assignment.yaml` into a handover directory before starting the run; the console writes `done-<batch_id>.yaml` back when the operator hands the batch in. The module docstring is the spec, mirrored on the writer's side in the platform repo.

```yaml
# assignment.yaml
schema_version: 1
batch_id: 2026-08-05-a
task: Pick up objects from the red tote and place them in the green tote.
episode_target: 20
notes: tote on the left                 # optional
created_at: 2026-08-05T09:14:03+00:00

# done-2026-08-05-a.yaml
batch_id: 2026-08-05-a
finished_at: 2026-08-05T11:02:41+00:00
operator_note: gripper slipped twice    # optional
```

An assignment carries no endpoint and no policy name, and the panel surfaces no policy label: the batch is recorded blind.

## The panel

`_build_assignment` sits between the trial controls and the tab bar — outside both tabs, so neither can hide it, and below the buttons so they do not shift when an assignment appears. `read_assignment` returns `Assignment`, `UnsupportedSchema` or `None`, and the panel has a state for each:

- **`Assignment`** — batch id, task text, notes, `Episodes recorded: N / target` (green once met), a note field and `Batch done`. Pressing it writes the marker, disables the control, shows `Handed back`. An existing marker is found on pick-up, so a restart mid-batch shows the truth rather than offering a second hand-back.
- **`UnsupportedSchema`** — the version is reported plainly, nothing else shown.
- **`None`** — one grey `No active assignment` line.

`_poll_assignment` runs on the existing editor tick, so an assignment landing after start-up is picked up. Progress counts from the episode count at pick-up, not the whole output directory. Episode scoring is untouched.

## Config

`--driver.handover_dir`, a configuronic param on the existing `eval_ui` config (which already carries `ui_scale`, overridden by `phail`), defaulting to `handover.DEFAULT_DIR`. Chosen over an env var because the launcher invokes this as a CLI and configuronic is the repo's config surface.

## Verification

`positronic/gui/tests/test_handover.py` (10 tests). `pytest positronic/gui positronic/tests positronic/cli/eval/tests` green; pre-commit green with **no basedpyright baseline growth** — the two new `with dpg.group(...)` lines take a narrow `pyright: ignore` for the dearpygui stub gap instead.

The panel was driven headlessly under Xvfb through all six transitions, reading the rendered widget values back. That caught a defect: change-detection meant the initial `No active assignment` line never drew on the first frame.

## Open questions

1. **`hardcoded-keys`, carried deliberately.** `read_assignment`/`write_completion` spell the YAML field names as literals. Two of three cold rule-checkers wanted a constants block; one cleared it as an ordinary boundary parser. Left as is — the other party to this contract is a different repo that cannot import from `positronic`, so the constants would be shared with nobody. Glad to add them if you read it otherwise.
2. **`DEFAULT_DIR = /home/rollout/handover`** is a rig-specific path in a general repo. It is the contract's stated default, but no default at all may be preferable.
3. **Progress counts raw recorded episodes**, so one dropped in the editor still counts. Counting curated ones would couple the panel to the edit log.
4. **`Batch done` stays enabled while a trial is RUNNING** — uncoupled from `State`.
5. **`positronic/gui/` had no `tests/` dir.** It creates one, per `check_tests_location`'s own hint — flagging rather than absorbing it.

Ticket: Positronic-Robotics/internal#204

<!-- opened-by: posi-agent -->