### PR TITLE
Start the trial budget at frame zero, not at `reset`

### DIFF
--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -306,8 +306,9 @@ class Harness(pimm.ControlSystem):
         (last in the round). The recorder drains its channels the turn it opens, so the pre-reset frame and
         the inter-episode home command — lingering there from before START — drop out and its first sample
         is the post-reset scene, which the harness infers on once it lands. The trial deadline (a task's
-        ``timeout``, bounding policy- and operator-driven trials alike) is armed here; a task-less attended
-        session has no deadline and ends only on a directive.
+        ``timeout``, bounding policy- and operator-driven trials alike) is armed here and re-anchored to
+        frame zero, so a frame zero that never lands is still bounded; a task-less attended session has no
+        deadline and ends only on a directive.
         """
         self.context = context
         # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
@@ -442,9 +443,13 @@ class Harness(pimm.ControlSystem):
         The session output already carries absolute timestamps (stamped by the
         outermost scheduling wrapper). The harness only demuxes by channel.
         """
+        awaiting_frame_zero = bool(self._awaiting_obs)  # ``_build_obs`` clears it, so read it first
         obs = self._build_obs(clock)
         if obs is None:
             return
+        if awaiting_frame_zero and self._task is not None:
+            # An env that paces the trial counts its own steps from frame zero, so the budget must too.
+            self._deadline = clock.now() + self._task.timeout
         self._telemetry.start_rollout(clock.now())
 
         # Advance the (sim) clock by the inference cost so rollouts feel the model's latency. We only

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -77,15 +77,8 @@ class _EpisodeTelemetry:
         telemetry.push_anchor(self._span)
 
     def start_rollout(self, virtual_now: float) -> None:
-        """Anchor the rollout's virtual duration at the first control cycle that has an observation.
-
-        A simulated producer's ``reset`` only arms frame zero, which it publishes on its next turn, and that
-        turn advances the virtual clock by a control period without stepping the environment. Anchoring when
-        the reset returns would charge that period to the rollout while its wall sits under reset, inflating
-        the real-time factor by one control period per episode. Called every cycle; only the first lands.
-        """
-        if self._virtual_start is None:
-            self._virtual_start = virtual_now
+        """Anchor the rollout's virtual duration at the instant its first observation landed."""
+        self._virtual_start = virtual_now
 
     def step(self) -> None:
         self._steps += 1
@@ -119,9 +112,8 @@ class _EpisodeTelemetry:
         telemetry.force_flush()
 
     def _close(self, virtual_now: float) -> None:
-        # A rollout that never reached its first observation — a reset that raised, or a task already done
-        # before frame zero landed — has zero virtual duration; only an anchored rollout measures from its
-        # start.
+        # A rollout whose first observation never landed — a reset that raised, or a task already done before
+        # it arrived — has zero virtual duration.
         virtual_s = max(virtual_now - self._virtual_start, 0.0) if self._virtual_start is not None else 0.0
         assert self._span is not None
         attrs = {telemetry_keys.ATTR_EPISODE_STEPS: self._steps, telemetry_keys.ATTR_EPISODE_VIRTUAL_S: virtual_s}
@@ -200,9 +192,9 @@ class Harness(pimm.ControlSystem):
         # A trial with a task is bounded by ``task.timeout``, set per episode; a task-less attended
         # session has no deadline and is ended by directives.
         self._deadline: float | None = None
-        # Whether ``_deadline`` has been moved to the episode's first observation. Until then it stands
-        # where the reset put it, which bounds an episode whose first observation never arrives.
-        self._budget_anchored = False
+        # Whether this episode's first observation has landed. Until it does the deadline stands where the
+        # reset put it, which bounds an episode whose first observation never arrives.
+        self._rollout_started = False
         # Wall-clock telemetry for the live rollout, opened under ``--timing`` and inert otherwise.
         self._telemetry = _EpisodeTelemetry()
         # Observation channels that have not delivered since this episode's reset. A receiver latches its
@@ -317,7 +309,7 @@ class Harness(pimm.ControlSystem):
         # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
         self._inference_latency = self.context.get('inference_latency', False)
         self._awaiting_obs = set(self._embodiment.observations)
