### PR TITLE
Let a run report its own progress, instead of being read from its log

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -42,8 +42,8 @@ class Driver:
     directive_wrapper: Callable
     control_systems: list[pimm.ControlSystem]
     manual_commands: pimm.SignalEmitter | None = None
-    # The port this surface serves the operator on; None where it is drawn on the rig's own screen
-    # and has no address. Only the driver knows: the UI itself is in another process by then.
+    # The port this surface serves the operator on; None where it is drawn on the rig's own
+    # screen. Only the driver knows: the UI is in another process by the time anything asks.
     console_port: int | None = None
 
 
@@ -87,9 +87,8 @@ def _run_world(
     ``driver`` (attended) and ``trials`` (unattended self-driving) are the two lifecycle sources, mutually
     exclusive per the caller. The shared ``policy``'s lifetime stays with ``main``.
 
-    ``state`` reports this World coming up and its cameras delivering their first frames. It is scheduled
-    rather than called: the World spawns its background processes before the first foreground round, so only
-    from inside ``world.run`` is the operator's UI known to exist.
+    ``state`` reports this World coming up and its cameras delivering their first frames. Scheduled rather
+    than called: only from inside ``world.run`` is the operator's UI known to exist.
     """
     harness = Harness(policy, embodiment, task=task, trials=trials, on_episode_complete=on_complete)
     gui = driver.gui if driver is not None else (dpg_ui() if show_gui else None)
@@ -110,8 +109,8 @@ def _run_world(
             for name, obs in embodiment.observations.items():
                 if name.startswith(keys.IMAGE_PREFIX):
                     world.connect(obs.source, gui.cameras[name])
-        # A second reader on the same emitters costs the producer a flag per frame: one frame goes
-        # into shared memory whatever the number of receivers.
+        # A second reader costs the producer a flag per frame: one frame into shared memory
+        # whatever the number of receivers.
         readiness = None
         if state.enabled:
             readiness = run_state.Readiness(state, cameras, driver.console_port if driver is not None else None)
@@ -137,9 +136,8 @@ def _run_world(
         # driver, and GUI placement is otherwise identical.
         producers = [cs for cs in embodiment.control_systems if cs is not None]
         foreground = driver.control_systems if driver is not None else []
-        # Last in the round on both paths, and in the foreground on both: it reports what the round
-        # produced, so it must not read ahead of the systems producing it, and its first round is
-        # what says the background processes are up — which only holds where it is not one of them.
+        # Foreground and last in the round: its first round is what says the background processes
+        # are up, which only holds where it is not one of them.
         watch = [readiness] if readiness is not None else []
         if embodiment.simulated:
             world.run([*foreground, harness, ds_agent, *producers, *watch], gui)
@@ -242,9 +240,8 @@ def main(
     the report, so a real embodiment in a timed sweep is rejected rather than allowed to pollute it.
     """
     assert (driver is None) != (evals is None), 'Provide exactly one of driver or evals'
-    # Built before anything else and handed to every World: an orchestrator watches the RUN, and a sweep is
-    # one run however many Worlds it raises. Inert unless something named this run (`ROLLOUT_RUN_ID`), which
-    # is every ordinary invocation — so nothing below is conditional on it.
+    # One per RUN, handed to every World a sweep raises. Inert unless something named this run, so
+    # nothing below is conditional on it.
     state = run_state.from_env()
     # Validate timing up front, before the policy warmup, so a rejected sweep fails before it spends anything.
     if timing:

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -47,6 +47,12 @@ class Driver:
     console_port: int | None = None
     console_ready: pimm.ControlSystemEmitter | None = None
 
+    def __post_init__(self):
+        # One console contract: a port nobody confirms would let a run advertise `ready` on an
+        # unbound socket, and a confirmation with no port names nothing to connect to.
+        both = (self.console_port is None) == (self.console_ready is None)
+        assert both, 'console_port and console_ready are one contract: give both or neither'
+
 
 def _seed_counter(policy, output_dir: Path):
     """If policy is a SampledPolicy, seed its episode counter from existing episodes in output_dir."""
@@ -83,8 +89,7 @@ def _wire_readiness(
     """
     if not state.enabled:
         return None
-    # One expression, two uses side by side: a console that must be waited for is exactly one whose
-    # signal is connected below.
+    # Readiness waits for a console exactly when one is connected below.
     console_ready = driver.console_ready if driver is not None else None
     readiness = run_state.Readiness(
         state, cameras, driver.console_port if driver is not None else None, awaits_console=console_ready is not None
@@ -118,6 +123,9 @@ def _run_world(
     ``state`` reports this World coming up and its cameras delivering their first frames. Scheduled rather
     than called: only from inside ``world.run`` is the operator's UI known to exist.
     """
+    # Before anything is constructed: in a sweep the previous World has exited while the state still
+    # says `ready`, and waiting for the next Readiness's first round would advertise it as up.
+    state.report(run_state.Phase.SETTING_UP)
     harness = Harness(policy, embodiment, task=task, trials=trials, on_episode_complete=on_complete)
     gui = driver.gui if driver is not None else (dpg_ui() if show_gui else None)
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -42,9 +42,10 @@ class Driver:
     directive_wrapper: Callable
     control_systems: list[pimm.ControlSystem]
     manual_commands: pimm.SignalEmitter | None = None
-    # The port this surface serves the operator on; None where it is drawn on the rig's own
-    # screen. Only the driver knows: the UI is in another process by the time anything asks.
+    # The port this surface serves the operator on, and the signal it raises once bound; both None
+    # where the surface is drawn on the rig's own screen and has no socket.
     console_port: int | None = None
+    console_ready: pimm.ControlSystemEmitter | None = None
 
 
 def _seed_counter(policy, output_dir: Path):
@@ -69,6 +70,33 @@ def _completion_sink(policy):
     policies. The harness fires it on each clean episode completion.
     """
     return policy.counter.record if isinstance(policy, SampledPolicy) else None
+
+
+def _wire_readiness(
+    world: pimm.World, state: run_state.StateFile, embodiment: Embodiment, driver: Driver | None, cameras: list[str]
+) -> run_state.Readiness | None:
+    """The progress watch for this World, tapped onto its cameras and console. None where nothing
+    is listening, so an unwatched run binds no extra receivers at all.
+
+    A second reader costs the producer a flag per frame: one frame into shared memory whatever the
+    number of receivers.
+    """
+    if not state.enabled:
+        return None
+    # One expression, two uses side by side: a console that must be waited for is exactly one whose
+    # signal is connected below.
+    console_ready = driver.console_ready if driver is not None else None
+    readiness = run_state.Readiness(
+        state, cameras, driver.console_port if driver is not None else None, awaits_console=console_ready is not None
+    )
+    if console_ready is not None:
+        world.connect(console_ready, readiness.console)
+    for name in cameras:
+        source = embodiment.observations[name].source
+        # `connect` asserts this too; the field is annotated as the wider `SignalEmitter`.
+        assert isinstance(source, pimm.ControlSystemEmitter)
+        world.connect(source, readiness.cameras[name])
+    return readiness
 
 
 def _run_world(
@@ -109,16 +137,7 @@ def _run_world(
             for name, obs in embodiment.observations.items():
                 if name.startswith(keys.IMAGE_PREFIX):
                     world.connect(obs.source, gui.cameras[name])
-        # A second reader costs the producer a flag per frame: one frame into shared memory
-        # whatever the number of receivers.
-        readiness = None
-        if state.enabled:
-            readiness = run_state.Readiness(state, cameras, driver.console_port if driver is not None else None)
-            for name in cameras:
-                source = embodiment.observations[name].source
-                # `connect` asserts this too; the field is annotated as the wider `SignalEmitter`.
-                assert isinstance(source, pimm.ControlSystemEmitter)
-                world.connect(source, readiness.cameras[name])
+        readiness = _wire_readiness(world, state, embodiment, driver, cameras)
         if driver is not None:
             world.connect(driver.directives, harness.directive, emitter_wrapper=driver.directive_wrapper)
             if driver.manual_commands is not None:
@@ -240,8 +259,8 @@ def main(
     the report, so a real embodiment in a timed sweep is rejected rather than allowed to pollute it.
     """
     assert (driver is None) != (evals is None), 'Provide exactly one of driver or evals'
-    # One per RUN, handed to every World a sweep raises. Inert unless something named this run, so
-    # nothing below is conditional on it.
+    # One `StateFile` spans the sweep, whatever number of Worlds it raises, and is inert when
+    # `ROLLOUT_RUN_ID` is unset.
     state = run_state.from_env()
     # Validate timing up front, before the policy warmup, so a rejected sweep fails before it spends anything.
     if timing:
@@ -262,6 +281,9 @@ def main(
     state.report(run_state.Phase.WARMING_UP)
     policy.new_session().close()
 
+    # The endpoints are warm from here; syncing the output directory and scanning what it holds can
+    # take minutes on its own, and reporting that as warm-up would name the wrong wait.
+    state.report(run_state.Phase.SETTING_UP)
     if output_dir is not None:
         output_dir = pos3.sync(output_dir, sync_on_error=True)
         utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -11,8 +11,9 @@ import pos3
 
 import pimm
 import positronic.cfg.policy as policy_cfg
-from positronic import telemetry, telemetry_keys, utils, wire
+from positronic import keys, telemetry, telemetry_keys, utils, wire
 from positronic.cfg.eval import placeholder
+from positronic.cli.eval import run_state
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.eval import Embodiment, Eval, Task
@@ -41,6 +42,9 @@ class Driver:
     directive_wrapper: Callable
     control_systems: list[pimm.ControlSystem]
     manual_commands: pimm.SignalEmitter | None = None
+    # The port this surface serves the operator on; None where it is drawn on the rig's own screen
+    # and has no address. Only the driver knows: the UI itself is in another process by then.
+    console_port: int | None = None
 
 
 def _seed_counter(policy, output_dir: Path):
@@ -76,11 +80,16 @@ def _run_world(
     output_dir: Path | None,
     show_gui: bool,
     on_complete,
+    state: run_state.StateFile,
 ):
     """Wire one embodiment under a fresh Harness + World and run it to completion.
 
     ``driver`` (attended) and ``trials`` (unattended self-driving) are the two lifecycle sources, mutually
     exclusive per the caller. The shared ``policy``'s lifetime stays with ``main``.
+
+    ``state`` reports this World coming up and its cameras delivering their first frames. It is scheduled
+    rather than called: the World spawns its background processes before the first foreground round, so only
+    from inside ``world.run`` is the operator's UI known to exist.
     """
     harness = Harness(policy, embodiment, task=task, trials=trials, on_episode_complete=on_complete)
     gui = driver.gui if driver is not None else (dpg_ui() if show_gui else None)
@@ -93,13 +102,24 @@ def _run_world(
         ds_agent = wire.wire_embodiment(
             world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
         )
+        # HACK: GUI cameras are matched to observations by the `image.` name prefix, which
+        # hard-binds GUI wiring to the observation naming convention. TODO: resolve this
+        # coupling (the right binding is still open).
+        cameras = [name for name in embodiment.observations if name.startswith(keys.IMAGE_PREFIX)]
         if gui is not None:
-            # HACK: GUI cameras are matched to observations by the `image.` name prefix, which
-            # hard-binds GUI wiring to the observation naming convention. TODO: resolve this
-            # coupling (the right binding is still open).
             for name, obs in embodiment.observations.items():
-                if name.startswith('image.'):
+                if name.startswith(keys.IMAGE_PREFIX):
                     world.connect(obs.source, gui.cameras[name])
+        # A second reader on the same emitters costs the producer a flag per frame: one frame goes
+        # into shared memory whatever the number of receivers.
+        readiness = None
+        if state.enabled:
+            readiness = run_state.Readiness(state, cameras, driver.console_port if driver is not None else None)
+            for name in cameras:
+                source = embodiment.observations[name].source
+                # `connect` asserts this too; the field is annotated as the wider `SignalEmitter`.
+                assert isinstance(source, pimm.ControlSystemEmitter)
+                world.connect(source, readiness.cameras[name])
         if driver is not None:
             world.connect(driver.directives, harness.directive, emitter_wrapper=driver.directive_wrapper)
             if driver.manual_commands is not None:
@@ -117,10 +137,14 @@ def _run_world(
         # driver, and GUI placement is otherwise identical.
         producers = [cs for cs in embodiment.control_systems if cs is not None]
         foreground = driver.control_systems if driver is not None else []
+        # Last in the round on both paths, and in the foreground on both: it reports what the round
+        # produced, so it must not read ahead of the systems producing it, and its first round is
+        # what says the background processes are up — which only holds where it is not one of them.
+        watch = [readiness] if readiness is not None else []
         if embodiment.simulated:
-            world.run([*foreground, harness, ds_agent, *producers], gui)
+            world.run([*foreground, harness, ds_agent, *producers, *watch], gui)
         else:
-            world.run([harness, *foreground], [*producers, ds_agent, gui])
+            world.run([harness, *foreground, *watch], [*producers, ds_agent, gui])
 
 
 def _validate_timing(embodiments: Iterable[Embodiment], output_dir: str | Path | None) -> None:
@@ -218,6 +242,10 @@ def main(
     the report, so a real embodiment in a timed sweep is rejected rather than allowed to pollute it.
     """
     assert (driver is None) != (evals is None), 'Provide exactly one of driver or evals'
+    # Built before anything else and handed to every World: an orchestrator watches the RUN, and a sweep is
+    # one run however many Worlds it raises. Inert unless something named this run (`ROLLOUT_RUN_ID`), which
+    # is every ordinary invocation — so nothing below is conditional on it.
+    state = run_state.from_env()
     # Validate timing up front, before the policy warmup, so a rejected sweep fails before it spends anything.
     if timing:
         if evals is not None:
@@ -234,6 +262,7 @@ def main(
     # TODO: a policy with recording taps (recording_dir set) records this throwaway warmup session —
     # an empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
     logger.info('Warming up policy endpoints')
+    state.report(run_state.Phase.WARMING_UP)
     policy.new_session().close()
 
     if output_dir is not None:
@@ -249,11 +278,13 @@ def main(
         with _timed_pass(output_dir, timing, policy):
             if driver is not None:
                 assert embodiment is not None, 'the attended (driver) path runs a single embodiment'
-                _run_world(policy, embodiment, None, None, driver(output_dir), output_dir, show_gui, on_complete)
+                _run_world(policy, embodiment, None, None, driver(output_dir), output_dir, show_gui, on_complete, state)
             else:
                 assert evals is not None  # driver/evals XOR asserted up front
                 for ev in evals:
-                    _run_world(policy, ev.embodiment, ev.task, ev.trials, None, output_dir, show_gui, on_complete)
+                    _run_world(
+                        policy, ev.embodiment, ev.task, ev.trials, None, output_dir, show_gui, on_complete, state
+                    )
     finally:
         policy.close()
 

--- a/positronic/cli/eval/run_state.py
+++ b/positronic/cli/eval/run_state.py
@@ -1,0 +1,288 @@
+"""Reporting a run's own progress to whatever launched it.
+
+From outside the process, "the run exists" and "the operator has a screen to work at" are minutes
+apart and look identical: a cold policy endpoint answers its handshake anywhere between seconds and
+a quarter of an hour later, and the World carrying the UI is built only once it does. The run knows
+which of those it is in, and how many of its cameras have delivered a frame. This writes that down
+where a reader can see it.
+
+THE CONTRACT, which a reader in another repository implements against:
+
+  path     `<dir>/positronic_rollout_state.<run_id>`; `<dir>` is `/run/lock` unless
+           `ROLLOUT_RUN_STATE_DIR` names another. Absolute — writer and reader are different
+           accounts, each resolving a relative path against its own directory. Per run, so a
+           leftover is inert. `run_id` is one path segment: no separator, not `.` or `..`.
+  content  one JSON object, `{"run_id", "phase", "cameras_open", "cameras_expected",
+           "console_port"}`. A reader ignores keys it does not know, so a field may be added
+           without a reader changing.
+  writer   this run and nothing else, world-readable (mode 0644 explicitly, since a `077` umask
+           would otherwise leave it unreadable by the reader), replaced atomically — a reader
+           polling it never observes half a write, and never has to retry a torn one.
+  phase    one of `Phase`, describing the run NOW rather than the furthest it has been. A sweep
+           that raises a second World reports that World coming up, which is the truth about the
+           arm; only an attended run, which raises one World, is monotonic.
+  console  the PORT its operator console is bound to, or null where the run has no console (a
+           local GUI on the rig's own screen has no address). A port and not a URL: the run is
+           reached over an interface it cannot name — it binds `0.0.0.0` and does not know which
+           address a reader comes from — so the host is the reader's to supply and the port is the
+           only half of that URL this side actually knows.
+  absent   a file that is not there is NOT a run that failed. It is a run that predates this
+           module, and a reader must report it as unknown rather than assume anything of it.
+
+Reporting is best-effort and never raises into the run: a state file nobody can write is a reader
+left uninformed, which is worth a log line and nothing more — the arm is mid-episode and there is
+no version of "the progress report failed" that is worth stopping it for. Inert when
+`ROLLOUT_RUN_ID` is unset, which is every ordinary invocation.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+
+import pimm
+
+logger = logging.getLogger(__name__)
+
+# Where state is written, and the name it takes there. Overridable so a test, or a rig running more
+# than one simulated run, gets a directory of its own.
+STATE_DIR_ENV = 'ROLLOUT_RUN_STATE_DIR'
+DEFAULT_STATE_DIR = Path('/run/lock')
+STATE_PREFIX = 'positronic_rollout_state.'
+# The run's own identity, set by whatever launched it. Its absence is what makes this inert.
+RUN_ID_ENV = 'ROLLOUT_RUN_ID'
+
+# The object's fields.
+RUN_ID_KEY = 'run_id'
+PHASE_KEY = 'phase'
+CAMERAS_OPEN_KEY = 'cameras_open'
+CAMERAS_EXPECTED_KEY = 'cameras_expected'
+CONSOLE_PORT_KEY = 'console_port'
+
+
+class Phase(StrEnum):
+    """What the run is doing, in the order it does it.
+
+    Each is the moment a reader has to be able to tell from its neighbours, and nothing else is a
+    phase: an episode being recorded is not here, because the console and the dataset already say
+    so far better than this file could.
+    """
+
+    # The process is up and holds this contract. Its own value because it is what separates a run
+    # that has not reached its warm-up from one whose writer is too old to have a phase at all.
+    STARTING = 'starting'
+    # Driving the policy endpoints through their cold start. The long wait, and the one whose
+    # length cannot be predicted from outside.
+    WARMING_UP = 'warming_up'
+    # The World is up and its background processes — the operator's UI among them — are spawned.
+    # Not yet usable: the cameras open after this, and one that does not open takes the World, the
+    # UI and the run down with it seconds later.
+    WORLD_UP = 'world_up'
+    # Every camera the run declared has delivered a frame. The UI has something to show and the
+    # operator has something to press.
+    READY = 'ready'
+
+
+# How often the cameras are counted. They arrive within seconds of the World coming up, and each
+# read is a shared-memory flag, so this paces nothing and costs nothing between transitions.
+POLL_INTERVAL_S = 1.0
+
+
+@dataclass(frozen=True)
+class State:
+    """One report: everything the file says, at one moment."""
+
+    run_id: str
+    phase: Phase
+    cameras_open: int = 0
+    cameras_expected: int = 0
+    console_port: int | None = None
+
+    def as_json(self) -> str:
+        return json.dumps({
+            RUN_ID_KEY: self.run_id,
+            PHASE_KEY: self.phase.value,
+            CAMERAS_OPEN_KEY: self.cameras_open,
+            CAMERAS_EXPECTED_KEY: self.cameras_expected,
+            CONSOLE_PORT_KEY: self.console_port,
+        })
+
+
+def state_dir() -> Path:
+    """Where state is written — the env override converted here, where the string enters."""
+    override = os.environ.get(STATE_DIR_ENV)
+    return Path(override) if override else DEFAULT_STATE_DIR
+
+
+def state_path(this_run: str) -> Path:
+    """Where `this_run` reports — the whole of the path contract."""
+    return state_dir() / f'{STATE_PREFIX}{this_run}'
+
+
+def names_one_segment(this_run: str) -> bool:
+    """Whether `this_run` can be a filename, which is what scoping the path by run id requires.
+
+    A run id carrying a separator would write to a directory nobody agreed on, so a run named that
+    way reports nowhere rather than somewhere unintended.
+    """
+    return bool(this_run) and this_run not in ('.', '..') and '/' not in this_run and '\0' not in this_run
+
+
+class StateFile:
+    """The run's state, and the file it is reported through.
+
+    An instance with no path is INERT: it holds the state and writes nothing. That is what every
+    ordinary invocation gets, which is why no call site guards — a run nobody is orchestrating
+    reports its progress to nobody, at the cost of a few attribute writes.
+    """
+
+    def __init__(self, path: Path | None, this_run: str):
+        self._path = path
+        self._state = State(run_id=this_run, phase=Phase.STARTING)
+        # The last write failure reported, so a directory that cannot be written is one log line
+        # rather than one per transition. Reported again when the reason changes.
+        self._reported = ''
+
+    @property
+    def enabled(self) -> bool:
+        """Whether anything is being reported. False on an ordinary run."""
+        return self._path is not None
+
+    @property
+    def state(self) -> State:
+        return self._state
+
+    def report(self, phase: Phase, **fields) -> None:
+        """Record `phase`, carrying every field not named forward, and write the result.
+
+        Carrying forward is the point: a camera count is measured once and holds until the next
+        camera, so a phase change must not silently reset it to the field's default.
+        """
+        self._state = replace(self._state, phase=phase, **fields)
+        self._write()
+
+    def _write(self) -> None:
+        """Replace the file with the current state, atomically. Never raises into the run."""
+        if self._path is None:
+            return
+        blob = self._state.as_json()
+        try:
+            # In the destination's own directory, so the rename is within one filesystem and is
+            # therefore atomic: a reader polling this path sees the old bytes or the new ones, and
+            # never a file opened between a truncate and a write.
+            fd, tmp = tempfile.mkstemp(dir=self._path.parent, prefix=f'{self._path.name}.')
+            try:
+                with os.fdopen(fd, 'w') as f:
+                    f.write(blob)
+                # mkstemp creates 0600 whatever the umask, and the reader is another account.
+                os.chmod(tmp, 0o644)
+                os.replace(tmp, self._path)
+            except OSError:
+                os.unlink(tmp)
+                raise
+        except OSError as e:
+            reason = f'run state could not be written to {self._path} ({e!r}); continuing to run'
+            if reason != self._reported:
+                self._reported = reason
+                logger.error(reason)
+            return
+        self._reported = ''
+
+
+class Readiness(pimm.ControlSystem):
+    """Reports the World coming up, and each of its cameras delivering its first frame.
+
+    A camera is up when its frames arrive, which is observable here: its producer is a background
+    process, but a producer's emitter fans out to every receiver bound to it.
+
+    It must run in the FOREGROUND, where its first round is the World-up report — the World spawns
+    every background process before scheduling the first foreground one, so the UI's process exists
+    by then. Scheduled as a background system it would be reporting on itself.
+
+    It never returns from its loop: a control system that returns sets the world's stop event, which
+    would end the run the moment every camera came up.
+    """
+
+    def __init__(
+        self,
+        state: StateFile,
+        camera_names: list[str],
+        console_port: int | None = None,
+        poll_interval_s: float = POLL_INTERVAL_S,
+    ):
+        self.cameras = pimm.ReceiverDict(self)
+        # Touched here rather than on first use, so the receivers exist to be connected and the
+        # expected count is fixed before anything reads it.
+        for name in camera_names:
+            _ = self.cameras[name]
+        self._state = state
+        self._console_port = console_port
+        self._poll_interval_s = poll_interval_s
+        self._open: set[str] = set()
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        self._state.report(
+            self._phase(), cameras_open=0, cameras_expected=len(self.cameras), console_port=self._console_port
+        )
+        while not should_stop.value:
+            self._count()
+            yield pimm.Sleep(self._poll_interval_s)
+
+    def _phase(self) -> Phase:
+        """Readiness, decided in one place: every camera the run declared has delivered a frame.
+
+        A World with no cameras satisfies that the moment it is up — a rig with nothing to open has
+        no device to wait on, which is the absence of the question rather than a waiver of it.
+        """
+        return Phase.READY if len(self._open) == len(self.cameras) else Phase.WORLD_UP
+
+    def _count(self) -> None:
+        """Report any camera seen for the first time, and readiness once none is left.
+
+        A receiver reads `None` until the first message reaches it and something from then on, so
+        first-frame is exactly the transition out of that — no ordering assumption, no counting of
+        frames, and a camera already up when this starts is seen on the first round.
+
+        Only channels not yet seen are read: a read takes the lock the producer, the harness, the
+        recorder and the UI contend for, and copies the whole frame out.
+        """
+        pending = [name for name in self.cameras if name not in self._open]
+        opened = {name for name in pending if self.cameras[name].read() is not None}
+        if not opened:
+            return
+        self._open |= opened
+        self._state.report(self._phase(), cameras_open=len(self._open))
+
+
+def from_env() -> StateFile:
+    """The state file this run reports through — inert unless something named the run.
+
+    Returns a file either way, so a caller reports its progress without asking whether anyone is
+    listening. The first report is made here: a reader meeting the file at all learns that the
+    process is up and speaks this contract, which is what separates it from one too old to.
+    """
+    this_run = os.environ.get(RUN_ID_ENV)
+    if not this_run:
+        return StateFile(None, '')
+    if not names_one_segment(this_run):
+        logger.error('%s=%r is not a single path segment, so this run cannot report its state', RUN_ID_ENV, this_run)
+        return StateFile(None, this_run)
+    directory = state_dir()
+    if not directory.is_absolute():
+        # Each account resolves a relative path against its own working directory, so this run and
+        # its reader would address different files from the same configuration.
+        logger.error(
+            '%s=%s is not absolute, so this run and its reader would not resolve it to the same '
+            'directory; this run cannot report its state',
+            STATE_DIR_ENV,
+            directory,
+        )
+        return StateFile(None, this_run)
+    path = state_path(this_run)
+    logger.info('run %s reports its progress to %s', this_run, path)
+    state = StateFile(path, this_run)
+    state.report(Phase.STARTING)
+    return state

--- a/positronic/cli/eval/run_state.py
+++ b/positronic/cli/eval/run_state.py
@@ -1,37 +1,24 @@
 """Reporting a run's own progress to whatever launched it.
 
-From outside the process, "the run exists" and "the operator has a screen to work at" are minutes
-apart and look identical: a cold policy endpoint answers its handshake anywhere between seconds and
-a quarter of an hour later, and the World carrying the UI is built only once it does. The run knows
-which of those it is in, and how many of its cameras have delivered a frame. This writes that down
-where a reader can see it.
+From outside, "the run exists" and "the operator has a screen" are minutes apart and look
+identical. This writes down which of the two it is.
 
 THE CONTRACT, which a reader in another repository implements against:
 
   path     `<dir>/positronic_rollout_state.<run_id>`; `<dir>` is `/run/lock` unless
-           `ROLLOUT_RUN_STATE_DIR` names another. Absolute — writer and reader are different
-           accounts, each resolving a relative path against its own directory. Per run, so a
-           leftover is inert. `run_id` is one path segment: no separator, not `.` or `..`.
+           `ROLLOUT_RUN_STATE_DIR` names another. Absolute, since writer and reader are different
+           accounts. `run_id` is one path segment: no separator, not `.` or `..`.
   content  one JSON object, `{"run_id", "phase", "cameras_open", "cameras_expected",
-           "console_port"}`. A reader ignores keys it does not know, so a field may be added
-           without a reader changing.
-  writer   this run and nothing else, world-readable (mode 0644 explicitly, since a `077` umask
-           would otherwise leave it unreadable by the reader), replaced atomically — a reader
-           polling it never observes half a write, and never has to retry a torn one.
-  phase    one of `Phase`, describing the run NOW rather than the furthest it has been. A sweep
-           that raises a second World reports that World coming up, which is the truth about the
-           arm; only an attended run, which raises one World, is monotonic.
-  console  the PORT its operator console is bound to, or null where the run has no console (a
-           local GUI on the rig's own screen has no address). A port and not a URL: the run is
-           reached over an interface it cannot name — it binds `0.0.0.0` and does not know which
-           address a reader comes from — so the host is the reader's to supply and the port is the
-           only half of that URL this side actually knows.
-  absent   a file that is not there is NOT a run that failed. It is a run that predates this
-           module, and a reader must report it as unknown rather than assume anything of it.
+           "console_port"}`. A reader ignores keys it does not know.
+  writer   this run alone, mode 0644 explicitly (a `077` umask would leave it unreadable by the
+           reader), replaced atomically, so a poll never sees half a write.
+  phase    one of `Phase`, the run NOW rather than the furthest it has been. A sweep raising a
+           second World reports that World coming up.
+  console  the PORT, or null where the run has no console. Not a URL: the run binds `0.0.0.0` and
+           cannot know which address a reader comes from, so the host is the reader's to supply.
+  absent   NOT a run that failed — a run predating this module. A reader reports unknown.
 
-Reporting is best-effort and never raises into the run: a state file nobody can write is a reader
-left uninformed, which is worth a log line and nothing more — the arm is mid-episode and there is
-no version of "the progress report failed" that is worth stopping it for. Inert when
+Best-effort: a failed write is logged, never raised into the run, which is mid-episode. Inert when
 `ROLLOUT_RUN_ID` is unset, which is every ordinary invocation.
 """
 
@@ -47,8 +34,7 @@ import pimm
 
 logger = logging.getLogger(__name__)
 
-# Where state is written, and the name it takes there. Overridable so a test, or a rig running more
-# than one simulated run, gets a directory of its own.
+# Overridable so a test, or a rig running more than one simulated run, gets its own directory.
 STATE_DIR_ENV = 'ROLLOUT_RUN_STATE_DIR'
 DEFAULT_STATE_DIR = Path('/run/lock')
 STATE_PREFIX = 'positronic_rollout_state.'
@@ -64,30 +50,20 @@ CONSOLE_PORT_KEY = 'console_port'
 
 
 class Phase(StrEnum):
-    """What the run is doing, in the order it does it.
+    """What the run is doing, in the order it does it."""
 
-    Each is the moment a reader has to be able to tell from its neighbours, and nothing else is a
-    phase: an episode being recorded is not here, because the console and the dataset already say
-    so far better than this file could.
-    """
-
-    # The process is up and holds this contract. Its own value because it is what separates a run
-    # that has not reached its warm-up from one whose writer is too old to have a phase at all.
+    # The process is up and holds this contract; separates it from a writer too old to have one.
     STARTING = 'starting'
-    # Driving the policy endpoints through their cold start. The long wait, and the one whose
-    # length cannot be predicted from outside.
+    # Driving the policy endpoints through their cold start: seconds to a quarter of an hour.
     WARMING_UP = 'warming_up'
-    # The World is up and its background processes — the operator's UI among them — are spawned.
-    # Not yet usable: the cameras open after this, and one that does not open takes the World, the
-    # UI and the run down with it seconds later.
+    # The World is up and its background processes, the operator's UI among them, are spawned.
+    # NOT usable yet: the cameras open after this, and one that will not takes the run down with it.
     WORLD_UP = 'world_up'
-    # Every camera the run declared has delivered a frame. The UI has something to show and the
-    # operator has something to press.
+    # Every camera the run declared has delivered a frame.
     READY = 'ready'
 
 
-# How often the cameras are counted. They arrive within seconds of the World coming up, and each
-# read is a shared-memory flag, so this paces nothing and costs nothing between transitions.
+# How often the cameras are counted; each read is a shared-memory flag, so this paces nothing.
 POLL_INTERVAL_S = 1.0
 
 
@@ -125,8 +101,7 @@ def state_path(this_run: str) -> Path:
 def names_one_segment(this_run: str) -> bool:
     """Whether `this_run` can be a filename, which is what scoping the path by run id requires.
 
-    A run id carrying a separator would write to a directory nobody agreed on, so a run named that
-    way reports nowhere rather than somewhere unintended.
+    One carrying a separator would write to a directory nobody agreed on, so it reports nowhere.
     """
     return bool(this_run) and this_run not in ('.', '..') and '/' not in this_run and '\0' not in this_run
 
@@ -134,16 +109,15 @@ def names_one_segment(this_run: str) -> bool:
 class StateFile:
     """The run's state, and the file it is reported through.
 
-    An instance with no path is INERT: it holds the state and writes nothing. That is what every
-    ordinary invocation gets, which is why no call site guards — a run nobody is orchestrating
-    reports its progress to nobody, at the cost of a few attribute writes.
+    An instance with no path is INERT — it holds the state and writes nothing — which is what every
+    ordinary invocation gets, and why no call site guards.
     """
 
     def __init__(self, path: Path | None, this_run: str):
         self._path = path
         self._state = State(run_id=this_run, phase=Phase.STARTING)
-        # The last write failure reported, so a directory that cannot be written is one log line
-        # rather than one per transition. Reported again when the reason changes.
+        # The last failure reported, so an unwritable directory is one log line, not one a
+        # transition. Reported again when the reason changes.
         self._reported = ''
 
     @property
@@ -158,8 +132,7 @@ class StateFile:
     def report(self, phase: Phase, **fields) -> None:
         """Record `phase`, carrying every field not named forward, and write the result.
 
-        Carrying forward is the point: a camera count is measured once and holds until the next
-        camera, so a phase change must not silently reset it to the field's default.
+        A camera count is measured once and holds, so a phase change must not reset it.
         """
         self._state = replace(self._state, phase=phase, **fields)
         self._write()
@@ -170,9 +143,7 @@ class StateFile:
             return
         blob = self._state.as_json()
         try:
-            # In the destination's own directory, so the rename is within one filesystem and is
-            # therefore atomic: a reader polling this path sees the old bytes or the new ones, and
-            # never a file opened between a truncate and a write.
+            # The destination's own directory, so the rename is within one filesystem: atomic.
             fd, tmp = tempfile.mkstemp(dir=self._path.parent, prefix=f'{self._path.name}.')
             try:
                 with os.fdopen(fd, 'w') as f:
@@ -195,15 +166,9 @@ class StateFile:
 class Readiness(pimm.ControlSystem):
     """Reports the World coming up, and each of its cameras delivering its first frame.
 
-    A camera is up when its frames arrive, which is observable here: its producer is a background
-    process, but a producer's emitter fans out to every receiver bound to it.
-
-    It must run in the FOREGROUND, where its first round is the World-up report — the World spawns
-    every background process before scheduling the first foreground one, so the UI's process exists
-    by then. Scheduled as a background system it would be reporting on itself.
-
-    It never returns from its loop: a control system that returns sets the world's stop event, which
-    would end the run the moment every camera came up.
+    FOREGROUND only: the World spawns every background process before scheduling the first
+    foreground round, which is what makes that round's World-up report true. It also never returns
+    from its loop — a control system that returns sets the world's stop event.
     """
 
     def __init__(
@@ -214,8 +179,7 @@ class Readiness(pimm.ControlSystem):
         poll_interval_s: float = POLL_INTERVAL_S,
     ):
         self.cameras = pimm.ReceiverDict(self)
-        # Touched here rather than on first use, so the receivers exist to be connected and the
-        # expected count is fixed before anything reads it.
+        # Touched here so the receivers exist to be connected and the count is fixed up front.
         for name in camera_names:
             _ = self.cameras[name]
         self._state = state
@@ -234,20 +198,16 @@ class Readiness(pimm.ControlSystem):
     def _phase(self) -> Phase:
         """Readiness, decided in one place: every camera the run declared has delivered a frame.
 
-        A World with no cameras satisfies that the moment it is up — a rig with nothing to open has
-        no device to wait on, which is the absence of the question rather than a waiver of it.
+        A World with no cameras satisfies it the moment it is up — nothing to wait on.
         """
         return Phase.READY if len(self._open) == len(self.cameras) else Phase.WORLD_UP
 
     def _count(self) -> None:
         """Report any camera seen for the first time, and readiness once none is left.
 
-        A receiver reads `None` until the first message reaches it and something from then on, so
-        first-frame is exactly the transition out of that — no ordering assumption, no counting of
-        frames, and a camera already up when this starts is seen on the first round.
-
-        Only channels not yet seen are read: a read takes the lock the producer, the harness, the
-        recorder and the UI contend for, and copies the whole frame out.
+        A receiver reads `None` until its first message ever arrives, so that transition IS
+        first-frame. Only channels not yet seen are read: a read takes the lock the producer, the
+        harness, the recorder and the UI contend for, and copies the whole frame out.
         """
         pending = [name for name in self.cameras if name not in self._open]
         opened = {name for name in pending if self.cameras[name].read() is not None}
@@ -260,9 +220,8 @@ class Readiness(pimm.ControlSystem):
 def from_env() -> StateFile:
     """The state file this run reports through — inert unless something named the run.
 
-    Returns a file either way, so a caller reports its progress without asking whether anyone is
-    listening. The first report is made here: a reader meeting the file at all learns that the
-    process is up and speaks this contract, which is what separates it from one too old to.
+    Returns a file either way, so no caller asks whether anyone is listening. The first report is
+    made here, so the file existing at all says the process speaks this contract.
     """
     this_run = os.environ.get(RUN_ID_ENV)
     if not this_run:
@@ -272,8 +231,7 @@ def from_env() -> StateFile:
         return StateFile(None, this_run)
     directory = state_dir()
     if not directory.is_absolute():
-        # Each account resolves a relative path against its own working directory, so this run and
-        # its reader would address different files from the same configuration.
+        # A relative path resolves per account, so run and reader would address different files.
         logger.error(
             '%s=%s is not absolute, so this run and its reader would not resolve it to the same '
             'directory; this run cannot report its state',

--- a/positronic/cli/eval/run_state.py
+++ b/positronic/cli/eval/run_state.py
@@ -16,10 +16,11 @@ THE CONTRACT, which a reader in another repository implements against:
            second World reports that World coming up.
   console  the PORT, or null where the run has no console. Not a URL: the run binds `0.0.0.0` and
            cannot know which address a reader comes from, so the host is the reader's to supply.
+           On `ready` it is bound and serving; before that it is only the port it will bind.
   absent   NOT a run that failed — a run predating this module. A reader reports unknown.
 
-Best-effort: a failed write is logged, never raised into the run, which is mid-episode. Inert when
-`ROLLOUT_RUN_ID` is unset, which is every ordinary invocation.
+A write failure is logged and suppressed, never raised. Reporting is inert when `ROLLOUT_RUN_ID`
+is unset.
 """
 
 import json
@@ -56,6 +57,9 @@ class Phase(StrEnum):
     STARTING = 'starting'
     # Driving the policy endpoints through their cold start: seconds to a quarter of an hour.
     WARMING_UP = 'warming_up'
+    # Endpoints warm; building what the run needs before a World exists — syncing the output
+    # directory, scanning what it already holds, constructing the operator surface.
+    SETTING_UP = 'setting_up'
     # The World is up and its background processes, the operator's UI among them, are spawned.
     # NOT usable yet: the cameras open after this, and one that will not takes the run down with it.
     WORLD_UP = 'world_up'
@@ -98,19 +102,10 @@ def state_path(this_run: str) -> Path:
     return state_dir() / f'{STATE_PREFIX}{this_run}'
 
 
-def names_one_segment(this_run: str) -> bool:
-    """Whether `this_run` can be a filename, which is what scoping the path by run id requires.
-
-    One carrying a separator would write to a directory nobody agreed on, so it reports nowhere.
-    """
-    return bool(this_run) and this_run not in ('.', '..') and '/' not in this_run and '\0' not in this_run
-
-
 class StateFile:
     """The run's state, and the file it is reported through.
 
-    An instance with no path is INERT — it holds the state and writes nothing — which is what every
-    ordinary invocation gets, and why no call site guards.
+    An instance with no path is INERT: it holds the state and writes nothing.
     """
 
     def __init__(self, path: Path | None, this_run: str):
@@ -164,7 +159,7 @@ class StateFile:
 
 
 class Readiness(pimm.ControlSystem):
-    """Reports the World coming up, and each of its cameras delivering its first frame.
+    """Reports the World coming up, then each camera's first frame and the console's bind.
 
     FOREGROUND only: the World spawns every background process before scheduling the first
     foreground round, which is what makes that round's World-up report true. It also never returns
@@ -177,14 +172,20 @@ class Readiness(pimm.ControlSystem):
         camera_names: list[str],
         console_port: int | None = None,
         poll_interval_s: float = POLL_INTERVAL_S,
+        awaits_console: bool = False,
     ):
         self.cameras = pimm.ReceiverDict(self)
+        # Bound only where a console announces itself; `awaits_console` is what says it will, so an
+        # unconnected receiver never holds readiness open forever.
+        self.console = pimm.ControlSystemReceiver(self)
         # Touched here so the receivers exist to be connected and the count is fixed up front.
         for name in camera_names:
             _ = self.cameras[name]
         self._state = state
         self._console_port = console_port
         self._poll_interval_s = poll_interval_s
+        self._awaits_console = awaits_console
+        self._console_up = False
         self._open: set[str] = set()
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
@@ -196,11 +197,13 @@ class Readiness(pimm.ControlSystem):
             yield pimm.Sleep(self._poll_interval_s)
 
     def _phase(self) -> Phase:
-        """Readiness, decided in one place: every camera the run declared has delivered a frame.
+        """Readiness, decided in one place: every camera delivering, and the console bound.
 
-        A World with no cameras satisfies it the moment it is up — nothing to wait on.
+        Whatever the run has nothing of — no cameras, no console — it does not wait on.
         """
-        return Phase.READY if len(self._open) == len(self.cameras) else Phase.WORLD_UP
+        cameras_up = len(self._open) == len(self.cameras)
+        console_up = self._console_up or not self._awaits_console
+        return Phase.READY if cameras_up and console_up else Phase.WORLD_UP
 
     def _count(self) -> None:
         """Report any camera seen for the first time, and readiness once none is left.
@@ -209,19 +212,31 @@ class Readiness(pimm.ControlSystem):
         first-frame. Only channels not yet seen are read: a read takes the lock the producer, the
         harness, the recorder and the UI contend for, and copies the whole frame out.
         """
+        console = self._console_up
+        if self._awaits_console and not console:
+            # A socket bound in another process: the run cannot report a console it only intends.
+            self._console_up = self.console.read() is not None
         pending = [name for name in self.cameras if name not in self._open]
         opened = {name for name in pending if self.cameras[name].read() is not None}
-        if not opened:
+        if not opened and console == self._console_up:
             return
         self._open |= opened
         self._state.report(self._phase(), cameras_open=len(self._open))
 
 
-def from_env() -> StateFile:
-    """The state file this run reports through — inert unless something named the run.
+def names_one_segment(this_run: str) -> bool:
+    """Whether `this_run` can be a filename, which is what scoping the path by run id requires.
 
-    Returns a file either way, so no caller asks whether anyone is listening. The first report is
-    made here, so the file existing at all says the process speaks this contract.
+    One carrying a separator would write to a directory nobody agreed on, so it reports nowhere.
+    """
+    return bool(this_run) and this_run not in ('.', '..') and '/' not in this_run and '\0' not in this_run
+
+
+def from_env() -> StateFile:
+    """The state file this run reports through.
+
+    Returns an inert pathless `StateFile` where `ROLLOUT_RUN_ID` names no run, or one bound to
+    `state_path` having already written its `STARTING` report.
     """
     this_run = os.environ.get(RUN_ID_ENV)
     if not this_run:

--- a/positronic/cli/eval/run_state.py
+++ b/positronic/cli/eval/run_state.py
@@ -117,7 +117,7 @@ class StateFile:
 
     @property
     def enabled(self) -> bool:
-        """Whether anything is being reported. False on an ordinary run."""
+        """Whether anything is being reported — that is, whether this instance has a path."""
         return self._path is not None
 
     @property

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -5,8 +5,10 @@ from typing import cast
 
 import pytest
 
+import pimm
 from positronic import telemetry, telemetry_keys
-from positronic.cli.eval.run import Driver, _pass_span, _timed_pass, main
+from positronic.cli.eval import run_state
+from positronic.cli.eval.run import Driver, _pass_span, _run_world, _timed_pass, main
 from positronic.eval import Embodiment, Eval, Task
 
 
@@ -88,3 +90,36 @@ def test_the_stats_sampler_runs_inside_the_pass_span(tmp_path, monkeypatch):
         pass
 
     assert order == ['sampler built', 'pass in', 'sampler in', 'sampler out', 'pass out']
+
+
+def test_a_console_port_without_its_ready_signal_is_rejected():
+    """A port nobody confirms would let a run advertise `ready` on a socket nothing is listening
+    on, so the two halves of the console contract are given together or not at all."""
+    with pytest.raises(AssertionError, match='one contract'):
+        Driver(None, cast(pimm.SignalEmitter, SimpleNamespace()), lambda x: x, [], console_port=8080)
+    with pytest.raises(AssertionError, match='one contract'):
+        Driver(
+            None,
+            cast(pimm.SignalEmitter, SimpleNamespace()),
+            lambda x: x,
+            [],
+            console_ready=cast(pimm.ControlSystemEmitter, SimpleNamespace()),
+        )
+
+
+def test_a_world_reports_setting_up_before_it_is_constructed(tmp_path, monkeypatch):
+    """In a sweep the previous World has exited while the state still says `ready`; waiting for the
+    next Readiness's first scheduler round would advertise a dead World as up for the whole of the
+    next one's construction."""
+    state = run_state.StateFile(tmp_path / 'state.json', 'run-sweep')
+    state.report(run_state.Phase.READY)
+
+    def _explode(*args, **kwargs):
+        raise RuntimeError('constructed')
+
+    monkeypatch.setattr(sys.modules['positronic.cli.eval.run'], 'Harness', _explode)
+
+    with pytest.raises(RuntimeError, match='constructed'):
+        _run_world(object(), cast(Embodiment, SimpleNamespace()), None, None, None, None, False, None, state)
+
+    assert state.state.phase is run_state.Phase.SETTING_UP

--- a/positronic/cli/eval/tests/test_run_state.py
+++ b/positronic/cli/eval/tests/test_run_state.py
@@ -322,6 +322,9 @@ def test_the_watch_does_not_end_the_world(named_run):
 def test_a_console_that_has_not_bound_holds_readiness_back(named_run):
     """The console's socket comes up inside the process the World spawned, after every producer, so
     a run can have every camera delivering while nothing answers on the port it reports."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
     state = run_state.from_env()
     _drive_console(state, Console(after=99))
     got = read_state(named_run)
@@ -330,6 +333,9 @@ def test_a_console_that_has_not_bound_holds_readiness_back(named_run):
 
 
 def test_a_console_that_binds_completes_readiness(named_run):
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
     state = run_state.from_env()
     _drive_console(state, Console(after=2))
     assert read_state(named_run)['phase'] == 'ready'
@@ -338,6 +344,9 @@ def test_a_console_that_binds_completes_readiness(named_run):
 def test_a_run_with_no_console_waits_on_none(named_run):
     """A surface drawn on the rig's own screen has no socket to wait for — the absence of the
     question, not a waiver of it."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
     state = run_state.from_env()
     _drive(state, {})
     assert read_state(named_run)['phase'] == 'ready'
@@ -346,6 +355,9 @@ def test_a_run_with_no_console_waits_on_none(named_run):
 def test_the_setup_after_the_warm_up_is_its_own_phase(named_run):
     """Syncing the output directory and scanning what it holds happen with the endpoints already
     warm, so reporting them as warm-up names the wrong wait."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
     state = run_state.from_env()
     state.report(run_state.Phase.WARMING_UP)
     state.report(run_state.Phase.SETTING_UP)

--- a/positronic/cli/eval/tests/test_run_state.py
+++ b/positronic/cli/eval/tests/test_run_state.py
@@ -191,6 +191,22 @@ def test_a_report_carries_unnamed_fields_forward(named_run):
 # --- the transitions ------------------------------------------------------------------------
 
 
+class Console(pimm.ControlSystem):
+    """A console that announces its bind after `after` rounds, standing in for uvicorn."""
+
+    def __init__(self, after: int = 0):
+        self.ready = pimm.ControlSystemEmitter(self)
+        self._after = after
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        rounds = 0
+        while not should_stop.value:
+            if rounds >= self._after:
+                self.ready.emit(True, clock.now_ns())
+            rounds += 1
+            yield pimm.Sleep(TICK_S)
+
+
 def _drive(state: run_state.StateFile, cameras: dict[str, Camera], rounds: int = 6) -> run_state.Readiness:
     """Run a world holding `cameras` and a readiness watch over them, for a bounded number of rounds."""
     readiness = run_state.Readiness(state, list(cameras), console_port=8080, poll_interval_s=TICK_S)
@@ -199,6 +215,14 @@ def _drive(state: run_state.StateFile, cameras: dict[str, Camera], rounds: int =
             world.connect(camera.frame, readiness.cameras[name])
         world.run([*cameras.values(), readiness, Stopper(rounds)])
     return readiness
+
+
+def _drive_console(state, console: Console, rounds: int = 8) -> None:
+    """A World whose only thing to wait on is a console."""
+    readiness = run_state.Readiness(state, [], console_port=8080, poll_interval_s=TICK_S, awaits_console=True)
+    with pimm.World(virtual_time=True) as world:
+        world.connect(console.ready, readiness.console)
+        world.run([console, readiness, Stopper(rounds)])
 
 
 def test_the_world_coming_up_is_reported_before_any_camera(named_run):
@@ -293,3 +317,36 @@ def test_the_watch_does_not_end_the_world(named_run):
         world.run([camera, readiness, stopper])
     assert rounds == 20
     assert read_state(named_run)['phase'] == 'ready'
+
+
+def test_a_console_that_has_not_bound_holds_readiness_back(named_run):
+    """The console's socket comes up inside the process the World spawned, after every producer, so
+    a run can have every camera delivering while nothing answers on the port it reports."""
+    state = run_state.from_env()
+    _drive_console(state, Console(after=99))
+    got = read_state(named_run)
+    assert got['phase'] == 'world_up'
+    assert got['console_port'] == 8080
+
+
+def test_a_console_that_binds_completes_readiness(named_run):
+    state = run_state.from_env()
+    _drive_console(state, Console(after=2))
+    assert read_state(named_run)['phase'] == 'ready'
+
+
+def test_a_run_with_no_console_waits_on_none(named_run):
+    """A surface drawn on the rig's own screen has no socket to wait for — the absence of the
+    question, not a waiver of it."""
+    state = run_state.from_env()
+    _drive(state, {})
+    assert read_state(named_run)['phase'] == 'ready'
+
+
+def test_the_setup_after_the_warm_up_is_its_own_phase(named_run):
+    """Syncing the output directory and scanning what it holds happen with the endpoints already
+    warm, so reporting them as warm-up names the wrong wait."""
+    state = run_state.from_env()
+    state.report(run_state.Phase.WARMING_UP)
+    state.report(run_state.Phase.SETTING_UP)
+    assert read_state(named_run)['phase'] == 'setting_up'

--- a/positronic/cli/eval/tests/test_run_state.py
+++ b/positronic/cli/eval/tests/test_run_state.py
@@ -1,0 +1,304 @@
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import pimm
+from positronic import keys
+from positronic.cli.eval import run_state
+
+
+def read_state(path: Path) -> dict:
+    """The file as a reader in another repository sees it: bytes, parsed as JSON, nothing else."""
+    return json.loads(path.read_text())
+
+
+@pytest.fixture
+def named_run(tmp_path, monkeypatch):
+    """A run that is being watched: an id and a directory of its own. Yields its state path."""
+    monkeypatch.setenv(run_state.RUN_ID_ENV, 'batch-1')
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, str(tmp_path))
+    return run_state.state_path('batch-1')
+
+
+# A round, in the virtual time these tests run under. Positive because pimm reserves zero for
+# `Yield`; the clock is virtual, so nothing waits for it.
+TICK_S = 0.001
+
+
+class Camera(pimm.ControlSystem):
+    """A producer that emits `count` frames and stops, standing in for a camera that comes up."""
+
+    def __init__(self, count: int = 1):
+        self.frame = pimm.ControlSystemEmitter(self)
+        self._count = count
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        emitted = 0
+        while not should_stop.value:
+            if emitted < self._count:
+                self.frame.emit(emitted, clock.now_ns())
+                emitted += 1
+            yield pimm.Sleep(TICK_S)
+
+
+class CountingReceiver(pimm.ControlSystemReceiver):
+    """A receiver that records how often it was read, to pin what the watch does NOT do."""
+
+    def __init__(self, owner: pimm.ControlSystem):
+        super().__init__(owner)
+        self.reads = 0
+
+    def read(self):
+        self.reads += 1
+        return super().read()
+
+
+class Stopper(pimm.ControlSystem):
+    """Ends the world after `rounds`, so a test's world terminates without the readiness watch —
+    which never returns — deciding when."""
+
+    def __init__(self, rounds: int):
+        self._rounds = rounds
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        for _ in range(self._rounds):
+            yield pimm.Sleep(TICK_S)
+
+
+# --- the contract ---------------------------------------------------------------------------
+
+
+def test_a_named_run_reports_that_it_has_started(named_run):
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    run_state.from_env()
+    assert read_state(named_run) == {
+        'run_id': 'batch-1',
+        'phase': 'starting',
+        'cameras_open': 0,
+        'cameras_expected': 0,
+        'console_port': None,
+    }
+
+
+def test_an_unnamed_run_reports_nothing(tmp_path, monkeypatch):
+    """Every ordinary invocation: nothing named it, so it writes no file anywhere."""
+    monkeypatch.delenv(run_state.RUN_ID_ENV, raising=False)
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, str(tmp_path))
+    state = run_state.from_env()
+    assert not state.enabled
+    state.report(run_state.Phase.WARMING_UP)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_the_path_is_scoped_to_the_run(tmp_path, monkeypatch):
+    """Two runs never share a file, which is what makes a leftover from a previous one inert."""
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, str(tmp_path))
+    assert run_state.state_path('a') != run_state.state_path('b')
+    assert run_state.state_path('a').parent == tmp_path
+
+
+def test_a_run_id_that_is_not_one_path_segment_reports_nowhere(tmp_path, monkeypatch):
+    """It would otherwise write into a directory nobody agreed on."""
+    monkeypatch.setenv(run_state.RUN_ID_ENV, '../elsewhere')
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, str(tmp_path))
+    assert not run_state.from_env().enabled
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_relative_directory_reports_nowhere(monkeypatch):
+    """The writer and its reader are different accounts, each resolving a relative path against its
+    own working directory — so they would address different files from the same configuration."""
+    monkeypatch.setenv(run_state.RUN_ID_ENV, 'batch-1')
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, 'run/lock')
+    assert not run_state.from_env().enabled
+
+
+def test_the_file_is_readable_by_another_account(named_run):
+    """`mkstemp` creates 0600 whatever the umask, and the reader is not this account."""
+    run_state.from_env()
+    assert stat.S_IMODE(named_run.stat().st_mode) == 0o644
+
+
+def test_a_report_leaves_no_temporary_file_behind(named_run):
+    state = run_state.from_env()
+    state.report(run_state.Phase.WARMING_UP)
+    assert [p.name for p in named_run.parent.iterdir()] == [named_run.name]
+
+
+def test_an_unwritable_directory_does_not_stop_the_run(tmp_path, monkeypatch, caplog):
+    """The arm is mid-episode; there is no version of "the progress report failed" worth raising."""
+    # rules-allow: hardcoded-keys — a fragment of this module's own log line, not a name any
+    # other scope agrees on.
+    if os.geteuid() == 0:
+        pytest.skip('root writes into a mode-500 directory, so the refused branch cannot be reached')
+    closed = tmp_path / 'closed'
+    closed.mkdir(mode=0o500)
+    monkeypatch.setenv(run_state.RUN_ID_ENV, 'batch-1')
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, str(closed))
+    state = run_state.from_env()
+    state.report(run_state.Phase.WARMING_UP)
+    assert state.state.phase is run_state.Phase.WARMING_UP
+    assert 'could not be written' in caplog.text
+
+
+def test_a_persistent_write_failure_is_logged_once(tmp_path, monkeypatch, caplog):
+    """A directory that cannot be written is one log line, not one per transition."""
+    if os.geteuid() == 0:
+        pytest.skip('root writes into a mode-500 directory, so the refused branch cannot be reached')
+    closed = tmp_path / 'closed'
+    closed.mkdir(mode=0o500)
+    monkeypatch.setenv(run_state.RUN_ID_ENV, 'batch-1')
+    monkeypatch.setenv(run_state.STATE_DIR_ENV, str(closed))
+    state = run_state.from_env()
+    for phase in (run_state.Phase.WARMING_UP, run_state.Phase.WORLD_UP, run_state.Phase.READY):
+        state.report(phase)
+    assert caplog.text.count('could not be written') == 1
+
+
+def test_a_report_replaces_the_file_rather_than_truncating_it(named_run):
+    """The reader polls this path and must never meet a half-written file, so the visible file is
+    only ever swapped for a complete one — its inode changes and its bytes never shorten in place."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    run_state.from_env()
+    before = named_run.stat().st_ino
+    state = run_state.StateFile(named_run, 'batch-1')
+    state.report(run_state.Phase.READY, cameras_open=2, cameras_expected=2)
+    assert named_run.stat().st_ino != before
+    assert read_state(named_run)['phase'] == 'ready'
+
+
+def test_a_report_carries_unnamed_fields_forward(named_run):
+    """A camera count is measured once and holds until the next camera; a phase change must not
+    silently reset it to the field's default."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    state.report(run_state.Phase.WORLD_UP, cameras_expected=2, console_port=8080)
+    state.report(run_state.Phase.READY, cameras_open=2)
+    assert read_state(named_run) == {
+        'run_id': 'batch-1',
+        'phase': 'ready',
+        'cameras_open': 2,
+        'cameras_expected': 2,
+        'console_port': 8080,
+    }
+
+
+# --- the transitions ------------------------------------------------------------------------
+
+
+def _drive(state: run_state.StateFile, cameras: dict[str, Camera], rounds: int = 6) -> run_state.Readiness:
+    """Run a world holding `cameras` and a readiness watch over them, for a bounded number of rounds."""
+    readiness = run_state.Readiness(state, list(cameras), console_port=8080, poll_interval_s=TICK_S)
+    with pimm.World(virtual_time=True) as world:
+        for name, camera in cameras.items():
+            world.connect(camera.frame, readiness.cameras[name])
+        world.run([*cameras.values(), readiness, Stopper(rounds)])
+    return readiness
+
+
+def test_the_world_coming_up_is_reported_before_any_camera(named_run):
+    """The first round is the report, and it is the fact a reader needs: the background processes
+    the operator's UI is one of have been spawned, and where to reach it. It is reported on its own,
+    ahead of any camera — which is the whole distinction between a UI that exists and one that works.
+    """
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    _drive(state, {keys.WRIST_IMAGE: Camera(count=0)}, rounds=1)
+    assert read_state(named_run) == {
+        'run_id': 'batch-1',
+        'phase': 'world_up',
+        'cameras_open': 0,
+        'cameras_expected': 1,
+        'console_port': 8080,
+    }
+
+
+def test_every_camera_delivering_a_frame_is_readiness(named_run):
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    _drive(state, {keys.WRIST_IMAGE: Camera(), keys.EXTERIOR_IMAGE: Camera()})
+    got = read_state(named_run)
+    assert got['phase'] == 'ready'
+    assert (got['cameras_open'], got['cameras_expected']) == (2, 2)
+
+
+def test_a_camera_that_never_opens_holds_readiness_back(named_run):
+    """The failure this whole file exists to make visible: one camera up and its neighbour missing
+    tears the World down as thoroughly as both missing, so it must never read as ready."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    _drive(state, {keys.WRIST_IMAGE: Camera(), keys.EXTERIOR_IMAGE: Camera(count=0)})
+    got = read_state(named_run)
+    assert got['phase'] == 'world_up'
+    assert (got['cameras_open'], got['cameras_expected']) == (1, 2)
+
+
+def test_a_run_with_no_cameras_is_ready_at_once(named_run):
+    """A rig with nothing to open has no device to wait on — the absence of a question."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    _drive(state, {})
+    assert read_state(named_run)['phase'] == 'ready'
+
+
+def test_a_camera_is_read_only_until_it_is_seen(named_run):
+    """Reading a frame takes the lock its producer, the harness, the recorder and the UI contend
+    for and copies the whole frame out, so a camera already known to be up is not read again."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    camera = Camera(count=4)
+    readiness = run_state.Readiness(state, [keys.WRIST_IMAGE], poll_interval_s=TICK_S)
+    counting = CountingReceiver(readiness)
+    readiness.cameras[keys.WRIST_IMAGE] = counting
+    with pimm.World(virtual_time=True) as world:
+        world.connect(camera.frame, counting)
+        world.run([camera, readiness, Stopper(8)])
+    assert read_state(named_run)['phase'] == 'ready'
+    # Once, on the round that found it. Every later round skips a channel already known to be up.
+    assert counting.reads == 1
+
+
+def test_the_watch_does_not_end_the_world(named_run):
+    """A control system that returns sets the world's stop event, which would end the run the
+    moment every camera was up — the exact opposite of what this reports. So the world must run
+    for as long as something else keeps it, with every camera up from the first round."""
+    # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
+    # repository sees it. Written through the constants these tests would still pass if one
+    # were renamed, which is the single thing they exist to catch.
+    state = run_state.from_env()
+    camera = Camera()
+    stopper = Stopper(20)
+    readiness = run_state.Readiness(state, [keys.WRIST_IMAGE], poll_interval_s=TICK_S)
+    rounds = 0
+
+    def counted_rounds(should_stop, clock, inner=stopper.run):
+        nonlocal rounds
+        for command in inner(should_stop, clock):
+            rounds += 1
+            yield command
+
+    stopper.run = counted_rounds
+    with pimm.World(virtual_time=True) as world:
+        world.connect(camera.frame, readiness.cameras[keys.WRIST_IMAGE])
+        world.run([camera, readiness, stopper])
+    assert rounds == 20
+    assert read_state(named_run)['phase'] == 'ready'

--- a/positronic/cli/eval/tests/test_run_state.py
+++ b/positronic/cli/eval/tests/test_run_state.py
@@ -57,8 +57,7 @@ class CountingReceiver(pimm.ControlSystemReceiver):
 
 
 class Stopper(pimm.ControlSystem):
-    """Ends the world after `rounds`, so a test's world terminates without the readiness watch —
-    which never returns — deciding when."""
+    """Ends the world after `rounds`, since the readiness watch never returns."""
 
     def __init__(self, rounds: int):
         self._rounds = rounds
@@ -111,8 +110,7 @@ def test_a_run_id_that_is_not_one_path_segment_reports_nowhere(tmp_path, monkeyp
 
 
 def test_a_relative_directory_reports_nowhere(monkeypatch):
-    """The writer and its reader are different accounts, each resolving a relative path against its
-    own working directory — so they would address different files from the same configuration."""
+    """A relative path resolves per account, so the two would address different files."""
     monkeypatch.setenv(run_state.RUN_ID_ENV, 'batch-1')
     monkeypatch.setenv(run_state.STATE_DIR_ENV, 'run/lock')
     assert not run_state.from_env().enabled
@@ -161,8 +159,7 @@ def test_a_persistent_write_failure_is_logged_once(tmp_path, monkeypatch, caplog
 
 
 def test_a_report_replaces_the_file_rather_than_truncating_it(named_run):
-    """The reader polls this path and must never meet a half-written file, so the visible file is
-    only ever swapped for a complete one — its inode changes and its bytes never shorten in place."""
+    """A poll must never meet a half-written file: the visible file is only ever swapped."""
     # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
     # repository sees it. Written through the constants these tests would still pass if one
     # were renamed, which is the single thing they exist to catch.
@@ -175,8 +172,7 @@ def test_a_report_replaces_the_file_rather_than_truncating_it(named_run):
 
 
 def test_a_report_carries_unnamed_fields_forward(named_run):
-    """A camera count is measured once and holds until the next camera; a phase change must not
-    silently reset it to the field's default."""
+    """A camera count is measured once and holds, so a phase change must not reset it."""
     # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
     # repository sees it. Written through the constants these tests would still pass if one
     # were renamed, which is the single thing they exist to catch.
@@ -206,10 +202,8 @@ def _drive(state: run_state.StateFile, cameras: dict[str, Camera], rounds: int =
 
 
 def test_the_world_coming_up_is_reported_before_any_camera(named_run):
-    """The first round is the report, and it is the fact a reader needs: the background processes
-    the operator's UI is one of have been spawned, and where to reach it. It is reported on its own,
-    ahead of any camera — which is the whole distinction between a UI that exists and one that works.
-    """
+    """Reported on its own, ahead of any camera — the distinction between a UI that exists and
+    one that works."""
     # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
     # repository sees it. Written through the constants these tests would still pass if one
     # were renamed, which is the single thing they exist to catch.
@@ -236,8 +230,7 @@ def test_every_camera_delivering_a_frame_is_readiness(named_run):
 
 
 def test_a_camera_that_never_opens_holds_readiness_back(named_run):
-    """The failure this whole file exists to make visible: one camera up and its neighbour missing
-    tears the World down as thoroughly as both missing, so it must never read as ready."""
+    """One camera up and its neighbour missing tears the World down as thoroughly as both."""
     # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
     # repository sees it. Written through the constants these tests would still pass if one
     # were renamed, which is the single thing they exist to catch.
@@ -259,8 +252,7 @@ def test_a_run_with_no_cameras_is_ready_at_once(named_run):
 
 
 def test_a_camera_is_read_only_until_it_is_seen(named_run):
-    """Reading a frame takes the lock its producer, the harness, the recorder and the UI contend
-    for and copies the whole frame out, so a camera already known to be up is not read again."""
+    """A read takes the lock four systems contend for and copies the whole frame out."""
     # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
     # repository sees it. Written through the constants these tests would still pass if one
     # were renamed, which is the single thing they exist to catch.
@@ -279,8 +271,7 @@ def test_a_camera_is_read_only_until_it_is_seen(named_run):
 
 def test_the_watch_does_not_end_the_world(named_run):
     """A control system that returns sets the world's stop event, which would end the run the
-    moment every camera was up — the exact opposite of what this reports. So the world must run
-    for as long as something else keeps it, with every camera up from the first round."""
+    moment every camera came up."""
     # rules-allow: hardcoded-keys — the wire shape, asserted the way a reader in another
     # repository sees it. Written through the constants these tests would still pass if one
     # were renamed, which is the single thing they exist to catch.

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -216,6 +216,10 @@ class WebEvalUI(pimm.ControlSystem):
         self.cameras = pimm.ReceiverDict(self, default=None)
         self.directive = pimm.ControlSystemEmitter(self)
         self.manual_command = pimm.ControlSystemEmitter(self)
+        # True once uvicorn has bound the port. The socket comes up inside this process, after the
+        # World has spawned it, so nothing outside can tell a console that is serving from one that
+        # is about to.
+        self.console_ready = pimm.ControlSystemEmitter[bool](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         templates = Jinja2Templates(directory=_pkg_path('templates'))
@@ -309,6 +313,10 @@ class WebEvalUI(pimm.ControlSystem):
                     stream.push(_tile([latest[name] for name in names], self.width))
                 if not server_thread.is_alive():
                     raise RuntimeError('Web eval server thread died')
+                # Emitted every round rather than once: a single emit made before the reader bound
+                # would be a console that silently never announced itself.
+                if server.started:
+                    self.console_ready.emit(True, clock.now_ns())
                 yield pimm.Sleep(1 / self.fps)
         finally:
             stream.close()

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -84,7 +84,7 @@ def web(port, fps, width, bitrate, translation_fine, translation_coarse, rotatio
             rotation_fine=rotation_fine,
             rotation_coarse=rotation_coarse,
         )
-        return Driver(ui, ui.directive, pimm.utils.identity, [], manual_commands=ui.manual_command)
+        return Driver(ui, ui.directive, pimm.utils.identity, [], manual_commands=ui.manual_command, console_port=port)
 
     return make
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -84,7 +84,15 @@ def web(port, fps, width, bitrate, translation_fine, translation_coarse, rotatio
             rotation_fine=rotation_fine,
             rotation_coarse=rotation_coarse,
         )
-        return Driver(ui, ui.directive, pimm.utils.identity, [], manual_commands=ui.manual_command, console_port=port)
+        return Driver(
+            ui,
+            ui.directive,
+            pimm.utils.identity,
+            [],
+            manual_commands=ui.manual_command,
+            console_port=port,
+            console_ready=ui.console_ready,
+        )
 
     return make
 

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -19,8 +19,14 @@ JOINT_VEL = 'robot_state.dq'
 EE_POSE = 'robot_state.ee_pose'
 GRIP = 'grip'
 TASK = 'task'
-WRIST_IMAGE = 'image.wrist'
-EXTERIOR_IMAGE = 'image.exterior'
+# Every camera signal is named under one prefix, and that is what identifies a camera on the wire:
+# an embodiment declares its cameras by naming them this way, and the GUIs, the probe and the
+# readiness report all pick them out of the observations by it. Owned here with the names built
+# from it, so the convention is one definition rather than a literal retyped wherever a consumer
+# needs to know which signals carry pictures.
+IMAGE_PREFIX = 'image.'
+WRIST_IMAGE = f'{IMAGE_PREFIX}wrist'
+EXTERIOR_IMAGE = f'{IMAGE_PREFIX}exterior'
 
 # The robot model, carried in episode statics for the transforms that solve against it (``IKJointsAction``).
 # ``CONTROL_FRAME`` names the frame in ``URDF`` that the embodiment reports ``EE_POSE`` in; every embodiment

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -19,11 +19,8 @@ JOINT_VEL = 'robot_state.dq'
 EE_POSE = 'robot_state.ee_pose'
 GRIP = 'grip'
 TASK = 'task'
-# Every camera signal is named under one prefix, and that is what identifies a camera on the wire:
-# an embodiment declares its cameras by naming them this way, and the GUIs, the probe and the
-# readiness report all pick them out of the observations by it. Owned here with the names built
-# from it, so the convention is one definition rather than a literal retyped wherever a consumer
-# needs to know which signals carry pictures.
+# The prefix that identifies a camera on the wire: an embodiment declares its cameras by naming
+# them this way, and every consumer picks them out of the observations by it.
 IMAGE_PREFIX = 'image.'
 WRIST_IMAGE = f'{IMAGE_PREFIX}wrist'
 EXTERIOR_IMAGE = f'{IMAGE_PREFIX}exterior'

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -43,7 +43,7 @@ _STATE_KEYS = (keys.JOINTS, keys.JOINT_VEL, keys.EE_POSE, keys.GRIP)
 
 def _build_wire_obs(sample: dict, task: str | None, now_ns: int, recorded_ts: int) -> dict:
     obs = {k: sample[k] for k in _STATE_KEYS if k in sample}
-    obs.update({k: v for k, v in sample.items() if k.startswith('image.')})
+    obs.update({k: v for k, v in sample.items() if k.startswith(keys.IMAGE_PREFIX)})
     if task:
         obs[keys.TASK] = task
     obs['wall_time_ns'] = now_ns  # rerun wall_time timeline
@@ -131,7 +131,7 @@ def main(
 
     now_ns = time.time_ns()
     obs = _build_wire_obs(sample, task, now_ns, ts)
-    image_keys = [k for k in obs if k.startswith('image.')]
+    image_keys = [k for k in obs if k.startswith(keys.IMAGE_PREFIX)]
 
     rec = Recorder(pos3.sync(output_dir))
     session = rec.tap(_TAP).wrap(policy).new_session({keys.TASK: task} if task else None, time.time)


### PR DESCRIPTION
From outside a run, "the process exists" and "the operator has a screen to work at" are minutes apart and look identical: a cold policy endpoint answers its handshake anywhere between seconds and a quarter of an hour later, and the World carrying the UI is built only once it does. An orchestrator had to infer it from log prose — including, for the cameras, a camera vendor's SDK banner, which carries no run id and describes a device rather than a run.

The run knows all of it. `cli/eval/run_state.py` writes what it knows to `/run/lock/positronic_rollout_state.<run_id>`, one JSON object replaced atomically at every transition, scoped by the same `ROLLOUT_RUN_ID` the finish request uses. The module docstring is the contract a reader in another repository implements against.

## The phases

| phase | means |
|---|---|
| `starting` | the process is up and holds this contract — what separates it from a writer too old to have a phase at all |
| `warming_up` | driving the policy endpoints through their cold start |
| `setting_up` | endpoints warm; syncing the output directory, scanning what it holds, building the driver and the World |
| `world_up` | the World is up and its background processes, the operator's UI among them, are spawned — **not** usable yet |
| `ready` | every camera the run declared is delivering, and the console is bound |

Each is taken at its own in-process seam. `world_up` is the **first round of a foreground control system**: the World spawns every background process before scheduling the first foreground one, so a call beside `world.run` could not claim it.

`phase` is the run NOW, not the furthest it has been. `_run_world` reports `setting_up` before it constructs anything, so in a sweep the previous World stops being advertised as `ready` when it exits rather than when the next `Readiness` gets its first scheduler round. A reader ignores a phase it does not know, so a value may be added without a reader changing.

## What `ready` waits on

**Cameras, by first frame.** A producer's emitter fans out to every receiver bound to it and writes one frame into shared memory whichever number that is, so the tap costs the producer a flag per frame and takes nothing from the harness, the recorder or the UI. A receiver reads `None` until its first message ever arrives — that transition *is* first-frame. A channel is read only until seen: a read takes the lock all four contend for and copies the whole frame out.

**The console's bind.** The UI is spawned last and its socket comes up inside that process afterwards, so the producers can fill every camera tap while nothing answers on the port this same file reports. `WebEvalUI` raises `console_ready` once uvicorn has bound and `ready` waits for it, so `console_port` is serving by the time the file says `ready`. It is a port, not a URL: the run binds `0.0.0.0`. A surface on the rig's own screen has no socket and waits on nothing, as a run with no cameras waits on none. Port and signal are one contract, asserted where `Driver` is constructed: the port alone advertises a console nothing confirmed, the signal alone names nothing to connect to.

## Skew

A rig running an older positronic writes no file, and a reader must report that as **unknown** — never a failure, never ready. No log-grep fallback, by design. Reporting is inert unless something named the run, and a write failure is logged and suppressed, never raised into the run.

`ROLLOUT_RUN_ID` is spelled here and in `finish_request.py` on #578. Whichever lands second deletes its own definition and imports the first's.

## Verification

1053 passed / 8 skipped; ruff clean; basedpyright 0 errors, baseline byte-identical. Tests pin the contract shape, atomic replacement, inertness, a camera that never opens, a console that never binds, that the watch never ends the World, that a port without its signal is refused, and that a World reports `setting_up` before construction. The 13-rule fan-out ran on this head: clean.

<!-- opened-by: posi-agent -->