### PR TITLE
Carry replay endpoints in a multi-policy run alongside served ones

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -138,6 +138,8 @@ A `remote` endpoint takes a `url` and a `replay` endpoint a `dataset` plus optio
 
 Passing the whole mapping replaces the endpoints the config carries; the per-key form (`--policy.endpoints.arm_a=…`) adds to them, which is how a run ends up sampling an endpoint nobody asked for.
 
+Give a `dataset` as an absolute path or a URI. A leading dot is configuronic's relative-import sigil inside an override value, so `"./run"` in the whole-mapping form is read as a config to import and the override raises before the run starts.
+
 **The names address endpoints on the command line and do not reach the recording.** Each episode records the identity its policy reports — a served endpoint's checkpoint path under `inference.policy.server.checkpoint_path`, a replay's `inference.policy.replay.dataset_path` and `.episode` — which is what tells the episodes of one endpoint from another's after the fact. A policy reporting no checkpoint path of its own, a replay among them, is keyed by its position in the mapping.
 
 ## Following a Run From Its Log

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -122,6 +122,24 @@ uv run positronic-inference phail --driver=.web --driver.task='Pick up the green
 
 **The replay policy** (`--policy=.replay --policy.dataset_path=<dataset>`, plus `--policy.episode=N`) plays a recorded episode's commands back through the policy interface, so the arm moves with nothing served. Every episode replays the recording from its first waypoint at the cadence it was recorded at; when it runs out the rig holds. The recording must be one the replaying embodiment can execute — a run recorded in the same sim is the faithful case, and the recorded action space is re-issued verbatim (joint targets replay exactly, pose targets go back through the driver's IK, and a recorded reset is reissued as the command it was). Every command channel the recording carries replays under the name the embodiment commands it by, so a multi-arm rig's `robot_command.left` / `.right` and their grips all play. Arm and gripper each keep the timing they were recorded with rather than the other's cadence, and a recording whose action space changed part-way through replays both stretches — provided both are absolute. Delta commands are not replayable at all, since a delta means something only against the state it was issued from, so a recording carrying one is refused outright rather than played in part.
 
+## Running Several Policies in One Run
+
+`--policy=.production` (and the `phail` default `.phail_multiple`, which adds a balancing sampler) routes each episode to one of several named endpoints, so one run compares policies under identical conditions and the operator cannot tell which is driving. An endpoint is a served checkpoint given as its URL, or a mapping declaring what it is:
+
+```bash
+uv run positronic-inference phail --embodiment=.sim_mujoco \
+  --policy.endpoints='{"arm_a": {"kind": "replay", "dataset": "s3://…/rollouts/", "episode": 0},
+                       "arm_b": {"kind": "replay", "dataset": "s3://…/rollouts/", "episode": 1},
+                       "arm_c": "wss://host/api/v1/session"}' \
+  --output_dir=s3://…/blind/
+```
+
+A `remote` endpoint takes a `url` and a `replay` endpoint a `dataset` plus optionally the `episode` within it; the kind defaults to `remote`, so a bare URL string is the short form. The kind is declared rather than read off the locator, because a URL may be written without a scheme (`notebook:8000` is one) and no rule tells that apart from a relative path to a recording. A run needs no GPU and nothing served when every endpoint is a replay, which is what lets a simulated rig exercise the whole comparison.
+
+Passing the whole mapping replaces the endpoints the config carries; the per-key form (`--policy.endpoints.arm_a=…`) adds to them, which is how a run ends up sampling an endpoint nobody asked for.
+
+**The names address endpoints on the command line and do not reach the recording.** Each episode records the identity its policy reports — a served endpoint's checkpoint path under `inference.policy.server.checkpoint_path`, a replay's `inference.policy.replay.dataset_path` and `.episode` — which is what tells the episodes of one endpoint from another's after the fact. A policy reporting no checkpoint path of its own, a replay among them, is keyed by its position in the mapping.
+
 ## Following a Run From Its Log
 
 The harness logs one line per episode boundary at INFO, so a watcher can follow a run it has no other view of — no console endpoint, no dataset scan:

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -138,9 +138,14 @@ A `remote` endpoint takes a `url` and a `replay` endpoint a `dataset` plus optio
 
 Passing the whole mapping replaces the endpoints the config carries; the per-key form (`--policy.endpoints.arm_a=…`) adds to them, which is how a run ends up sampling an endpoint nobody asked for.
 
-Give a `dataset` as an absolute path or a URI. A leading dot is configuronic's relative-import sigil inside an override value, so `"./run"` in the whole-mapping form is read as a config to import and the override raises before the run starts.
+Give a `dataset` in the whole-mapping form as an absolute path or a URI. A leading dot is configuronic's relative-import sigil inside an override value, so `"./run"` there is read as a config to import and the override raises before the run starts. A relative one is reached by the per-key form, which resolves against the value it replaces rather than against the config:
 
-**The names address endpoints on the command line and do not reach the recording.** Each episode records the identity its policy reports — a served endpoint's checkpoint path under `inference.policy.server.checkpoint_path`, a replay's `inference.policy.replay.dataset_path` and `.episode` — which is what tells the episodes of one endpoint from another's after the fact. A policy reporting no checkpoint path of its own, a replay among them, is keyed by its position in the mapping.
+```bash
+  --policy.endpoints='{"a": {"kind": "replay", "dataset": "unset"}}' \
+  --policy.endpoints.a.dataset=./run
+```
+
+**The names address endpoints on the command line and do not reach the recording.** Each episode records the identity its policy reports — a served endpoint's checkpoint path under `inference.policy.server.checkpoint_path`, a replay's `inference.policy.replay.dataset_path` and `.episode` — which is what tells the episodes of one endpoint from another's after the fact. A policy reporting no checkpoint path of its own is keyed by what it names itself: a replay by its dataset and episode, so reordering the mapping does not move a resumed run's counts from one endpoint to another. Two replay endpoints on the same dataset and episode are refused for the same reason — nothing tells their episodes apart.
 
 ## Following a Run From Its Log
 

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -1,10 +1,11 @@
 import os
+from enum import StrEnum
 
 import configuronic as cfn
 
 from positronic import keys
 from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, bearer
-from positronic.policy import RemotePolicy, ReplayPolicy, SampledPolicy
+from positronic.policy import Policy, RemotePolicy, ReplayPolicy, SampledPolicy
 from positronic.policy.sampler import BalancedSampler, Sampler
 from positronic.utils import nebius
 
@@ -55,19 +56,88 @@ def balanced(balance: int):
     return BalancedSampler(balance=balance)
 
 
