### PR TITLE
Let a human authorize one merge from chat, and honour it here

### DIFF
--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -25,11 +25,20 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
+from pathlib import Path
 
 DENY_TAIL = (
     ' Merging to main requires a PR and an explicit human/operator command — a named human must run the merge'
     ' themselves (e.g. via the `!` prefix or their own shell).'
+)
+MERGE_ESCAPE = (
+    ' A named human can authorize THIS ONE merge from chat with `!allow_merge <pr>`, which the merge then spends.'
+)
+UNNUMBERED_MSG = (
+    'BLOCKED: name the pull request to merge (`gh pr merge <number>`) — an authorization names one pull'
+    ' request, so a merge that names none can never match it.'
 )
 AMEND_MSG = 'BLOCKED: Never amend commits, create new ones instead.'
 
@@ -152,9 +161,9 @@ def _strip_heredoc_bodies(cmd: str) -> str:
     entirely different repos.
 
     Dropping the body loses nothing analyzable, because a QUOTED delimiter suppresses every
-    expansion: the text reaches the command literally and cannot execute. Unquoted `<<EOF` is
-    deliberately left in place — its body DOES expand `$(…)`, so it keeps failing closed, and
-    `_substitution_bodies` still scans the untouched command for what such a body might run.
+    expansion: the text reaches the command literally and cannot execute, so a backtick in such
+    a body is prose rather than a substitution. Unquoted `<<EOF` is deliberately left in place —
+    its body DOES expand `$(…)`, so it keeps failing closed.
     """
     lines = cmd.split('\n')
     kept: list[str] = []
@@ -323,26 +332,68 @@ def _subcmd(words: list[str]) -> tuple[str, list[str]]:
     return '', []
 
 
-def _is_gh_pr_merge(words: list[str]) -> bool:
-    """gh (cobra) accepts persistent flags between `pr` and the subcommand — `gh pr -R o/r merge 1`."""
-    seen_pr = skip = False
+MERGE_ALLOW_DIR = Path.home() / '.local' / 'state' / 'relay' / 'merge_allows'
+# The receipt is written by `listen_chat_receiver/relay/merge_allow.py` in the `os` repository,
+# which cannot import from here and is imported by nothing here — so the file layout is the whole
+# of the contract, and it is named once on each side rather than spelled out at every use.
+RECEIPT_NAME = 'pr{number}.json'
+RECEIPT_NUMBER = 'number'
+RECEIPT_REPO = 'repo'
+RECEIPT_ISSUED_AT = 'issued_at'
+RECEIPT_TTL_S = 'ttl_s'
+
+
+def consume_merge_allow(
+    number: int, guarded_slug: str, directory: Path = MERGE_ALLOW_DIR, now: float | None = None
+) -> bool:
+    """Whether a human has authorized merging this pull request, spending the authorization.
+
+    The relay writes the receipt when a whitelisted human types `!allow_merge` in chat, and
+    refuses to write one for an injected message, so the agent cannot mint its own. An empty
+    repo names only a number, which resolves against the guarded repository.
+    """
+    path = directory / RECEIPT_NAME.format(number=number)
+    try:
+        receipt = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if receipt.get(RECEIPT_NUMBER) != number:
+        return False
+    repo = str(receipt.get(RECEIPT_REPO) or '').casefold()
+    slug = guarded_slug.casefold()
+    if repo and repo != slug and repo != slug.rpartition('/')[2]:
+        return False
+    issued_at, ttl = receipt.get(RECEIPT_ISSUED_AT, 0), receipt.get(RECEIPT_TTL_S, 0)
+    fresh = (now if now is not None else time.time()) - issued_at < ttl
+    path.unlink(missing_ok=True)
+    return fresh
+
+
+def _gh_positionals(words: list[str]) -> list[str]:
+    """The invocation's positional words: flags dropped, and the values of those that take one."""
+    out, skip = [], False
     for w in words:
         if skip:
             skip = False
-            continue
-        if w.startswith('-'):
-            if w in ('-R', '--repo'):
-                skip = True
-            continue
-        w = re.sub(r'[)}].*$', '', w)
-        if not w:
-            continue
-        if not seen_pr:
-            if w == 'pr':
-                seen_pr = True
-            continue
-        return w == 'merge'
-    return False
+        elif w.startswith('-'):
+            skip = w in ('-R', '--repo')
+        elif bare := re.sub(r'[)}].*$', '', w):  # a lossy parse leaves a closing delimiter glued on
+            out.append(bare)
+    return out
+
+
+def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None]:
+    """Whether this is `gh pr merge`, and the pull request it names — None when it names none.
+
+    gh (cobra) accepts persistent flags between `pr` and the subcommand — `gh pr -R o/r merge 1`.
+    """
+    positional = _gh_positionals(words)
+    if 'pr' not in positional:
+        return False, None
+    after = positional[positional.index('pr') + 1 :]
+    if not after or after[0] != 'merge':
+        return False, None
+    return True, next((int(w) for w in after[1:] if w.isdigit()), None)
 
 
 def _push_dest_slug(inv_dir: str | None, rest: list[str], git: GitInfo) -> str:  # noqa: C901
@@ -397,15 +448,23 @@ def _push_dest_slug(inv_dir: str | None, rest: list[str], git: GitInfo) -> str: 
     return repo_slug(git.remote_url(inv_dir, remote))
 
 
-def analyze(cmd: str, cwd: str, guarded_slug: str, git: GitInfo, path_exists=os.path.isdir, _depth=0) -> str | None:  # noqa: C901
+def analyze(  # noqa: C901
+    cmd: str,
+    cwd: str,
+    guarded_slug: str,
+    git: GitInfo,
+    path_exists=os.path.isdir,
+    _depth=0,
+    allow_merge=consume_merge_allow,
+) -> str | None:
     """The deny message for `cmd`, or None to allow it."""
     guarded_slug = guarded_slug.casefold()
     # A command substitution runs its own command (same cwd) before the outer command, so a git
     # invocation hidden inside `` `…` `` / `$(…)` must be analyzed too. Bounded recursion depth
     # guards against pathological nesting.
     if _depth < 8:
