### PR TITLE
Read a merge's repository the way pflag does, and refuse one the shell builds

### DIFF
--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -442,14 +442,49 @@ def _carries_substitution(cmd: str) -> bool:
     return any(word == SUBST or '<(' in word or '>(' in word for segment in segments for word in segment)
 
 
-def _carries_expansion(words: list[str]) -> bool:
-    """Whether the shell builds any of `words` at runtime.
+# Shell syntax that turns one written word into arguments the text does not spell out: a parameter
+# expansion, whose value is word-split; a brace list; a glob, which matches as many names as it finds.
+EXPANDING_CHARS = '$*?[{'
+# `NAME=value` before the command word. Its value reaches the environment whole — never word-split
+# into arguments — so an expansion there says nothing about what the command is asked to do.
+ASSIGNMENT_RE = re.compile(r'\w+=')
 
-    An expansion's value is unknown before the command runs, and the shell word-SPLITS it after
-    it: `EXTRA='-R other/repo'; gh pr merge 566 $EXTRA` reaches gh as a repository selector no
-    authorization named. `$(…)` leaves a bare `$` among the tokens, which this reads the same way.
+
+def _expands(word: str) -> bool:
+    """Whether the shell builds `word` into something other than its own text.
+
+    Quoting is what decides, and it is per REGION rather than per word: `--subject='$x'` is a
+    literal while `--subject=$x` is not. A backslash escapes the character after it.
     """
-    return any('$' in word for word in words)
+    quote = ''
+    i = 0
+    while i < len(word):
+        c = word[i]
+        if quote:
+            quote = '' if c == quote else quote
+        elif c == '\\':
+            i += 1
+        elif c in '\'"':
+            quote = c
+        elif c in EXPANDING_CHARS:
+            return True
+        i += 1
+    return False
+
+
+def _carries_expansion(cmd: str) -> bool:
+    """Whether `cmd` hands the shell an argument its own text does not spell out.
+
+    `EXTRA='-R other/repo'; gh pr merge 566 $EXTRA` reaches gh as a repository selector no
+    authorization named, and `{-R,other/repo}` and a glob do the same with no `$` in sight. The
+    quoting that would make each one literal is removed before a word reaches `_segments`, so this
+    reads the command's own text.
+    """
+    try:
+        words = shlex.split(_strip_heredoc_bodies(cmd), posix=False)
+    except ValueError:
+        return True
+    return any(_expands(w) for w in words if not ASSIGNMENT_RE.match(w))
 
 
 def _sets_gh_repo(cmd: str) -> bool:
@@ -481,6 +516,9 @@ def _gh_repo(explicit: str, inv_dir: str | None, git: GitInfo, cmd: str, gh_repo
     return repo_slug(git.origin_url(inv_dir)) if inv_dir is not None else ''
 
 
+# gh's own spellings of the flag that selects a repository — the one value a merge is read for,
+# so every reader of it agrees here rather than repeating the pair.
+GH_REPO_FLAGS = ('-R', '--repo')
 # `gh pr merge` flags that consume the following argument, so its value is never the pull
 # request being merged: `gh pr merge --subject 566 999` merges 999.
 GH_MERGE_VALUE_FLAGS = frozenset({
@@ -493,8 +531,7 @@ GH_MERGE_VALUE_FLAGS = frozenset({
     '--match-head-commit',
     '-t',
     '--subject',
-    '-R',
-    '--repo',
+    *GH_REPO_FLAGS,
 })
 
 
@@ -526,7 +563,7 @@ def _gh_flag(word: str) -> tuple[bool, str, str]:
     if flag in GH_MERGE_VALUE_FLAGS:
         if not eq:
             return False, '', flag
-        return False, value if flag in ('-R', '--repo') else '', ''
+        return False, value if flag in GH_REPO_FLAGS else '', ''
     if word.startswith('--'):
         return False, '', ''
     short, attached = _gh_shorthand(word)
@@ -534,7 +571,7 @@ def _gh_flag(word: str) -> tuple[bool, str, str]:
         return True, '', ''
     if not attached:
         return False, '', short
-    return False, attached if short == '-R' else '', ''
+    return False, attached if short in GH_REPO_FLAGS else '', ''
 
 
 def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
@@ -548,7 +585,7 @@ def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
     repo = pending = ''
     for w in words:
         if pending:
-            repo, pending = (w if pending in ('-R', '--repo') else repo), ''
+            repo, pending = (w if pending in GH_REPO_FLAGS else repo), ''
         elif w.startswith('-'):
             asks_help, named, pending = _gh_flag(w)
             if asks_help:
@@ -667,7 +704,7 @@ def analyze(  # noqa: C901
         if is_merge:
             if in_substitution or _carries_substitution(cmd):
                 return MERGE_SUBSTITUTION_MSG
-            if _carries_expansion(inv.words):
+            if _carries_expansion(cmd):
                 return MERGE_EXPANSION_MSG
             if number is None:
                 return UNNUMBERED_MSG

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -453,17 +453,22 @@ COMMAND_SEPARATORS = ';&|\n()'
 def _expands(word: str) -> bool:
     """Whether the shell builds `word` into something other than its own text.
 
