### PR TITLE
Advise the `add-rule` skill when a tool call edits the rules file

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/utilities/advise_code_rules_edit.py\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,7 +43,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Bash|Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/utilities/advise_code_rules_edit.py
+++ b/utilities/advise_code_rules_edit.py
@@ -5,8 +5,8 @@ Advisory, never a refusal: the skill's own final step is a write to that file. T
 as `additionalContext` because a PreToolUse hook's plain stdout reaches the debug log and nothing
 else.
 
-Wired in `.claude/settings.json` (PreToolUse, matcher Edit|Write|MultiEdit): reads the hook payload
-on stdin, prints JSON to stdout, exits 0. Stdlib-only so it runs without the project venv.
+Wired in `.claude/settings.json` (PreToolUse, matcher Bash|Edit|Write|MultiEdit): reads the hook
+payload on stdin, prints JSON to stdout, exits 0. Stdlib-only so it runs without the project venv.
 """
 
 from __future__ import annotations
@@ -26,8 +26,16 @@ ADVICE = (
 
 
 def advises(payload: dict) -> bool:
-    """Whether this tool call writes the rules file."""
-    return os.path.basename(hook_payload.target_path(payload)) == RULES_FILE
+    """Whether this tool call could write the rules file.
+
+    A shell command is matched on the file's name appearing anywhere in it, since a write reaches
+    the file through `cat >`, `tee`, `sed -i`, a heredoc or a python one-liner, and reading the
+    shell well enough to tell those apart is a parser this does not need. Advice on a command that
+    merely mentions the file costs a line; missing the way an agent most often writes one does not.
+    """
+    if os.path.basename(hook_payload.target_path(payload)) == RULES_FILE:
+        return True
+    return RULES_FILE in hook_payload.command(payload)
 
 
 def main() -> int:

--- a/utilities/advise_code_rules_edit.py
+++ b/utilities/advise_code_rules_edit.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
-"""Claude Code PreToolUse hook: an edit to `CODE_RULES.md` goes through the `add-rule` skill.
+"""Claude Code PreToolUse hook: advise the `add-rule` skill on a write to `CODE_RULES.md`.
 
-The rules file is read on every review in every Positronic repository, so what it says is worth a
-process: the skill asks what real code triggered the change, rules out the cheaper homes (a Ruff
-check, an existing rule), and shows the wording for approval before writing. Editing the file
-directly skips all three, and nothing about the edit itself reveals that it did.
-
-Advisory, never a refusal — the skill's own final step is an edit to this file, so a hook that
-blocked would block the remedy it names. The advice is emitted as `additionalContext`, because a
-PreToolUse hook's plain stdout reaches the debug log and nothing else.
+Advisory, never a refusal: the skill's own final step is a write to that file. The advice goes out
+as `additionalContext` because a PreToolUse hook's plain stdout reaches the debug log and nothing
+else.
 
 Wired in `.claude/settings.json` (PreToolUse, matcher Edit|Write|MultiEdit): reads the hook payload
 on stdin, prints JSON to stdout, exits 0. Stdlib-only so it runs without the project venv.

--- a/utilities/advise_code_rules_edit.py
+++ b/utilities/advise_code_rules_edit.py
@@ -41,7 +41,7 @@ def main() -> int:
     except (json.JSONDecodeError, UnicodeDecodeError):
         return 0
     if advises(payload):
-        print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'additionalContext': ADVICE}}))
+        print(json.dumps(hook_payload.additional_context(ADVICE)))
     return 0
 
 

--- a/utilities/advise_code_rules_edit.py
+++ b/utilities/advise_code_rules_edit.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook: an edit to `CODE_RULES.md` goes through the `add-rule` skill.
+
+The rules file is read on every review in every Positronic repository, so what it says is worth a
+process: the skill asks what real code triggered the change, rules out the cheaper homes (a Ruff
+check, an existing rule), and shows the wording for approval before writing. Editing the file
+directly skips all three, and nothing about the edit itself reveals that it did.
+
+Advisory, never a refusal — the skill's own final step is an edit to this file, so a hook that
+blocked would block the remedy it names. Wired in `.claude/settings.json` (PreToolUse, matcher
+Edit|Write|MultiEdit): reads the hook payload on stdin, prints to stdout, exits 0. Stdlib-only so
+it runs without the project venv.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+RULES_FILE = 'CODE_RULES.md'
+ADVICE = (
+    f'{RULES_FILE} is edited through the `add-rule` skill, not by hand: it asks what code triggered'
+    ' the change, rules out a Ruff check or an existing rule covering it, and shows the wording for'
+    ' approval before writing. Run the skill unless you are already inside it.'
+)
+
+
+def advises(payload: dict) -> bool:
+    """Whether this tool call writes the rules file."""
+    tool_input = payload.get('tool_input') or {}
+    path = tool_input.get('file_path') or tool_input.get('notebook_path') or ''
+    return os.path.basename(str(path)) == RULES_FILE
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return 0
+    if advises(payload):
+        print(ADVICE)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/utilities/advise_code_rules_edit.py
+++ b/utilities/advise_code_rules_edit.py
@@ -7,9 +7,11 @@ check, an existing rule), and shows the wording for approval before writing. Edi
 directly skips all three, and nothing about the edit itself reveals that it did.
 
 Advisory, never a refusal — the skill's own final step is an edit to this file, so a hook that
-blocked would block the remedy it names. Wired in `.claude/settings.json` (PreToolUse, matcher
-Edit|Write|MultiEdit): reads the hook payload on stdin, prints to stdout, exits 0. Stdlib-only so
-it runs without the project venv.
+blocked would block the remedy it names. The advice is emitted as `additionalContext`, because a
+PreToolUse hook's plain stdout reaches the debug log and nothing else.
+
+Wired in `.claude/settings.json` (PreToolUse, matcher Edit|Write|MultiEdit): reads the hook payload
+on stdin, prints JSON to stdout, exits 0. Stdlib-only so it runs without the project venv.
 """
 
 from __future__ import annotations