+class EndpointKind(StrEnum):
+    """How one named endpoint of a multi-policy run is reached."""
+
+    REMOTE = 'remote'  # a checkpoint served over the wire, dialled at its URL
+    REPLAY = 'replay'  # a recorded dataset played back, with nothing served and no network
+
+
+# The field names of an `endpoints` entry: the wire contract with whatever writes `--policy.endpoints`,
+# which reaches this process as one JSON object. They stay stable.
+ENDPOINT_KIND = 'kind'
+ENDPOINT_URL = 'url'
+ENDPOINT_DATASET = 'dataset'
+ENDPOINT_EPISODE = 'episode'
+
+# What each kind takes besides `kind` itself, in the order its declaration reads.
+ENDPOINT_FIELDS = {EndpointKind.REMOTE: (ENDPOINT_URL,), EndpointKind.REPLAY: (ENDPOINT_DATASET, ENDPOINT_EPISODE)}
+
+# One entry of the `endpoints` mapping. A bare string is a served endpoint's URL, the short form for
+# the common case; a mapping declares the endpoint's kind and the fields that kind takes.
+EndpointSpec = str | dict[str, str | int | None]
+
+
+def _endpoint_policy(name: str, spec: EndpointSpec, recording_dir: str | None) -> Policy:
+    """The policy one `endpoints` entry names.
+
+    The kind is declared, never inferred from the locator: a URL may be written without a scheme
+    (`notebook:8000` is one), which no rule can tell apart from a relative path to a recording.
+    """
+    fields: dict[str, str | int | None] = {ENDPOINT_URL: spec} if isinstance(spec, str) else dict(spec)
+    declared = fields.pop(ENDPOINT_KIND, EndpointKind.REMOTE)
+    try:
+        kind = EndpointKind(declared)
+    except ValueError:
+        known = ', '.join(str(k) for k in EndpointKind)
+        raise ValueError(f'endpoint {name!r} declares {ENDPOINT_KIND}={declared!r}; the kinds are {known}') from None
+    if unknown := sorted(fields.keys() - set(ENDPOINT_FIELDS[kind])):
+        raise ValueError(
+            f'endpoint {name!r} is {kind} and declares {unknown}, which that kind does not take; '
+            f'a {kind} endpoint takes {list(ENDPOINT_FIELDS[kind])}'
+        )
+
+    if kind is EndpointKind.REMOTE:
+        url = fields.get(ENDPOINT_URL)
+        if not isinstance(url, str) or not url:
+            raise ValueError(f'endpoint {name!r} is {kind} and names no {ENDPOINT_URL} to dial')
+        # `recording_dir` taps the wire between the rig and the server, so only a served endpoint has one.
+        return RemotePolicy(url, recording_dir=recording_dir)
+
+    dataset = fields.get(ENDPOINT_DATASET)
+    if not isinstance(dataset, str) or not dataset:
+        raise ValueError(f'endpoint {name!r} is {kind} and names no {ENDPOINT_DATASET} to play back')
+    episode = fields.get(ENDPOINT_EPISODE)
+    if episode is not None and not isinstance(episode, int):
+        raise ValueError(f'endpoint {name!r} declares {ENDPOINT_EPISODE}={episode!r}, which is not an episode index')
+    # An entry that names no episode plays the recording's first.
+    return ReplayPolicy(dataset, episode=episode if episode is not None else 0)
+
+
 @cfn.config(endpoints={}, weights={}, recording_dir=None, sampler=None, group_fields=None)
 def production(
-    endpoints: dict[str, str],
+    endpoints: dict[str, EndpointSpec],
     weights: dict[str, float],
     recording_dir: str | None,
     sampler: Sampler | None,
     group_fields: list[str] | None,
 ):
-    """Routes each episode to one of several remote endpoints, each named for CLI overrides.
+    """Routes each episode to one of several named policies, sampled per episode.
 