-        self._budget_anchored = False
+        self._rollout_started = False
         # Open the episode span before the reset, so the phase spans (reset, env.step, policy.infer,
         # record.io) parent to it.
         self._telemetry.begin(context)
@@ -450,12 +442,14 @@ class Harness(pimm.ControlSystem):
         obs = self._build_obs(clock)
         if obs is None:
             return
-        if not self._budget_anchored and self._task is not None:
-            # The episode begins at its first observation, not when the reset returned: a reset only asks
-            # the producer for a new scene, and the turns it spends delivering one are not the trial's.
-            self._budget_anchored = True
-            self._deadline = clock.now() + self._task.timeout
-        self._telemetry.start_rollout(clock.now())
+        if not self._rollout_started:
+            # The rollout begins at its first observation, not when the reset returned: a reset only asks the
+            # producer for a new scene, and the turns it spends delivering one belong to neither the trial's
+            # budget nor its measured duration.
+            self._rollout_started = True
+            self._telemetry.start_rollout(clock.now())
+            if self._task is not None:
+                self._deadline = clock.now() + self._task.timeout
 
         # Advance the (sim) clock by the inference cost so rollouts feel the model's latency. We only
         # sleep on cycles where inference actually ran (session returned a chunk) — otherwise blocked

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -200,6 +200,9 @@ class Harness(pimm.ControlSystem):
         # A trial with a task is bounded by ``task.timeout``, set per episode; a task-less attended
         # session has no deadline and is ended by directives.
         self._deadline: float | None = None
+        # Whether ``_deadline`` has been moved to the episode's first observation. Until then it stands
+        # where the reset put it, which bounds an episode whose first observation never arrives.
+        self._budget_anchored = False
         # Wall-clock telemetry for the live rollout, opened under ``--timing`` and inert otherwise.
         self._telemetry = _EpisodeTelemetry()
         # Observation channels that have not delivered since this episode's reset. A receiver latches its
@@ -306,14 +309,15 @@ class Harness(pimm.ControlSystem):
         (last in the round). The recorder drains its channels the turn it opens, so the pre-reset frame and
         the inter-episode home command — lingering there from before START — drop out and its first sample
         is the post-reset scene, which the harness infers on once it lands. The trial deadline (a task's
-        ``timeout``, bounding policy- and operator-driven trials alike) is armed here and re-anchored to
-        frame zero, so a frame zero that never lands is still bounded; a task-less attended session has no
-        deadline and ends only on a directive.
+        ``timeout``, bounding policy- and operator-driven trials alike) is armed here and moved to the
+        episode's first observation once one arrives, so an episode that never gets one is still bounded;
+        a task-less attended session has no deadline and ends only on a directive.
         """
         self.context = context
         # ``inference_latency`` rides the RUN context (and lands in episode meta with it).
         self._inference_latency = self.context.get('inference_latency', False)
         self._awaiting_obs = set(self._embodiment.observations)
+        self._budget_anchored = False
         # Open the episode span before the reset, so the phase spans (reset, env.step, policy.infer,
         # record.io) parent to it.
         self._telemetry.begin(context)
@@ -443,12 +447,13 @@ class Harness(pimm.ControlSystem):
         The session output already carries absolute timestamps (stamped by the
         outermost scheduling wrapper). The harness only demuxes by channel.
         """
-        awaiting_frame_zero = bool(self._awaiting_obs)  # ``_build_obs`` clears it, so read it first
         obs = self._build_obs(clock)
         if obs is None:
             return
-        if awaiting_frame_zero and self._task is not None:
-            # An env that paces the trial counts its own steps from frame zero, so the budget must too.
+        if not self._budget_anchored and self._task is not None:
+            # The episode begins at its first observation, not when the reset returned: a reset only asks
+            # the producer for a new scene, and the turns it spends delivering one are not the trial's.
+            self._budget_anchored = True
             self._deadline = clock.now() + self._task.timeout
         self._telemetry.start_rollout(clock.now())
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -611,12 +611,25 @@ def test_trial_timeout_self_terminates(world):
 
 
 @pytest.mark.timeout(3.0)