@@ -17,6 +19,8 @@ from __future__ import annotations
 import json
 import os
 import sys
+
+import hook_payload
 
 RULES_FILE = 'CODE_RULES.md'
 ADVICE = (
@@ -28,9 +32,7 @@ ADVICE = (
 
 def advises(payload: dict) -> bool:
     """Whether this tool call writes the rules file."""
-    tool_input = payload.get('tool_input') or {}
-    path = tool_input.get('file_path') or tool_input.get('notebook_path') or ''
-    return os.path.basename(str(path)) == RULES_FILE
+    return os.path.basename(hook_payload.target_path(payload)) == RULES_FILE
 
 
 def main() -> int:
@@ -39,7 +41,7 @@ def main() -> int:
     except (json.JSONDecodeError, UnicodeDecodeError):
         return 0
     if advises(payload):
-        print(ADVICE)
+        print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'additionalContext': ADVICE}}))
     return 0
 
 

--- a/utilities/guard_main_merge.py
+++ b/utilities/guard_main_merge.py
@@ -30,6 +30,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+import hook_payload
+
 DENY_TAIL = (
     ' Merging to main requires a PR and an explicit human/operator command — a named human must run the merge'
     ' themselves (e.g. via the `!` prefix or their own shell).'
@@ -848,10 +850,10 @@ def main() -> int:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, UnicodeDecodeError):
         return 0
-    cmd = (payload.get('tool_input') or {}).get('command') or ''
+    cmd = hook_payload.command(payload)
     if not cmd:
         return 0
-    cwd = payload.get('cwd') or os.getcwd()
+    cwd = payload.get(hook_payload.CWD) or os.getcwd()
     git = GitInfo()
     guarded_slug = repo_slug(git.origin_url(os.environ.get('CLAUDE_PROJECT_DIR') or os.getcwd()))
     deny = analyze(cmd, cwd, guarded_slug, git, gh_repo_env=os.environ.get(GH_REPO_ENV, ''))