-        for body in _substitution_bodies(cmd):
-            deny = analyze(body, cwd, guarded_slug, git, path_exists, _depth + 1)
+        for body in _substitution_bodies(_strip_heredoc_bodies(cmd)):
+            deny = analyze(body, cwd, guarded_slug, git, path_exists, _depth + 1, allow_merge)
             if deny:
                 return deny
     invs = parse_invocations(cmd, cwd, path_exists)
@@ -430,8 +489,14 @@ def analyze(cmd: str, cwd: str, guarded_slug: str, git: GitInfo, path_exists=os.
         return on_main(inv_dir) or switches_to_main()
 
     for inv in invs:
-        if inv.kind == 'gh' and _is_gh_pr_merge(inv.words):
-            return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL
+        if inv.kind != 'gh':
+            continue
+        is_merge, number = _gh_pr_merge(inv.words)
+        if is_merge:
+            if number is None:
+                return UNNUMBERED_MSG
+            if not allow_merge(number, guarded_slug):
+                return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL + MERGE_ESCAPE
 
     for inv, sub, rest in git_invs:
         if exempt(inv.dir):

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -426,6 +426,21 @@ GH_MERGE_VALUE_FLAGS = frozenset({
 })
 
 
+def _gh_repo(explicit: str, inv_dir: str | None, git: GitInfo, cmd: str, gh_repo_env: str) -> str:
+    """The repository a `gh` invocation acts on, or '' when that cannot be established.
+
+    `-R` names it outright; `GH_REPO` does the same from the environment, and an environment is
+    not something a command can be read for, so its mere mention gives up. Otherwise gh resolves
+    the repository from the working directory, which is why an unresolvable directory gives up
+    too — a merge is not this repository's just because nothing said otherwise.
+    """
+    if gh_repo_env or 'GH_REPO' in cmd:
+        return ''
+    if explicit:
+        return explicit.casefold()
+    return repo_slug(git.origin_url(inv_dir)) if inv_dir is not None else ''
+
+
 def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
     """Whether this is `gh pr merge`, the pull request it names, and the repository it targets.
 
@@ -517,6 +532,7 @@ def analyze(  # noqa: C901
     path_exists=os.path.isdir,
     _depth=0,
     allow_merge=consume_merge_allow,
+    gh_repo_env='',
 ) -> str | None:
     """The deny message for `cmd`, or None to allow it."""
     guarded_slug = guarded_slug.casefold()
@@ -525,7 +541,7 @@ def analyze(  # noqa: C901
     # guards against pathological nesting.
     if _depth < 8:
         for body in _substitution_bodies(_strip_heredoc_bodies(cmd)):
-            deny = analyze(body, cwd, guarded_slug, git, path_exists, _depth + 1, allow_merge)
+            deny = analyze(body, cwd, guarded_slug, git, path_exists, _depth + 1, allow_merge, gh_repo_env)
             if deny:
                 return deny
     invs = parse_invocations(cmd, cwd, path_exists)
@@ -549,6 +565,7 @@ def analyze(  # noqa: C901
     def targets_main(inv_dir: str | None) -> bool:
         return on_main(inv_dir) or switches_to_main()
 
+    authorized_merge = None
     for inv in invs:
         if inv.kind != 'gh':
             continue
@@ -556,11 +573,11 @@ def analyze(  # noqa: C901
         if is_merge:
             if number is None:
                 return UNNUMBERED_MSG
-            # An authorization is for this repository's pull request; `-R` selects another, whose
-            # merges this guard has no receipt for.
-            elsewhere = target.casefold() not in ('', guarded_slug, guarded_slug.rpartition('/')[2])
-            if elsewhere or not allow_merge(number, guarded_slug):
+            if _gh_repo(target, inv.dir, git, cmd, gh_repo_env) != guarded_slug:
                 return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL + MERGE_ESCAPE
+            # Spending it here would pay for a merge a later invocation in the same command can
+            # still block, so the authorization is consulted once everything else has passed.
+            authorized_merge = number
 
     for inv, sub, rest in git_invs:
         if exempt(inv.dir):
@@ -597,6 +614,9 @@ def analyze(  # noqa: C901
             deny = _check_push_refspecs(rest, targets_main(inv.dir))
             if deny:
                 return deny
+
+    if authorized_merge is not None and not allow_merge(authorized_merge, guarded_slug):
+        return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL + MERGE_ESCAPE
     return None
 
 
@@ -642,7 +662,7 @@ def main() -> int:
     cwd = payload.get('cwd') or os.getcwd()
     git = GitInfo()
     guarded_slug = repo_slug(git.origin_url(os.environ.get('CLAUDE_PROJECT_DIR') or os.getcwd()))
-    deny = analyze(cmd, cwd, guarded_slug, git)
+    deny = analyze(cmd, cwd, guarded_slug, git, gh_repo_env=os.environ.get('GH_REPO', ''))
     if deny:
         print(deny, file=sys.stderr)
         return 2

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -45,6 +45,10 @@ MULTIPLE_MERGES_MSG = (
     'BLOCKED: merge one pull request per command — an authorization names one, and a command'
     ' merging several would have to spend the first before knowing the rest are allowed.'
 )
+MERGE_SUBSTITUTION_MSG = (
+    'BLOCKED: a merge in a command carrying a command substitution cannot be verified — the'
+    ' substitution decides at runtime what is merged, and where.'
+)
 AMEND_MSG = 'BLOCKED: Never amend commits, create new ones instead.'
 
 # git global options that consume the following argument in their space-separated form
@@ -434,6 +438,19 @@ GH_MERGE_VALUE_FLAGS = frozenset({
 })
 
 
+def _carries_substitution(cmd: str) -> bool:
+    """Whether `cmd` carries a command substitution, or quoting that cannot be read.
+
+    A substitution's value exists only at runtime, so it can name the pull request, the
+    repository, or the variable that selects either. None of those can be weighed beforehand.
+    """
+    try:
+        segments = _segments(_strip_heredoc_bodies(cmd))
+    except ValueError:
+        return True
+    return any(word == SUBST for segment in segments for word in segment)
+
+
 def _sets_gh_repo(cmd: str) -> bool:
     """Whether `cmd` sets `GH_REPO` for anything it runs.
 
@@ -553,6 +570,7 @@ def analyze(  # noqa: C901
     git: GitInfo,
     path_exists=os.path.isdir,
     _depth=0,
+    in_substitution=False,
     allow_merge=consume_merge_allow,
     gh_repo_env='',
 ) -> str | None:
@@ -563,7 +581,7 @@ def analyze(  # noqa: C901
     # guards against pathological nesting.
     if _depth < 8:
         for body in _substitution_bodies(_strip_heredoc_bodies(cmd)):
-            deny = analyze(body, cwd, guarded_slug, git, path_exists, _depth + 1, allow_merge, gh_repo_env)
+            deny = analyze(body, cwd, guarded_slug, git, path_exists, _depth + 1, True, allow_merge, gh_repo_env)
             if deny:
                 return deny
     invs = parse_invocations(cmd, cwd, path_exists)
@@ -593,6 +611,8 @@ def analyze(  # noqa: C901
             continue
         is_merge, number, target = _gh_pr_merge(inv.words)
         if is_merge:
+            if in_substitution or _carries_substitution(cmd):
+                return MERGE_SUBSTITUTION_MSG
             if number is None:
                 return UNNUMBERED_MSG
             if pending_merge is not None:

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -3,7 +3,8 @@
 
 Blocks history-rewriting `git commit --amend`, merges / integrating pulls / direct pushes to
 `main`, and `gh pr merge`. Amend rewrites history — create a new commit instead. Integrating
-into main requires an explicit human/operator command run outside the agent's Bash tool.
+into main requires an explicit human/operator command run outside the agent's Bash tool, or a
+receipt a human wrote from chat authorizing one named pull request (see `consume_merge_allow`).
 
 Scope: the git-command guards apply only to invocations that operate on THIS repo — same
 `origin` as the session's project repo, which covers clones and worktrees. A `git -C <dir> …`
@@ -332,7 +333,10 @@ def _subcmd(words: list[str]) -> tuple[str, list[str]]:
     return '', []
 
 
-MERGE_ALLOW_DIR = Path.home() / '.local' / 'state' / 'relay' / 'merge_allows'
+MERGE_ALLOW_DIR = Path('/var/lib/relay/merge_allows')
+# Where an honoured receipt is recorded so it cannot serve a second merge. Separate from the
+# receipts because that directory is root-only-writable and this hook does not run as root.
+MERGE_SPENT_DIR = Path.home() / '.local' / 'state' / 'relay' / 'merge_allows_spent'
 # The receipt is written by `listen_chat_receiver/relay/merge_allow.py` in the `os` repository,
 # which cannot import from here and is imported by nothing here — so the file layout is the whole
 # of the contract, and it is named once on each side rather than spelled out at every use.
@@ -341,18 +345,46 @@ RECEIPT_NUMBER = 'number'
 RECEIPT_REPO = 'repo'
 RECEIPT_ISSUED_AT = 'issued_at'
 RECEIPT_TTL_S = 'ttl_s'
+# Distinct per authorization, which is what a spend mark names. A receipt without one is refused:
+# without it the mark would have to key on something that is not an identity, and a second
+# authorization sharing that value would be read as already spent.
+RECEIPT_ID = 'id'
+
+
+def _written_by_root(path: Path, directory: Path) -> bool:
+    """Whether only root could have put `path` where it is.
+
+    Ownership is the provenance check, so it has to cover the directory too: a file root owns
+    inside a directory anyone may write is a file anyone may replace.
+    """
+    try:
+        file_stat, dir_stat = path.stat(), directory.stat()
+    except OSError:
+        return False
+    return file_stat.st_uid == 0 and dir_stat.st_uid == 0 and not dir_stat.st_mode & 0o022
 
 
 def consume_merge_allow(
-    number: int, guarded_slug: str, directory: Path = MERGE_ALLOW_DIR, now: float | None = None
+    number: int,
+    guarded_slug: str,
+    directory: Path = MERGE_ALLOW_DIR,
+    spent_dir: Path = MERGE_SPENT_DIR,
+    now: float | None = None,
 ) -> bool:
     """Whether a human has authorized merging this pull request, spending the authorization.
 
-    The relay writes the receipt when a whitelisted human types `!allow_merge` in chat, and
-    refuses to write one for an injected message, so the agent cannot mint its own. An empty
-    repo names only a number, which resolves against the guarded repository.
+    The relay writes the receipt as root when a whitelisted human types `!allow_merge` in chat,
+    and refuses to write one for an injected message. A receipt cannot be forged without root,
+    since only root may write into the receipt directory; and it serves one merge, since
+    honouring it records a spend mark this process owns. Neither property holds against root,
+    which any process on this host can reach through the account's sudo.
+
+    An empty repo in the receipt names only a number, which resolves against the guarded
+    repository.
     """
     path = directory / RECEIPT_NAME.format(number=number)
+    if not _written_by_root(path, directory):
+        return False
     try:
         receipt = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
@@ -364,36 +396,65 @@ def consume_merge_allow(
     if repo and repo != slug and repo != slug.rpartition('/')[2]:
         return False
     issued_at, ttl = receipt.get(RECEIPT_ISSUED_AT, 0), receipt.get(RECEIPT_TTL_S, 0)
-    fresh = (now if now is not None else time.time()) - issued_at < ttl
-    path.unlink(missing_ok=True)
-    return fresh
+    if (now if now is not None else time.time()) - issued_at >= ttl:
+        return False
+    identifier = str(receipt.get(RECEIPT_ID) or '')
+    if not re.fullmatch(r'\w{4,64}', identifier):
+        return False
+    spent = spent_dir / f'pr{number}-{identifier}'
+    if spent.exists():
+        return False
+    spent_dir.mkdir(parents=True, exist_ok=True)
+    spent.touch()
+    return True
 
 
-def _gh_positionals(words: list[str]) -> list[str]:
-    """The invocation's positional words: flags dropped, and the values of those that take one."""
-    out, skip = [], False
-    for w in words:
-        if skip:
-            skip = False
-        elif w.startswith('-'):
-            skip = w in ('-R', '--repo')
-        elif bare := re.sub(r'[)}].*$', '', w):  # a lossy parse leaves a closing delimiter glued on
-            out.append(bare)
-    return out
+# `gh pr merge` flags that consume the following argument, so its value is never the pull
+# request being merged: `gh pr merge --subject 566 999` merges 999.
+GH_MERGE_VALUE_FLAGS = frozenset({
+    '-A',
+    '--author-email',
+    '-b',
+    '--body',
+    '-F',
+    '--body-file',
+    '--match-head-commit',
+    '-t',
+    '--subject',
+    '-R',
+    '--repo',
+})
 
 
-def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None]:
-    """Whether this is `gh pr merge`, and the pull request it names — None when it names none.
+def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
+    """Whether this is `gh pr merge`, the pull request it names, and the repository it targets.
 
+    The number is None unless the merge target is written as one, and the repository is '' unless
+    `-R` names another — gh takes a URL or a branch there too, which no authorization can name.
     gh (cobra) accepts persistent flags between `pr` and the subcommand — `gh pr -R o/r merge 1`.
     """
-    positional = _gh_positionals(words)
-    if 'pr' not in positional:
-        return False, None
+    positional: list[str] = []
+    repo = pending = ''
+    for w in words:
+        if pending:
+            repo, pending = (w if pending in ('-R', '--repo') else repo), ''
+        elif w.startswith('-'):
+            flag, eq, value = w.partition('=')
+            if flag in ('--help', '-h'):
+                return False, None, ''
+            if flag in ('-R', '--repo') and eq:
+                repo = value
+            elif flag in GH_MERGE_VALUE_FLAGS and not eq:
+                pending = flag
+        elif bare := re.sub(r'[)}].*$', '', w):  # a lossy parse leaves a closing delimiter glued on
+            positional.append(bare)
+    if not positional or positional[0] == 'help' or 'pr' not in positional:
+        return False, None, ''
     after = positional[positional.index('pr') + 1 :]
     if not after or after[0] != 'merge':
-        return False, None
-    return True, next((int(w) for w in after[1:] if w.isdigit()), None)
+        return False, None, ''
+    target = after[1] if len(after) > 1 else ''
+    return True, int(target) if target.isdigit() else None, repo
 
 
 def _push_dest_slug(inv_dir: str | None, rest: list[str], git: GitInfo) -> str:  # noqa: C901
@@ -491,11 +552,14 @@ def analyze(  # noqa: C901
     for inv in invs:
         if inv.kind != 'gh':
             continue
-        is_merge, number = _gh_pr_merge(inv.words)
+        is_merge, number, target = _gh_pr_merge(inv.words)
         if is_merge:
             if number is None:
                 return UNNUMBERED_MSG
-            if not allow_merge(number, guarded_slug):
+            # An authorization is for this repository's pull request; `-R` selects another, whose
+            # merges this guard has no receipt for.
+            elsewhere = target.casefold() not in ('', guarded_slug, guarded_slug.rpartition('/')[2])
+            if elsewhere or not allow_merge(number, guarded_slug):
                 return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL + MERGE_ESCAPE
 
     for inv, sub, rest in git_invs:

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -414,10 +414,12 @@ def consume_merge_allow(
     if not re.fullmatch(r'\w{4,64}', identifier):
         return False
     spent = spent_dir / f'pr{number}-{identifier}'
-    if spent.exists():
-        return False
     spent_dir.mkdir(parents=True, exist_ok=True)
-    spent.touch()
+    try:
+        # Exclusive create, so two hooks racing the same receipt cannot both find it unspent.
+        os.close(os.open(spent, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+    except FileExistsError:
+        return False
     return True
 
 
@@ -439,16 +441,18 @@ GH_MERGE_VALUE_FLAGS = frozenset({
 
 
 def _carries_substitution(cmd: str) -> bool:
-    """Whether `cmd` carries a command substitution, or quoting that cannot be read.
+    """Whether `cmd` carries a substitution, or quoting that cannot be read.
 
     A substitution's value exists only at runtime, so it can name the pull request, the
     repository, or the variable that selects either. None of those can be weighed beforehand.
+    A PROCESS substitution runs a command of its own besides — and its `<(` keeps that command
+    in the same segment as the one it feeds, where only the first tool word is ever read.
     """
     try:
         segments = _segments(_strip_heredoc_bodies(cmd))
     except ValueError:
         return True
-    return any(word == SUBST for segment in segments for word in segment)
+    return any(word == SUBST or '<(' in word or '>(' in word for segment in segments for word in segment)
 
 
 def _sets_gh_repo(cmd: str) -> bool:

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -41,6 +41,10 @@ UNNUMBERED_MSG = (
     'BLOCKED: name the pull request to merge (`gh pr merge <number>`) — an authorization names one pull'
     ' request, so a merge that names none can never match it.'
 )
+MULTIPLE_MERGES_MSG = (
+    'BLOCKED: merge one pull request per command — an authorization names one, and a command'
+    ' merging several would have to spend the first before knowing the rest are allowed.'
+)
 AMEND_MSG = 'BLOCKED: Never amend commits, create new ones instead.'
 
 # git global options that consume the following argument in their space-separated form
@@ -59,6 +63,10 @@ SUBST = '\x00subst'
 # A word that names `main` as a push target or checkout target: `main`, `+main`, `HEAD:main`,
 # `origin/main`, `main:other` — but not `mainline` or `feature/main2`.
 MAIN_REF_RE = re.compile(r'(^|[:/+])main(?![\w/\-])')
+
+# gh's own name for the variable that selects a repository, read from the command and from the
+# environment — two places that have to agree with gh and with each other.
+GH_REPO_ENV = 'GH_REPO'
 
 # A heredoc opener whose delimiter is QUOTED — `<<'EOF'`, `<<"EOF"`, `<<-'EOF'`. The quoting is
 # what makes the body inert: it suppresses every expansion, so the text cannot execute.
@@ -426,15 +434,29 @@ GH_MERGE_VALUE_FLAGS = frozenset({
 })
 
 
+def _sets_gh_repo(cmd: str) -> bool:
+    """Whether `cmd` sets `GH_REPO` for anything it runs.
+
+    The shell removes quotes before it reads an assignment, so `G''H_REPO=x` sets the variable
+    while the raw text never spells its name. Quoting the tokenizer cannot read is itself an
+    answer of yes, since what it hides could be the assignment.
+    """
+    try:
+        segments = _segments(_strip_heredoc_bodies(cmd))
+    except ValueError:
+        return True
+    return any(word.startswith(GH_REPO_ENV + '=') for segment in segments for word in segment)
+
+
 def _gh_repo(explicit: str, inv_dir: str | None, git: GitInfo, cmd: str, gh_repo_env: str) -> str:
     """The repository a `gh` invocation acts on, or '' when that cannot be established.
 
-    `-R` names it outright; `GH_REPO` does the same from the environment, and an environment is
-    not something a command can be read for, so its mere mention gives up. Otherwise gh resolves
+    `-R` names it outright, and `GH_REPO` does the same from the environment — which is not
+    something a command can be read for, so either source of it gives up. Otherwise gh resolves
     the repository from the working directory, which is why an unresolvable directory gives up
-    too — a merge is not this repository's just because nothing said otherwise.
+    too: a merge is not this repository's just because nothing said otherwise.
     """
-    if gh_repo_env or 'GH_REPO' in cmd:
+    if gh_repo_env or _sets_gh_repo(cmd):
         return ''
     if explicit:
         return explicit.casefold()
@@ -565,7 +587,7 @@ def analyze(  # noqa: C901
     def targets_main(inv_dir: str | None) -> bool:
         return on_main(inv_dir) or switches_to_main()
 
-    authorized_merge = None
+    pending_merge = None
     for inv in invs:
         if inv.kind != 'gh':
             continue
@@ -573,11 +595,13 @@ def analyze(  # noqa: C901
         if is_merge:
             if number is None:
                 return UNNUMBERED_MSG
+            if pending_merge is not None:
+                return MULTIPLE_MERGES_MSG
             if _gh_repo(target, inv.dir, git, cmd, gh_repo_env) != guarded_slug:
                 return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL + MERGE_ESCAPE
             # Spending it here would pay for a merge a later invocation in the same command can
             # still block, so the authorization is consulted once everything else has passed.
-            authorized_merge = number
+            pending_merge = number
 
     for inv, sub, rest in git_invs:
         if exempt(inv.dir):
@@ -615,7 +639,7 @@ def analyze(  # noqa: C901
             if deny:
                 return deny
 
-    if authorized_merge is not None and not allow_merge(authorized_merge, guarded_slug):
+    if pending_merge is not None and not allow_merge(pending_merge, guarded_slug):
         return 'BLOCKED: gh pr merge is not allowed.' + DENY_TAIL + MERGE_ESCAPE
     return None
 
@@ -662,7 +686,7 @@ def main() -> int:
     cwd = payload.get('cwd') or os.getcwd()
     git = GitInfo()
     guarded_slug = repo_slug(git.origin_url(os.environ.get('CLAUDE_PROJECT_DIR') or os.getcwd()))
-    deny = analyze(cmd, cwd, guarded_slug, git, gh_repo_env=os.environ.get('GH_REPO', ''))
+    deny = analyze(cmd, cwd, guarded_slug, git, gh_repo_env=os.environ.get(GH_REPO_ENV, ''))
     if deny:
         print(deny, file=sys.stderr)
         return 2

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -326,6 +326,23 @@ def test_an_authorization_is_not_spent_by_a_command_the_guard_blocks_anyway(git)
     assert asked == []
 
 
+def test_a_merge_inside_a_command_substitution_is_refused_and_spends_nothing(git):
+    """The body runs before the outer command, which can then be refused with the receipt gone."""
+    asked = []
+    cmd = 'echo ' + chr(96) + 'gh pr merge 566' + chr(96) + ' && git push origin main'
+    assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None
+    assert asked == []
+
+
+def test_a_merge_beside_a_command_substitution_is_refused(git):
+    """A substituted assignment name reaches the tokens as a sentinel, not as `GH_REPO=`."""
+    asked = []
+    cmd = 'env G' + chr(96) + 'printf H_REPO' + chr(96) + '=someone/other gh pr merge 566'
+    denial = verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True)
+    assert denial is not None and 'command substitution' in denial
+    assert asked == []
+
+
 def test_a_command_merging_two_pull_requests_is_refused(git):
     """One authorization names one merge, and the first would be spent before the rest is known."""
     asked = []

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -77,8 +77,10 @@ def no_allow(number, guarded_slug):
     return False
 
 
-def verdict(git, cmd, cwd=CLONE, allow_merge=no_allow):
-    return gmm.analyze(cmd, cwd, GUARDED, git, path_exists=fake_path_exists, allow_merge=allow_merge)
+def verdict(git, cmd, cwd=CLONE, allow_merge=no_allow, gh_repo_env=''):
+    return gmm.analyze(
+        cmd, cwd, GUARDED, git, path_exists=fake_path_exists, allow_merge=allow_merge, gh_repo_env=gh_repo_env
+    )
 
 
 BLOCKED = [
@@ -291,6 +293,46 @@ def test_a_merge_in_another_repository_is_refused_without_consulting_any_authori
     asked = []
     assert (
         verdict(git, 'gh pr -R someone/other merge 566', allow_merge=lambda n, slug: asked.append(n) or True)
+        is not None
+    )
+    assert asked == []
+
+
+def test_a_merge_run_from_another_repo_is_not_this_repository_s(git):
+    """gh resolves the repository from the working directory when nothing names one."""
+    asked = []
+    assert (
+        verdict(git, f'cd {INFRA} && gh pr merge 566', allow_merge=lambda n, slug: asked.append(n) or True) is not None
+    )
+    assert asked == []
+
+
+def test_a_merge_whose_repository_cannot_be_established_is_refused(git):
+    asked = []
+    for cmd in ('cd /missing; gh pr merge 566', 'GH_REPO=someone/other gh pr merge 566'):
+        assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None
+    assert asked == []
+
+
+def test_an_authorization_is_not_spent_by_a_command_the_guard_blocks_anyway(git):
+    """The merge never runs, so the human's one authorization must survive the refusal."""
+    asked = []
+    assert (
+        verdict(
+            git, 'gh pr merge 566 --squash && git push origin main', allow_merge=lambda n, slug: asked.append(n) or True
+        )
+        is not None
+    )
+    assert asked == []
+
+
+def test_gh_repo_in_the_environment_is_enough_to_refuse(git):
+    """It selects the repository the way `-R` does, and a command cannot be read for it."""
+    asked = []
+    assert (
+        verdict(
+            git, 'gh pr merge 566', gh_repo_env='someone/other', allow_merge=lambda n, slug: asked.append(n) or True
+        )
         is not None
     )
     assert asked == []

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -343,6 +343,21 @@ def test_a_merge_beside_a_command_substitution_is_refused(git):
     assert asked == []
 
 
+def test_a_process_substitution_hides_a_second_command_in_the_same_segment(git):
+    """`<(` keeps the command it feeds and the one it runs together, where only the first is read."""
+    asked = []
+    cmd = 'gh pr merge 566 --body-file <' + '(gh pr merge 567)'
+    assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None
+    assert asked == []
+
+
+def test_a_spend_mark_cannot_be_taken_twice(tmp_path, as_root):
+    """Exclusive create, so two hooks racing one receipt cannot both find it unspent."""
+    write_allow(tmp_path, 566)
+    assert consume(566, tmp_path)
+    assert not consume(566, tmp_path)
+
+
 def test_a_command_merging_two_pull_requests_is_refused(git):
     """One authorization names one merge, and the first would be spent before the rest is known."""
     asked = []

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -326,6 +326,31 @@ def test_an_authorization_is_not_spent_by_a_command_the_guard_blocks_anyway(git)
     assert asked == []
 
 
+def test_a_command_merging_two_pull_requests_is_refused(git):
+    """One authorization names one merge, and the first would be spent before the rest is known."""
+    asked = []
+    verdict = gmm.analyze(
+        'gh pr merge 566 && gh pr merge 567',
+        CLONE,
+        GUARDED,
+        git,
+        path_exists=fake_path_exists,
+        allow_merge=lambda n, slug: asked.append(n) or True,
+    )
+    assert verdict is not None and 'one pull request per command' in verdict
+    assert asked == []
+
+
+def test_a_quoted_gh_repo_assignment_is_read_as_the_shell_reads_it(git):
+    """Quote removal happens before the assignment, so the raw text never spells the name."""
+    asked = []
+    assert (
+        verdict(git, "env G''H_REPO=someone/other gh pr merge 566", allow_merge=lambda n, slug: asked.append(n) or True)
+        is not None
+    )
+    assert asked == []
+
+
 def test_gh_repo_in_the_environment_is_enough_to_refuse(git):
     """It selects the repository the way `-R` does, and a command cannot be read for it."""
     asked = []

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -275,8 +275,30 @@ def test_an_authorized_merge_goes_through(git):
 
 def test_the_authorization_is_asked_for_the_pull_request_being_merged(git):
     asked = []
-    verdict(git, 'gh pr -R o/r merge 566 --delete-branch', allow_merge=lambda n, slug: asked.append((n, slug)) or False)
+    verdict(git, 'gh pr merge 566 --delete-branch', allow_merge=lambda n, slug: asked.append((n, slug)) or False)
     assert asked == [(566, GUARDED.casefold())]
+
+
+def test_a_value_taking_flag_does_not_donate_its_value_as_the_pull_request(git):
+    """`gh pr merge --subject 566 999` merges 999; authorizing 566 must not clear it."""
+    asked = []
+    verdict(git, 'gh pr merge --subject 566 999 --squash', allow_merge=lambda n, slug: asked.append(n) or False)
+    assert asked == [999]
+
+
+def test_a_merge_in_another_repository_is_refused_without_consulting_any_authorization(git):
+    """`-R` selects a repository this guard holds no receipts for."""
+    asked = []
+    assert (
+        verdict(git, 'gh pr -R someone/other merge 566', allow_merge=lambda n, slug: asked.append(n) or True)
+        is not None
+    )
+    assert asked == []
+
+
+def test_reading_the_help_is_not_a_merge(git):
+    assert verdict(git, 'gh pr merge --help') is None
+    assert verdict(git, 'gh help pr merge') is None
 
 
 def test_a_commit_message_quoting_a_blocked_command_is_not_itself_blocked(git):
@@ -291,7 +313,7 @@ def test_an_unquoted_heredoc_still_fails_closed(git):
     assert verdict(git, cmd) is not None
 
 
-def write_allow(directory, number, repo='', issued_at=1_000_000, ttl_s=1800):
+def write_allow(directory, number, repo='', issued_at=1_000_000, ttl_s=1800, receipt_id='abcd1234'):
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / gmm.RECEIPT_NAME.format(number=number)
     path.write_text(
@@ -300,45 +322,80 @@ def write_allow(directory, number, repo='', issued_at=1_000_000, ttl_s=1800):
             gmm.RECEIPT_NUMBER: number,
             gmm.RECEIPT_ISSUED_AT: issued_at,
             gmm.RECEIPT_TTL_S: ttl_s,
+            gmm.RECEIPT_ID: receipt_id,
             'by': 'U0',
         })
     )
     return path
 
 
-def test_an_authorization_is_spent_by_the_merge_it_permits(tmp_path):
-    path = write_allow(tmp_path, 566)
-    assert gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
-    assert not path.exists()
-    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+@pytest.fixture
+def as_root(monkeypatch):
+    """Stand in for the ownership check: a test cannot create a root-owned file."""
+    monkeypatch.setattr(gmm, '_written_by_root', lambda path, directory: path.exists())
 
 
-def test_an_expired_authorization_is_refused_and_cleared(tmp_path):
-    path = write_allow(tmp_path, 566)
-    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_002_000)
-    assert not path.exists()
+def consume(number, tmp_path, now=1_000_060, repo=GUARDED):
+    return gmm.consume_merge_allow(number, repo, tmp_path, tmp_path / 'spent', now=now)
 
 
-def test_an_authorization_for_another_pull_request_does_not_carry(tmp_path):
+def test_an_authorization_is_spent_by_the_merge_it_permits(tmp_path, as_root):
     write_allow(tmp_path, 566)
-    assert not gmm.consume_merge_allow(565, GUARDED, tmp_path, now=1_000_060)
+    assert consume(566, tmp_path)
+    assert not consume(566, tmp_path)
+
+
+def test_a_second_authorization_is_honoured_however_close_it_follows_the_first(tmp_path, as_root):
+    """The spend mark names the authorization, so two of them never collide."""
+    write_allow(tmp_path, 566, receipt_id='aaaa1111')
+    assert consume(566, tmp_path)
+    write_allow(tmp_path, 566, receipt_id='bbbb2222')
+    assert consume(566, tmp_path)
+
+
+@pytest.mark.parametrize('receipt_id', ['', None, 'no', 'has space', 'x' * 65])
+def test_a_receipt_that_names_no_usable_authorization_is_refused(tmp_path, as_root, receipt_id):
+    write_allow(tmp_path, 566, receipt_id=receipt_id)
+    assert not consume(566, tmp_path)
+
+
+def test_a_receipt_that_root_did_not_write_is_no_authorization(tmp_path):
+    """The real check, unpatched: this test's own file is not root's."""
+    write_allow(tmp_path, 566)
+    assert not consume(566, tmp_path)
+
+
+def test_an_expired_authorization_is_refused(tmp_path, as_root):
+    write_allow(tmp_path, 566)
+    assert not consume(566, tmp_path, now=1_002_000)
+
+
+def test_an_authorization_for_another_pull_request_does_not_carry(tmp_path, as_root):
+    write_allow(tmp_path, 566)
+    assert not consume(565, tmp_path)
 
 
 @pytest.mark.parametrize('repo', ['', 'positronic', 'Positronic-Robotics/positronic'])
-def test_a_reference_naming_this_repository_is_honoured(tmp_path, repo):
+def test_a_reference_naming_this_repository_is_honoured(tmp_path, as_root, repo):
     write_allow(tmp_path, 566, repo=repo)
-    assert gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+    assert consume(566, tmp_path)
 
 
-def test_an_authorization_for_another_repository_is_refused(tmp_path):
+def test_an_authorization_for_another_repository_is_refused(tmp_path, as_root):
     write_allow(tmp_path, 566, repo='someone/other')
-    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+    assert not consume(566, tmp_path)
 
 
-def test_a_missing_or_unreadable_receipt_is_simply_no_authorization(tmp_path):
-    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+def test_a_missing_or_unreadable_receipt_is_simply_no_authorization(tmp_path, as_root):
+    assert not consume(566, tmp_path)
     (tmp_path / gmm.RECEIPT_NAME.format(number=566)).write_text('{not json')
-    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+    assert not consume(566, tmp_path)
+
+
+def test_a_world_writable_receipt_directory_is_not_root_only(tmp_path):
+    path = write_allow(tmp_path, 566)
+    tmp_path.chmod(0o777)
+    assert not gmm._written_by_root(path, tmp_path)
 
 
 def _init_repo(path, url, branch='main'):

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -73,8 +73,12 @@ def git():
     })
 
 
-def verdict(git, cmd, cwd=CLONE):
-    return gmm.analyze(cmd, cwd, GUARDED, git, path_exists=fake_path_exists)
+def no_allow(number, guarded_slug):
+    return False
+
+
+def verdict(git, cmd, cwd=CLONE, allow_merge=no_allow):
+    return gmm.analyze(cmd, cwd, GUARDED, git, path_exists=fake_path_exists, allow_merge=allow_merge)
 
 
 BLOCKED = [
@@ -254,6 +258,87 @@ def test_deny_messages_name_the_operation(git):
     assert 'amend' in verdict(git, 'git commit --amend')
     assert 'gh pr merge' in verdict(git, 'gh pr merge 5')
     assert 'push to main' in verdict(git, 'git push origin main')
+
+
+def test_a_lossily_parsed_merge_is_denied_rather_than_crashing(git):
+    """An unparseable command falls back to a coarse scan, whose words carry shell punctuation."""
+    assert verdict(git, "echo don't && gh pr merge)") is not None
+
+
+def test_a_merge_naming_no_pull_request_says_to_name_one(git):
+    assert 'name the pull request' in verdict(git, 'gh pr merge --squash', allow_merge=lambda *_: True)
+
+
+def test_an_authorized_merge_goes_through(git):
+    assert verdict(git, 'gh pr merge 566 --squash', allow_merge=lambda *_: True) is None
+
+
+def test_the_authorization_is_asked_for_the_pull_request_being_merged(git):
+    asked = []
+    verdict(git, 'gh pr -R o/r merge 566 --delete-branch', allow_merge=lambda n, slug: asked.append((n, slug)) or False)
+    assert asked == [(566, GUARDED.casefold())]
+
+
+def test_a_commit_message_quoting_a_blocked_command_is_not_itself_blocked(git):
+    """A backtick inside a quoted heredoc is prose: the delimiter suppresses every expansion."""
+    cmd = "cd /w/positronic && git commit -F- -- x.py <<'EOF'\nthe guard blocks `gh pr merge` outright\nEOF"
+    assert verdict(git, cmd) is None
+
+
+def test_an_unquoted_heredoc_still_fails_closed(git):
+    """Its body DOES expand, so a substitution in it is a command, not prose."""
+    cmd = 'cd /w/positronic && git commit -F- -- x.py <<EOF\n`git push origin main`\nEOF'
+    assert verdict(git, cmd) is not None
+
+
+def write_allow(directory, number, repo='', issued_at=1_000_000, ttl_s=1800):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / gmm.RECEIPT_NAME.format(number=number)
+    path.write_text(
+        json.dumps({
+            gmm.RECEIPT_REPO: repo,
+            gmm.RECEIPT_NUMBER: number,
+            gmm.RECEIPT_ISSUED_AT: issued_at,
+            gmm.RECEIPT_TTL_S: ttl_s,
+            'by': 'U0',
+        })
+    )
+    return path
+
+
+def test_an_authorization_is_spent_by_the_merge_it_permits(tmp_path):
+    path = write_allow(tmp_path, 566)
+    assert gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+    assert not path.exists()
+    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+
+
+def test_an_expired_authorization_is_refused_and_cleared(tmp_path):
+    path = write_allow(tmp_path, 566)
+    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_002_000)
+    assert not path.exists()
+
+
+def test_an_authorization_for_another_pull_request_does_not_carry(tmp_path):
+    write_allow(tmp_path, 566)
+    assert not gmm.consume_merge_allow(565, GUARDED, tmp_path, now=1_000_060)
+
+
+@pytest.mark.parametrize('repo', ['', 'positronic', 'Positronic-Robotics/positronic'])
+def test_a_reference_naming_this_repository_is_honoured(tmp_path, repo):
+    write_allow(tmp_path, 566, repo=repo)
+    assert gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+
+
+def test_an_authorization_for_another_repository_is_refused(tmp_path):
+    write_allow(tmp_path, 566, repo='someone/other')
+    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+
+
+def test_a_missing_or_unreadable_receipt_is_simply_no_authorization(tmp_path):
+    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
+    (tmp_path / gmm.RECEIPT_NAME.format(number=566)).write_text('{not json')
+    assert not gmm.consume_merge_allow(566, GUARDED, tmp_path, now=1_000_060)
 
 
 def _init_repo(path, url, branch='main'):


### PR DESCRIPTION
`utilities/guard_main_merge.py` blocked `gh pr merge` outright, so the only way to land a pull request was for a human to run the merge themselves. That leaves the agent holding none of what follows a merge — closing the ticket, harvesting the review worktree, reporting the outcome — and it is the whole cost of the guard, whose purpose is only to stop the agent merging on its own say-so.

The guard now honours a receipt naming one pull request, and spends it. `gh pr merge 566` proceeds when a receipt for 566 is present, root-written and unexpired.

## Why

The receipt is written by the relay when a human types `!allow_merge <ref>` in chat (`listen_chat_receiver/relay/merge_allow.py` in the `os` repository). Three things stand between an agent and one of its own making:

- the command arrives through the same ingest as every other relay control, so only a whitelisted human in a whitelisted channel produces one;
- a **synthetic** message is refused — an injection is owner-authored by construction, so anything able to inject could otherwise mint its own permission;
- the file is written **as root** into a root-only-writable directory, and the guard honours it only when the file and its directory are root-owned and the directory is writable by nobody else.

None of that holds against root, and every agent here reaches root through the account's sudo. That is the deliberate limit: the property is *a non-root process cannot forge an authorization*, and the docstrings say exactly that rather than implying more.

Root-only-writable has a consequence: this hook is not root, so it cannot delete what it honours. Spending is recorded as a mark it owns, keyed on an id the receipt carries. Keyed on the timestamp the mark would collide — two authorizations of one pull request in the same second share a whole-second `issued_at`, and the second would read as already spent.

The alternative considered was a GitHub `APPROVED` review on the current head: no new mechanism, permanent record. It splits the act across two surfaces, and against an agent with root it is no stronger. The receipt keeps the human's act to one word in the chat they are already in.

## Reading the merge command

Three parsing defects, each with a test that fails against the previous code:

- `gh pr merge --subject 566 999` merges **999**, but the first digit after `merge` was taken as the target, so authorizing 566 cleared it. Flags that consume the following argument are now consumed with it, and the target must be the first positional written as a number — a URL or a branch names nothing an authorization can match.
- `gh pr -R someone/other merge 566` was allowed by a receipt for *this* repository's 566. The repository is part of a pull request's identity, so `-R` naming another is refused without consulting any authorization, as it was before this escape existed.
- A lossily-parsed `gh pr merge)` vetted as a merge and then had no word `merge` to index, raising `ValueError` instead of returning a verdict. Vetting and the target are one function now.

Reading the manual is not merging: `gh pr merge --help` and `gh help pr merge` were both blocked.

Separately, command substitutions were scanned before quoted heredoc bodies were stripped. A quoted delimiter suppresses every expansion, so a backtick there is prose — and a commit message describing a blocked command blocked its own commit.

## Verification

`utilities/tests/` green (125), covering the receipt lifecycle: spent by the merge it permits, a second authorization honoured however close it follows, refused when expired, when written by anyone but root, when the directory is world-writable, when it names another pull request or repository, and when it carries no usable id. `pre-commit run` over both files passes every hook; six repo rules clean. The `os` side is on trunk: `82a91e7`, `68e6c43`.

**Not yet exercised end to end** — the root write path needs one `install -d` as root on this host, which is a gated step.

<!-- opened-by: posi-agent -->