-def test_trial_budget_starts_at_the_first_complete_observation(world):
-    """Frame zero lands at 0.02 and a marked observation at 0.06, against a 0.05 budget: anchored at
-    ``reset`` the trial expires at 0.05 and the policy never sees the mark, anchored at frame zero it runs
-    to 0.07 and does."""
+def test_trial_budget_starts_at_the_first_usable_observation(world):
+    """The 0.05 budget is measured from the episode's first usable observation, not from the reset.
+
+    The driver holds every channel silent for 0.02, so the episode opens with nothing to infer on. The
+    delivery at 0.02 is rejected by the camera serializer — the state a real embodiment is in while the
+    arm resets — so the first usable observation is the one at 0.04, and a third at 0.06 carries grip 0.75
+    as a marker. Measured from the reset the budget ends at 0.05 and the policy never sees the marker;
+    measured from the first usable observation it ends at 0.09 and the policy does.
+
+    The rejected delivery matters on its own: it clears the channels out of ``_awaiting_obs`` without
+    yielding an observation, so a budget anchored on that set alone would never move off the reset.
+    """
     policy = SpyPolicy()
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=0.05), trials=[{}])
+    embodiment = make_embodiment()
+    usable = iter([None])  # the first camera sample is not ready; every later one is
+    embodiment.observations['image.cam'] = Observation(
+        pimm.NoOpEmitter(), lambda frames: next(usable, Serializers.camera_images(frames))
+    )
+    harness = Harness(policy, embodiment, task=Task(instruction='test', timeout=0.05), trials=[{}])
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.2, 0.0, -0.1], [0.7, 0.1, -0.2])
     payload = partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
@@ -625,13 +638,13 @@ def test_trial_budget_starts_at_the_first_complete_observation(world):
         payload()
         p['grip_em'].emit(0.75)
 
-    driver = ManualDriver([(None, 0.02), (payload, 0.04), (marked, 0.2)])
+    driver = ManualDriver([(None, 0.02), (payload, 0.02), (payload, 0.02), (marked, 0.2)])
 
     scheduler = world.start([harness, driver])
     drive_scheduler(scheduler, steps=400)
 
-    assert policy.last_obs is not None, 'the trial expired before frame zero ever landed'
-    assert policy.last_obs[keys.GRIP] == 0.75, 'the budget expired early — it ran from reset, not frame zero'
+    assert policy.last_obs is not None, 'the trial expired before its first observation landed'
+    assert policy.last_obs[keys.GRIP] == 0.75, 'the budget expired early — measured from reset, not the first obs'
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -35,6 +35,10 @@ from positronic.policy.remote import RemoteSession
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
 
+# The camera channel every embodiment these tests build carries, named by the producer and the tests that
+# pair against it alike.
+CAM = 'image.cam'
+
 
 @contextmanager
 def _eval_pass(run_id: str):
@@ -49,7 +53,7 @@ def _eval_pass(run_id: str):
         telemetry.pop_anchor(span)
 
 