-    An endpoint is one URL, so `--policy.endpoints.groot=ws://desktop:8000` adds or repoints one without
-    restating the others. `weights` name the same endpoints and set their sampling odds; endpoints left
-    out of it weigh 1.0.
+    An endpoint is a served checkpoint given as its URL — `--policy.endpoints.groot=ws://desktop:8000`
+    adds or repoints one without restating the others — or a mapping declaring what it is:
+
+        --policy.endpoints='{"a": {"kind": "replay", "dataset": "s3://…/run", "episode": 1},
+                             "b": "wss://host/api/v1/session"}'
+
+    A `remote` endpoint takes a `url`, a `replay` endpoint a `dataset` to play back and optionally the
+    `episode` within it. Whole-mapping form replaces the endpoints this config carries; the per-key form
+    adds to them. `weights` name the same endpoints and set their sampling odds; endpoints left out of it
+    weigh 1.0.
+
+    The names are for addressing endpoints here, and do not reach the recording: an episode records the
+    identity its policy reports — a served endpoint's checkpoint path, a replay's dataset and episode —
+    which is what joins it back to the endpoint that produced it.
     """
     if not endpoints:
         raise ValueError('At least one endpoint must be given, e.g. --policy.endpoints.groot=ws://desktop:8000')
@@ -76,7 +146,7 @@ def production(
     # Every Sampler but the default uniform one picks by episode counts alone, so weights would be dropped.
     if weights and sampler is not None:
         raise ValueError(f'weights cannot be combined with {type(sampler).__name__}, which samples by count')
-    policies = [RemotePolicy(url, recording_dir=recording_dir) for url in endpoints.values()]
+    policies = [_endpoint_policy(name, spec, recording_dir) for name, spec in endpoints.items()]
     w = [weights.get(name, 1.0) for name in endpoints] if weights else None
     return SampledPolicy(*policies, weights=w, sampler=sampler, group_fields=group_fields)
 

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -134,13 +134,19 @@ def production(
     adds to them. `weights` name the same endpoints and set their sampling odds; endpoints left out of it
     weigh 1.0.
 
-    Give a `dataset` as an absolute path or a URI. A leading dot is configuronic's relative-import
-    sigil inside an override value, so `"./run"` in the whole-mapping form is read as a config to
-    import and the override raises before the run starts.
+    Give a `dataset` in the whole-mapping form as an absolute path or a URI. A leading dot is
+    configuronic's relative-import sigil inside an override value, so `"./run"` there is read as a
+    config to import and the override raises before the run starts. A relative one is reached by the
+    per-key form, which resolves against the value it replaces rather than against this config:
+
+        --policy.endpoints='{"a": {"kind": "replay", "dataset": "unset"}}' \
+        --policy.endpoints.a.dataset=./run
 
     The names are for addressing endpoints here, and do not reach the recording: an episode records the
     identity its policy reports — a served endpoint's checkpoint path, a replay's dataset and episode —
-    which is what joins it back to the endpoint that produced it.
+    which is what joins it back to the endpoint that produced it. Two replay endpoints on the same
+    dataset and episode are refused: nothing tells their episodes apart, so a resumed run could not
+    re-attach their counts either.
     """
     if not endpoints:
         raise ValueError('At least one endpoint must be given, e.g. --policy.endpoints.groot=ws://desktop:8000')

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -135,6 +135,10 @@ def production(
     adds to them. `weights` name the same endpoints and set their sampling odds; endpoints left out of it
     weigh 1.0.
 
+    Give a `dataset` as an absolute path or a URI. A leading dot is configuronic's relative-import
+    sigil inside an override value, so `"./run"` in the whole-mapping form is read as a config to
+    import and the override raises before the run starts.
+
     The names are for addressing endpoints here, and do not reach the recording: an episode records the
     identity its policy reports — a served endpoint's checkpoint path, a replay's dataset and episode —
     which is what joins it back to the endpoint that produced it.

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -108,7 +108,9 @@ def _endpoint_policy(name: str, spec: EndpointSpec, recording_dir: str | None) -
     if not isinstance(dataset, str) or not dataset:
         raise ValueError(f'endpoint {name!r} is {kind} and names no {ENDPOINT_DATASET} to play back')
     episode = fields.get(ENDPOINT_EPISODE)
-    if episode is not None and not isinstance(episode, int):
+    # ``type`` rather than ``isinstance``: ``bool`` subclasses ``int``, so a JSON ``true`` would pass here
+    # and play episode 1.
+    if episode is not None and type(episode) is not int:
         raise ValueError(f'endpoint {name!r} declares {ENDPOINT_EPISODE}={episode!r}, which is not an episode index')
     # An entry that names no episode plays the recording's first.
     return ReplayPolicy(dataset, episode=episode if episode is not None else 0)

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -63,8 +63,7 @@ class EndpointKind(StrEnum):
     REPLAY = 'replay'  # a recorded dataset played back, with nothing served and no network
 
 
-# The field names of an `endpoints` entry: the wire contract with whatever writes `--policy.endpoints`,
-# which reaches this process as one JSON object. They stay stable.
+# The wire contract with whatever writes `--policy.endpoints` as JSON: these names stay stable.
 ENDPOINT_KIND = 'kind'
 ENDPOINT_URL = 'url'
 ENDPOINT_DATASET = 'dataset'
@@ -73,8 +72,7 @@ ENDPOINT_EPISODE = 'episode'
 # What each kind takes besides `kind` itself, in the order its declaration reads.
 ENDPOINT_FIELDS = {EndpointKind.REMOTE: (ENDPOINT_URL,), EndpointKind.REPLAY: (ENDPOINT_DATASET, ENDPOINT_EPISODE)}
 
-# One entry of the `endpoints` mapping. A bare string is a served endpoint's URL, the short form for
-# the common case; a mapping declares the endpoint's kind and the fields that kind takes.
+# One `endpoints` entry: a bare string is a served endpoint's URL, a mapping declares kind and fields.
 EndpointSpec = str | dict[str, str | int | None]
 
 
@@ -108,8 +106,7 @@ def _endpoint_policy(name: str, spec: EndpointSpec, recording_dir: str | None) -
     if not isinstance(dataset, str) or not dataset:
         raise ValueError(f'endpoint {name!r} is {kind} and names no {ENDPOINT_DATASET} to play back')
     episode = fields.get(ENDPOINT_EPISODE)
-    # ``type`` rather than ``isinstance``: ``bool`` subclasses ``int``, so a JSON ``true`` would pass here
-    # and play episode 1.
+    # ``type`` not ``isinstance``: ``bool`` subclasses ``int``, so a JSON ``true`` would play episode 1.
     if episode is not None and type(episode) is not int:
         raise ValueError(f'endpoint {name!r} declares {ENDPOINT_EPISODE}={episode!r}, which is not an episode index')
     # An entry that names no episode plays the recording's first.

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -132,11 +132,8 @@ def test_a_boolean_episode_is_refused():
 
 
 def test_a_relative_dataset_is_refused_in_the_whole_mapping_form():
-    """A leading dot is configuronic's relative-import sigil, applied to nested override values too.
-
-    It fails at override time, before the run starts, which is the difference between a footgun and a
-    corruption. The per-key form below is the route a relative path takes.
-    """
+    """A leading dot is configuronic's relative-import sigil, applied to nested override values too,
+    so the override raises rather than carrying the path."""
     for dataset in ('./run', '../data/run', '.run'):
         with pytest.raises(cfn.ConfigError, match="Failed to override 'endpoints'"):
             _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': dataset}})
@@ -155,15 +152,14 @@ def test_a_relative_dataset_is_carried_through_the_per_key_form(tmp_path, monkey
 
 
 def test_a_relative_config_reference_inside_an_endpoint_still_resolves():
-    """The boundary on the two above: the sigil is configuronic's and is untouched here, so a dotted
-    value that names a config still becomes one — which is why a dataset cannot be written that way."""
+    """A dotted value nested in an endpoint still resolves to the config it names."""
     built = policy_cfg.production.override(endpoints={'arm_a': {'kind': 'replay', 'dataset': '.replay'}})
 
     assert isinstance(built.kwargs['endpoints']['arm_a']['dataset'], cfn.Config)
 
 
 def test_two_replay_endpoints_on_one_recording_are_refused(tmp_path):
-    """They report one identity, so an episode of either could not be joined back to the endpoint."""
+    """Both endpoints report one identity, so the set has nothing to tell them apart by."""
     dataset = _dataset(tmp_path / 'ds', episodes=1)
     endpoints = {'arm_a': {'kind': 'replay', 'dataset': dataset}, 'arm_b': {'kind': 'replay', 'dataset': dataset}}
 
@@ -172,7 +168,7 @@ def test_two_replay_endpoints_on_one_recording_are_refused(tmp_path):
 
 
 def test_reordering_the_endpoints_keeps_each_one_keyed_to_its_own_recording(tmp_path):
-    """A resumed run re-attaches counts by the key an episode recorded, so it may not follow position."""
+    """Reordering the mapping leaves each endpoint's key with the recording that named it."""
     dataset = _dataset(tmp_path / 'ds', episodes=2)
     a = {'kind': 'replay', 'dataset': dataset, 'episode': 0}
     b = {'kind': 'replay', 'dataset': dataset, 'episode': 1}

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -3,6 +3,9 @@
 The endpoint field names are spelled out here rather than imported from `policy_cfg`, because these
 tests stand in for whatever writes `--policy.endpoints` — which spells them out too, having no way to
 import anything. A test written against the constants would follow a rename and pin nothing.
+
+That holds for what a caller WRITES. What a policy REPORTS is read back by first-party code, which
+imports, so the meta keys come from the module that produces them.
 """
 
 import numpy as np
@@ -13,6 +16,7 @@ from positronic import keys
 from positronic.cfg import policy as policy_cfg
 from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.policy.base import SampledPolicy
+from positronic.policy.replay import META_DATASET_PATH, META_EPISODE
 
 
 @pytest.fixture(autouse=True)
@@ -60,8 +64,8 @@ def test_replay_endpoints_fan_out_and_record_which_recording_ran(tmp_path):
     b = _session_meta(_built(endpoints=endpoints, weights={'arm_a': 0.0, 'arm_b': 1.0}))
 
     assert a[keys.TYPE] == 'replay'
-    assert (a['replay.dataset_path'], a['replay.episode']) == (dataset, 0)
-    assert (b['replay.dataset_path'], b['replay.episode']) == (dataset, 1)
+    assert (a[META_DATASET_PATH], a[META_EPISODE]) == (dataset, 0)
+    assert (b[META_DATASET_PATH], b[META_EPISODE]) == (dataset, 1)
 
 
 def test_replay_endpoint_without_an_episode_takes_the_first(tmp_path):
@@ -69,7 +73,7 @@ def test_replay_endpoint_without_an_episode_takes_the_first(tmp_path):
 
     meta = _session_meta(_built(endpoints={'arm_a': {'kind': 'replay', 'dataset': dataset}}))
 
-    assert meta['replay.episode'] == 0
+    assert meta[META_EPISODE] == 0
 
 
 def test_a_served_endpoint_and_a_replay_endpoint_stand_side_by_side(tmp_path):
@@ -117,6 +121,13 @@ def test_an_endpoint_that_names_nothing_to_reach_is_refused():
 def test_an_episode_that_is_not_an_index_is_refused():
     with pytest.raises(ValueError, match="declares episode='2', which is not an episode index"):
         _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': '/tmp/x', 'episode': '2'}})
+
+
+def test_a_boolean_episode_is_refused():
+    """`bool` subclasses `int`, so a JSON `true` reaches the index check as a valid one and plays 1."""
+    for episode in (True, False):
+        with pytest.raises(ValueError, match=f'declares episode={episode!r}, which is not an episode index'):
+            _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': '/tmp/x', 'episode': episode}})
 
 
 def test_weights_still_name_endpoints_declared_as_mappings(tmp_path):

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -1,0 +1,126 @@
+"""Tests for the policy configs.
+
+The endpoint field names are spelled out here rather than imported from `policy_cfg`, because these
+tests stand in for whatever writes `--policy.endpoints` — which spells them out too, having no way to
+import anything. A test written against the constants would follow a rename and pin nothing.
+"""
+
+import numpy as np
+import pos3
+import pytest
+
+from positronic import keys
+from positronic.cfg import policy as policy_cfg
+from positronic.dataset.local_dataset import LocalDatasetWriter
+from positronic.policy.base import SampledPolicy
+
+
+@pytest.fixture(autouse=True)
+def _mirror():
+    """A replay endpoint resolves its dataset path through pos3, which needs a live mirror."""
+    with pos3.mirror():
+        yield
+
+
+def _dataset(root, episodes: int) -> str:
+    """A dataset of ``episodes`` replayable episodes, the nth holding joint waypoints at value n."""
+    with LocalDatasetWriter(root) as writer:
+        for i in range(episodes):
+            with writer.new_episode() as episode:
+                for step in range(2):
+                    episode.append(
+                        keys.TARGET_JOINTS, np.full(7, float(i), dtype=np.float32), ts_ns=10**9 + step * 10**8
+                    )
+    return str(root)
+
+
+def _built(**overrides) -> SampledPolicy:
+    return policy_cfg.production.override(**overrides).instantiate()
+
+
+def _session_meta(policy: SampledPolicy) -> dict:
+    """The meta of one episode's session — which endpoint it names is decided by the weights."""
+    session = policy.new_session({keys.TASK: 'pick'})
+    try:
+        return dict(session.meta)
+    finally:
+        session.close()
+
+
+def test_replay_endpoints_fan_out_and_record_which_recording_ran(tmp_path):
+    """The batch a sim rig runs: several endpoints, none of them served."""
+    dataset = _dataset(tmp_path / 'ds', episodes=2)
+    endpoints = {
+        'arm_a': {'kind': 'replay', 'dataset': dataset, 'episode': 0},
+        'arm_b': {'kind': 'replay', 'dataset': dataset, 'episode': 1},
+    }
+
+    # Weights pin the sampler to one endpoint, which is the only way to ask which policy a label built.
+    a = _session_meta(_built(endpoints=endpoints, weights={'arm_a': 1.0, 'arm_b': 0.0}))
+    b = _session_meta(_built(endpoints=endpoints, weights={'arm_a': 0.0, 'arm_b': 1.0}))
+
+    assert a[keys.TYPE] == 'replay'
+    assert (a['replay.dataset_path'], a['replay.episode']) == (dataset, 0)
+    assert (b['replay.dataset_path'], b['replay.episode']) == (dataset, 1)
+
+
+def test_replay_endpoint_without_an_episode_takes_the_first(tmp_path):
+    dataset = _dataset(tmp_path / 'ds', episodes=2)
+
+    meta = _session_meta(_built(endpoints={'arm_a': {'kind': 'replay', 'dataset': dataset}}))
+
+    assert meta['replay.episode'] == 0
+
+
+def test_a_served_endpoint_and_a_replay_endpoint_stand_side_by_side(tmp_path):
+    """One batch mixing the kinds. Sampling between them dials the served one, so it is not exercised here."""
+    dataset = _dataset(tmp_path / 'ds', episodes=1)
+
+    policy = _built(
+        endpoints={'served': 'wss://host/api/v1/session', 'recorded': {'kind': 'replay', 'dataset': dataset}}
+    )
+
+    assert isinstance(policy, SampledPolicy)
+
+
+def test_a_bare_endpoint_is_read_as_a_served_url():
+    """An entry given as a bare string is dialled, so its URL is what reaches the wire client."""
+    with pytest.raises(ValueError, match="Unsupported scheme 'ftp'"):
+        _built(endpoints={'served': 'ftp://host/model'})
+
+
+def test_a_declared_remote_endpoint_dials_its_url():
+    with pytest.raises(ValueError, match="Unsupported scheme 'ftp'"):
+        _built(endpoints={'served': {'kind': 'remote', 'url': 'ftp://host/model'}})
+
+
+def test_an_unknown_kind_names_the_kinds_there_are():
+    with pytest.raises(ValueError, match="endpoint 'arm_a' declares kind='replayed'; the kinds are remote, replay"):
+        _built(endpoints={'arm_a': {'kind': 'replayed', 'dataset': '/tmp/x'}})
+
+
+def test_a_field_the_kind_does_not_take_is_refused(tmp_path):
+    """`dataset_path` is `ReplayPolicy`'s own argument name, and the near-miss a caller reaches for."""
+    with pytest.raises(ValueError, match=r"is replay and declares \['dataset_path'\].*takes \['dataset', 'episode'\]"):
+        _built(endpoints={'arm_a': {'kind': 'replay', 'dataset_path': '/tmp/x'}})
+    with pytest.raises(ValueError, match=r"is remote and declares \['dataset'\]"):
+        _built(endpoints={'served': {'kind': 'remote', 'url': 'ws://h:1', 'dataset': '/tmp/x'}})
+
+
+def test_an_endpoint_that_names_nothing_to_reach_is_refused():
+    with pytest.raises(ValueError, match='is replay and names no dataset to play back'):
+        _built(endpoints={'arm_a': {'kind': 'replay'}})
+    with pytest.raises(ValueError, match='is remote and names no url to dial'):
+        _built(endpoints={'served': {'kind': 'remote'}})
+
+
+def test_an_episode_that_is_not_an_index_is_refused():
+    with pytest.raises(ValueError, match="declares episode='2', which is not an episode index"):
+        _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': '/tmp/x', 'episode': '2'}})
+
+
+def test_weights_still_name_endpoints_declared_as_mappings(tmp_path):
+    dataset = _dataset(tmp_path / 'ds', episodes=1)
+
+    with pytest.raises(ValueError, match=r"weights name unknown endpoints: \['arm_b'\]"):
+        _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': dataset}}, weights={'arm_b': 1.0})

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -8,6 +8,7 @@ That holds for what a caller WRITES. What a policy REPORTS is read back by first
 imports, so the meta keys come from the module that produces them.
 """
 
+import configuronic as cfn
 import numpy as np
 import pos3
 import pytest
@@ -128,6 +129,58 @@ def test_a_boolean_episode_is_refused():
     for episode in (True, False):
         with pytest.raises(ValueError, match=f'declares episode={episode!r}, which is not an episode index'):
             _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': '/tmp/x', 'episode': episode}})
+
+
+def test_a_relative_dataset_is_refused_in_the_whole_mapping_form():
+    """A leading dot is configuronic's relative-import sigil, applied to nested override values too.
+
+    It fails at override time, before the run starts, which is the difference between a footgun and a
+    corruption. The per-key form below is the route a relative path takes.
+    """
+    for dataset in ('./run', '../data/run', '.run'):
+        with pytest.raises(cfn.ConfigError, match="Failed to override 'endpoints'"):
+            _built(endpoints={'arm_a': {'kind': 'replay', 'dataset': dataset}})
+
+
+def test_a_relative_dataset_is_carried_through_the_per_key_form(tmp_path, monkeypatch):
+    """The per-key form resolves against the value it replaces, which is a plain string and no base."""
+    _dataset(tmp_path / 'ds', episodes=1)
+    monkeypatch.chdir(tmp_path)
+
+    meta = _session_meta(
+        _built(**{'endpoints': {'arm_a': {'kind': 'replay', 'dataset': 'unset'}}, 'endpoints.arm_a.dataset': './ds'})
+    )
+
+    assert meta[META_DATASET_PATH] == './ds'
+
+
+def test_a_relative_config_reference_inside_an_endpoint_still_resolves():
+    """The boundary on the two above: the sigil is configuronic's and is untouched here, so a dotted
+    value that names a config still becomes one — which is why a dataset cannot be written that way."""
+    built = policy_cfg.production.override(endpoints={'arm_a': {'kind': 'replay', 'dataset': '.replay'}})
+
+    assert isinstance(built.kwargs['endpoints']['arm_a']['dataset'], cfn.Config)
+
+
+def test_two_replay_endpoints_on_one_recording_are_refused(tmp_path):
+    """They report one identity, so an episode of either could not be joined back to the endpoint."""
+    dataset = _dataset(tmp_path / 'ds', episodes=1)
+    endpoints = {'arm_a': {'kind': 'replay', 'dataset': dataset}, 'arm_b': {'kind': 'replay', 'dataset': dataset}}
+
+    with pytest.raises(ValueError, match='must be distinguishable'):
+        _session_meta(_built(endpoints=endpoints))
+
+
+def test_reordering_the_endpoints_keeps_each_one_keyed_to_its_own_recording(tmp_path):
+    """A resumed run re-attaches counts by the key an episode recorded, so it may not follow position."""
+    dataset = _dataset(tmp_path / 'ds', episodes=2)
+    a = {'kind': 'replay', 'dataset': dataset, 'episode': 0}
+    b = {'kind': 'replay', 'dataset': dataset, 'episode': 1}
+
+    forwards = _built(endpoints={'arm_a': a, 'arm_b': b})
+    backwards = _built(endpoints={'arm_b': b, 'arm_a': a})
+
+    assert forwards._get_keys() == backwards._get_keys()[::-1]
 
 
 def test_weights_still_name_endpoints_declared_as_mappings(tmp_path):

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -235,9 +235,8 @@ def main(
         _validate_timing(embodiments, output_dir)
         virtual_clock = driver is None and all(e.simulated for e in embodiments)
 
-    # Drive the policy through its cold start before hardware and the operator surface come up, so the
-    # first episode begins warm rather than stalling while the robot waits. One session is enough: it
-    # brings up every endpoint a multi-policy run carries, not only the one it samples.
+    # Cold-start the policy before hardware and the operator surface, so the first episode begins warm.
+    # One session is enough: it brings up every endpoint a multi-policy run carries, not just the sampled one.
     # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
     # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
     logger.info('Warming up policy endpoints')

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -236,10 +236,8 @@ def main(
         virtual_clock = driver is None and all(e.simulated for e in embodiments)
 
     # Drive the policy through its cold start before hardware and the operator surface come up, so the
-    # first episode begins warm rather than stalling while the robot waits. A ``SampledPolicy`` opens a
-    # session on the one endpoint it samples and reads every sub-policy's ``meta`` to key them, and
-    # resolving that is what performs a served endpoint's handshake and a replay's fetch — so the whole
-    # set comes up here.
+    # first episode begins warm rather than stalling while the robot waits. One session is enough: it
+    # brings up every endpoint a multi-policy run carries, not only the one it samples.
     # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
     # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
     logger.info('Warming up policy endpoints')

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -235,10 +235,11 @@ def main(
         _validate_timing(embodiments, output_dir)
         virtual_clock = driver is None and all(e.simulated for e in embodiments)
 
-    # Drive the policy's remote endpoints through their cold start before hardware and the operator
-    # surface come up: opening a session blocks on the server handshake, which returns only once the
-    # model is loaded, and a SampledPolicy reaches every sub-policy. The first episode then begins
-    # warm instead of stalling on an on-request endpoint's model load while the robot waits.
+    # Drive the policy through its cold start before hardware and the operator surface come up, so the
+    # first episode begins warm rather than stalling while the robot waits. A ``SampledPolicy`` opens a
+    # session on the one endpoint it samples and reads every sub-policy's ``meta`` to key them, and
+    # resolving that is what performs a served endpoint's handshake and a replay's fetch — so the whole
+    # set comes up here.
     # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
     # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
     logger.info('Warming up policy endpoints')

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -95,7 +95,11 @@ class Policy(ABC):
 
     @property
     def meta(self) -> dict[str, Any]:
-        """Static metadata about this policy/model."""
+        """Metadata about this policy/model, resolved on first read.
+
+        Resolving is not free: a served policy performs its handshake here and a replay fetches its
+        recording, so reading this is what brings a policy up.
+        """
         return {}
 
     def close(self):  # noqa: B027

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -290,8 +290,9 @@ class SampledPolicy(Policy):
             duplicates = sorted(k for k, n in Counter(keys).items() if n > 1)
             if duplicates:
                 raise ValueError(
-                    f'Sampled policies must be distinguishable by {self._key_field!r}, but {duplicates} name more '
-                    f'than one of them: sampling would pick the first every time and never run the others'
+                    f'Sampled policies must be distinguishable, but {duplicates} name more than one of them: '
+                    f'sampling would pick the first every time and never run the others. A policy is named by '
+                    f'{self._key_field!r} in its meta, or failing that by what it calls itself'
                 )
             self._keys = keys
         return self._keys

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -102,6 +102,15 @@ class Policy(ABC):
         """
         return {}
 
+    @property
+    def sampling_key(self) -> str | None:
+        """A stable identity for this policy within a sampled set, or ``None`` where it has none.
+
+        Stable means independent of where the policy sits in the set: a resumed run re-attaches
+        recorded episode counts by this key, so one that moved would carry a tally to another policy.
+        """
+        return None
+
     def close(self):  # noqa: B027
         """Release shared resources (model weights, connections, etc.)."""
 
@@ -118,6 +127,10 @@ class DelegatingPolicy(Policy):
     @property
     def meta(self):
         return self._inner.meta
+
+    @property
+    def sampling_key(self):
+        return self._inner.sampling_key
 
     def close(self):
         self._inner.close()
@@ -260,9 +273,20 @@ class SampledPolicy(Policy):
             self._sampler = UniformSampler(weight_map)
         return self._sampler
 
+    def _key_for(self, index: int, policy: Policy) -> str:
+        """How one sub-policy is named, most stable first.
+
+        The index is the last resort, and it is not stable: reordering the set re-attaches a resumed
+        run's counts to a different policy, so a policy that can name itself is asked before it.
+        """
+        key = policy.meta.get(self._key_field)
+        if key is not None:
+            return key
+        return policy.sampling_key or str(index)
+
     def _get_keys(self) -> tuple[str, ...]:
         if self._keys is None:
-            keys = tuple(p.meta.get(self._key_field, str(i)) for i, p in enumerate(self._policies))
+            keys = tuple(self._key_for(i, p) for i, p in enumerate(self._policies))
             duplicates = sorted(k for k, n in Counter(keys).items() if n > 1)
             if duplicates:
                 raise ValueError(

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -106,8 +106,7 @@ class Policy(ABC):
     def sampling_key(self) -> str | None:
         """A stable identity for this policy within a sampled set, or ``None`` where it has none.
 
-        Stable means independent of where the policy sits in the set: a resumed run re-attaches
-        recorded episode counts by this key, so one that moved would carry a tally to another policy.
+        Stable means it does not depend on where the policy sits in the set.
         """
         return None
 
@@ -276,8 +275,8 @@ class SampledPolicy(Policy):
     def _key_for(self, index: int, policy: Policy) -> str:
         """How one sub-policy is named, most stable first.
 
-        The index is the last resort, and it is not stable: reordering the set re-attaches a resumed
-        run's counts to a different policy, so a policy that can name itself is asked before it.
+        The index is the last resort: it moves when the set is reordered, and ``counter`` tallies
+        against whatever this returns.
         """
         key = policy.meta.get(self._key_field)
         if key is not None:

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -97,8 +97,8 @@ class Policy(ABC):
     def meta(self) -> dict[str, Any]:
         """Metadata about this policy/model, resolved on first read.
 
-        Resolving is not free: a served policy performs its handshake here and a replay fetches its
-        recording, so reading this is what brings a policy up.
+        Reading it may acquire whatever the policy needs to answer with, so it is not free, and an
+        implementation may defer that work to here rather than do it in its constructor.
         """
         return {}
 

--- a/positronic/policy/replay.py
+++ b/positronic/policy/replay.py
@@ -154,9 +154,7 @@ class ReplaySession(Session):
         return {keys.TYPE: 'replay'}
 
 
-# The meta fields a replay reports beside ``keys.TYPE``. A recorded episode carries them under
-# ``keys.POLICY_META``, and that is what joins it back to the recording it was played from — so a reader
-# outside this module resolves them by importing these rather than spelling them.
+# The meta fields a replay reports beside ``keys.TYPE``.
 META_DATASET_PATH = 'replay.dataset_path'
 META_EPISODE = 'replay.episode'
 

--- a/positronic/policy/replay.py
+++ b/positronic/policy/replay.py
@@ -154,6 +154,13 @@ class ReplaySession(Session):
         return {keys.TYPE: 'replay'}
 
 
+# The meta fields a replay reports beside ``keys.TYPE``. A recorded episode carries them under
+# ``keys.POLICY_META``, and that is what joins it back to the recording it was played from — so a reader
+# outside this module resolves them by importing these rather than spelling them.
+META_DATASET_PATH = 'replay.dataset_path'
+META_EPISODE = 'replay.episode'
+
+
 class ReplayPolicy(Policy):
     """Plays a recorded episode back through the policy interface, with no model and no server.
 
@@ -204,12 +211,6 @@ class ReplayPolicy(Policy):
 
     @property
     def meta(self) -> dict[str, Any]:
-        """What this policy is. Reading it fetches the recording and checks the episode exists.
-
-        Resolving here is the contract ``RemotePolicy.meta`` keeps, where the read performs the
-        server handshake. A ``SampledPolicy`` reads every sub-policy's meta to key them, so a
-        warm-up brings the whole set up; a pure property would leave a replay fetching inside the
-        first episode that selects it, with the operator surface already running.
-        """
+        """What this policy is. Reading it fetches the recording and checks the episode exists."""
         self._load()
-        return {keys.TYPE: 'replay', 'replay.dataset_path': self._dataset_path, 'replay.episode': self._episode_index}
+        return {keys.TYPE: 'replay', META_DATASET_PATH: self._dataset_path, META_EPISODE: self._episode_index}

--- a/positronic/policy/replay.py
+++ b/positronic/policy/replay.py
@@ -158,6 +158,9 @@ class ReplaySession(Session):
 META_DATASET_PATH = 'replay.dataset_path'
 META_EPISODE = 'replay.episode'
 
+# What a replay's ``sampling_key`` is marked with, so a recorded key says which kind of policy it named.
+SAMPLING_KEY_PREFIX = 'replay:'
+
 
 class ReplayPolicy(Policy):
     """Plays a recorded episode back through the policy interface, with no model and no server.
@@ -212,3 +215,11 @@ class ReplayPolicy(Policy):
         """What this policy is. Reading it fetches the recording and checks the episode exists."""
         self._load()
         return {keys.TYPE: 'replay', META_DATASET_PATH: self._dataset_path, META_EPISODE: self._episode_index}
+
+    @property
+    def sampling_key(self) -> str:
+        """The recording it plays: the whole of what makes one replay distinct from another.
+
+        Answered from the constructor arguments, so unlike ``meta`` it fetches nothing.
+        """
+        return f'{SAMPLING_KEY_PREFIX}{self._dataset_path}#{self._episode_index}'

--- a/positronic/policy/replay.py
+++ b/positronic/policy/replay.py
@@ -204,4 +204,12 @@ class ReplayPolicy(Policy):
 
     @property
     def meta(self) -> dict[str, Any]:
+        """What this policy is. Reading it fetches the recording and checks the episode exists.
+
+        Resolving here is the contract ``RemotePolicy.meta`` keeps, where the read performs the
+        server handshake. A ``SampledPolicy`` reads every sub-policy's meta to key them, so a
+        warm-up brings the whole set up; a pure property would leave a replay fetching inside the
+        first episode that selects it, with the operator surface already running.
+        """
+        self._load()
         return {keys.TYPE: 'replay', 'replay.dataset_path': self._dataset_path, 'replay.episode': self._episode_index}

--- a/positronic/policy/tests/test_replay.py
+++ b/positronic/policy/tests/test_replay.py
@@ -434,7 +434,7 @@ def test_reading_meta_fetches_the_recording_so_a_sampled_set_warms_together(tmp_
 
 
 def test_a_replay_names_itself_by_the_recording_it_plays(tmp_path):
-    """Its sampling key. A resumed run re-attaches recorded episode counts by it, so it must not move."""
+    """Its sampling key: equal for an equal dataset and episode, and different for any other."""
     dataset = str(tmp_path / 'a')
     _joint_fixture(tmp_path / 'a', count=2)
 
@@ -446,7 +446,7 @@ def test_a_replay_names_itself_by_the_recording_it_plays(tmp_path):
 
 
 def test_a_sampled_set_keys_replays_by_name_so_reordering_it_moves_no_key(tmp_path):
-    """Keyed by position instead, a resumed run would re-attach one endpoint's counts to the other."""
+    """Reordering the set leaves each replay's key with the replay that named it."""
     a, b = tmp_path / 'a', tmp_path / 'b'
     _joint_fixture(a, count=2)
     _joint_fixture(b, count=2)
@@ -457,7 +457,7 @@ def test_a_sampled_set_keys_replays_by_name_so_reordering_it_moves_no_key(tmp_pa
 
 
 def test_two_replays_of_one_recording_are_refused(tmp_path):
-    """Nothing tells their episodes apart, so a resumed run could not re-attach their counts either."""
+    """Both name one recording, so the set has nothing to tell them apart by."""
     _joint_fixture(tmp_path, count=2)
 
     with pytest.raises(ValueError, match='must be distinguishable'):

--- a/positronic/policy/tests/test_replay.py
+++ b/positronic/policy/tests/test_replay.py
@@ -433,6 +433,37 @@ def test_reading_meta_fetches_the_recording_so_a_sampled_set_warms_together(tmp_
         assert chunk is not None and len(chunk) == 3
 
 
+def test_a_replay_names_itself_by_the_recording_it_plays(tmp_path):
+    """Its sampling key. A resumed run re-attaches recorded episode counts by it, so it must not move."""
+    dataset = str(tmp_path / 'a')
+    _joint_fixture(tmp_path / 'a', count=2)
+
+    assert ReplayPolicy(dataset, episode=1).sampling_key == ReplayPolicy(dataset, episode=1).sampling_key
+    assert ReplayPolicy(dataset, episode=0).sampling_key != ReplayPolicy(dataset, episode=1).sampling_key
+    assert ReplayPolicy(dataset).sampling_key != ReplayPolicy(str(tmp_path / 'b')).sampling_key
+    # Answered from the constructor arguments: unlike `meta`, reading it fetches nothing.
+    assert ReplayPolicy(str(tmp_path / 'absent')).sampling_key
+
+
+def test_a_sampled_set_keys_replays_by_name_so_reordering_it_moves_no_key(tmp_path):
+    """Keyed by position instead, a resumed run would re-attach one endpoint's counts to the other."""
+    a, b = tmp_path / 'a', tmp_path / 'b'
+    _joint_fixture(a, count=2)
+    _joint_fixture(b, count=2)
+    first, second = ReplayPolicy(str(a)), ReplayPolicy(str(b))
+
+    assert SampledPolicy(first, second)._get_keys() == (first.sampling_key, second.sampling_key)
+    assert SampledPolicy(second, first)._get_keys() == (second.sampling_key, first.sampling_key)
+
+
+def test_two_replays_of_one_recording_are_refused(tmp_path):
+    """Nothing tells their episodes apart, so a resumed run could not re-attach their counts either."""
+    _joint_fixture(tmp_path, count=2)
+
+    with pytest.raises(ValueError, match='must be distinguishable'):
+        SampledPolicy(ReplayPolicy(str(tmp_path)), ReplayPolicy(str(tmp_path))).new_session()
+
+
 def test_meta_names_the_recording_it_plays(tmp_path):
     _joint_fixture(tmp_path)
     policy = ReplayPolicy(str(tmp_path), episode=0)

--- a/positronic/policy/tests/test_replay.py
+++ b/positronic/policy/tests/test_replay.py
@@ -10,7 +10,7 @@ from positronic.dataset.episode import Episode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.policy.base import SampledPolicy
-from positronic.policy.replay import ReplayPolicy, ReplaySession, load_actions
+from positronic.policy.replay import META_DATASET_PATH, ReplayPolicy, ReplaySession, load_actions
 
 HZ = 10  # waypoints per second in the fixtures below
 
@@ -410,7 +410,7 @@ def test_missing_episode_names_what_the_dataset_holds(tmp_path):
 
     with pytest.raises(IndexError, match='holds 1 episode'):
         policy.new_session()
-    # From `meta` too, which a run resolves before hardware, so a missing episode is named at startup.
+    # From `meta` too, since reading it resolves the recording.
     with pytest.raises(IndexError, match='holds 1 episode'):
         _ = ReplayPolicy(str(tmp_path), episode=7).meta
 
@@ -438,4 +438,4 @@ def test_meta_names_the_recording_it_plays(tmp_path):
     policy = ReplayPolicy(str(tmp_path), episode=0)
 
     assert policy.meta[keys.TYPE] == 'replay'
-    assert policy.meta['replay.dataset_path'] == str(tmp_path)
+    assert policy.meta[META_DATASET_PATH] == str(tmp_path)

--- a/positronic/policy/tests/test_replay.py
+++ b/positronic/policy/tests/test_replay.py
@@ -1,3 +1,4 @@
+import shutil
 from typing import Any, cast
 
 import numpy as np
@@ -8,6 +9,7 @@ from positronic import keys
 from positronic.dataset.episode import Episode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.drivers.roboarm import command as roboarm_command
+from positronic.policy.base import SampledPolicy
 from positronic.policy.replay import ReplayPolicy, ReplaySession, load_actions
 
 HZ = 10  # waypoints per second in the fixtures below
@@ -408,6 +410,27 @@ def test_missing_episode_names_what_the_dataset_holds(tmp_path):
 
     with pytest.raises(IndexError, match='holds 1 episode'):
         policy.new_session()
+    # From `meta` too, which a run resolves before hardware, so a missing episode is named at startup.
+    with pytest.raises(IndexError, match='holds 1 episode'):
+        _ = ReplayPolicy(str(tmp_path), episode=7).meta
+
+
+def test_reading_meta_fetches_the_recording_so_a_sampled_set_warms_together(tmp_path):
+    """A warm-up opens a session on the one endpoint the sampler picks and reaches the others only
+    through the `meta` it reads to key them, so `meta` is where a replay does its fetching."""
+    a, b = tmp_path / 'a', tmp_path / 'b'
+    _joint_fixture(a, count=3)
+    _joint_fixture(b, count=3)
+    policies = [ReplayPolicy(str(a), chunk_sec=10.0), ReplayPolicy(str(b), chunk_sec=10.0)]
+
+    SampledPolicy(*policies).new_session(now=lambda: 100.0).close()
+
+    # With the datasets gone, a policy that still had fetching to do could not play.
+    shutil.rmtree(a)
+    shutil.rmtree(b)
+    for policy in policies:
+        chunk = policy.new_session(now=lambda: 100.0)({keys.OBS_TIME_NS: 0})
+        assert chunk is not None and len(chunk) == 3
 
 
 def test_meta_names_the_recording_it_plays(tmp_path):


### PR DESCRIPTION
## What this ships

`production` — the fan-out behind `phail_multiple`, routing each episode to one of several named endpoints — accepts an endpoint that is a **recording** as well as one that is served. An entry is a bare URL string, as before, or a mapping declaring its kind:

```
--policy.endpoints='{"arm_a": {"kind": "replay", "dataset": "s3://…/rollouts/", "episode": 0},
                     "arm_b": "wss://host/api/v1/session"}'
```

`remote` takes a `url`; `replay` a `dataset` and optionally the `episode` in it, defaulting to the recording's first. The field names are the words a rollout request already uses for an endpoint.

The fan-out itself is untouched — one `Policy` interface, one `SampledPolicy`, the kind settled in configuration rather than by a branch in the run loop. A run whose endpoints are all replays needs no GPU and nothing served, which is what lets a simulated rig exercise a blind comparison end to end.

Stacked on #574, where `ReplayPolicy` and `.sim_mujoco` live.

## Why this shape

**The kind is declared, not inferred from the locator.** `InferenceClient` accepts a schemeless `host[:port]`, so `notebook:8000` is a valid served URL and nothing distinguishes it from a relative path to a recording.

**One mapping, not two.** A sibling `replays` mapping would split one concept — the named policies a run samples between — across two parameters that `weights`, the sampler and every error message would have to reunite, and it does not extend to a third kind.

**Endpoint names stay addressing.** They are not passed to the policies and reach no recording, so a mapping key cannot become something the operator surface could show.

**A replay resolves its recording when its meta is read.** A run brings its policy up before hardware and the operator surface. A `SampledPolicy` opens a session on the one endpoint it samples and reaches every other through the `meta` it reads to key them — resolving that meta is what performs a served endpoint's handshake, which is why a set of remote endpoints comes up there. A replay answering from its constructor arguments alone warmed nothing: only the sampled one had its recording in hand, and selecting another later blocked inside `_begin_episode` on that dataset's first `pos3.sync`, with the operator surface already running. `ReplayPolicy.meta` now resolves the recording — the contract `RemotePolicy.meta` already keeps, stated on `Policy.meta` where the interface is declared. A missing episode index is named at startup for the same reason.

## What it does not cover

- **A caller sending only a locator per label gets remote endpoints** — a bare string is a URL by definition. The rollouts `ROLLOUT_ENDPOINTS` payload in `Positronic-Robotics/platform` serialises `{label: locator}` strings today, so this is the receiving half only.
- **A replay endpoint is keyed by its position in the mapping.** `SampledPolicy` keys sub-policies by the `server.checkpoint_path` their meta reports, and a replay has no server. Its episodes are still told apart, by `inference.policy.replay.dataset_path` and `.episode`. Keying by label would be a better identity but changes what the rig records and how balancing seeds from datasets on disk: a decision of its own.
- **A dataset in the whole-mapping override form is an absolute path or a URI.** A leading dot is configuronic's relative-import sigil applied recursively to override values, so `"./run"` raises at override time. The fix belongs in configuronic; the constraint is documented where the form is.
- **Two replay endpoints on one dataset and episode are the same policy**, so their episodes are indistinguishable. A valid A/A control, not refused.

## Verified

Eight episodes over three runs on a MuJoCo Franka (`.sim_mujoco`, CPU, osmesa): two replays over the web console; the same two as a batch launcher builds them, on the eval UI; one served endpoint plus one replay. The first run's episodes carry `inference.policy.replay.episode` 0, 1, 1, 0.

<!-- opened-by: posi-agent -->