--- a/utilities/hook_payload.py
+++ b/utilities/hook_payload.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-"""The Claude Code hook payload, named once.
+"""The field names of the JSON a Claude Code hook is handed on stdin, and readers for them.
 
-A hook is handed JSON on stdin whose field names belong to the harness, not to this repository, and
-both hooks here read them. The harness runs each hook by path, which puts this directory on
-`sys.path`, so both import these names rather than spelling them again. Stdlib-only, so a hook that
-imports it still runs without the project venv.
+The names belong to the harness. Stdlib-only, so a hook that imports this still runs without the
+project venv; the harness runs a hook by path, which puts this directory on `sys.path`.
 """
 
 from __future__ import annotations

--- a/utilities/hook_payload.py
+++ b/utilities/hook_payload.py
@@ -14,6 +14,10 @@ COMMAND = 'command'
 FILE_PATH = 'file_path'
 NOTEBOOK_PATH = 'notebook_path'
 CWD = 'cwd'
+HOOK_SPECIFIC_OUTPUT = 'hookSpecificOutput'
+HOOK_EVENT_NAME = 'hookEventName'
+ADDITIONAL_CONTEXT = 'additionalContext'
+PRE_TOOL_USE = 'PreToolUse'
 
 
 def command(payload: dict) -> str:
@@ -25,3 +29,11 @@ def target_path(payload: dict) -> str:
     """The file a write-shaped tool call targets, or '' when it names none."""
     tool_input = payload.get(TOOL_INPUT) or {}
     return str(tool_input.get(FILE_PATH) or tool_input.get(NOTEBOOK_PATH) or '')
+
+
+def additional_context(text: str) -> dict:
+    """A PreToolUse reply putting `text` in front of the model and deciding nothing else.
+
+    A hook's plain stdout reaches the debug log, so anything a model must read goes here.
+    """
+    return {HOOK_SPECIFIC_OUTPUT: {HOOK_EVENT_NAME: PRE_TOOL_USE, ADDITIONAL_CONTEXT: text}}

--- a/utilities/hook_payload.py
+++ b/utilities/hook_payload.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""The Claude Code hook payload, named once.
+
+A hook is handed JSON on stdin whose field names belong to the harness, not to this repository, and
+both hooks here read them. The harness runs each hook by path, which puts this directory on
+`sys.path`, so both import these names rather than spelling them again. Stdlib-only, so a hook that
+imports it still runs without the project venv.
+"""
+
+from __future__ import annotations
+
+TOOL_INPUT = 'tool_input'
+COMMAND = 'command'
+FILE_PATH = 'file_path'
+NOTEBOOK_PATH = 'notebook_path'
+CWD = 'cwd'
+
+
+def command(payload: dict) -> str:
+    """The shell command a Bash tool call runs, or '' when the payload carries none."""
+    return str((payload.get(TOOL_INPUT) or {}).get(COMMAND) or '')
+
+
+def target_path(payload: dict) -> str:
+    """The file a write-shaped tool call targets, or '' when it names none."""
+    tool_input = payload.get(TOOL_INPUT) or {}
+    return str(tool_input.get(FILE_PATH) or tool_input.get(NOTEBOOK_PATH) or '')