-    Quoting is what decides, and it is per REGION rather than per word: `--subject='$x'` is a
-    literal while `--subject=$x` is not. A backslash escapes the character after it.
+    Quoting decides, per REGION rather than per word, and the two quotes differ: single quotes
+    suppress everything, while double quotes still expand a parameter — `"$EXTRA"` reaches gh as
+    whatever EXTRA holds. A backslash escapes the character after it.
     """
     quote = ''
     i = 0
     while i < len(word):
         c = word[i]
-        if quote:
-            quote = '' if c == quote else quote
+        if quote == "'":
+            quote = '' if c == "'" else quote
         elif c == '\\':
             i += 1
+        elif quote == '"':
+            quote = '' if c == '"' else quote
+            if c == '$':
+                return True
         elif c in '\'"':
             quote = c
         elif c in EXPANDING_CHARS:
@@ -514,29 +519,39 @@ def _raw_words(cmd: str) -> list[str]:
 ASSIGNMENT_RE = re.compile(r'\w+=')
 
 
+def _builds_arguments(words: list[str]) -> bool:
+    """Whether one command's words carry an argument its own text does not spell out.
+
+    An assignment is exempt only where it stands before the command word, since there its value
+    reaches the environment whole; written as an argument, `--body x=$EXTRA` is split like anything
+    else.
+    """
+    at_command_start = True
+    for w in words:
+        if at_command_start and ASSIGNMENT_RE.match(w):
+            continue
+        at_command_start = False
+        if _expands(w):
+            return True
+    return False
+
+
 def _carries_expansion(cmd: str) -> bool:
-    """Whether `cmd` hands the shell an argument its own text does not spell out.
+    """Whether a `gh` command in `cmd` is handed an argument its own text does not spell out.
 
     `EXTRA='-R other/repo'; gh pr merge 566 $EXTRA` reaches gh as a repository selector no
-    authorization named, and `{-R,other/repo}` and a glob do the same with no `$` in sight. An
-    assignment is exempt only where it stands before a command word, since there its value reaches
-    the environment whole; written as an argument, `--body x=$EXTRA` is split like anything else.
+    authorization named, and `{-R,other/repo}` and a glob do the same with no `$` in sight. Only
+    the command that runs gh is read: an expansion in a `&& echo $HOME` beside it cannot reach
+    gh's arguments.
     """
     try:
         words = _raw_words(_strip_heredoc_bodies(cmd))
     except ValueError:
         return True
-    at_command_start = True
+    segments: list[list[str]] = [[]]
     for w in words:
-        if w in COMMAND_SEPARATORS:
-            at_command_start = True
-        elif at_command_start and ASSIGNMENT_RE.match(w):
-            continue
-        else:
-            at_command_start = False
-            if _expands(w):
-                return True
-    return False
+        segments.append([]) if w in COMMAND_SEPARATORS else segments[-1].append(w)
+    return any(_builds_arguments(s) for s in segments if any(os.path.basename(w) == 'gh' for w in s))
 
 
 def _sets_gh_repo(cmd: str) -> bool:

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -49,6 +49,10 @@ MERGE_SUBSTITUTION_MSG = (
     'BLOCKED: a merge in a command carrying a command substitution cannot be verified — the'
     ' substitution decides at runtime what is merged, and where.'
 )
