### PR TITLE
Fix the `opencv.py` camera demo

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -4126,14 +4126,6 @@
                     "endColumn": 48,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
             }
         ],
         "./positronic/drivers/camera/zed.py": [

--- a/positronic/drivers/camera/opencv.py
+++ b/positronic/drivers/camera/opencv.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
             self.filename = filename
             self.fps = fps
             self.codec = codec
-            self.frame = pimm.ControlSystemReceiver(self, default=None)
+            self.frame = pimm.ControlSystemReceiver[pimm.shared_memory.NumpySMAdapter](self, default=None)
 
         def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
             logging.info(f'Writing to {self.filename}')
@@ -66,7 +66,7 @@ if __name__ == '__main__':
                         yield pimm.Sleep(0.5 / self.fps)
                         continue
 
-                    frame = av.VideoFrame.from_ndarray(frame_msg.data.value, format='rgb24')
+                    frame = av.VideoFrame.from_ndarray(frame_msg.data.array, format='rgb24')
                     packet = stream.encode(frame)
                     container.mux(packet)
                     fps_counter.tick()

--- a/positronic/drivers/camera/opencv.py
+++ b/positronic/drivers/camera/opencv.py
@@ -76,5 +76,5 @@ if __name__ == '__main__':
         writer = VideoWriter(sys.argv[1], 30)
         world.connect(camera.frame, writer.frame)
 
-        for sleep_cmd in world.start(writer, camera):
-            time.sleep(sleep_cmd.seconds)
+        for cmd in world.start(writer, camera):
+            time.sleep(cmd.seconds if isinstance(cmd, pimm.Sleep) else 0)


### PR DESCRIPTION
## Summary
The `__main__` demo raised on the first frame and, once that was fixed, crashed again in its
scheduler loop. Both were invisible to CI: nothing imports the `__main__` block.

- `OpenCVCamera` emits a `NumpySMAdapter`, which exposes `.array`, not `.value` — the writer
  raised `AttributeError` on the first frame that arrived.
- The demo drove the world with `time.sleep(cmd.seconds)`, but `interleave` emits `Yield()`
  whenever the next instant is already due — which happens as soon as the writer overruns its
  frame deadline. Handled the way `drivers/roboarm/yam.py` does.
- Typed the writer's receiver as `ControlSystemReceiver[NumpySMAdapter]`, putting the demo
  under `basedpyright`.

The `Yield` crash was already a grandfathered error in `.basedpyright/baseline.json`; the fix
retires that entry, so the baseline ratchets down by one.

Fixes #527

## Test plan
Ran the demo end to end without a webcam: a `sitecustomize.py` swaps `cv2.VideoCapture` for a
looping file-backed capture (needed in the child process too — `world.start(writer, camera)`
runs the camera in the background), then SIGINT after 4s.

- Result: 2197 frames written, output decodes as a valid 640x480 mp4, container finalized on
  Ctrl-C. Before the fixes: `AttributeError` on `.value`, then on `Yield.seconds`.
- `basedpyright` over `positronic`: clean. Reverting `.array` to `.value` with the annotation
  in place fails with `Cannot access attribute "value" for class "NumpySMAdapter"`.
- `pytest --no-cov`: 1016 passed, 8 skipped.
- Not run against real camera hardware.