--- a/utilities/tests/test_advise_code_rules_edit.py
+++ b/utilities/tests/test_advise_code_rules_edit.py
@@ -1,0 +1,46 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import advise_code_rules_edit as advise  # noqa: E402
+
+HOOK = Path(__file__).resolve().parents[1] / 'advise_code_rules_edit.py'
+
+
+def payload(path):
+    return {'tool_name': 'Edit', 'tool_input': {'file_path': path}}
+
+
+def test_it_advises_on_the_rules_file_wherever_the_checkout_sits():
+    for path in ('/w/positronic/CODE_RULES.md', 'CODE_RULES.md', '/somewhere/else/CODE_RULES.md'):
+        assert advise.advises(payload(path)), path
+
+
+def test_it_says_nothing_about_any_other_file():
+    for path in ('/w/positronic/CLAUDE.md', '/w/positronic/utilities/x.py', '/w/CODE_RULES.md.bak', ''):
+        assert not advise.advises(payload(path)), path
+
+
+def test_a_payload_it_cannot_read_is_not_a_rules_edit():
+    assert not advise.advises({})
+    assert not advise.advises({'tool_input': {}})
+
+
+def test_it_allows_the_edit_and_names_the_skill():
+    """Advisory: the skill's own last step is an edit to this file, so a refusal would block it."""
+    run = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload('/w/positronic/CODE_RULES.md')),
+        capture_output=True,
+        text=True,
+    )
+    assert run.returncode == 0
+    assert 'add-rule' in run.stdout
+
+
+def test_an_unreadable_payload_is_silent():
+    run = subprocess.run([sys.executable, str(HOOK)], input='not json', capture_output=True, text=True)
+    assert run.returncode == 0
+    assert run.stdout == ''

--- a/utilities/tests/test_advise_code_rules_edit.py
+++ b/utilities/tests/test_advise_code_rules_edit.py
@@ -24,6 +24,17 @@ def test_it_says_nothing_about_any_other_file():
         assert not advise.advises(payload(path)), path
 
 
+def test_it_advises_on_a_shell_command_that_could_write_the_file():
+    """A heredoc, a redirect or an in-place edit reaches the file without a file_path."""
+    for command in ('cat > CODE_RULES.md <<EOF', "sed -i s/x/y/ CODE_RULES.md", 'tee ../CODE_RULES.md'):
+        assert advise.advises({'tool_input': {'command': command}}), command
+
+
+def test_it_says_nothing_about_a_shell_command_that_does_not_name_it():
+    for command in ('git status', 'cat CLAUDE.md', 'pytest utilities/tests/'):
+        assert not advise.advises({'tool_input': {'command': command}}), command
+
+
 def test_a_payload_it_cannot_read_is_not_a_rules_edit():
     assert not advise.advises({})
     assert not advise.advises({'tool_input': {}})

--- a/utilities/tests/test_advise_code_rules_edit.py
+++ b/utilities/tests/test_advise_code_rules_edit.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import advise_code_rules_edit as advise  # noqa: E402
+import hook_payload  # noqa: E402
 
 HOOK = Path(__file__).resolve().parents[1] / 'advise_code_rules_edit.py'
 
@@ -38,9 +39,9 @@ def test_it_allows_the_edit_and_reaches_the_model_with_the_skill_s_name():
         text=True,
     )
     assert run.returncode == 0
-    emitted = json.loads(run.stdout)['hookSpecificOutput']
-    assert emitted['hookEventName'] == 'PreToolUse'
-    assert 'add-rule' in emitted['additionalContext']
+    emitted = json.loads(run.stdout)[hook_payload.HOOK_SPECIFIC_OUTPUT]
+    assert emitted[hook_payload.HOOK_EVENT_NAME] == hook_payload.PRE_TOOL_USE
+    assert 'add-rule' in emitted[hook_payload.ADDITIONAL_CONTEXT]
 
 
 def test_an_unreadable_payload_is_silent():

--- a/utilities/tests/test_advise_code_rules_edit.py
+++ b/utilities/tests/test_advise_code_rules_edit.py
@@ -28,8 +28,9 @@ def test_a_payload_it_cannot_read_is_not_a_rules_edit():
     assert not advise.advises({'tool_input': {}})
 
 
