### PR TITLE
Fit the eval UI to the display it opens on

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -6047,7 +6047,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 91,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -6055,7 +6055,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 91,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -6063,7 +6063,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 91,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -6071,7 +6071,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 91,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -6815,7 +6815,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 13,
-                    "endColumn": 116,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
@@ -6823,7 +6823,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 13,
-                    "endColumn": 116,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
@@ -6831,7 +6831,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 13,
-                    "endColumn": 116,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
@@ -6839,7 +6839,7 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 13,
-                    "endColumn": 116,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -6047,38 +6047,6 @@
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 17,
                     "endColumn": 112,
                     "lineCount": 1
                 }
@@ -6808,38 +6776,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 97,
                     "lineCount": 1
                 }
             },

--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -1,3 +1,4 @@
+import time
 from collections import deque
 from collections.abc import Iterator
 from datetime import datetime
@@ -40,6 +41,39 @@ SIDES = ['left', 'right', 'NA']
 
 EDITOR_POLL_SEC = 0.5
 
+# Extent of the panel at `ui_scale=1`, in pixels: the taller of the two tabs, with one camera feed.
+# Obtained by reading `get_item_rect_size` of the window's top group after a frame. The fixed padding
+# inside it does not follow the font scale, so the extent per unit of scale falls as the scale rises and
+# fitting against this over-estimates what a larger scale needs — never the other way round.
+CONTENT_SIZE = (1317, 657)
+
+# Below this the panel is unscaled, which is the size it was laid out at.
+MIN_UI_SCALE = 1.0
+
+MAXIMIZE_WAIT_SEC = 1.0
+
+
+def fit_ui_scale(requested: float, viewport_size: tuple[int, int]) -> float:
+    """The largest scale up to `requested` at which the panel fits a viewport of this size."""
+    fits = min(avail / need for avail, need in zip(viewport_size, CONTENT_SIZE, strict=True))
+    return min(requested, max(fits, MIN_UI_SCALE))
+
+
+def maximized_viewport_size() -> tuple[int, int]:
+    """Client size of the viewport once maximizing it has taken effect.
+
+    Maximizing is a request to the window manager, answered through the event queue some frames later —
+    or not at all where nothing manages the window, so the wait is bounded and the created size stands.
+    """
+    created = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
+    deadline = time.monotonic() + MAXIMIZE_WAIT_SEC
+    while time.monotonic() < deadline:
+        dpg.render_dearpygui_frame()
+        size = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
+        if size != created:
+            return size
+    return created
+
 
 # TODO(#433): split this into a reusable review surface (episode navigation + per-field edits over the dataset's
 # edit log) and the lifecycle driver (RUN/FINISH/HOME + time budget). The review half is the sharable one — ideally
@@ -62,7 +96,7 @@ class EvalUI(pimm.ControlSystem):
         self.state = State.WAITING
         self.output_dir = output_dir
         self.ui_scale = ui_scale
-        self.max_im_size = (self.size(max_im_size[0]), self.size(max_im_size[1]))
+        self.max_im_size = max_im_size
 
         # --- Inputs/Outputs ---
         self.cameras = pimm.ReceiverDict(self, default=None)
@@ -171,7 +205,9 @@ class EvalUI(pimm.ControlSystem):
     def _build_configuration(self):
         dpg.add_text('Configuration')
         with dpg.group(horizontal=True):