-def make_embodiment(descriptor: str = '', cameras=('image.cam',), static_meta=None) -> Embodiment:
+def make_embodiment(descriptor: str = '', cameras=(CAM,), static_meta=None) -> Embodiment:
     """Minimal Franka-shaped embodiment for harness unit tests.
 
     The sources/dests are no-ops: these tests pair the harness ports directly
@@ -237,7 +241,7 @@ def _pair_all(world, harness):
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     return {
-        'frame_em': world.pair(harness.observations['image.cam']),
+        'frame_em': world.pair(harness.observations[CAM]),
         'robot_em': world.pair(harness.observations['robot_state']),
         'grip_em': world.pair(harness.observations[keys.GRIP]),
         'directive_em': world.pair(harness.directive),
@@ -303,7 +307,7 @@ def test_harness_emits_cartesian_move(world):
     harness.commands['target_grip']._bind(grip_recorder)
     harness.ds_command._bind(RecordingEmitter())
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
     directive_em = world.pair(harness.directive)
@@ -321,7 +325,7 @@ def test_harness_emits_cartesian_move(world):
 
     assert policy.last_obs is not None
     obs = policy.last_obs
-    assert 'image.cam' in obs
+    assert CAM in obs
     expected_pose = np.concatenate([robot_state.ee_pose.translation, robot_state.ee_pose.rotation.as_quat])
     np.testing.assert_allclose(obs[keys.EE_POSE], expected_pose)
     np.testing.assert_allclose(obs[keys.JOINTS], robot_state.q)
@@ -332,7 +336,7 @@ def test_harness_emits_cartesian_move(world):
     # Recording == canonical policy I/O: the policy sees the same ``robot_state`` serializer
     # the dataset records. wall/obs timestamps carry volatile values, so lock the stable key set.
     assert set(obs) - {'wall_time_ns', 'obs_time_ns'} == {
-        'image.cam',
+        CAM,
         keys.JOINTS,
         keys.JOINT_VEL,
         keys.EE_POSE,
@@ -362,7 +366,7 @@ def test_harness_passes_descriptor_to_policy(world):
     harness.commands['target_grip']._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
     directive_em = world.pair(harness.directive)
@@ -392,7 +396,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     harness.commands['target_grip']._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations['grip'])
     directive_em = world.pair(harness.directive)
@@ -463,12 +467,12 @@ def test_harness_waits_for_complete_inputs(world):
     harness.commands['target_grip']._bind(grip_recorder)
     harness.ds_command._bind(RecordingEmitter())
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
     directive_em = world.pair(harness.directive)
 
-    assert 'image.cam' in harness.observations
+    assert CAM in harness.observations
 
     robot_state = make_robot_state([0.2, 0.0, -0.1], [0.7, 0.1, -0.2])
 
@@ -626,7 +630,7 @@ def test_trial_budget_starts_at_the_first_usable_observation(world):
     policy = SpyPolicy()
     embodiment = make_embodiment()
     usable = iter([None])  # the first camera sample is not ready; every later one is
-    embodiment.observations['image.cam'] = Observation(
+    embodiment.observations[CAM] = Observation(
         pimm.NoOpEmitter(), lambda frames: next(usable, Serializers.camera_images(frames))
     )
     harness = Harness(policy, embodiment, task=Task(instruction='test', timeout=0.05), trials=[{}])
@@ -939,7 +943,7 @@ def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
     harness.commands['target_grip']._bind(grip_recorder)
     harness.ds_command._bind(ds_recorder)
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
 
@@ -1068,7 +1072,7 @@ def test_finish_cancels_buffered_trajectory_before_stop_episode(world):
     harness.commands['target_grip']._bind(_LabeledRecorder('target_grip', events))
     harness.ds_command._bind(_LabeledRecorder('ds_command', events))
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
     directive_em = world.pair(harness.directive)
@@ -1122,7 +1126,7 @@ def test_empty_chunk_cancels_both_robot_and_grip(world):
     harness.commands['target_grip']._bind(grip_recorder)
     harness.ds_command._bind(RecordingEmitter())
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
     directive_em = world.pair(harness.directive)
@@ -1372,7 +1376,7 @@ def test_shutdown_cancels_trajectory_before_stop(world):
     harness.commands['target_grip']._bind(_LabeledRecorder('target_grip'))
     harness.ds_command._bind(_LabeledRecorder('ds_command'))
 
-    frame_em = world.pair(harness.observations['image.cam'])
+    frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations['robot_state'])
     grip_em = world.pair(harness.observations[keys.GRIP])
     directive_em = world.pair(harness.directive)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -611,6 +611,30 @@ def test_trial_timeout_self_terminates(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_trial_budget_starts_at_the_first_complete_observation(world):
+    """Frame zero lands at 0.02 and a marked observation at 0.06, against a 0.05 budget: anchored at
+    ``reset`` the trial expires at 0.05 and the policy never sees the mark, anchored at frame zero it runs
+    to 0.07 and does."""
+    policy = SpyPolicy()
+    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=0.05), trials=[{}])
+    p = _pair_all(world, harness)
+    robot_state = make_robot_state([0.2, 0.0, -0.1], [0.7, 0.1, -0.2])
+    payload = partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
+
+    def marked():
+        payload()
+        p['grip_em'].emit(0.75)
+
+    driver = ManualDriver([(None, 0.02), (payload, 0.04), (marked, 0.2)])
+
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=400)
+
+    assert policy.last_obs is not None, 'the trial expired before frame zero ever landed'
+    assert policy.last_obs[keys.GRIP] == 0.75, 'the budget expired early — it ran from reset, not frame zero'
+
+
+@pytest.mark.timeout(3.0)
 def test_attended_task_run_respects_timeout(world):
     """A task's ``timeout`` bounds an attended (directive-driven) run too: RUN arrives but no FINISH, yet
     the trial still self-terminates at the deadline. The deadline is armed whenever a task is supplied, not

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -35,10 +35,6 @@ from positronic.policy.remote import RemoteSession
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
 
