### PR TITLE
Declare the EE frame every openpi deployment serves in

### DIFF
--- a/.claude/skills/remote-training/SKILL.md
+++ b/.claude/skills/remote-training/SKILL.md
@@ -184,8 +184,10 @@ bash workflows/nebius/serve.sh lerobot_0_3_3 my-act-demo demo
 bash workflows/nebius/serve.sh lerobot_0_3_3 act-server ee \
   --pipeline.source.checkpoints_dir=<ckpt-dir>
 
+# openpi's ee pipeline also needs the EE frame the checkpoint speaks; None means the rig's default.
 bash workflows/nebius/serve.sh openpi pi-server ee \
-  --pipeline.source.checkpoints_dir=<ckpt-dir>
+  --pipeline.source.checkpoints_dir=<ckpt-dir> \
+  --pipeline.ee_frame=None
 
 bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d \
   --pipeline.source.checkpoints_dir=<ckpt-dir>

--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -56,7 +56,7 @@ These timestamps are **relative** — seconds from the start of the trajectory. 
 It is declared in two places, for the two things it does:
 
 - **Training** — `compose(ee_frame=DROID_EE_FRAME)` re-expresses the dataset in that frame, which is what makes the resulting checkpoint speak it. It defaults to unset, which trains in `default`.
-- **Serving** — the OpenPI pipeline's `ee_frame=` puts the codec left of the `remote` marker, so the rig converts and the server stays frame-agnostic. It has no default: every deployment states its frame, `None` for a checkpoint trained in `default` or one that speaks joints — joints are unambiguous. Nothing verifies a stated frame against how the checkpoint was actually trained, and a wrong one is silent, so the frame is set beside the checkpoint path it belongs to.
+- **Serving** — the OpenPI pipeline's `ee_frame=` puts the codec left of the `remote` marker, so the rig converts and the server stays frame-agnostic. It has no default: every deployment states its frame — `None` for a checkpoint trained in `default`, or one that speaks joints, which are unambiguous. Nothing checks a stated frame against how the checkpoint was trained, so it is set beside the checkpoint path it belongs to.
 
 Both take the transform itself — `models.DROID_EE_FRAME` is the one we ship — so a checkpoint declares its own frame and no robot model is consulted to serve it. The other vendor servers take no `ee_frame`: every checkpoint they serve was trained in the rig's `default`, so none has a transform to declare.
 

--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -55,10 +55,10 @@ These timestamps are **relative** — seconds from the start of the trajectory. 
 
 It is declared in two places, for the two things it does:
 
-- **Training** — `compose(ee_frame=DROID_EE_FRAME)` re-expresses the dataset in that frame, which is what makes the resulting checkpoint speak it.
-- **Serving** — the vendor pipeline's `ee_frame=` puts the codec left of the `remote` marker, so the rig converts and the server stays frame-agnostic.
+- **Training** — `compose(ee_frame=DROID_EE_FRAME)` re-expresses the dataset in that frame, which is what makes the resulting checkpoint speak it. It defaults to unset, which trains in `default`.
+- **Serving** — the OpenPI pipeline's `ee_frame=` puts the codec left of the `remote` marker, so the rig converts and the server stays frame-agnostic. It has no default: every deployment states its frame, `None` for a checkpoint trained in `default` or one that speaks joints — joints are unambiguous. Nothing verifies a stated frame against how the checkpoint was actually trained, and a wrong one is silent, so the frame is set beside the checkpoint path it belongs to.
 
-Both take the transform itself — `models.DROID_EE_FRAME` is the one we ship — so a checkpoint declares its own frame and no robot model is consulted to serve it. Leave it unset for a checkpoint trained in `default` or one that speaks joints — joints are unambiguous — and behavior is unchanged.
+Both take the transform itself — `models.DROID_EE_FRAME` is the one we ship — so a checkpoint declares its own frame and no robot model is consulted to serve it. The other vendor servers take no `ee_frame`: every checkpoint they serve was trained in the rig's `default`, so none has a transform to declare.
 
 A `CartesianDelta` is the one command this cannot convert on its own: a delta has no anchor pose, so it carries `frame` and the driver composes it where the measured pose lives.
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -23,9 +23,10 @@ cd docker && docker compose run --rm --service-ports lerobot-0_3_3-server ee \
 cd docker && docker compose run --rm --service-ports groot-server ee_rot6d_joints \
   --pipeline.source.checkpoints_dir=~/checkpoints/groot/experiment_v1/
 