-            with dpg.child_window(height=self.size(210), width=self.size(480), border=True):
+            # Autosized rather than given a width: the task labels are whole sentences, and a width in
+            # pixels cuts them off at whatever the font scale turns out to be.
+            with dpg.child_window(height=self.size(210), auto_resize_x=True, border=True):
                 dpg.add_text('Task')
                 self._register(
                     dpg.add_radio_button(
@@ -671,8 +707,22 @@ class EvalUI(pimm.ControlSystem):
         with dpg.texture_registry(show=False):
             dpg.add_raw_texture(320, 240, default_value=self.rv_texture, format=dpg.mvFormat_Float_rgba, tag='rv_tex')
 
-        # Window
-        with dpg.window(label='Evaluation Control', width=self.size(1200), height=self.size(800), tag='main_window'):
+        dpg.create_viewport(title='Eval UI', width=self.size(CONTENT_SIZE[0]), height=self.size(CONTENT_SIZE[1]))
+        dpg.set_viewport_vsync(True)
+        dpg.configure_app(keyboard_navigation=True)
+        dpg.setup_dearpygui()
+        dpg.show_viewport()
+        dpg.maximize_viewport()
+
+        # The requested scale is an upper bound: nothing pans the viewport, so a panel wider than it
+        # puts the stop controls out of reach.
+        self.ui_scale = fit_ui_scale(self.ui_scale, maximized_viewport_size())
+        if self.ui_scale != 1.0:
+            dpg.set_global_font_scale(self.ui_scale)
+
+        # Window. It fills the viewport and scrolls, so anything the fitted scale still leaves oversized —
+        # a camera feed joining after the fit widens the panel — stays reachable.
+        with dpg.window(label='Evaluation Control', horizontal_scrollbar=True, tag='main_window'):
             with dpg.group(horizontal=True):
                 # Left side: live camera feeds, fixed in place across tabs so the operator's view never jumps.
                 with dpg.group(horizontal=False, tag='image_grid_group'):
@@ -696,16 +746,8 @@ class EvalUI(pimm.ControlSystem):
                             dpg.add_spacer(height=self.size(10))
                             self._build_editor()
 
+        dpg.set_primary_window('main_window', True)
         self._setup_key_handlers()
-
-        dpg.create_viewport(title='Eval UI', width=self.size(520), height=self.size(850))
-        dpg.set_viewport_vsync(True)
-        dpg.configure_app(keyboard_navigation=True)
-        if self.ui_scale != 1.0:
-            dpg.set_global_font_scale(self.ui_scale)
-        dpg.setup_dearpygui()
-        dpg.show_viewport()
-        dpg.maximize_viewport()
 
         # Initialize UI state; open the editor on the newest episode of an existing dataset
         self.update_ui()
@@ -737,7 +779,7 @@ class EvalUI(pimm.ControlSystem):
                         orig_height, orig_width = image.shape[:2]
 
                         # Calculate display size (downsample if needed)
-                        max_width, max_height = self.max_im_size
+                        max_width, max_height = (self.size(v) for v in self.max_im_size)
                         scale = min(max_width / orig_width, max_height / orig_height, 1.0)
                         display_width = int(orig_width * scale)
                         display_height = int(orig_height * scale)

--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -47,10 +47,9 @@ EDITOR_POLL_SEC = 0.5
 # fitting against this over-estimates what a larger scale needs — never the other way round.
 CONTENT_SIZE = (1317, 657)
 
-# Below this the panel is unscaled, which is the size it was laid out at.
+# The fit stops here rather than shrinking text below the size the panel was laid out at; a display
+# that cannot hold it at 1 gets scrollbars instead.
 MIN_UI_SCALE = 1.0
-
-MAXIMIZE_WAIT_SEC = 1.0
 
 
 def fit_ui_scale(requested: float, viewport_size: tuple[int, int]) -> float:
@@ -685,6 +684,8 @@ class EvalUI(pimm.ControlSystem):
 
     # --- Control System Run Loop ---
 
+    MAXIMIZE_WAIT_SEC = 1.0
+
     @staticmethod
     def _maximized_viewport_size() -> tuple[int, int]:
         """Client size of the viewport once maximizing it has taken effect.
@@ -693,7 +694,7 @@ class EvalUI(pimm.ControlSystem):
         or not at all where nothing manages the window, so the wait is bounded and the created size stands.
         """
         created = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
-        deadline = time.monotonic() + MAXIMIZE_WAIT_SEC
+        deadline = time.monotonic() + EvalUI.MAXIMIZE_WAIT_SEC
         while time.monotonic() < deadline:
             dpg.render_dearpygui_frame()
             size = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())

--- a/positronic/gui/eval.py
+++ b/positronic/gui/eval.py
@@ -59,22 +59,6 @@ def fit_ui_scale(requested: float, viewport_size: tuple[int, int]) -> float:
     return min(requested, max(fits, MIN_UI_SCALE))
 
 
-def maximized_viewport_size() -> tuple[int, int]:
-    """Client size of the viewport once maximizing it has taken effect.
-
-    Maximizing is a request to the window manager, answered through the event queue some frames later —
-    or not at all where nothing manages the window, so the wait is bounded and the created size stands.
-    """
-    created = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
-    deadline = time.monotonic() + MAXIMIZE_WAIT_SEC
-    while time.monotonic() < deadline:
-        dpg.render_dearpygui_frame()
-        size = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
-        if size != created:
-            return size
-    return created
-
-
 # TODO(#433): split this into a reusable review surface (episode navigation + per-field edits over the dataset's
 # edit log) and the lifecycle driver (RUN/FINISH/HOME + time budget). The review half is the sharable one — ideally
 # the positronic server grows into it — and owning `output_dir` there frees the driver from the factory closure.
@@ -207,7 +191,10 @@ class EvalUI(pimm.ControlSystem):
         with dpg.group(horizontal=True):
             # Autosized rather than given a width: the task labels are whole sentences, and a width in
             # pixels cuts them off at whatever the font scale turns out to be.
-            with dpg.child_window(height=self.size(210), auto_resize_x=True, border=True):
+            # dearpygui declares its context managers as `int | str`, so the `with` is unanalysable.
+            with dpg.child_window(  # pyright: ignore[reportGeneralTypeIssues]
+                height=self.size(210), auto_resize_x=True, border=True
+            ):
                 dpg.add_text('Task')
                 self._register(
                     dpg.add_radio_button(
@@ -698,6 +685,22 @@ class EvalUI(pimm.ControlSystem):
 
     # --- Control System Run Loop ---
 
+    @staticmethod
+    def _maximized_viewport_size() -> tuple[int, int]:
+        """Client size of the viewport once maximizing it has taken effect.
+
+        Maximizing is a request to the window manager, answered through the event queue some frames later —
+        or not at all where nothing manages the window, so the wait is bounded and the created size stands.
+        """
+        created = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
+        deadline = time.monotonic() + MAXIMIZE_WAIT_SEC
+        while time.monotonic() < deadline:
+            dpg.render_dearpygui_frame()
+            size = (dpg.get_viewport_client_width(), dpg.get_viewport_client_height())
+            if size != created:
+                return size
+        return created
+
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         self.clock = clock
         # Initialize DPG Context
@@ -716,13 +719,16 @@ class EvalUI(pimm.ControlSystem):
 
         # The requested scale is an upper bound: nothing pans the viewport, so a panel wider than it
         # puts the stop controls out of reach.
-        self.ui_scale = fit_ui_scale(self.ui_scale, maximized_viewport_size())
+        self.ui_scale = fit_ui_scale(self.ui_scale, self._maximized_viewport_size())
         if self.ui_scale != 1.0:
             dpg.set_global_font_scale(self.ui_scale)
 
         # Window. It fills the viewport and scrolls, so anything the fitted scale still leaves oversized —
         # a camera feed joining after the fit widens the panel — stays reachable.
-        with dpg.window(label='Evaluation Control', horizontal_scrollbar=True, tag='main_window'):
+        # dearpygui declares its context managers as `int | str`, so the `with` is unanalysable.
+        with dpg.window(  # pyright: ignore[reportGeneralTypeIssues]
+            label='Evaluation Control', horizontal_scrollbar=True, tag='main_window'
+        ):
             with dpg.group(horizontal=True):
                 # Left side: live camera feeds, fixed in place across tabs so the operator's view never jumps.
                 with dpg.group(horizontal=False, tag='image_grid_group'):

--- a/positronic/gui/tests/test_eval.py
+++ b/positronic/gui/tests/test_eval.py
@@ -1,0 +1,41 @@
+from positronic.gui.eval import CONTENT_SIZE, MIN_UI_SCALE, fit_ui_scale
+
+ROOMY = (CONTENT_SIZE[0] * 10, CONTENT_SIZE[1] * 10)
+
+
+def fits(scale: float, viewport: tuple[int, int]) -> bool:
+    return all(need * scale <= avail for avail, need in zip(viewport, CONTENT_SIZE, strict=True))
+
+
+def test_scale_drops_to_what_the_viewport_holds():
+    viewport = (CONTENT_SIZE[0] * 2, CONTENT_SIZE[1] * 2)
+
+    assert fit_ui_scale(3.0, viewport) == 2.0
+    assert fits(fit_ui_scale(3.0, viewport), viewport)
+
+
+def test_scale_follows_the_axis_that_binds():
+    wide = (CONTENT_SIZE[0] * 8, CONTENT_SIZE[1] * 2)
+    tall = (CONTENT_SIZE[0] * 2, CONTENT_SIZE[1] * 8)
+
+    assert fit_ui_scale(4.0, wide) == 2.0
+    assert fit_ui_scale(4.0, tall) == 2.0
+
+
+def test_a_viewport_with_room_leaves_the_requested_scale_alone():
+    assert fit_ui_scale(3.0, ROOMY) == 3.0
+
+
+def test_a_viewport_that_exactly_holds_the_request_leaves_it_alone():
+    exact = (CONTENT_SIZE[0] * 3, CONTENT_SIZE[1] * 3)
+
+    assert fit_ui_scale(3.0, exact) == 3.0
+
+
+def test_the_floor_holds_on_a_viewport_nothing_fits():
+    assert fit_ui_scale(3.0, (10, 10)) == MIN_UI_SCALE
+
+
+def test_a_scale_below_the_floor_is_never_raised_to_it():
+    assert fit_ui_scale(0.5, ROOMY) == 0.5
+    assert fit_ui_scale(0.5, (10, 10)) == 0.5


### PR DESCRIPTION
## The defect

`EvalUI` applied `ui_scale` verbatim. At `phail`'s `driver.ui_scale=3` the panel lays out at **3255x1703** device px; the rig's usable area is **2494x1568**, so `Reset`, the episode timer, the Object column and the Total items / Successful / Cap-per-item row sat **past the right edge with nothing to scroll them back** — the operator could not stop or reset a run. `create_viewport(520x850)` was wrong on both axes; the intrinsic extent is nearer `1317x657` unscaled.

## The fix

`ui_scale` becomes an upper bound, clamped to what the display holds:

```python
def fit_ui_scale(requested: float, viewport_size: tuple[int, int]) -> float:
    fits = min(avail / need for avail, need in zip(viewport_size, CONTENT_SIZE, strict=True))
    return min(requested, max(fits, MIN_UI_SCALE))
```

`min(requested, …)` is what stops it ever scaling *up*; `max(fits, MIN_UI_SCALE)` floors it at 1, and a request below the floor comes back unchanged rather than raised to it.

`run()` creates, shows and maximizes the viewport **before** building any widget, so the fit sees a real number. The viewport is created at `CONTENT_SIZE * requested`; `maximized_viewport_size()` renders frames until the client size changes, bounded by `MAXIMIZE_WAIT_SEC`. Maximizing is a *request* to the window manager, answered through the event queue some frames later — and not at all on a bare X display, where the created size stands and the clamp is a no-op: the behaviour before this change, and the right fallback.

`CONTENT_SIZE` is one named constant, measured by reading `get_item_rect_size` of the window's top group after a frame, across both tabs and one and two camera feeds. Fixed padding does not follow the font scale, so the extent per unit of scale *falls* as the scale rises (1317 → 1277 between scale 1 and 3): fitting against the scale-1 figure over-estimates what a larger scale needs, never the reverse. Build-measure-rebuild would need no constant, but would need teardown of the item tree, its themes and its handler registries at startup.

Two supporting changes:

- The Task radio held whole sentences inside a `size(480)` child window and clipped them at **every** scale (widest label 724px unscaled). `auto_resize_x=True` now. That widens the panel, which is why the rig fits at \~1.89 rather than \~2.27 — the fit accounts for it.
- `main_window` is the primary window with a horizontal scrollbar, replacing a hardcoded `size(1200) x size(800)`. The clamp runs before any camera connects and feeds arrive later, so one can still widen the panel; the worst case is then a scrollbar, not an unreachable control.

## `phail`'s `driver.ui_scale: 3` — kept

With a clamp, `3` means "as large as this display allows", which is what an operator seat wants. A number that fits natively would encode one rig's screen into a preset shared by every display, and cap a larger monitor below what it could show. It resolves to 1.89 on the rig, 2.92 on a 3840x2160 display, and supersedes the rig checkout's temporary local 2.1 edit.

## Verification

Driven offscreen at the rig's exact 2494x1568, with a stand-in for the window manager resizing the window as a maximize would:

| | before | after |
|---|---|---|
| effective scale | 3.0 | 1.894 |
| Trial tab | 3833x1247 | 2437x807 |
| Episodes tab | 3255x1703 | 2090x1112 |

Both tabs fit, with the button row, the timer, both columns and every task sentence legible.

`positronic/gui/tests/test_eval.py` covers the clamp with no display: a smaller viewport reduces the scale; the fit follows whichever axis binds; a roomy and an exactly-fitting viewport leave the request untouched; the floor holds where nothing fits; a request below the floor is never raised. Whole suite green (1016 passed, 8 skipped).

`eval.py`'s basedpyright entries are re-anchored: two `with dpg.…` lines changed width, moving 8 column spans of pre-existing errors dearpygui's stubs raise on every such line. Count unchanged at 161, no file grew.

<!-- opened-by: posi-agent -->