-def test_it_allows_the_edit_and_names_the_skill():
-    """Advisory: the skill's own last step is an edit to this file, so a refusal would block it."""
+def test_it_allows_the_edit_and_reaches_the_model_with_the_skill_s_name():
+    """Advisory, so exit 0 — and as `additionalContext`, since a PreToolUse hook's plain stdout
+    reaches the debug log and nothing else."""
     run = subprocess.run(
         [sys.executable, str(HOOK)],
         input=json.dumps(payload('/w/positronic/CODE_RULES.md')),
@@ -37,7 +38,9 @@ def test_it_allows_the_edit_and_names_the_skill():
         text=True,
     )
     assert run.returncode == 0
-    assert 'add-rule' in run.stdout
+    emitted = json.loads(run.stdout)['hookSpecificOutput']
+    assert emitted['hookEventName'] == 'PreToolUse'
+    assert 'add-rule' in emitted['additionalContext']
 
 
 def test_an_unreadable_payload_is_silent():

--- a/utilities/tests/test_advise_code_rules_edit.py
+++ b/utilities/tests/test_advise_code_rules_edit.py
@@ -11,11 +11,11 @@ HOOK = Path(__file__).resolve().parents[1] / 'advise_code_rules_edit.py'
 
 
 def payload(path):
-    return {'tool_name': 'Edit', hook_payload.TOOL_INPUT: {hook_payload.FILE_PATH: path}}
+    return {hook_payload.TOOL_INPUT: {hook_payload.FILE_PATH: path}}
 
 
 def bash(command):
-    return {'tool_name': 'Bash', hook_payload.TOOL_INPUT: {hook_payload.COMMAND: command}}
+    return {hook_payload.TOOL_INPUT: {hook_payload.COMMAND: command}}
 
 
 def test_it_advises_on_the_rules_file_wherever_the_checkout_sits():

--- a/utilities/tests/test_advise_code_rules_edit.py
+++ b/utilities/tests/test_advise_code_rules_edit.py
@@ -11,7 +11,11 @@ HOOK = Path(__file__).resolve().parents[1] / 'advise_code_rules_edit.py'
 
 
 def payload(path):
-    return {'tool_name': 'Edit', 'tool_input': {'file_path': path}}
+    return {'tool_name': 'Edit', hook_payload.TOOL_INPUT: {hook_payload.FILE_PATH: path}}
+
+
+def bash(command):
+    return {'tool_name': 'Bash', hook_payload.TOOL_INPUT: {hook_payload.COMMAND: command}}
 
 
 def test_it_advises_on_the_rules_file_wherever_the_checkout_sits():
@@ -27,17 +31,17 @@ def test_it_says_nothing_about_any_other_file():
 def test_it_advises_on_a_shell_command_that_could_write_the_file():
     """A heredoc, a redirect or an in-place edit reaches the file without a file_path."""
     for command in ('cat > CODE_RULES.md <<EOF', "sed -i s/x/y/ CODE_RULES.md", 'tee ../CODE_RULES.md'):
-        assert advise.advises({'tool_input': {'command': command}}), command
+        assert advise.advises(bash(command)), command
 
 
 def test_it_says_nothing_about_a_shell_command_that_does_not_name_it():
     for command in ('git status', 'cat CLAUDE.md', 'pytest utilities/tests/'):
-        assert not advise.advises({'tool_input': {'command': command}}), command
+        assert not advise.advises(bash(command)), command
 
 
 def test_a_payload_it_cannot_read_is_not_a_rules_edit():
     assert not advise.advises({})
-    assert not advise.advises({'tool_input': {}})
+    assert not advise.advises({hook_payload.TOOL_INPUT: {}})
 
 
 def test_it_allows_the_edit_and_reaches_the_model_with_the_skill_s_name():

--- a/utilities/tests/test_hook_payload.py
+++ b/utilities/tests/test_hook_payload.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import hook_payload  # noqa: E402
+
+
+def test_it_reads_the_command_a_bash_call_runs():
+    assert hook_payload.command({'tool_input': {'command': 'git push'}}) == 'git push'
+
+
+def test_it_reads_the_file_a_write_targets_under_either_name():
+    assert hook_payload.target_path({'tool_input': {'file_path': '/w/x.py'}}) == '/w/x.py'
+    assert hook_payload.target_path({'tool_input': {'notebook_path': '/w/x.ipynb'}}) == '/w/x.ipynb'
+
+
+def test_a_payload_carrying_neither_reads_empty():
+    for payload in ({}, {'tool_input': {}}, {'tool_input': None}):
+        assert hook_payload.command(payload) == ''
+        assert hook_payload.target_path(payload) == ''