-# OpenPI
+# OpenPI (--pipeline.ee_frame states the EE frame the checkpoint speaks; None means the rig's `default`)
 cd docker && docker compose run --rm --service-ports openpi-server ee \
-  --pipeline.source.checkpoints_dir=~/checkpoints/openpi/experiment_v1/
+  --pipeline.source.checkpoints_dir=~/checkpoints/openpi/experiment_v1/ \
+  --pipeline.ee_frame=None
 ```
 
 Check server: `curl http://localhost:8000/api/v1/models` returns available model IDs.

--- a/docs/training-workflow.md
+++ b/docs/training-workflow.md
@@ -205,7 +205,8 @@ cd docker && docker compose run --rm --service-ports groot-server ee_rot6d_joint
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server ee \
-  --pipeline.source.checkpoints_dir=~/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/
+  --pipeline.source.checkpoints_dir=~/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/ \
+  --pipeline.ee_frame=None
 ```
 
 ### Server Parameters
@@ -215,6 +216,7 @@ cd docker && docker compose run --rm --service-ports openpi-server ee \
 | subcommand | Named policy pipeline: the server-side codec (must match training). Each vendor lists its pipeline names in its README | `ee` |
 | `--pipeline.source.checkpoints_dir` | Path to experiment directory (contains checkpoint folders) | `~/checkpoints/lerobot/experiment_v1/` |
 | `--pipeline.source.checkpoint` | (Optional) Specific checkpoint ID to load | `10000`, `20000` |
+| `--pipeline.ee_frame` | OpenPI only: the EE frame the checkpoint speaks, relative to the rig's `default` | `None` |
 | `--port` | Server port | `8000` (default) |
 | `--host` | Server host | `0.0.0.0` (default, binds to all interfaces) |
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -318,6 +318,8 @@ class Gr00tSource(ModelSource):
 gr00t_source = cfn.Config(Gr00tSource)
 
 
+# No ``ee_frame``: every checkpoint served here was trained on poses the rig reported in its ``default``,
+# so none has a transform to declare.
 @cfn.config(codec=codecs.ee_quat, source=gr00t_source)
 def pipeline(codec, source):
     return ChunkedSchedule() | RestrictImageSize(224, 224) | remote | codec | source

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -55,6 +55,8 @@ class LerobotSource(ModelSource):
 lerobot_source = cfn.Config(LerobotSource, checkpoint=None, device=None)
 
 
+# No ``ee_frame``: every checkpoint served here was trained on poses the rig reported in its ``default``,
+# so none has a transform to declare.
 @cfn.config(codec=lerobot_codecs.ee, source=lerobot_source)
 def pipeline(codec: Codec, source: ModelSource) -> Pipeline:
     return ChunkedSchedule() | RestrictImageSize(512, 512) | remote | codec | source

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -77,6 +77,8 @@ class LerobotSource(ModelSource):
 lerobot_source = cfn.Config(LerobotSource, policy_factory=act)
 
 
+# No ``ee_frame``: every checkpoint served here was trained on poses the rig reported in its ``default``,
+# so none has a transform to declare.
 @cfn.config(codec=lerobot_codecs.ee, source=lerobot_source)
 def pipeline(codec: Codec, source: ModelSource):
     return ChunkedSchedule() | RestrictImageSize(224, 224) | remote | codec | source

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -132,11 +132,9 @@ emits absolute `JointPosition` chunks executed at RoboLab's leaderboard cadence 
   `droid_jointpos` / `libero`, the paired OpenPI config. Available: `ee`, `ee_joints`, `ee_traj`,
   `ee_joints_traj`, `joints_traj`, `ee_flip_grip`, `droid`, `droid_jointpos`, `libero`
 - `--pipeline.source.checkpoints_dir`: Full path to the experiment directory containing checkpoints
-- `--pipeline.ee_frame`: The end-effector frame the checkpoint speaks, placed relative to the rig's `default`
-  (`@positronic.drivers.roboarm.models.DROID_EE_FRAME` is the one we ship). Required on the EE pipelines, since
-  a wrong or missing frame is silent — the arm goes to the wrong place and nothing errors. Pass `None` for a
-  checkpoint trained in `default`. The joint-space pipelines (`joints_traj`, `droid`, `droid_jointpos`) set it
-  themselves: no pose crosses the wire
+- `--pipeline.ee_frame`: The end-effector frame the checkpoint speaks, relative to the rig's `default`
+  (`@positronic.drivers.roboarm.models.DROID_EE_FRAME` is the one we ship). Required on the EE pipelines — pass
+  `None` for a checkpoint trained in `default`. The joint-space pipelines set it themselves: no pose crosses the wire
 - `--pipeline.source.checkpoint`: (Optional) Specific checkpoint step to load. If omitted, loads the latest checkpoint
 - `--pipeline.source.config_name`: (Optional) OpenPI config name; overrides the pipeline's pairing (base pipelines use `pi05_positronic_lowmem`)
 - `--port`: (Optional) Port to serve on (default: 8000)

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -101,13 +101,15 @@ The OpenPI inference server wraps the OpenPI policy in a FastAPI server that pro
 ### Starting the Server
 
 ```bash
