### PR TITLE
Spawn the `check-rules` fan-out on Sonnet

### DIFF
--- a/.claude/skills/check-rules/SKILL.md
+++ b/.claude/skills/check-rules/SKILL.md
@@ -39,6 +39,13 @@ of one cleanly checked. Each needs its rule and a way to tell which code changed
 not know how that code came to be: a cold-headed reviewer answering one question, not a colleague who
 sat through the reasoning.
 
+**Spawn them on Sonnet** — `model: 'sonnet'`, on every agent. Each one answers a narrow question: one
+rule against one diff. A fan-out of that width spends most of what it costs on being that wide rather
+than on the judging. The parameter is not optional: omitted, an agent inherits whatever model the
+session runs, which is the caller's business and not the checker's. Raise a single rule to `opus` where
+its verdict turns on the change as a whole rather than on a shape in the diff, and name that rule in
+the report, so a reader can tell what judged what.
+
 Each agent returns two sections, either of which may be empty:
 
 ```


### PR DESCRIPTION
## What

`.claude/skills/check-rules/SKILL.md` Step 2 now names the model the per-rule agents run on: `model: 'sonnet'` on every agent, stated as non-optional, with `opus` reserved for a single rule whose verdict turns on the change as a whole — and that raise named in the report so a reader can tell what judged what.

## Why

Each agent in the fan-out answers a narrow question: one rule, against one diff. The run's cost is dominated by how wide it is, not by how hard any one verdict is, so the default that fits the work is the cheaper model. Left unnamed, an agent inherits whatever model the invoking session happens to be running — which makes the check's cost and its consistency a property of the caller rather than of the check. A run from an Opus session and a run from a Sonnet session then measure the same diff differently and bill very differently, for no reason a reader of the report can see.

The alternative was to leave the model to the caller and note the recommendation in prose. Rejected: the skill already fixes the other properties that make a fan-out reproducible (one rule per agent, no fork, the rule text verbatim in the prompt), and a model default the caller may silently override belongs in the same set.

This mirrors the paragraph already carried by the global `check-rules` skill installed on the agent boxes. Step 0 of that skill hands the procedure to a repository shipping its own copy, so without this line a run against this repository — where it runs most — ignores the default entirely.

## Verification

Docs only; no code path changes. The paragraph was read against the surrounding Step 2 text for consistency with how the skill states its other non-optional spawn properties.

<!-- opened-by: posi-agent -->