--- a/utilities/tests/test_hook_payload.py
+++ b/utilities/tests/test_hook_payload.py
@@ -4,6 +4,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import hook_payload  # noqa: E402
 
+# rules-allow: hardcoded-keys — these tests spell the harness's field names rather than importing
+# the constants under test. Asserting a constant against itself passes however far it has drifted
+# from what the harness actually sends; the literal is the independent statement of the wire.
+
 
 def test_it_reads_the_command_a_bash_call_runs():
     assert hook_payload.command({'tool_input': {'command': 'git push'}}) == 'git push'

--- a/utilities/tests/test_hook_payload.py
+++ b/utilities/tests/test_hook_payload.py
@@ -18,3 +18,8 @@ def test_a_payload_carrying_neither_reads_empty():
     for payload in ({}, {'tool_input': {}}, {'tool_input': None}):
         assert hook_payload.command(payload) == ''
         assert hook_payload.target_path(payload) == ''
+
+
+def test_the_reply_carries_the_text_where_the_harness_reads_it():
+    reply = hook_payload.additional_context('read the rules first')
+    assert reply == {'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'additionalContext': 'read the rules first'}}


### PR DESCRIPTION
`CODE_RULES.md` is read on every review in every Positronic repository, and `.claude/skills/add-rule` is the process that keeps it worth reading: it asks which code triggered the change, rules out the cheaper homes (a Ruff check, an existing rule that should be sharpened instead), and shows the wording for approval before writing. Editing the file directly skips all three, and nothing about the edit reveals that it did — which is how a session ends up hand-writing a rule that then takes several review rounds to calibrate.

A PreToolUse hook on `Bash|Edit|Write|MultiEdit` now names the skill whenever a tool call could write a file called `CODE_RULES.md`. The advice goes out as `hookSpecificOutput.additionalContext`, which is what the harness puts in front of the model; a hook's plain stdout on exit 0 reaches the debug log and nobody else.

`utilities/hook_payload.py` holds the harness's field names, read side and reply side, and both hooks import it — the harness runs each by path, which puts that directory on `sys.path`. `guard_main_merge.py` reads its command through it rather than spelling `tool_input` a second time.

## Why it matches the way it does

A Bash command is matched on the file's name appearing anywhere in it. A write reaches the file through `cat >`, `tee`, `sed -i`, a heredoc or a python one-liner, and reading the shell well enough to tell those from a `grep` is a parser this does not need: advice on a command that merely mentions the file costs a line of context, while missing the route an agent most often takes costs the reminder entirely. An Edit or Write is matched on the basename, so it holds in a worktree, a clone, or a repository that vendors the file.

## Why advisory

The skill's own last step is a write to that file, so a hook that refused would refuse the remedy it names. Nothing distinguishes the skill's write from a hand edit, and inventing a marker would put the guard's correctness in the hands of whoever remembers to set it. The reader is an agent that has just been told which process applies.

## Verification

`utilities/tests/` green (151). The hook: the rules file under three roots, four paths that must stay silent (including `CODE_RULES.md.bak`), three shell commands that could write it and three that could not, a payload naming nothing, unreadable stdin producing nothing, and the emitted JSON asserted by shape rather than by stdout text. `hook_payload`: a command read, a path read under either field, an empty payload under both, and the reply's shape — spelled as literals on purpose, waived at the block, because a test that asserts a constant against itself passes however far it has drifted from the harness. `pre-commit run` over the changed files passes every hook; the thirteen repo rules are clean.

<!-- opened-by: posi-agent -->