-# Default pipeline (ee codec)
+# Default pipeline (ee codec). `--pipeline.ee_frame=None` says the checkpoint speaks the rig's `default`
 docker compose run --rm --service-ports -v ~/checkpoints:/checkpoints openpi-server ee \
-  --pipeline.source.checkpoints_dir=/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/
+  --pipeline.source.checkpoints_dir=/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/ \
+  --pipeline.ee_frame=None
 
 # With joint feedback
 docker compose run --rm --service-ports -v ~/checkpoints:/checkpoints openpi-server ee_joints \
-  --pipeline.source.checkpoints_dir=/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/
+  --pipeline.source.checkpoints_dir=/checkpoints/openpi/pi05_positronic_lowmem/experiment_v1/ \
+  --pipeline.ee_frame=None
 
 # Pretrained DROID model (pi05_droid) — preset pipeline (codec + config) and public checkpoint
 docker compose run --rm --service-ports openpi-server droid
@@ -130,6 +132,11 @@ emits absolute `JointPosition` chunks executed at RoboLab's leaderboard cadence 
   `droid_jointpos` / `libero`, the paired OpenPI config. Available: `ee`, `ee_joints`, `ee_traj`,
   `ee_joints_traj`, `joints_traj`, `ee_flip_grip`, `droid`, `droid_jointpos`, `libero`
 - `--pipeline.source.checkpoints_dir`: Full path to the experiment directory containing checkpoints
+- `--pipeline.ee_frame`: The end-effector frame the checkpoint speaks, placed relative to the rig's `default`
+  (`@positronic.drivers.roboarm.models.DROID_EE_FRAME` is the one we ship). Required on the EE pipelines, since
+  a wrong or missing frame is silent — the arm goes to the wrong place and nothing errors. Pass `None` for a
+  checkpoint trained in `default`. The joint-space pipelines (`joints_traj`, `droid`, `droid_jointpos`) set it
+  themselves: no pose crosses the wire
 - `--pipeline.source.checkpoint`: (Optional) Specific checkpoint step to load. If omitted, loads the latest checkpoint
 - `--pipeline.source.config_name`: (Optional) OpenPI config name; overrides the pipeline's pairing (base pipelines use `pi05_positronic_lowmem`)
 - `--port`: (Optional) Port to serve on (default: 8000)

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -238,12 +238,14 @@ class OpenpiSource(ModelSource):
 openpi_source = cfn.Config(OpenpiSource)
 
 
-@cfn.config(codec=codecs.ee, source=openpi_source, ee_frame=None)
+# ``ee_frame`` takes no default: a missing frame does not error, it just puts the arm somewhere else, so a
+# deployment that omits one is indistinguishable from a deployment that means ``None``.
+@cfn.config(codec=codecs.ee, source=openpi_source)
 def pipeline(codec: Codec, source: ModelSource, ee_frame: geom.Transform3D | None):
     """The OpenPI serving pipeline: rig-side chunk scheduling, the server-side codec, the checkpoint source.
 
     ``ee_frame`` places the end-effector frame this checkpoint's poses live in relative to ``DEFAULT_FRAME``
-    (``models.DROID_EE_FRAME``). Leave it unset for a checkpoint trained in ``default``, or one speaking joints.
+    (``models.DROID_EE_FRAME``); ``None`` for a checkpoint trained in ``default``, or one speaking joints.
     """
     local = ChunkedSchedule() | RestrictImageSize(224, 224)
     if ee_frame is not None:
@@ -252,17 +254,20 @@ def pipeline(codec: Codec, source: ModelSource, ee_frame: geom.Transform3D | Non
     return local | remote | codec | source
 
 
+# These bind no checkpoint, so they state no frame: whoever binds one passes ``--pipeline.ee_frame`` with it.
 ee = pipeline
 ee_joints = pipeline.override(codec=codecs.ee_joints)
 ee_traj = pipeline.override(codec=codecs.ee_traj)
 ee_joints_traj = pipeline.override(codec=codecs.ee_joints_traj)
-joints_traj = pipeline.override(codec=codecs.joints_traj)
 # For checkpoints trained on inverted-grip (1 = open) data, e.g. the sim_stack recordings.
 ee_flip_grip = pipeline.override(**{'codec.flip_grip': True})
-# Both DROID deployments are joint-space, so they declare no frame. An EE-space DROID checkpoint would set
-# ``ee_frame=models.DROID_EE_FRAME`` here.
-droid_pipe = pipeline.override(codec=codecs.droid, **{'source.config_name': 'pi05_droid'})
-droid_jointpos_pipe = pipeline.override(codec=codecs.droid_jointpos, **{'source.config_name': 'pi05_droid_jointpos'})
+# The joint-space codecs put no pose on the wire, so the codec settles the frame and no checkpoint bound here
+# can unsettle it. An EE-space DROID checkpoint would take ``ee_frame=models.DROID_EE_FRAME`` instead.
+joints_traj = pipeline.override(codec=codecs.joints_traj, ee_frame=None)
+droid_pipe = pipeline.override(codec=codecs.droid, ee_frame=None, **{'source.config_name': 'pi05_droid'})
+droid_jointpos_pipe = pipeline.override(
+    codec=codecs.droid_jointpos, ee_frame=None, **{'source.config_name': 'pi05_droid_jointpos'}
+)
 libero_pipe = pipeline.override(codec=codecs.libero, **{'source.config_name': 'pi05_libero'})
 
 
@@ -276,17 +281,24 @@ COMMANDS = {
     'ee_joints_traj': serve.override(pipeline=ee_joints_traj),
     'joints_traj': serve.override(pipeline=joints_traj),
     'ee_flip_grip': serve.override(pipeline=ee_flip_grip),
+    # Trained on phail recordings, which carry whatever the real Franka reported as its end effector — that
+    # rig's ``default`` — so there is no transform, as long as it is served on that rig.
+    # TODO(#550): that rig's ``default`` moves to the flange, so this checkpoint will need a transform here.
     'phail': serve.override(
-        pipeline=ee.override(**{
-            'source.checkpoints_dir': 's3://checkpoints/phail_unified/openpi/pi05_positronic_lowmem/270226-ee/'
-        }),
+        pipeline=ee.override(
+            ee_frame=None,
+            **{'source.checkpoints_dir': 's3://checkpoints/phail_unified/openpi/pi05_positronic_lowmem/270226-ee/'},
+        ),
         recording_dir='s3://inference/phail_unified/server_recordings/openpi/270226-ee/',
     ),
     # The sim_stack checkpoint was trained on inverted-grip (1 = open) sim data, hence the flip-grip pipeline.
+    # Its poses are the sim panda's ``default``, so no transform — but that frame sits 45 mm along the approach
+    # axis from the FR3's, so this checkpoint is off by that much on the real arm until #550 unifies the two.
     'sim_stack': serve.override(
-        pipeline=ee_flip_grip.override(**{
-            'source.checkpoints_dir': 's3://checkpoints/sim_stack/openpi/ee/pi05_positronic_lowmem/230226/'
-        }),
+        pipeline=ee_flip_grip.override(
+            ee_frame=None,
+            **{'source.checkpoints_dir': 's3://checkpoints/sim_stack/openpi/ee/pi05_positronic_lowmem/230226/'},
+        ),
         recording_dir='s3://inference/sim_stack/server_recordings/openpi/230226/',
     ),
     'droid': serve.override(
@@ -301,8 +313,13 @@ COMMANDS = {
             'source.checkpoints_dir': 'gs://openpi-assets-simeval/pi05_droid_jointpos'
         })
     ),
+    # TODO(#557): LIBERO reports its eef 38 mm and 90° from where the shipped panda model puts ``default``, and
+    # the codec is calibrated against what the env actually reports. ``None`` is what keeps that pairing intact;
+    # the frame this checkpoint speaks can be stated only once the env stops mislabelling its poses.
     'libero': serve.override(
-        pipeline=libero_pipe.override(**{'source.checkpoints_dir': 'gs://openpi-assets/checkpoints/pi05_libero'})
+        pipeline=libero_pipe.override(
+            ee_frame=None, **{'source.checkpoints_dir': 'gs://openpi-assets/checkpoints/pi05_libero'}
+        )
     ),
 }
 

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -261,8 +261,8 @@ ee_traj = pipeline.override(codec=codecs.ee_traj)
 ee_joints_traj = pipeline.override(codec=codecs.ee_joints_traj)
 # For checkpoints trained on inverted-grip (1 = open) data, e.g. the sim_stack recordings.
 ee_flip_grip = pipeline.override(**{'codec.flip_grip': True})