-# The camera channel every embodiment these tests build carries, named by the producer and the tests that
-# pair against it alike.
-CAM = 'image.cam'
-
 
 @contextmanager
 def _eval_pass(run_id: str):
@@ -51,6 +47,9 @@ def _eval_pass(run_id: str):
     finally:
         span.end()
         telemetry.pop_anchor(span)
+
+
+CAM = 'image.cam'
 
 
 def make_embodiment(descriptor: str = '', cameras=(CAM,), static_meta=None) -> Embodiment:

--- a/positronic/policy/tests/test_sampled_e2e.py
+++ b/positronic/policy/tests/test_sampled_e2e.py
@@ -24,7 +24,7 @@ from positronic.policy.base import Policy, SampledPolicy, Session
 from positronic.policy.codec import ActionTiming
 from positronic.policy.harness import Directive, Harness
 from positronic.policy.sampler import BalancedSampler
-from positronic.policy.tests.test_harness import make_embodiment
+from positronic.policy.tests.test_harness import CAM, make_embodiment
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
 
 
@@ -88,7 +88,7 @@ def _pair_all(world, harness):
     grip_recorder = RecordingEmitter()
     harness.commands['target_grip']._bind(grip_recorder)
     return {
-        'frame_em': world.pair(harness.observations['image.cam']),
+        'frame_em': world.pair(harness.observations[CAM]),
         'robot_em': world.pair(harness.observations['robot_state']),
         'grip_em': world.pair(harness.observations[keys.GRIP]),
         'directive_em': world.pair(harness.directive),


### PR DESCRIPTION
## Summary

A trial's deadline was armed when `task.reset()` returned, but a simulated producer's `reset` only *arms* frame zero — the proxy publishes it on its next turn, and that turn advances the virtual clock by one control period without stepping the env. So every trial spent a control period of its budget before its episode had started, and an env's own N-step horizon landed at `(N+1)·dt` on the harness clock.

The harness already knows this. `TelemetryScope.start_rollout` anchors a rollout's virtual duration at the first control cycle that has an observation, for exactly this reason, and two tests pin that behaviour. The deadline was the last consumer still measuring from `reset`.

- Re-anchor `_deadline` to the episode's first complete observation, where an env that paces the trial starts counting its own steps.
- The arming at `reset` stays as the provisional bound, so a frame zero that never lands is still caught — without it, an observation channel that never delivers would remove the trial's deadline entirely.

This affects every env-server sim (libero, robolab) equally; their timeout margins were absorbing the offset silently.

## Test plan

`test_trial_budget_starts_at_the_first_complete_observation` — frame zero at 0.02 and a marked observation at 0.06 against a 0.05 budget. Anchored at `reset` the trial expires at 0.05 and the policy never sees the mark; anchored at frame zero it runs to 0.07 and does. Verified it fails on `main` and passes here.

Full suite: 1016 passed, 8 skipped. One pre-existing failure unrelated to this change — `utilities/tests/test_check_basedpyright_baseline_ratchet.py::test_build_rename_map_includes_staged_rename` raises `CalledProcessError` from git, and reproduces with these changes stashed (it appears to dislike running in a linked worktree).