+MERGE_EXPANSION_MSG = (
+    'BLOCKED: a merge whose words the shell expands cannot be verified — the expansion is split'
+    ' into further arguments, which can select a repository the authorization never named.'
+)
 AMEND_MSG = 'BLOCKED: Never amend commits, create new ones instead.'
 
 # git global options that consume the following argument in their space-separated form
@@ -423,23 +427,6 @@ def consume_merge_allow(
     return True
 
 
-# `gh pr merge` flags that consume the following argument, so its value is never the pull
-# request being merged: `gh pr merge --subject 566 999` merges 999.
-GH_MERGE_VALUE_FLAGS = frozenset({
-    '-A',
-    '--author-email',
-    '-b',
-    '--body',
-    '-F',
-    '--body-file',
-    '--match-head-commit',
-    '-t',
-    '--subject',
-    '-R',
-    '--repo',
-})
-
-
 def _carries_substitution(cmd: str) -> bool:
     """Whether `cmd` carries a substitution, or quoting that cannot be read.
 
@@ -453,6 +440,16 @@ def _carries_substitution(cmd: str) -> bool:
     except ValueError:
         return True
     return any(word == SUBST or '<(' in word or '>(' in word for segment in segments for word in segment)
+
+
+def _carries_expansion(words: list[str]) -> bool:
+    """Whether the shell builds any of `words` at runtime.
+
+    An expansion's value is unknown before the command runs, and the shell word-SPLITS it after
+    it: `EXTRA='-R other/repo'; gh pr merge 566 $EXTRA` reaches gh as a repository selector no
+    authorization named. `$(…)` leaves a bare `$` among the tokens, which this reads the same way.
+    """
+    return any('$' in word for word in words)
 
 
 def _sets_gh_repo(cmd: str) -> bool:
@@ -484,6 +481,62 @@ def _gh_repo(explicit: str, inv_dir: str | None, git: GitInfo, cmd: str, gh_repo
     return repo_slug(git.origin_url(inv_dir)) if inv_dir is not None else ''
 
 
+# `gh pr merge` flags that consume the following argument, so its value is never the pull
+# request being merged: `gh pr merge --subject 566 999` merges 999.
+GH_MERGE_VALUE_FLAGS = frozenset({
+    '-A',
+    '--author-email',
+    '-b',
+    '--body',
+    '-F',
+    '--body-file',
+    '--match-head-commit',
+    '-t',
+    '--subject',
+    '-R',
+    '--repo',
+})
+
+
+def _gh_shorthand(word: str) -> tuple[str, str]:
+    """The value-taking shorthand in a `-abc` cluster, and the value written onto it.
+
+    pflag clusters shorthands and takes a value attached to the last of them, so
+    `-dRowner/repo` is `--delete-branch --repo owner/repo`. An empty value means the next word
+    carries it. ('', '') when the cluster takes none, and ('-h', '') for help, which merges nothing.
+    """
+    for i, letter in enumerate(word[1:], 1):
+        short = '-' + letter
+        if short == '-h':
+            return short, ''
+        if short in GH_MERGE_VALUE_FLAGS:
+            return short, word[i + 1 :].removeprefix('=')
+    return '', ''
+
+
+def _gh_flag(word: str) -> tuple[bool, str, str]:
+    """How one flag word bears on a merge.
+
+    Whether it asks for help — which makes gh print it and merge nothing — the repository it
+    names, and the value-taking flag it leaves for the NEXT word to fill.
+    """
+    flag, eq, value = word.partition('=')
+    if flag in ('--help', '-h'):
+        return True, '', ''
+    if flag in GH_MERGE_VALUE_FLAGS:
+        if not eq:
+            return False, '', flag
+        return False, value if flag in ('-R', '--repo') else '', ''
+    if word.startswith('--'):
+        return False, '', ''
+    short, attached = _gh_shorthand(word)
+    if short == '-h':
+        return True, '', ''
+    if not attached:
+        return False, '', short
+    return False, attached if short == '-R' else '', ''
+
+
 def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
     """Whether this is `gh pr merge`, the pull request it names, and the repository it targets.
 
@@ -497,13 +550,10 @@ def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
         if pending:
             repo, pending = (w if pending in ('-R', '--repo') else repo), ''
         elif w.startswith('-'):
-            flag, eq, value = w.partition('=')
-            if flag in ('--help', '-h'):
+            asks_help, named, pending = _gh_flag(w)
+            if asks_help:
                 return False, None, ''
-            if flag in ('-R', '--repo') and eq:
-                repo = value
-            elif flag in GH_MERGE_VALUE_FLAGS and not eq:
-                pending = flag
+            repo = named or repo
         elif bare := re.sub(r'[)}].*$', '', w):  # a lossy parse leaves a closing delimiter glued on
             positional.append(bare)
     if not positional or positional[0] == 'help' or 'pr' not in positional:
@@ -617,6 +667,8 @@ def analyze(  # noqa: C901
         if is_merge:
             if in_substitution or _carries_substitution(cmd):
                 return MERGE_SUBSTITUTION_MSG
+            if _carries_expansion(inv.words):
+                return MERGE_EXPANSION_MSG
             if number is None:
                 return UNNUMBERED_MSG
             if pending_merge is not None:

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -516,9 +516,10 @@ def _gh_repo(explicit: str, inv_dir: str | None, git: GitInfo, cmd: str, gh_repo
     return repo_slug(git.origin_url(inv_dir)) if inv_dir is not None else ''
 
 
-# gh's own spellings of the flag that selects a repository — the one value a merge is read for,
-# so every reader of it agrees here rather than repeating the pair.
+# gh's own spellings of the flag that selects a repository.
 GH_REPO_FLAGS = ('-R', '--repo')
+# Asking for help makes gh print it and merge nothing.
+GH_HELP_FLAGS = ('--help', '-h')
 # `gh pr merge` flags that consume the following argument, so its value is never the pull
 # request being merged: `gh pr merge --subject 566 999` merges 999.
 GH_MERGE_VALUE_FLAGS = frozenset({
@@ -536,42 +537,27 @@ GH_MERGE_VALUE_FLAGS = frozenset({
 
 
 def _gh_shorthand(word: str) -> tuple[str, str]:
-    """The value-taking shorthand in a `-abc` cluster, and the value written onto it.
+    """The flag a `-abc` cluster names, and the value written onto it.
 
-    pflag clusters shorthands and takes a value attached to the last of them, so
-    `-dRowner/repo` is `--delete-branch --repo owner/repo`. An empty value means the next word
-    carries it. ('', '') when the cluster takes none, and ('-h', '') for help, which merges nothing.
+    pflag clusters shorthands and takes a value attached to the last of them, so `-dRowner/repo`
+    is `--delete-branch --repo owner/repo`.
     """
     for i, letter in enumerate(word[1:], 1):
         short = '-' + letter
-        if short == '-h':
-            return short, ''
-        if short in GH_MERGE_VALUE_FLAGS:
+        if short in GH_HELP_FLAGS or short in GH_MERGE_VALUE_FLAGS:
             return short, word[i + 1 :].removeprefix('=')
     return '', ''
 
 
-def _gh_flag(word: str) -> tuple[bool, str, str]:
-    """How one flag word bears on a merge.
+def _gh_flag(word: str) -> tuple[str, str]:
+    """The flag one word names, and the value written onto it.
 
-    Whether it asks for help — which makes gh print it and merge nothing — the repository it
-    names, and the value-taking flag it leaves for the NEXT word to fill.
+    An empty value means the next word carries it; ('', '') is a word naming no flag read here.
     """
     flag, eq, value = word.partition('=')
-    if flag in ('--help', '-h'):
-        return True, '', ''
-    if flag in GH_MERGE_VALUE_FLAGS:
-        if not eq:
-            return False, '', flag
-        return False, value if flag in GH_REPO_FLAGS else '', ''
-    if word.startswith('--'):
-        return False, '', ''
-    short, attached = _gh_shorthand(word)
-    if short == '-h':
-        return True, '', ''
-    if not attached:
-        return False, '', short
-    return False, attached if short in GH_REPO_FLAGS else '', ''
+    if flag in GH_HELP_FLAGS or flag in GH_MERGE_VALUE_FLAGS:
+        return flag, value if eq else ''
+    return ('', '') if word.startswith('--') else _gh_shorthand(word)
 
 
 def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
@@ -587,10 +573,12 @@ def _gh_pr_merge(words: list[str]) -> tuple[bool, int | None, str]:
         if pending:
             repo, pending = (w if pending in GH_REPO_FLAGS else repo), ''
         elif w.startswith('-'):
-            asks_help, named, pending = _gh_flag(w)
-            if asks_help:
+            flag, value = _gh_flag(w)
+            if flag in GH_HELP_FLAGS:
                 return False, None, ''
-            repo = named or repo
+            pending = flag if flag and not value else ''
+            if value and flag in GH_REPO_FLAGS:
+                repo = value
         elif bare := re.sub(r'[)}].*$', '', w):  # a lossy parse leaves a closing delimiter glued on
             positional.append(bare)
     if not positional or positional[0] == 'help' or 'pr' not in positional:

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -445,9 +445,9 @@ def _carries_substitution(cmd: str) -> bool:
 # Shell syntax that turns one written word into arguments the text does not spell out: a parameter
 # expansion, whose value is word-split; a brace list; a glob, which matches as many names as it finds.
 EXPANDING_CHARS = '$*?[{'
-# `NAME=value` before the command word. Its value reaches the environment whole — never word-split
-# into arguments — so an expansion there says nothing about what the command is asked to do.
-ASSIGNMENT_RE = re.compile(r'\w+=')
+# Characters that end one command and start the next, so the word after them can be an assignment
+# prefix again. Braces are NOT among them: `{-R,o/r}` is one word, and the brace is what gives it away.
+COMMAND_SEPARATORS = ';&|\n()'
 
 
 def _expands(word: str) -> bool:
@@ -472,19 +472,71 @@ def _expands(word: str) -> bool:
     return False
 
 
+def _raw_words(cmd: str) -> list[str]:
+    """`cmd` cut into words and command separators, with its quoting left in place.
+
+    `shlex` cannot serve: posix mode removes the quotes that decide whether a `$` expands, and
+    non-posix mode opens a quoted region only at a word boundary, so `--subject='a $b'` comes back
+    as fragments carrying a bare `$b` that never expands. Raises ValueError on unbalanced quoting.
+    """
+    words: list[str] = []
+    word = quote = ''
+    i = 0
+    while i < len(cmd):
+        c = cmd[i]
+        if quote:
+            word += c
+            quote = '' if c == quote else quote
+        elif c == '\\':
+            word += cmd[i : i + 2]
+            i += 1
+        elif c in '\'"':
+            word, quote = word + c, c
+        elif c.isspace() or c in COMMAND_SEPARATORS:
+            if word:
+                words.append(word)
+                word = ''
+            if not c.isspace():
+                words.append(c)
+        else:
+            word += c
+        i += 1
+    if quote:
+        raise ValueError('unbalanced quoting')
+    if word:
+        words.append(word)
+    return words
+
+
+# `NAME=value` ahead of the command word. Its value reaches the environment whole — never word-split
+# into arguments — while the same shape written as an argument (`--body x=$V`) is word-split like any
+# other, so the position is half of the meaning.
+ASSIGNMENT_RE = re.compile(r'\w+=')
+
+
 def _carries_expansion(cmd: str) -> bool:
     """Whether `cmd` hands the shell an argument its own text does not spell out.
 
     `EXTRA='-R other/repo'; gh pr merge 566 $EXTRA` reaches gh as a repository selector no
-    authorization named, and `{-R,other/repo}` and a glob do the same with no `$` in sight. The
-    quoting that would make each one literal is removed before a word reaches `_segments`, so this
-    reads the command's own text.
+    authorization named, and `{-R,other/repo}` and a glob do the same with no `$` in sight. An
+    assignment is exempt only where it stands before a command word, since there its value reaches
+    the environment whole; written as an argument, `--body x=$EXTRA` is split like anything else.
     """
     try:
-        words = shlex.split(_strip_heredoc_bodies(cmd), posix=False)
+        words = _raw_words(_strip_heredoc_bodies(cmd))
     except ValueError:
         return True
-    return any(_expands(w) for w in words if not ASSIGNMENT_RE.match(w))
+    at_command_start = True
+    for w in words:
+        if w in COMMAND_SEPARATORS:
+            at_command_start = True
+        elif at_command_start and ASSIGNMENT_RE.match(w):
+            continue
+        else:
+            at_command_start = False
+            if _expands(w):
+                return True
+    return False
 
 
 def _sets_gh_repo(cmd: str) -> bool:

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -320,15 +320,21 @@ def test_a_merge_word_the_shell_builds_is_refused(git):
         'gh pr merge 566 $(echo -R someone/other)',
         'gh pr merge 566 {-R,someone/other}',
         f'gh pr merge 566 --repo {GUARDED} --body-file /tmp/pr*.md',
+        # `NAME=` is an assignment only ahead of the command word; written as an argument the shell
+        # splits it like any other, so `x=junk -R someone/other` reaches gh.
+        f'gh pr merge 566 --repo {GUARDED} --body x=$EXTRA',
     ):
         assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None, cmd
     assert asked == []
 
 
 def test_a_quoted_dollar_is_a_literal_the_shell_never_builds(git):
-    """Quoting decides whether a `$` expands, and the tokenizer removes the quotes."""
-    cmd = f"gh pr merge 566 --repo {GUARDED} --subject 'Read $EXTRA as text'"
-    assert verdict(git, cmd, allow_merge=lambda *_: True) is None
+    """Quoting decides whether a `$` expands, wherever in the word the quote opens."""
+    for cmd in (
+        f"gh pr merge 566 --repo {GUARDED} --subject 'Read $EXTRA as text'",
+        f"gh pr merge 566 --repo {GUARDED} --subject='Read $EXTRA as text'",
+    ):
+        assert verdict(git, cmd, allow_merge=lambda *_: True) is None, cmd
 
 
 def test_a_merge_reading_its_token_from_a_substitution_still_passes(git):

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -323,6 +323,8 @@ def test_a_merge_word_the_shell_builds_is_refused(git):
         # `NAME=` is an assignment only ahead of the command word; written as an argument the shell
         # splits it like any other, so `x=junk -R someone/other` reaches gh.
         f'gh pr merge 566 --repo {GUARDED} --body x=$EXTRA',
+        # double quotes suppress a glob but not a parameter expansion
+        'gh pr merge 566 "$EXTRA" someone/other',
     ):
         assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None, cmd
     assert asked == []
@@ -335,6 +337,12 @@ def test_a_quoted_dollar_is_a_literal_the_shell_never_builds(git):
         f"gh pr merge 566 --repo {GUARDED} --subject='Read $EXTRA as text'",
     ):
         assert verdict(git, cmd, allow_merge=lambda *_: True) is None, cmd
+
+
+def test_an_expansion_beside_the_merge_cannot_reach_its_arguments(git):
+    """A separator ends the command, so a later word is never one of gh's."""
+    cmd = f'gh pr merge 566 --repo {GUARDED} --squash && echo $HOME'
+    assert verdict(git, cmd, allow_merge=lambda *_: True) is None
 
 
 def test_a_merge_reading_its_token_from_a_substitution_still_passes(git):

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -312,12 +312,23 @@ def test_a_repository_shorthand_selects_it_however_pflag_writes_it(git):
     assert verdict(git, f'gh pr merge 566 -dR{GUARDED}', allow_merge=lambda *_: True) is None
 
 
-def test_a_merge_word_the_shell_expands_is_refused(git):
-    """The shell splits an expansion into further arguments, `-R other/repo` among them."""
+def test_a_merge_word_the_shell_builds_is_refused(git):
+    """A brace list, a glob and an expansion each hand gh an argument the text does not spell out."""
     asked = []
-    for cmd in ('gh pr merge 566 $EXTRA', 'gh pr merge 566 $(echo -R someone/other)'):
+    for cmd in (
+        'gh pr merge 566 $EXTRA',
+        'gh pr merge 566 $(echo -R someone/other)',
+        'gh pr merge 566 {-R,someone/other}',
+        f'gh pr merge 566 --repo {GUARDED} --body-file /tmp/pr*.md',
+    ):
         assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None, cmd
     assert asked == []
+
+
+def test_a_quoted_dollar_is_a_literal_the_shell_never_builds(git):
+    """Quoting decides whether a `$` expands, and the tokenizer removes the quotes."""
+    cmd = f"gh pr merge 566 --repo {GUARDED} --subject 'Read $EXTRA as text'"
+    assert verdict(git, cmd, allow_merge=lambda *_: True) is None
 
 
 def test_a_merge_reading_its_token_from_a_substitution_still_passes(git):

--- a/utilities/tests/test_guard_main_merge.py
+++ b/utilities/tests/test_guard_main_merge.py
@@ -298,6 +298,34 @@ def test_a_merge_in_another_repository_is_refused_without_consulting_any_authori
     assert asked == []
 
 
+def test_a_repository_shorthand_selects_it_however_pflag_writes_it(git):
+    """pflag takes a shorthand's value attached, and clusters shorthands ahead of it."""
+    asked = []
+    for cmd in (
+        'gh pr -Rsomeone/other merge 566',
+        'gh pr merge 566 -R=someone/other',
+        'gh pr merge 566 -dRsomeone/other',
+        'gh pr merge 566 -dR someone/other',
+    ):
+        assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None, cmd
+    assert asked == []
+    assert verdict(git, f'gh pr merge 566 -dR{GUARDED}', allow_merge=lambda *_: True) is None
+
+
+def test_a_merge_word_the_shell_expands_is_refused(git):
+    """The shell splits an expansion into further arguments, `-R other/repo` among them."""
+    asked = []
+    for cmd in ('gh pr merge 566 $EXTRA', 'gh pr merge 566 $(echo -R someone/other)'):
+        assert verdict(git, cmd, allow_merge=lambda n, slug: asked.append(n) or True) is not None, cmd
+    assert asked == []
+
+
+def test_a_merge_reading_its_token_from_a_substitution_still_passes(git):
+    """The assignment prefix expands into the environment, not into gh's arguments."""
+    cmd = f'GH_TOKEN=$(cat ~/tokens/gh) gh pr merge 566 --repo {GUARDED} --squash'
+    assert verdict(git, cmd, allow_merge=lambda *_: True) is None
+
+
 def test_a_merge_run_from_another_repo_is_not_this_repository_s(git):
     """gh resolves the repository from the working directory when nothing names one."""
     asked = []


### PR DESCRIPTION
Two escapes past the merge authorization `utilities/guard_main_merge.py` gained in #570. Both let a command spend this repository's receipt for pull request N while `gh` merged something else.

## What

`gh pr -Rsomeone/other merge 566` was read as naming no repository at all, so it resolved against the local clone, cleared 566's receipt, and merged 566 of `someone/other`. pflag takes a shorthand's value written onto it and clusters shorthands ahead of it, so `-Ro/r`, `-R=o/r` and `-dRo/r` all select a repository; only the separated `-R o/r` and `--repo=o/r` forms were read. One flag reader now covers every form.

`gh pr merge 566 $EXTRA` was cleared by 566's receipt although the shell splits the expansion into further arguments, `-R other/repo` among them. A brace list and a glob do the same with no `$` in sight, `"$EXTRA"` does it through double quotes, and an assignment-shaped argument (`--body x=$EXTRA`) does it past the exemption that assignments get. A merge is now read from the command's own text, cut into words the way the shell cuts them.

## Why

The guard's whole claim is that a receipt names one pull request in one repository, so the reading of the command decides whether that claim holds. Everything it cannot settle is refused rather than assumed local — the posture the command-substitution and process-substitution checks already take.

`shlex` cannot do that reading in either mode: posix removes the quotes that decide whether a `$` expands, and non-posix opens a quoted region only at a word boundary, so `--subject='a $b'` comes back as fragments carrying a bare `$b`. `_raw_words` keeps the quoting and marks the command separators, which is what the other two answers need: an assignment reaches the environment whole only ahead of a command word, and only the command that runs gh is read at all — an expansion in `&& echo $HOME` cannot reach gh's arguments. The exemptions are what keep `GH_TOKEN=$(cat …) gh pr merge …` working.

## Verification

`utilities/tests/` green (140). New cases, each failing against the code before this change: the attached, `=`-attached, clustered-attached and clustered-separated spellings of `-R`; a `$EXTRA` word, a `$(…)` word, a brace list, a glob, an assignment-shaped argument and a double-quoted expansion; a single-quoted `$` in both the separated and attached spellings, an expansion in a command beside the merge, and the token-prefixed merge naming this repository — all of which must pass. Every refusal asserts the receipt was never consulted. `pre-commit run` over both files passes every hook; the six repo rules are clean.

Refs: internal#212.

<!-- opened-by: posi-agent -->