-# The joint-space codecs put no pose on the wire, so the codec settles the frame and no checkpoint bound here
-# can unsettle it. An EE-space DROID checkpoint would take ``ee_frame=models.DROID_EE_FRAME`` instead.
+# The joint-space codecs put no pose on the wire, so no checkpoint bound here can need a transform. An EE-space
+# DROID checkpoint would take ``ee_frame=models.DROID_EE_FRAME`` instead.
 joints_traj = pipeline.override(codec=codecs.joints_traj, ee_frame=None)
 droid_pipe = pipeline.override(codec=codecs.droid, ee_frame=None, **{'source.config_name': 'pi05_droid'})
 droid_jointpos_pipe = pipeline.override(
@@ -281,8 +281,8 @@ COMMANDS = {
     'ee_joints_traj': serve.override(pipeline=ee_joints_traj),
     'joints_traj': serve.override(pipeline=joints_traj),
     'ee_flip_grip': serve.override(pipeline=ee_flip_grip),
-    # Trained on phail recordings, which carry whatever the real Franka reported as its end effector — that
-    # rig's ``default`` — so there is no transform, as long as it is served on that rig.
+    # Trained on phail recordings, whose poses are the real Franka's ``default``, so no transform — provided it
+    # is served on that rig.
     # TODO(#550): that rig's ``default`` moves to the flange, so this checkpoint will need a transform here.
     'phail': serve.override(
         pipeline=ee.override(
@@ -292,8 +292,9 @@ COMMANDS = {
         recording_dir='s3://inference/phail_unified/server_recordings/openpi/270226-ee/',
     ),
     # The sim_stack checkpoint was trained on inverted-grip (1 = open) sim data, hence the flip-grip pipeline.
-    # Its poses are the sim panda's ``default``, so no transform — but that frame sits 45 mm along the approach
-    # axis from the FR3's, so this checkpoint is off by that much on the real arm until #550 unifies the two.
+    # Its poses are the sim panda's ``default``, which sits 45 mm along the approach axis from the FR3's, so
+    # this checkpoint is off by that much on the real arm.
+    # TODO(#550): both ``default`` frames move to the flange, so this checkpoint will need a transform here.
     'sim_stack': serve.override(
         pipeline=ee_flip_grip.override(
             ee_frame=None,
@@ -314,8 +315,8 @@ COMMANDS = {
         })
     ),
     # TODO(#557): LIBERO reports its eef 38 mm and 90° from where the shipped panda model puts ``default``, and
-    # the codec is calibrated against what the env actually reports. ``None`` is what keeps that pairing intact;
-    # the frame this checkpoint speaks can be stated only once the env stops mislabelling its poses.
+    # the codec is calibrated against what the env actually reports. ``None`` holds that pairing; the frame this
+    # checkpoint speaks can be stated only once the env stops mislabelling its poses.
     'libero': serve.override(
         pipeline=libero_pipe.override(
             ee_frame=None, **{'source.checkpoints_dir': 'gs://openpi-assets/checkpoints/pi05_libero'}

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -230,8 +230,10 @@ matching checkpoint:
 bash workflows/nebius/serve.sh lerobot smolvla-server ee \
   --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/smolvla/<exp_name>/
 
+# --pipeline.ee_frame states the EE frame the checkpoint speaks; None means the rig's `default`
 bash workflows/nebius/serve.sh openpi my-openpi ee \
-  --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/
+  --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/ \
+  --pipeline.ee_frame=None
 
 bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \
   --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/groot/<exp_name>/

--- a/workflows/nebius/e2e.sh
+++ b/workflows/nebius/e2e.sh
@@ -132,7 +132,12 @@ case "$VENDOR" in
       "--exp_name=$EXP_NAME" \
       --num_train_steps=500 2>&1)
     # openpi.train writes to <output_path>/<config_name>/<exp_name>/
-    SERVE_SUBCMD=(ee --pipeline.source.checkpoints_dir="${CKPT_DIR%/}/pi05_positronic_lowmem/$EXP_NAME/")
+    # The run trains in the rig's default frame, so the checkpoint declares no transform.
+    SERVE_SUBCMD=(
+      ee
+      --pipeline.source.checkpoints_dir="${CKPT_DIR%/}/pi05_positronic_lowmem/$EXP_NAME/"
+      --pipeline.ee_frame=None
+    )
     ;;
   gr00t)
     TRAIN_OUT=$(bash "$SCRIPT_DIR/train.sh" gr00t \

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -46,9 +46,10 @@ Examples:
   bash workflows/nebius/serve.sh lerobot smolvla-server ee \
     --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/smolvla/<exp_name>/
 
-  # OpenPI
+  # OpenPI (ee_frame is the EE frame the checkpoint speaks; None means the rig's default)
   bash workflows/nebius/serve.sh openpi pi-server ee \
-    --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/
+    --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/openpi/<exp_name>/ \
+    --pipeline.ee_frame=None
 
   # GR00T
   bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \


### PR DESCRIPTION
## Summary

The frame audit from #558. `openpi.server.pipeline` defaulted `ee_frame=None`, so an EE-space deployment that said nothing silently got no conversion — and a missing conversion looks like a worse policy, not like an error. The default is gone: every deployment states its frame beside the checkpoint path it belongs to.

The audit's answers, as set in code:

| Deployment | `ee_frame` | Why |
| --- | --- | --- |
| `phail` | `None` | Trained on poses the real Franka reported — that rig's `default`. Holds while served on that rig; `TODO(#550)` |
| `sim_stack` | `None` | The sim panda's `default`, which sits 45 mm along the approach axis from the FR3's — noted at the site; `TODO(#550)` |
| `libero` | `None` | `TODO(#557)`: the codec is calibrated against what the env actually reports, and the env mislabels its poses |
| `joints_traj`, `droid`, `droid_jointpos` | `None`, at the pipeline | No pose crosses the wire, so no checkpoint bound there can need a transform |
| `ee`, `ee_joints`, `ee_traj`, `ee_joints_traj`, `ee_flip_grip` | required | They bind no checkpoint — whoever binds one states the frame |

`lerobot`, `lerobot_0_3_3` and `gr00t` gain no `ee_frame` parameter: each serves only checkpoints trained in the rig's `default`, and each says so where its pipeline is defined. `dreamzero` and `molmoact2` are joint-space throughout.

Carrying the trained frame in `ModelSource.meta` and checking it against the pipeline is dropped from the issue, per the discussion there: third-party checkpoints (`pi05_droid`, `pi05_droid_jointpos`, `pi05_libero`) will never hold one, and we do not own the training script that writes ours.

Doc and invocation examples for the bare pipelines pick up `--pipeline.ee_frame=None` — that friction is the point.

Left open, tracked by the `TODO`s in the diff: the re-audit after #550 moves `default` to the flange, and `libero`'s real frame once #557 lands.

## Test plan

- `uv run --locked --extra dev pytest --no-cov` — 1016 passed, 8 skipped
- Instantiated all five shipped deployments: each builds the same component list as before the change (`ChunkedSchedule | RestrictImageSize | remote | codec`, no `ChangeEEFrame`), so serving behaviour is unchanged
- `ee` with a transform still installs one: `['ChangeEEFrame', 'ChunkedSchedule', 'RestrictImageSize', 'RemoteMarker', '_ComposedCodec']`
- Omitting the frame fails at launch — `TypeError: pipeline() missing 1 required positional argument: 'ee_frame'`; `--help` lists `pipeline.ee_frame: <REQUIRED>`
- `--pipeline.ee_frame=None` parses through the CLI and reaches the config as `None`

No CI job installs the `openpi` extra, so these checks were run locally against a stubbed `openpi_client` import; there is no test file to add that CI would execute.