### PR TITLE
Migrate `joint_signal` to plural `joint_signals` and show a model per arm

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -8256,38 +8256,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 41,
                     "endColumn": 43,
                     "lineCount": 1

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -35,8 +35,8 @@ _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
 # Signal-name pointers the 3D viewer reads. They must name the signals as they exist after the
 # transform, so the transform always supplies them — overriding any stale value a recording baked
 # into static (pre-rename recordings carry `robot_commands.pose` in their `pose_signals`).
-_ROBOT_SIGNAL_POINTERS = Derive(
-    joint_signal=FromValue(keys.JOINTS), pose_signals=FromValue([keys.EE_POSE, keys.TARGET_EE_POSE])
+ROBOT_SIGNAL_POINTERS = Derive(
+    joint_signals=FromValue([keys.JOINTS]), pose_signals=FromValue([keys.EE_POSE, keys.TARGET_EE_POSE])
 )
 
 # The bundled model (URDF + collision meshes + joint names + control frame + gripper) for the real
@@ -54,9 +54,9 @@ _RENAME_ROBOT_COMMAND = Derive(**{keys.TARGET_EE_POSE: Get('robot_commands.pose'
 # `_REAL_MODEL`). The sim's model always comes from the transform — older sim recordings store raw
 # MuJoCo XML under `urdf` — so the bundled panda overwrites (`_SIM_MODEL` before Identity).
 REAL_ROBOT_TRANSFORM = Group(
-    _ROBOT_SIGNAL_POINTERS, Identity(remove=_REMOVE_SIGNALS), _REAL_MODEL, _RENAME_ROBOT_COMMAND
+    ROBOT_SIGNAL_POINTERS, Identity(remove=_REMOVE_SIGNALS), _REAL_MODEL, _RENAME_ROBOT_COMMAND
 )
-SIM_ROBOT_TRANSFORM = Group(_ROBOT_SIGNAL_POINTERS, _SIM_MODEL, Identity(remove=_REMOVE_SIGNALS), _RENAME_ROBOT_COMMAND)
+SIM_ROBOT_TRANSFORM = Group(ROBOT_SIGNAL_POINTERS, _SIM_MODEL, Identity(remove=_REMOVE_SIGNALS), _RENAME_ROBOT_COMMAND)
 
 RECOVERY_TASK = 'Recovery cases.'
 

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -9,6 +9,8 @@ These datasets remain on the private s3://raw/ bucket and include:
 - Full combined datasets for multi-task training
 """
 
+from typing import Any
+
 import configuronic as cfn
 import numpy as np
 import pos3
@@ -35,9 +37,11 @@ _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
 # Signal-name pointers the 3D viewer reads. They must name the signals as they exist after the
 # transform, so the transform always supplies them — overriding any stale value a recording baked
 # into static (pre-rename recordings carry `robot_commands.pose` in their `pose_signals`).
-ROBOT_SIGNAL_POINTERS = Derive(
-    joint_signals=FromValue([keys.JOINTS]), pose_signals=FromValue([keys.EE_POSE, keys.TARGET_EE_POSE])
-)
+_POINTER_VALUES: dict[str, Any] = {
+    keys.JOINT_SIGNALS: FromValue([keys.JOINTS]),
+    keys.POSE_SIGNALS: FromValue([keys.EE_POSE, keys.TARGET_EE_POSE]),
+}
+ROBOT_SIGNAL_POINTERS = Derive(**_POINTER_VALUES)
 
 # The bundled model (URDF + collision meshes + joint names + control frame + gripper) for the real
 # arm and the MuJoCo sim.

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -109,9 +109,9 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
     }
     joint_signals = {side: f'robot_state.{side}.q' for side in arms}
     static_meta = {
-        'joint_signals': list(joint_signals.values()),
-        'pose_signals': [f'robot_state.{s}.ee_pose' for s in arms] + [f'robot_command.{s}.pose' for s in arms],
-        'mounts': {sig: mounts[side] for side, sig in joint_signals.items()},
+        keys.JOINT_SIGNALS: list(joint_signals.values()),
+        keys.POSE_SIGNALS: [f'robot_state.{s}.ee_pose' for s in arms] + [f'robot_command.{s}.pose' for s in arms],
+        keys.MOUNTS: {sig: mounts[side] for side, sig in joint_signals.items()},
     }
     return Embodiment(
         descriptor='yam_bimanual',

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -85,7 +85,8 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
     Per-arm channels are the flat names the whole stack shares: ``robot_state.{side}`` expands into
     ``robot_state.{side}.q/.dq/.ee_pose`` on record and commands are ``robot_command.{side}`` +
     ``target_grip.{side}``. Each arm is mounted at ``mounts[side]``, so real ``ee_pose`` lands in the world
-    frame the training data uses; static_meta records the mount of every arm built, naming the sides.
+    frame the training data uses; static_meta records the mount of every arm built, keyed by the joint
+    signal that drives it.
     """
     from positronic import geom
     from positronic.drivers.roboarm import yam as yam_driver
@@ -106,10 +107,11 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
         },
         **{f'target_grip.{s}': Command(arm.target_grip, 0.0, None) for s, arm in arms.items()},
     }
+    joint_signals = {side: f'robot_state.{side}.q' for side in arms}
     static_meta = {
-        'joint_signals': [f'robot_state.{s}.q' for s in arms],
+        'joint_signals': list(joint_signals.values()),
         'pose_signals': [f'robot_state.{s}.ee_pose' for s in arms] + [f'robot_command.{s}.pose' for s in arms],
-        'mounts': {side: mounts[side] for side in arms},
+        'mounts': {sig: mounts[side] for side, sig in joint_signals.items()},
     }
     return Embodiment(
         descriptor='yam_bimanual',

--- a/positronic/cfg/phail/v1_0.py
+++ b/positronic/cfg/phail/v1_0.py
@@ -15,7 +15,7 @@ import pos3
 
 from positronic import keys
 from positronic.cfg.ds import group, local_all, transform
-from positronic.cfg.ds.internal import REAL_ROBOT_TRANSFORM
+from positronic.cfg.ds.internal import REAL_ROBOT_TRANSFORM, ROBOT_SIGNAL_POINTERS
 from positronic.cfg.eval.real.tasks import UNIFIED_TASK
 from positronic.dataset import Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Identity
@@ -81,7 +81,11 @@ phail_with_started = transform.override(
     base=ds.teleop,
     transforms=[
         group.override(
-            transforms=[Identity(), Derive(started=lambda ep: datetime.fromtimestamp(ep.meta['created_ts_ns'] / 1e9))]
+            transforms=[
+                ROBOT_SIGNAL_POINTERS,  # first, so it wins over what the released episodes baked into their static
+                Identity(),
+                Derive(started=lambda ep: datetime.fromtimestamp(ep.meta['created_ts_ns'] / 1e9)),
+            ]
         )
     ],
     extra_meta={'name': 'PhAIL Public Dataset'},

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import nullcontext
 from enum import Enum
+from typing import Any
 
 import configuronic as cfn
 import numpy as np
@@ -296,7 +297,7 @@ def main_sim(
     cameras = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
     gui = dpg_ui()
 
-    static_meta = dict(wire.ROBOT_STATIC_META)
+    static_meta: dict[str, Any] = dict(wire.ROBOT_STATIC_META)
     if task is not None:
         static_meta[keys.TASK] = task
 

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -7,7 +7,7 @@ from positronic import keys
 from positronic.dataset.serializers import Serializer
 
 # Embodiment-level static meta: how recorded signals map to the canonical robot fields.
-ROBOT_STATIC_META = {'joint_signal': keys.JOINTS, 'pose_signals': [keys.EE_POSE, keys.TARGET_EE_POSE]}
+ROBOT_STATIC_META = {'joint_signals': [keys.JOINTS], 'pose_signals': [keys.EE_POSE, keys.TARGET_EE_POSE]}
 
 
 @dataclass

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -7,7 +7,7 @@ from positronic import keys
 from positronic.dataset.serializers import Serializer
 
 # Embodiment-level static meta: how recorded signals map to the canonical robot fields.
-ROBOT_STATIC_META = {'joint_signals': [keys.JOINTS], 'pose_signals': [keys.EE_POSE, keys.TARGET_EE_POSE]}
+ROBOT_STATIC_META = {keys.JOINT_SIGNALS: [keys.JOINTS], keys.POSE_SIGNALS: [keys.EE_POSE, keys.TARGET_EE_POSE]}
 
 
 @dataclass

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -33,6 +33,12 @@ JOINT_NAMES = 'joint_names'
 # transform. Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.
 EE_FRAME = 'ee_frame'
 
+# The 3D viewer's pointers into an episode: which signals carry joint angles, which carry poses. One arm per
+# ``JOINT_SIGNALS`` entry, each running ``URDF`` and standing where ``MOUNTS`` places it, keyed by that signal.
+JOINT_SIGNALS = 'joint_signals'
+POSE_SIGNALS = 'pose_signals'
+MOUNTS = 'mounts'
+
 # The inference handshake: a policy reports these through its ``meta``, a remote policy nests the serving
 # half under ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy
 # at the top level and the vendor under ``SERVER``, so a reader composes a prefix with a field:

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -504,7 +504,7 @@ def test_harness_waits_for_complete_inputs(world):
 @pytest.mark.timeout(3.0)
 def test_episode_meta_stamped_at_finalize(world):
     policy = StubPolicy(meta={'type': 'stub', 'checkpoint': 'v1'})
-    harness = Harness(policy, make_embodiment(), static_meta={'joint_signals': [keys.JOINTS]})
+    harness = Harness(policy, make_embodiment(), static_meta={keys.JOINT_SIGNALS: [keys.JOINTS]})
     p = _pair_all(world, harness)
 
     driver = ManualDriver([
@@ -520,7 +520,7 @@ def test_episode_meta_stamped_at_finalize(world):
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
     meta = stops[0].static_data
-    assert meta['joint_signals'] == [keys.JOINTS]
+    assert meta[keys.JOINT_SIGNALS] == [keys.JOINTS]
     assert meta[keys.URDF] == '<robot/>'
     assert meta[keys.JOINT_NAMES] == ['j1']
     assert meta['inference.policy.type'] == 'stub'

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -504,7 +504,7 @@ def test_harness_waits_for_complete_inputs(world):
 @pytest.mark.timeout(3.0)
 def test_episode_meta_stamped_at_finalize(world):
     policy = StubPolicy(meta={'type': 'stub', 'checkpoint': 'v1'})
-    harness = Harness(policy, make_embodiment(), static_meta={'joint_signal': keys.JOINTS})
+    harness = Harness(policy, make_embodiment(), static_meta={'joint_signals': [keys.JOINTS]})
     p = _pair_all(world, harness)
 
     driver = ManualDriver([
@@ -520,7 +520,7 @@ def test_episode_meta_stamped_at_finalize(world):
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
     meta = stops[0].static_data
-    assert meta['joint_signal'] == keys.JOINTS
+    assert meta['joint_signals'] == [keys.JOINTS]
     assert meta[keys.URDF] == '<robot/>'
     assert meta[keys.JOINT_NAMES] == ['j1']
     assert meta['inference.policy.type'] == 'stub'

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -165,9 +165,18 @@ def _unplotted_notice(unplotted: dict[str, int]) -> str:
     )
 
 
+# The retired singular spelling of `keys.JOINT_SIGNALS`. It lives here rather than in `keys` because nothing
+# writes it any more — only released data carries it, and only until #587 converts that data.
+_SINGULAR_JOINT_SIGNAL = 'joint_signal'
+
+
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
     pose_set = set(ep.static.get(keys.POSE_SIGNALS, []))
     joint_set = set(ep.static.get(keys.JOINT_SIGNALS, []))
+    # TODO(#587): drop once the published PhAIL dataset carries the plural key. Its `static.json` has the
+    # singular one baked in, so without this a released episode loses its arm model and joint names.
+    if _SINGULAR_JOINT_SIGNAL in ep.static:
+        joint_set.add(ep.static[_SINGULAR_JOINT_SIGNAL])
     signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[], joints=[])
     for name, sig in ep.signals.items():
         if sig.kind == Kind.IMAGE:

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -166,8 +166,8 @@ def _unplotted_notice(unplotted: dict[str, int]) -> str:
 
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
-    pose_set = set(ep.static.get('pose_signals', []))
-    joint_set = set(ep.static.get('joint_signals', []))
+    pose_set = set(ep.static.get(keys.POSE_SIGNALS, []))
+    joint_set = set(ep.static.get(keys.JOINT_SIGNALS, []))
     signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[], joints=[])
     for name, sig in ep.signals.items():
         if sig.kind == Kind.IMAGE:
@@ -470,7 +470,7 @@ def _log_urdf_robot(
             f'{joint_sig} carries {q_vals.shape[1]} angles for {len(joint_names)} model joints; skipping its model'
         )
         return
-    mount = ep.static.get('mounts', {}).get(joint_sig)
+    mount = ep.static.get(keys.MOUNTS, {}).get(joint_sig)
     namespace = f'{joint_sig}.'
     prefix = f'/3d/robot/{joint_sig}'
 

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -26,11 +26,11 @@ from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.video import VideoSignal
 from positronic.utils.rerun_compat import flatten_numeric, log_series_styles, set_timeline_time
 
-# TODO: 3D visualization roles (pose_signals, joint_signal) are currently read from episode
+# TODO: 3D visualization roles (pose_signals, joint_signals) are currently read from episode
 # static data as flat keys. A cleaner long-term solution is signal-level metadata: each Signal
 # would carry a `role` (e.g. 'transform3d', 'joint_position') and optionally a `robot` reference
 # linking it to a robot model in static. This would:
-# - Eliminate the need for pose_signals/joint_signal keys in static
+# - Eliminate the need for pose_signals/joint_signals keys in static
 # - Support multiple robots naturally (each signal references its own model)
 # - Keep semantics with the signal that produces them, not in a parallel list
 # - Require extending SignalMeta (currently dtype/shape/kind) with user-settable fields
@@ -64,6 +64,7 @@ class EpisodeSignals:
     numerics: list[str]
     dims: dict[str, int]
     poses: list[str]
+    joints: list[str]
 
     @property
     def plotted(self) -> dict[str, int]:
@@ -166,7 +167,8 @@ def _unplotted_notice(unplotted: dict[str, int]) -> str:
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
     pose_set = set(ep.static.get('pose_signals', []))
-    signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[])
+    joint_set = set(ep.static.get('joint_signals', []))
+    signals = EpisodeSignals(videos=[], numerics=[], dims={}, poses=[], joints=[])
     for name, sig in ep.signals.items():
         if sig.kind == Kind.IMAGE:
             try:
@@ -184,6 +186,8 @@ def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
         signals.dims[name] = dim
         if name in pose_set:
             signals.poses.append(name)
+        if name in joint_set:
+            signals.joints.append(name)
     return signals
 
 
@@ -251,15 +255,8 @@ def _build_blueprint(signals: EpisodeSignals, ep: Episode) -> rrb.Blueprint:
     )
 
 
-def _joint_signals(ep: Episode) -> set[str]:
-    names: set[str] = set(ep.static.get('joint_signals', ()))
-    if ep.static.get('joint_signal'):  # TODO(#511): drop the singular fallback once published datasets migrate.
-        names.add(ep.static['joint_signal'])
-    return names
-
-
 def _setup_series_names(signals: EpisodeSignals, ep: Episode) -> None:
-    joint_set = _joint_signals(ep)
+    joint_set = set(signals.joints)
     joint_names = ep.static.get(keys.JOINT_NAMES)
     pose_set = set(signals.poses)
     for key, dim in signals.plotted.items():
@@ -369,9 +366,8 @@ def _log_numeric_signals(
     A signal too wide to plot is still read, so that a joint or pose vector of any width reaches the
     3D view.
     """
-    pose_set = set(signals.poses)
     gripper = ep.static.get('gripper')
-    stash_keys = pose_set | _joint_signals(ep)
+    stash_keys = set(signals.poses) | set(signals.joints)
     if gripper:
         stash_keys.add(gripper['signal'])
     pose_data = {}
@@ -407,9 +403,13 @@ def _log_numeric_signals(
 _ROBOT_VISUAL_RGBA = '1 1 1 0.5'
 
 
-def _write_urdf_to_dir(urdf_str: str, meshes: dict[str, bytes], dest: Path) -> Path:
-    """Write URDF and mesh files to a directory, rewriting mesh filenames to absolute paths and
-    tinting every visual translucent white."""
+def _write_urdf_to_dir(urdf_str: str, meshes: dict[str, bytes], dest: Path, namespace: str) -> Path:
+    """Write URDF and mesh files to a directory, rewriting mesh filenames to absolute paths, tinting
+    every visual translucent white, and prefixing every link and joint name with ``namespace``.
+
+    Rerun keys a transform on the link name, so two arms driving the same model need their link names
+    apart or they resolve to one another's frames.
+    """
     root = ET.fromstring(urdf_str)
     for mesh_el in root.iter('mesh'):
         filename = mesh_el.get('filename', '')
@@ -418,6 +418,11 @@ def _write_urdf_to_dir(urdf_str: str, meshes: dict[str, bytes], dest: Path) -> P
     for visual_el in root.iter('visual'):
         material_el = ET.SubElement(visual_el, 'material', name='viewer_translucent')
         ET.SubElement(material_el, 'color', rgba=_ROBOT_VISUAL_RGBA)
+    for el in root.iter():
+        if el.tag in ('link', 'joint'):
+            el.set('name', namespace + el.get('name', ''))
+        elif el.tag in ('parent', 'child'):
+            el.set('link', namespace + el.get('link', ''))
     urdf_path = dest / 'robot.urdf'
     urdf_path.write_text(ET.tostring(root, encoding='unicode'))
     for name, data in meshes.items():
@@ -426,7 +431,7 @@ def _write_urdf_to_dir(urdf_str: str, meshes: dict[str, bytes], dest: Path) -> P
     return urdf_path
 
 
-def _animate_joint(joint, q_column: np.ndarray, ts_arr: np.ndarray, prefix: str) -> None:
+def _animate_joint(joint, q_column: np.ndarray, ts_arr: np.ndarray, entity_path: str) -> None:
     """Compute and log transforms for a single URDF joint across all timesteps."""
     n = len(ts_arr)
     translations = np.empty((n, 3), dtype=np.float64)
@@ -436,7 +441,7 @@ def _animate_joint(joint, q_column: np.ndarray, ts_arr: np.ndarray, prefix: str)
         translations[i] = t.translation.as_arrow_array().to_pylist()[0]
         quaternions[i] = t.quaternion.as_arrow_array().to_pylist()[0]
     rr.send_columns(
-        f'{prefix}/{joint.child_link}',
+        entity_path,
         indexes=[rr.TimeColumn('time', timestamp=ts_arr)],
         columns=rr.Transform3D.columns(
             translation=translations,
@@ -451,26 +456,34 @@ _URDF_ANIM_HZ = 15
 
 
 def _log_urdf_robot(
-    ep: Episode, numeric_data: dict[str, tuple[np.ndarray, np.ndarray]], drainer: _BinaryStreamDrainer
-) -> Generator[bytes, None, str | None]:
-    """Log URDF robot model with animated joint angles. Returns root frame name."""
-    joint_sigs = sorted(_joint_signals(ep) & numeric_data.keys())
+    ep: Episode, joint_sig: str, numeric_data: dict[str, tuple[np.ndarray, np.ndarray]], drainer: _BinaryStreamDrainer
+) -> Iterator[bytes]:
+    """Log the episode's robot model, its joints animated by `joint_sig`."""
     joint_names = ep.static.get(keys.JOINT_NAMES)
     urdf_str = ep.static.get(keys.URDF)
     meshes = ep.static.get('meshes')
-    if not all((joint_sigs, joint_names, urdf_str, meshes)):
-        return None
-    ts_arr, q_vals = numeric_data[joint_sigs[0]]
+    if not (joint_names and urdf_str and meshes):
+        return
+    ts_arr, q_vals = numeric_data[joint_sig]
     if q_vals.shape[1] != len(joint_names):
-        return None
+        logging.warning(
+            f'{joint_sig} carries {q_vals.shape[1]} angles for {len(joint_names)} model joints; skipping its model'
+        )
+        return
+    mount = ep.static.get('mounts', {}).get(joint_sig)
+    namespace = f'{joint_sig}.'
+    prefix = f'/3d/robot/{joint_sig}'
 
-    prefix = '/3d/robot'
+    def link_path(joint) -> str:
+        return f'{prefix}/{joint.child_link.removeprefix(namespace)}'
+
     with tempfile.TemporaryDirectory() as tmp:
-        urdf_path = _write_urdf_to_dir(urdf_str, meshes, Path(tmp))
+        urdf_path = _write_urdf_to_dir(urdf_str, meshes, Path(tmp), namespace)
         rr.log_file_from_path(str(urdf_path), entity_path_prefix=prefix, static=True)
         tree = UrdfTree.from_file_path(str(urdf_path), entity_path_prefix=prefix)
 
-    root_frame = tree.root_link().name
+    # An unattached root link frame shares no space with the poses, and the loader leaves it that way.
+    rr.log(prefix, rr.Transform3D(translation=mount or np.zeros(3), child_frame=tree.root_link().name), static=True)
     yield from drainer.drain()
 
     # Downsample to ~15Hz — robot motion is smooth enough, avoids bloating the RRD
@@ -482,25 +495,25 @@ def _log_urdf_robot(
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         for j_idx, name in enumerate(joint_names):
-            joint = tree.get_joint_by_name(name)
+            joint = tree.get_joint_by_name(namespace + name)
             if joint is not None:
-                _animate_joint(joint, q_ds[:, j_idx], ts_ds, prefix)
+                _animate_joint(joint, q_ds[:, j_idx], ts_ds, link_path(joint))
                 yield from drainer.drain()
 
         # A single ``grip`` signal in [0, 1] drives the gripper joints, each joint's axis sign setting
         # its direction; recordings can overshoot slightly, so clip before scaling by ``travel``.
+        # TODO: the spec names one signal, so every model grips with it. Arms that grip independently
+        # need it pluralized the way `joint_signals` is.
         gripper = ep.static.get('gripper')
         if gripper and gripper['signal'] in numeric_data:
             grip_ts, grip_vals = numeric_data[gripper['signal']]
             grip_step = max(1, len(grip_ts) // target_samples)
             finger_pos = np.clip(grip_vals[::grip_step, 0], 0.0, 1.0) * gripper['travel']
             for name in gripper['joints']:
-                joint = tree.get_joint_by_name(name)
+                joint = tree.get_joint_by_name(namespace + name)
                 if joint is not None:
-                    _animate_joint(joint, finger_pos, grip_ts[::grip_step], prefix)
+                    _animate_joint(joint, finger_pos, grip_ts[::grip_step], link_path(joint))
                     yield from drainer.drain()
-
-    return root_frame
 
 
 def _log_pose_signals(
@@ -509,8 +522,10 @@ def _log_pose_signals(
     numeric_data: dict[str, tuple[np.ndarray, np.ndarray]],
     drainer: _BinaryStreamDrainer,
 ) -> Iterator[bytes]:
-    """Log 3D pose: static full trajectory + current position ball + optional URDF robot."""
-    root_frame = yield from _log_urdf_robot(ep, numeric_data, drainer)
+    """Log 3D pose: static full trajectory + current position ball + a URDF model per joint signal."""
+    for joint_sig in signals.joints:
+        if joint_sig in numeric_data:
+            yield from _log_urdf_robot(ep, joint_sig, numeric_data, drainer)
 
     for key in signals.poses:
         if key not in numeric_data:
@@ -520,11 +535,6 @@ def _log_pose_signals(
             continue
         positions = vals[:, :3]
         color = _pose_color(key)
-
-        # Connect pose entities to the URDF root frame so they share the same 3D space
-        if root_frame:
-            rr.log(f'/3d/{key}', rr.Transform3D(parent_frame=root_frame), static=True)
-            rr.log(f'/3d/{key}/trail', rr.Transform3D(parent_frame=root_frame), static=True)
 
         _log_static_trail(f'/3d/{key}/trail', positions, color)
 

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -55,6 +55,13 @@ def test_every_joint_signal_the_episode_records_is_collected(tmp_path):
     assert sorted(signals.joints) == ['robot_state.left.q', 'robot_state.right.q']
 
 
+def test_released_episodes_singular_joint_signal_still_counts(tmp_path):
+    # TODO(#587): delete with the bridge in `_collect_signal_groups`.
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', {keys.JOINTS: 7}, {'joint_signal': keys.JOINTS}))
+
+    assert signals.joints == [keys.JOINTS]
+
+
 def test_urdf_link_and_joint_names_carry_the_namespace(tmp_path):
     urdf = """<robot name="toy">
       <link name="base"/>

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -1,15 +1,25 @@
+import xml.etree.ElementTree as ET
+from typing import Any
+
 import numpy as np
 
 from positronic import keys
 from positronic.dataset.local_dataset import DiskEpisode, DiskEpisodeWriter
-from positronic.server.dataset_utils import _MAX_PLOTTED_WIDTH, _collect_signal_groups, _unplotted_notice
+from positronic.server.dataset_utils import (
+    _MAX_PLOTTED_WIDTH,
+    _collect_signal_groups,
+    _unplotted_notice,
+    _write_urdf_to_dir,
+)
 
 
-def _episode(ep_dir, widths: dict[str, int]) -> DiskEpisode:
+def _episode(ep_dir, widths: dict[str, int], static: dict[str, Any] | None = None) -> DiskEpisode:
     with DiskEpisodeWriter(ep_dir) as writer:
         for name, width in widths.items():
             writer.append(name, np.zeros(width, dtype=np.float32), 1000)
             writer.append(name, np.ones(width, dtype=np.float32), 2000)
+        for name, value in (static or {}).items():
+            writer.set_static(name, value)
     return DiskEpisode(ep_dir)
 
 
@@ -34,6 +44,34 @@ def test_wide_signal_still_reaches_the_3d_view(tmp_path):
 
     assert signals.numerics == [keys.JOINTS]
     assert signals.dims == {keys.JOINTS: width}
+
+
+def test_every_joint_signal_the_episode_records_is_collected(tmp_path):
+    widths = {'robot_state.left.q': 6, 'robot_state.right.q': 6, keys.GRIP: 1}
+    static = {'joint_signals': ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
+
+    signals = _collect_signal_groups(_episode(tmp_path / 'ep', widths, static))
+
+    assert sorted(signals.joints) == ['robot_state.left.q', 'robot_state.right.q']
+
+
+def test_urdf_link_and_joint_names_carry_the_namespace(tmp_path):
+    urdf = """<robot name="toy">
+      <link name="base"/>
+      <link name="arm"/>
+      <joint name="shoulder" type="revolute">
+        <parent link="base"/>
+        <child link="arm"/>
+      </joint>
+    </robot>"""
+
+    urdf_path = _write_urdf_to_dir(urdf, {}, tmp_path, 'robot_state.left.q.')
+
+    root = ET.fromstring(urdf_path.read_text())
+    assert [el.get('name') for el in root.iter('link')] == ['robot_state.left.q.base', 'robot_state.left.q.arm']
+    assert [el.get('name') for el in root.iter('joint')] == ['robot_state.left.q.shoulder']
+    assert [el.get('link') for el in root.iter('parent')] == ['robot_state.left.q.base']
+    assert [el.get('link') for el in root.iter('child')] == ['robot_state.left.q.arm']
 
 
 def test_notice_names_every_unplotted_signal_and_its_width():

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -48,7 +48,7 @@ def test_wide_signal_still_reaches_the_3d_view(tmp_path):
 
 def test_every_joint_signal_the_episode_records_is_collected(tmp_path):
     widths = {'robot_state.left.q': 6, 'robot_state.right.q': 6, keys.GRIP: 1}
-    static = {'joint_signals': ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
+    static = {keys.JOINT_SIGNALS: ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
 
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', widths, static))
 


### PR DESCRIPTION
## Summary

Closes #511.

- `joint_signals` (plural) is now the only key the 3D viewer reads — the singular fallback in `dataset_utils` is gone.
- `ROBOT_SIGNAL_POINTERS` (was private) supplies the plural key, and `phail_with_started` applies it, so published datasets carrying the singular key baked into `static.json` keep their joint legend names and their animated model.
- The viewer builds **one URDF instance per joint signal** instead of one per episode. Each instance namespaces its link and joint names — rerun keys a transform on the link name, so two arms on the same model would otherwise resolve into each other's frames — and stands at its own mount. A bimanual episode now shows both arms.
- `yam_bimanual` keys `mounts` by the joint signal that drives each arm rather than by side, which is what lets the viewer place them.

The `gripper` spec still names a single signal, so every arm's gripper follows it; marked with a TODO, since no embodiment records per-arm grip today.

## Test plan

- `uv run --locked --extra dev pytest --no-cov` — 1026 passed, 7 skipped
- New coverage in `positronic/server/tests/test_dataset_utils.py`: joint signals collected from the plural key, and URDF link/joint namespacing
- Verified in the viewer against a synthetic dataset (single-arm and bimanual episodes, bundled Franka model): single-arm renders model, trail and ball exactly as before; bimanual renders two independently animated arms at their mounts, where `main` renders one arm and a stray trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Compatibility

The published PhAIL dataset has the singular `joint_signal` baked into its `static.json`, so `_collect_signal_groups` still folds that key in, marked `TODO(#587)`. Without it a released episode read outside the PhAIL viewer config — a bare `positronic-server --dataset.path=…` — would lose its arm model and its joint-name legends. #587 converts the released data and deletes the bridge along with the test that pins it.
