### PR TITLE
docs: an end-to-end eval path that needs no checkpoint of your own

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -17,40 +17,25 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 
 You keep the weights. Your model runs as an inference server behind one WebSocket endpoint; a lightweight client streams observations and executes the returned trajectory — identical for sim and real. See [Connect your model](connect-your-model.md) and [Inference](inference.md).
 
-## End to end in ten minutes, with no checkpoint of your own
+## One CLI, any benchmark
 
-Two commands take you from an empty machine to a scored run. The first serves a
-public reference policy — openpi fetches the checkpoint itself, nothing to mount:
+The same command runs any benchmark — only the `--eval` target changes, and the endpoint it points at is any model served over the protocol. With no checkpoint of your own, serve a public reference policy: openpi fetches the checkpoint itself, nothing to mount.
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server libero
 ```
 
-The second scores it on a LIBERO suite and writes every trial as a dataset:
+Score it, and browse every trial — video, robot state, per-trial success:
 
 ```bash
-uv run --locked positronic eval run --eval=.sim.libero.object \
+uv run positronic eval run --eval=.sim.libero.object \
   --policy=.remote --policy.url=localhost:8000 \
   --eval.trial_count=10 --output_dir=~/evals/libero
+
+uv run positronic-server --dataset.path=~/evals/libero
 ```
 
-Then browse what happened — video, robot state, per-trial success:
-
-```bash
-uv run --locked python -m positronic.server.positronic_server --dataset.path=~/evals/libero
-```
-
-`pi05_libero` scores 21/21 through this path across the spatial, object and goal
-suites, against its published ~97%, so a run that reproduces those numbers says
-the loop is faithful before your own model is anywhere near it. Swap
-`openpi-server libero` for `openpi-server droid_jointpos` and
-`--eval=.sim.robolab.banana_in_bowl` to do the same against RoboLab — that one
-needs an RTX-class GPU host, see below. Serving your own model instead is
-[Connect your model](connect-your-model.md); the eval command does not change.
-
-## One CLI, any benchmark
-
-The same command runs any benchmark — only the `--eval` target changes. Start your model as an inference server (see [Connect your model](connect-your-model.md)), then point the eval runner at it:
+`pi05_libero` scores 21/21 that way across the spatial, object and goal suites, against its published ~97%: a run reproducing those numbers says the loop is faithful before your own model is anywhere near it. Your own model is served the same way ([Connect your model](connect-your-model.md)) and nothing about the eval command changes.
 
 ```bash
 # LIBERO — the 40-task benchmark (four suites), in sim
@@ -80,7 +65,7 @@ scores never do. See [Eval telemetry](telemetry.md).
 
 ## Three ways to start
 
-1. **Run it yourself, in sim.** Free, self-serve, on your own compute — the ten-minute path above. LIBERO is hardware-free; RoboLab renders in Isaac Sim and wants an RTX-class host.
+1. **Run it yourself, in sim.** Free, self-serve, on your own compute — the reference-policy path above takes about ten minutes. LIBERO is hardware-free; RoboLab renders in Isaac Sim and wants an RTX-class host.
 2. **Have us run the sim.** Point us at your endpoint and we run the suite on our GPUs and return the runs, so no one on your side provisions a GPU or installs Isaac. Ask at hi@phail.ai.
 3. **Get evaluated on real hardware.** The same endpoint, on our rigs, operated and operator-scored. The first real-hardware eval is on us, with full results back within a day.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -19,7 +19,7 @@ You keep the weights. Your model runs as an inference server behind one WebSocke
 
 ## Try it now
 
-Two commands and you have a scored run: no checkpoint of your own, nothing to download, no rig. Serve a public policy — Ubuntu with an NVIDIA card, and it holds its terminal, so run the eval from a second one.
+Two commands and you have a scored run: no checkpoint of your own, no rig. The first run pulls the image, the checkpoint and LIBERO itself, so give it a few minutes and some disk. Serve a public policy — Ubuntu with an NVIDIA card, and it holds its terminal, so run the eval from a second one.
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server libero

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -8,7 +8,7 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 
 ## What you get
 
-- **Sim and real through the same tasks and API.** Sim today: LIBERO, NVIDIA Isaac Lab, MuJoCo. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. Same model, same client — sim for cheap, broad iteration; real hardware as ground truth.
+- **Sim and real through the same tasks and API.** Sim today: LIBERO (40 tasks), RoboLab (NVIDIA Isaac Lab, 120 DROID tasks), MuJoCo; MolmoSpaces lands next, through the same adapter. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. **An endpoint that runs against a sim target runs against the rig unchanged** — same wire protocol, same client, nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
 - **Blinded A/B.** Your checkpoint against your own previous checkpoints, or against our maintained baselines (π0.5, GR00T, SmolVLA, ACT) — randomized and blinded, so lighting and setup drift don't bias the result.
 - **Every run returned.** Multi-view video, full telemetry, and the complete run dataset — not just a success rate. Yours to analyze.
 - **Latency-honest execution.** On real hardware, inference and network delay are real — a slow model is scored as slow. In sim the world pauses during inference by default (as in other harnesses), but you can charge the model's measured inference time with `--inference_latency=True`, so sim scores reflect the delay the robot would actually feel — something sim-only harnesses can't model.
@@ -16,6 +16,37 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 ## How it works
 
 You keep the weights. Your model runs as an inference server behind one WebSocket endpoint; a lightweight client streams observations and executes the returned trajectory — identical for sim and real. See [Connect your model](connect-your-model.md) and [Inference](inference.md).
+
+## End to end in ten minutes, with no checkpoint of your own
+
+Two commands take you from an empty machine to a scored run. The first serves a
+public reference policy — openpi fetches the checkpoint itself, nothing to mount:
+
+```bash
+cd docker && docker compose run --rm --service-ports openpi-server libero
+```
+
+The second scores it on a LIBERO suite and writes every trial as a dataset:
+
+```bash
+uv run --locked positronic eval run --eval=.sim.libero.object \
+  --policy=.remote --policy.url=localhost:8000 \
+  --eval.trial_count=10 --output_dir=~/evals/libero
+```
+
+Then browse what happened — video, robot state, per-trial success:
+
+```bash
+uv run --locked python -m positronic.server.positronic_server --dataset.path=~/evals/libero
+```
+
+`pi05_libero` scores 21/21 through this path across the spatial, object and goal
+suites, against its published ~97%, so a run that reproduces those numbers says
+the loop is faithful before your own model is anywhere near it. Swap
+`openpi-server libero` for `openpi-server droid_jointpos` and
+`--eval=.sim.robolab.banana_in_bowl` to do the same against RoboLab — that one
+needs an RTX-class GPU host, see below. Serving your own model instead is
+[Connect your model](connect-your-model.md); the eval command does not change.
 
 ## One CLI, any benchmark
 
@@ -38,7 +69,7 @@ uv run positronic eval run --eval=.sim.robolab.benchmark \
 
 Narrow the scope to any sim target the catalog exposes — a single suite or category (`.sim.libero.spatial`, `.sim.robolab.visual`) or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
 
-Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. That's the paid path under [Two ways to start](#two-ways-to-start).
+Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. That's the paid path under [Three ways to start](#three-ways-to-start).
 
 ## What a run cost
 
@@ -47,10 +78,11 @@ recording, the machine's load, and the inference-latency distribution — into s
 dataset, and `positronic eval timing-report` reduces them. Sizing and performance work reads that; a run's
 scores never do. See [Eval telemetry](telemetry.md).
 
-## Two ways to start
+## Three ways to start
 
-1. **Try it yourself, in sim.** A public checkpoint runs end-to-end in about ten minutes — see [Connect your model](connect-your-model.md).
-2. **Get evaluated.** Send us a checkpoint or point us at an endpoint; the first real-hardware eval is on us, with full results back within a day. Reach out at hi@phail.ai.
+1. **Run it yourself, in sim.** Free, self-serve, on your own compute — the ten-minute path above. LIBERO is hardware-free; RoboLab renders in Isaac Sim and wants an RTX-class host.
+2. **Have us run the sim.** Point us at your endpoint and we run the suite on our GPUs and return the runs, so no one on your side provisions a GPU or installs Isaac. Ask at hi@phail.ai.
+3. **Get evaluated on real hardware.** The same endpoint, on our rigs, operated and operator-scored. The first real-hardware eval is on us, with full results back within a day.
 
 ## Public or private
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -8,7 +8,7 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 
 ## What you get
 
-- **Sim and real through the same tasks and API.** Sim today: LIBERO (40 tasks), RoboLab (NVIDIA Isaac Lab, 120 DROID tasks), MuJoCo — each through the same adapter. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. **An endpoint that runs against a sim target runs against the rig unchanged** — same wire protocol, same client, nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
+- **Sim and real through the same tasks and API.** Sim: LIBERO, RoboLab (NVIDIA Isaac Lab), MolmoSpaces. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. **An endpoint that runs against a sim target runs against the rig unchanged** — same wire protocol, same client, nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
 - **Blinded A/B.** Your checkpoint against your own previous checkpoints, or against our maintained baselines (π0.5, GR00T, SmolVLA, ACT) — randomized and blinded, so lighting and setup drift don't bias the result.
 - **Every run returned.** Multi-view video, full telemetry, and the complete run dataset — not just a success rate. Yours to analyze.
 - **Latency-honest execution.** On real hardware, inference and network delay are real — a slow model is scored as slow. In sim the world pauses during inference by default (as in other harnesses), but you can charge the model's measured inference time with `--inference_latency=True`, so sim scores reflect the delay the robot would actually feel — something sim-only harnesses can't model.
@@ -19,25 +19,23 @@ You keep the weights. Your model runs as an inference server behind one WebSocke
 
 ## One CLI, any benchmark
 
-The same command runs any benchmark — only the `--eval` target changes, as long as the model behind the endpoint speaks that benchmark's observations. With no checkpoint of your own, serve a public reference policy: openpi fetches the checkpoint itself, nothing to mount.
+The same command runs any benchmark — only the `--eval` target changes, as long as the model behind the endpoint speaks that benchmark's observations. With no checkpoint of your own, serve a public reference policy: openpi fetches the checkpoint itself, nothing to mount. The server needs an NVIDIA GPU with the Container Toolkit, and holds the terminal — run the eval from a second one.
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server libero
 ```
 
-Score one task, and browse every trial — video, robot state, per-trial success:
+Score the suite, and browse every trial — video, robot state, per-trial success:
 
 ```bash
-uv run positronic eval run --eval=.sim.libero.object --eval.task_id=0 \
+uv run positronic eval run --eval=.sim.libero.object \
   --policy=.remote --policy.url=localhost:8000 \
-  --eval.trial_count=5 --output_dir=~/evals/libero
+  --eval.trial_count=10 --output_dir=~/evals/libero
 
 uv run positronic-server --dataset.path=~/evals/libero
 ```
 
-`pi05_libero` reproduces its published LIBERO success rates through this path across the spatial, object and goal suites, so a sweep that lands near them says the loop is faithful before your own model is anywhere near it. Drop `--eval.task_id` to sweep the whole suite, at `trial_count` episodes per task.
-
-Your own model is served the same way ([Connect your model](connect-your-model.md)) and the eval command does not change. The **deployment** does: a serving pipeline binds the codec its benchmark expects — `openpi-server libero` reads `image.agentview`, where a RoboLab target supplies the standard exterior image — so switch the deployment with the target (`openpi-server droid_jointpos` for RoboLab) rather than pointing one endpoint at every suite.
+Your own model is served the same way ([Connect your model](connect-your-model.md)) and the eval command does not change. The **deployment** does: a serving pipeline binds the codec its benchmark expects — `openpi-server libero` reads `image.agentview`, where a RoboLab target supplies the standard exterior image — so switch the deployment with the target (`openpi-server droid_jointpos` for RoboLab). Both of those presets serve public reference checkpoints; point `--pipeline.source.checkpoints_dir` at your own to evaluate it instead.
 
 ```bash
 # LIBERO — the 40-task benchmark (four suites), in sim
@@ -56,7 +54,7 @@ uv run positronic eval run --eval=.sim.robolab.benchmark \
 
 Narrow the scope to any sim target the catalog exposes — a single suite or category (`.sim.libero.spatial`, `.sim.robolab.visual`) or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
 
-Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. That's the paid path under [Three ways to start](#three-ways-to-start).
+Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. Write to hi@phail.ai for those.
 
 ## What a run cost
 
@@ -67,9 +65,11 @@ scores never do. See [Eval telemetry](telemetry.md).
 
 ## Three ways to start
 
-1. **Run it yourself, in sim.** Free, self-serve, on your own compute — the reference-policy path above takes about ten minutes. LIBERO is hardware-free; RoboLab renders in Isaac Sim and wants an RTX-class host.
-2. **Have us run the sim.** Point us at your endpoint and we run the suite on our GPUs and return the runs, so no one on your side provisions a GPU or installs Isaac. Ask at hi@phail.ai.
-3. **Get evaluated on real hardware.** The same endpoint, on our rigs, operated and operator-scored. The first real-hardware eval is on us, with full results back within a day.
+1. **Run it yourself, in sim.** Self-serve, on your own compute — the reference-policy path above. RoboLab renders in Isaac Sim and wants an RTX-class host.
+2. **Have us run the sim.** Point us at your endpoint and we run the suite on our GPUs and return the runs, so nobody on your side provisions a GPU or installs Isaac.
+3. **Get evaluated on real hardware.** The same endpoint, on our rigs, operated and operator-scored. The first one is on us, with full results back within a day.
+
+Both of the last two start at hi@phail.ai.
 
 ## Public or private
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -8,7 +8,7 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 
 ## What you get
 
-- **Sim and real through the same tasks and API.** Sim: LIBERO, RoboLab (NVIDIA Isaac Lab), MolmoSpaces. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. **An endpoint that runs against a sim target runs against the rig unchanged** — same wire protocol, same client, nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
+- **One checkpoint, every target.** Sim: LIBERO, RoboLab (NVIDIA Isaac Lab), MolmoSpaces. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. Serve a DROID policy once and it runs across all of them, and on the rig, with nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
 - **Blinded A/B.** Your checkpoint against your own previous checkpoints, or against our maintained baselines (π0.5, GR00T, SmolVLA, ACT) — randomized and blinded, so lighting and setup drift don't bias the result.
 - **Every run returned.** Multi-view video, full telemetry, and the complete run dataset — not just a success rate. Yours to analyze.
 - **Latency-honest execution.** On real hardware, inference and network delay are real — a slow model is scored as slow. In sim the world pauses during inference by default (as in other harnesses), but you can charge the model's measured inference time with `--inference_latency=True`, so sim scores reflect the delay the robot would actually feel — something sim-only harnesses can't model.
@@ -19,40 +19,25 @@ You keep the weights. Your model runs as an inference server behind one WebSocke
 
 ## One CLI, any benchmark
 
-The same command runs any benchmark — only the `--eval` target changes, as long as the model behind the endpoint speaks that benchmark's observations. With no checkpoint of your own, serve a public reference policy: openpi fetches the checkpoint itself, nothing to mount. The server needs an NVIDIA GPU with the Container Toolkit, and holds the terminal — run the eval from a second one.
+Serve a DROID policy once, then point the eval at whichever target you want — only `--eval` changes. With no checkpoint of your own, the preset below serves openpi's public `pi05_droid_jointpos`; openpi fetches it, nothing to mount. Needs Ubuntu with an NVIDIA card, and holds its terminal, so run the eval from a second one.
 
 ```bash
-cd docker && docker compose run --rm --service-ports openpi-server libero
+cd docker && docker compose run --rm --service-ports openpi-server droid_jointpos
 ```
 
-Score the suite, and browse every trial — video, robot state, per-trial success:
+Score a suite, and browse every trial — video, robot state, per-trial success:
 
 ```bash
-uv run positronic eval run --eval=.sim.libero.object \
-  --policy=.remote --policy.url=localhost:8000 \
-  --eval.trial_count=10 --output_dir=~/evals/libero
-
-uv run positronic-server --dataset.path=~/evals/libero
-```
-
-Your own model is served the same way ([Connect your model](connect-your-model.md)) and the eval command does not change. The **deployment** does: a serving pipeline binds the codec its benchmark expects — `openpi-server libero` reads `image.agentview`, where a RoboLab target supplies the standard exterior image — so switch the deployment with the target (`openpi-server droid_jointpos` for RoboLab). Both of those presets serve public reference checkpoints; point `--pipeline.source.checkpoints_dir` at your own to evaluate it instead.
-
-```bash
-# LIBERO — the 40-task benchmark (four suites), in sim
-uv run positronic eval run --eval=.sim.libero.all \
-  --policy=.remote --policy.url=<gpu-host>:8000 \
-  --eval.trial_count=10 --output_dir=~/evals/libero
-
-# RoboLab — NVIDIA Isaac Lab, 120 DROID tasks, in sim
-# Isaac Sim renders with RT cores, so RoboLab needs an RTX-class GPU host
-# (L40S / L4 / RTX 40xx) — datacenter A100/H100 won't run it. One L40S fits
-# the sim and a pi0.5-size policy on the same card.
 uv run positronic eval run --eval=.sim.robolab.benchmark \
-  --policy=.remote --policy.url=<gpu-host>:8000 \
+  --policy=.remote --policy.url=localhost:8000 \
   --eval.trial_count=10 --output_dir=~/evals/robolab
+
+uv run positronic-server --dataset.path=~/evals/robolab
 ```
 
-Narrow the scope to any sim target the catalog exposes — a single suite or category (`.sim.libero.spatial`, `.sim.robolab.visual`) or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
+That same endpoint serves the other DROID targets and our real rig without being restarted. Your own model is served the same way ([Connect your model](connect-your-model.md)); point `--pipeline.source.checkpoints_dir` at your checkpoint instead of taking the reference one.
+
+Any target the catalog exposes goes in `--eval`: a whole benchmark (`.sim.libero.all`), a suite or category (`.sim.libero.spatial`, `.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
 
 Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. Write to hi@phail.ai for those.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -17,9 +17,9 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 
 You keep the weights. Your model runs as an inference server behind one WebSocket endpoint; a lightweight client streams observations and executes the returned trajectory — identical for sim and real. See [Connect your model](connect-your-model.md) and [Inference](inference.md).
 
-## One CLI, any benchmark
+## Try it now
 
-Serve a DROID policy once, and every benchmark is one CLI parameter away. With no checkpoint of your own, the preset below serves openpi's public `pi05_droid_jointpos`; openpi fetches it, nothing to mount. Needs Ubuntu with an NVIDIA card, and holds its terminal, so run the eval from a second one.
+Two commands and you have a scored run: no checkpoint of your own, nothing to download, no rig. Serve a public DROID policy — Ubuntu with an NVIDIA card, and it holds its terminal, so run the eval from a second one.
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server droid_jointpos

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -19,7 +19,7 @@ You keep the weights. Your model runs as an inference server behind one WebSocke
 
 ## One CLI, any benchmark
 
-Serve a DROID policy once, then point the eval at whichever target you want — only `--eval` changes. With no checkpoint of your own, the preset below serves openpi's public `pi05_droid_jointpos`; openpi fetches it, nothing to mount. Needs Ubuntu with an NVIDIA card, and holds its terminal, so run the eval from a second one.
+Serve a DROID policy once, and every benchmark is one CLI parameter away. With no checkpoint of your own, the preset below serves openpi's public `pi05_droid_jointpos`; openpi fetches it, nothing to mount. Needs Ubuntu with an NVIDIA card, and holds its terminal, so run the eval from a second one.
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server droid_jointpos
@@ -28,6 +28,7 @@ cd docker && docker compose run --rm --service-ports openpi-server droid_jointpo
 Score a suite, and browse every trial — video, robot state, per-trial success:
 
 ```bash
+# --policy.url is where the server is — <remote-server>:8000 if it runs on another machine
 uv run positronic eval run --eval=.sim.robolab.benchmark \
   --policy=.remote --policy.url=localhost:8000 \
   --eval.trial_count=10 --output_dir=~/evals/robolab
@@ -35,9 +36,9 @@ uv run positronic eval run --eval=.sim.robolab.benchmark \
 uv run positronic-server --dataset.path=~/evals/robolab
 ```
 
-That same endpoint serves the other DROID targets and our real rig without being restarted. Your own model is served the same way ([Connect your model](connect-your-model.md)); point `--pipeline.source.checkpoints_dir` at your checkpoint instead of taking the reference one.
+That same endpoint serves the other DROID targets and our real rig without being restarted, and your own model is served the same way — [Connect your model](connect-your-model.md).
 
-Any target the catalog exposes goes in `--eval`: a whole benchmark (`.sim.libero.all`), a suite or category (`.sim.libero.spatial`, `.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
+`--eval` takes any target the catalog exposes: a whole benchmark, a suite or category (`.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). LIBERO speaks its own observations, so it runs off its own deployment (`openpi-server libero`, then `--eval=.sim.libero.all`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
 
 Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. Write to hi@phail.ai for those.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -19,26 +19,26 @@ You keep the weights. Your model runs as an inference server behind one WebSocke
 
 ## Try it now
 
-Two commands and you have a scored run: no checkpoint of your own, nothing to download, no rig. Serve a public DROID policy — Ubuntu with an NVIDIA card, and it holds its terminal, so run the eval from a second one.
+Two commands and you have a scored run: no checkpoint of your own, nothing to download, no rig. Serve a public policy — Ubuntu with an NVIDIA card, and it holds its terminal, so run the eval from a second one.
 
 ```bash
-cd docker && docker compose run --rm --service-ports openpi-server droid_jointpos
+cd docker && docker compose run --rm --service-ports openpi-server libero
 ```
 
 Score a suite, and browse every trial — video, robot state, per-trial success:
 
 ```bash
 # --policy.url is where the server is — <remote-server>:8000 if it runs on another machine
-uv run positronic eval run --eval=.sim.robolab.benchmark \
+uv run positronic eval run --eval=.sim.libero.object \
   --policy=.remote --policy.url=localhost:8000 \
-  --eval.trial_count=10 --output_dir=~/evals/robolab
+  --eval.trial_count=10 --output_dir=~/evals/libero
 
-uv run positronic-server --dataset.path=~/evals/robolab
+uv run positronic-server --dataset.path=~/evals/libero
 ```
 
-That same endpoint serves the other DROID targets and our real rig without being restarted, and your own model is served the same way — [Connect your model](connect-your-model.md).
+**One server, many targets.** A DROID policy served once is scored on RoboLab, on MolmoSpaces and on our real rig without a restart — the target is a parameter, not an integration. RoboLab renders in Isaac Sim, so it wants an RTX-class host; the rig is ours. Your own model is served the same way — [Connect your model](connect-your-model.md).
 
-`--eval` takes any target the catalog exposes: a whole benchmark, a suite or category (`.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). LIBERO speaks its own observations, so it runs off its own deployment (`openpi-server libero`, then `--eval=.sim.libero.all`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
+`--eval` takes any target the catalog exposes: a whole benchmark (`.sim.libero.all`), a suite or category (`.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`.
 
 Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. Write to hi@phail.ai for those.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -33,7 +33,8 @@ uv run positronic eval run --eval=.sim.libero.object \
   --policy=.remote --policy.url=localhost:8000 \
   --eval.trial_count=10 --output_dir=~/evals/libero
 
-uv run positronic-server --dataset.path=~/evals/libero
+uv run positronic-server --dataset.path=~/evals/libero \
+  --ep_table_cfg=@positronic.cfg.server.eval_table
 ```
 
 **One server, many targets.** A DROID policy served once is scored on RoboLab, on MolmoSpaces and on our real rig without a restart — the target is a parameter, not an integration. RoboLab renders in Isaac Sim, so it wants an RTX-class host; the rig is ours. Your own model is served the same way — [Connect your model](connect-your-model.md).

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -8,7 +8,7 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 
 ## What you get
 
-- **Sim and real through the same tasks and API.** Sim today: LIBERO (40 tasks), RoboLab (NVIDIA Isaac Lab, 120 DROID tasks), MuJoCo; MolmoSpaces lands next, through the same adapter. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. **An endpoint that runs against a sim target runs against the rig unchanged** — same wire protocol, same client, nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
+- **Sim and real through the same tasks and API.** Sim today: LIBERO (40 tasks), RoboLab (NVIDIA Isaac Lab, 120 DROID tasks), MuJoCo — each through the same adapter. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. **An endpoint that runs against a sim target runs against the rig unchanged** — same wire protocol, same client, nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
 - **Blinded A/B.** Your checkpoint against your own previous checkpoints, or against our maintained baselines (π0.5, GR00T, SmolVLA, ACT) — randomized and blinded, so lighting and setup drift don't bias the result.
 - **Every run returned.** Multi-view video, full telemetry, and the complete run dataset — not just a success rate. Yours to analyze.
 - **Latency-honest execution.** On real hardware, inference and network delay are real — a slow model is scored as slow. In sim the world pauses during inference by default (as in other harnesses), but you can charge the model's measured inference time with `--inference_latency=True`, so sim scores reflect the delay the robot would actually feel — something sim-only harnesses can't model.
@@ -19,23 +19,25 @@ You keep the weights. Your model runs as an inference server behind one WebSocke
 
 ## One CLI, any benchmark
 
-The same command runs any benchmark — only the `--eval` target changes, and the endpoint it points at is any model served over the protocol. With no checkpoint of your own, serve a public reference policy: openpi fetches the checkpoint itself, nothing to mount.
+The same command runs any benchmark — only the `--eval` target changes, as long as the model behind the endpoint speaks that benchmark's observations. With no checkpoint of your own, serve a public reference policy: openpi fetches the checkpoint itself, nothing to mount.
 
 ```bash
 cd docker && docker compose run --rm --service-ports openpi-server libero
 ```
 
-Score it, and browse every trial — video, robot state, per-trial success:
+Score one task, and browse every trial — video, robot state, per-trial success:
 
 ```bash
-uv run positronic eval run --eval=.sim.libero.object \
+uv run positronic eval run --eval=.sim.libero.object --eval.task_id=0 \
   --policy=.remote --policy.url=localhost:8000 \
-  --eval.trial_count=10 --output_dir=~/evals/libero
+  --eval.trial_count=5 --output_dir=~/evals/libero
 
 uv run positronic-server --dataset.path=~/evals/libero
 ```
 
-`pi05_libero` scores 21/21 that way across the spatial, object and goal suites, against its published ~97%: a run reproducing those numbers says the loop is faithful before your own model is anywhere near it. Your own model is served the same way ([Connect your model](connect-your-model.md)) and nothing about the eval command changes.
+`pi05_libero` reproduces its published LIBERO success rates through this path across the spatial, object and goal suites, so a sweep that lands near them says the loop is faithful before your own model is anywhere near it. Drop `--eval.task_id` to sweep the whole suite, at `trial_count` episodes per task.
+
+Your own model is served the same way ([Connect your model](connect-your-model.md)) and the eval command does not change. The **deployment** does: a serving pipeline binds the codec its benchmark expects — `openpi-server libero` reads `image.agentview`, where a RoboLab target supplies the standard exterior image — so switch the deployment with the target (`openpi-server droid_jointpos` for RoboLab) rather than pointing one endpoint at every suite.
 
 ```bash
 # LIBERO — the 40-task benchmark (four suites), in sim

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -366,7 +366,7 @@ def uph_sim(episode: Episode) -> float | None:
     return 1 / (t / 3600)
 
 
-sim_episodes = base_cfg.transform.override(
+stacking_episodes = base_cfg.transform.override(
     base=base_cfg.local_all,
     transforms=[
         Group(
@@ -389,7 +389,7 @@ sim_episodes = base_cfg.transform.override(
 
 
 @cfn.config()
-def sim_episodes_table():
+def stacking_episodes_table():
     return {
         '__index__': C(label='#', format='%d'),
         '__duration__': C(label='Duration', format='%.2f sec'),
@@ -416,7 +416,7 @@ def _effective_duration(key: str, ep: Episode) -> float:
 
 
 @cfn.config()
-def sim_checkpoint_table():
+def stacking_checkpoint_table():
     """Grouped table by checkpoint with UPH and MTBF metrics."""
 
     def group_fn(episodes: list[Episode]):
@@ -903,8 +903,8 @@ def phail_leaderboard():
 # Pre-configured servers
 # ========================================================================================
 #
-# Sim evaluation:
-#   uv run --locked python -m positronic.cfg.analysis sim --dataset.base.path=s3://inference/sim_stack_validation/090226/
+# Cube-stacking evaluation:
+#   uv run --locked python -m positronic.cfg.analysis stacking --dataset.base.path=s3://inference/sim_stack_validation/090226/
 #
 # Real (unified) evaluation:
 #   uv run --locked python -m positronic.cfg.analysis real --dataset.base.path=s3://inference/real/191225/
@@ -921,10 +921,10 @@ server = server_main.override(
     port=5001,
 )
 
-sim_server = server_main.override(
-    dataset=sim_episodes,
-    ep_table_cfg=sim_episodes_table,
-    group_tables={'checkpoints': sim_checkpoint_table},
+stacking_server = server_main.override(
+    dataset=stacking_episodes,
+    ep_table_cfg=stacking_episodes_table,
+    group_tables={'checkpoints': stacking_checkpoint_table},
     home_page='checkpoints',
     port=5001,
 )
@@ -940,4 +940,4 @@ phail_server = server_main.override(
 if __name__ == '__main__':
     init_logging()
     with pos3.mirror():
-        cfn.cli({'sim': sim_server, 'real': server, 'phail': phail_server})
+        cfn.cli({'stacking': stacking_server, 'real': server, 'phail': phail_server})

--- a/positronic/cfg/server.py
+++ b/positronic/cfg/server.py
@@ -9,7 +9,7 @@ from positronic import keys
 from positronic.dataset import Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Group, Identity, Rename
 from positronic.server.positronic_server import ColumnConfig as C
-from positronic.server.positronic_server import GroupTableConfig
+from positronic.server.positronic_server import GroupTableConfig, RendererConfig
 from positronic.server.positronic_server import main as server_main
 from positronic.utils.logging import init_logging
 
@@ -17,6 +17,29 @@ from . import analysis as analysis_cfg
 from . import ds
 from .analysis import calculate_units
 from .ds import internal
+
+
+@cfn.config()
+def eval_table():
+    """The episode table for an eval run: only what every eval writes, nothing task-specific.
+
+    ``eval.success`` is absent on an episode that never reached its terminal, so it defaults to False;
+    ``eval.terminated`` separates a task the policy failed from one whose budget ran out.
+    """
+    return {
+        '__index__': C(label='#', format='%d'),
+        '__duration__': C(label='Duration', format='%.2f sec'),
+        keys.TASK: C(label='Task', filter=True),
+        'eval.success': C(
+            label='Pass',
+            default=False,
+            renderer=RendererConfig(
+                type='badge',
+                options={True: {'label': 'Pass', 'variant': 'success'}, False: {'label': 'Fail', 'variant': 'danger'}},
+            ),
+        ),
+        'eval.terminated': C(label='Ended', default=False),
+    }
 
 
 def uph(ep: Episode) -> float | None:

--- a/positronic/cfg/server.py
+++ b/positronic/cfg/server.py
@@ -30,7 +30,7 @@ def eval_table():
         '__index__': C(label='#', format='%d'),
         '__duration__': C(label='Duration', format='%.2f sec'),
         keys.TASK: C(label='Task', filter=True),
-        'eval.success': C(
+        keys.EVAL_SUCCESS: C(
             label='Pass',
             default=False,
             renderer=RendererConfig(
@@ -38,7 +38,7 @@ def eval_table():
                 options={True: {'label': 'Pass', 'variant': 'success'}, False: {'label': 'Fail', 'variant': 'danger'}},
             ),
         ),
-        'eval.terminated': C(label='Ended', default=False),
+        keys.EVAL_TERMINATED: C(label='Ended', default=False),
     }
 
 

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -58,3 +58,10 @@ POSITRONIC_VERSION = 'positronic_version'
 
 POLICY_META = 'inference.policy'
 SERVER_META = f'{POLICY_META}.{SERVER}'
+
+# What a trial reports when it ends, in its episode's statics. The harness writes ``EVAL_TERMINATED``:
+# True when a terminal was delivered inside the budget, False when the budget ran out. ``EVAL_SUCCESS``
+# rides in the terminal payload an env's adapter returns, so an env that reports it only on success
+# leaves it absent on failure — a reader defaults it rather than assuming a False.
+EVAL_SUCCESS = 'eval.success'
+EVAL_TERMINATED = 'eval.terminated'

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -454,9 +454,9 @@ class Harness(pimm.ControlSystem):
         """
         done_msg = self.done.read()
         if done_msg.updated and done_msg.data and done_msg.ts <= self._deadline * 1e9:
-            return {**done_msg.data, 'eval.terminated': True}
+            return {**done_msg.data, keys.EVAL_TERMINATED: True}
         if clock.now() >= self._deadline:
-            return {'eval.terminated': False}
+            return {keys.EVAL_TERMINATED: False}
         return None
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -609,7 +609,7 @@ def test_trial_timeout_self_terminates(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is False
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
     assert isinstance(_last_command(p), Reset)
 
 
@@ -665,7 +665,7 @@ def test_attended_task_run_respects_timeout(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is False
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
     assert isinstance(_last_command(p), Reset)
 
 
@@ -684,12 +684,12 @@ def test_attended_task_run_respects_done(world):
     drive_scheduler(scheduler, steps=5)
     assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
 
-    done_em.emit({'eval.success': True})
+    done_em.emit({keys.EVAL_SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is True
-    assert stops[0].static_data['eval.success'] is True
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is True
+    assert stops[0].static_data[keys.EVAL_SUCCESS] is True
 
 
 @pytest.mark.timeout(3.0)
@@ -706,13 +706,13 @@ def test_trial_stop_signal_terminates(world):
     # Trial is live and unbounded by the clock: nothing committed yet.
     assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
 
-    done_em.emit({'eval.success': True})
+    done_em.emit({keys.EVAL_SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is True
-    assert stops[0].static_data['eval.success'] is True  # the delivered payload lands in static data
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is True
+    assert stops[0].static_data[keys.EVAL_SUCCESS] is True  # the delivered payload lands in static data
     assert isinstance(_last_command(p), Reset)
 
 
@@ -736,7 +736,7 @@ def test_stale_done_does_not_terminate_next_trial(world):
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 0
 
-    done_em.emit({'eval.success': True})  # fresh truthy: ends trial 0
+    done_em.emit({keys.EVAL_SUCCESS: True})  # fresh truthy: ends trial 0
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
@@ -744,11 +744,11 @@ def test_stale_done_does_not_terminate_next_trial(world):
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
-    done_em.emit({'eval.success': True})  # a fresh delivery ends trial 1
+    done_em.emit({keys.EVAL_SUCCESS: True})  # a fresh delivery ends trial 1
     drive_scheduler(scheduler, steps=10)
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2
-    assert all(s.static_data['eval.terminated'] is True for s in stops)
+    assert all(s.static_data[keys.EVAL_TERMINATED] is True for s in stops)
 
 
 class _FrameIndexDevice(pimm.ControlSystem):
@@ -825,7 +825,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
                 self.state.emit(0.0)
                 n += 1
                 if n == 5:
-                    self.done.emit({'eval.success': True})
+                    self.done.emit({keys.EVAL_SUCCESS: True})
                 yield pimm.Sleep(0.01)
 
     device = _Device()
@@ -849,8 +849,8 @@ def test_task_done_terminates_through_wire_embodiment(world):
 
     stops = [d for _, d in ds_recorder.emitted if d.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is True
-    assert stops[0].static_data['eval.success'] is True
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is True
+    assert stops[0].static_data[keys.EVAL_SUCCESS] is True
 
 
 @pytest.mark.timeout(3.0)
@@ -869,7 +869,7 @@ def test_done_after_deadline_is_a_timeout(world):
     # delivered at ~0.1s — past the deadline but before the harness next polls. The timeout must win.
     driver = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.1),
-        (partial(done_em.emit, {'eval.success': True}), 0.3),
+        (partial(done_em.emit, {keys.EVAL_SUCCESS: True}), 0.3),
         (None, 0.0),
     ])
     scheduler = world.start([harness, driver])
@@ -877,8 +877,8 @@ def test_done_after_deadline_is_a_timeout(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is False
-    assert 'eval.success' not in stops[0].static_data
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
+    assert keys.EVAL_SUCCESS not in stops[0].static_data
 
 
 @pytest.mark.timeout(3.0)
@@ -923,7 +923,7 @@ def test_trial_plan_self_drives(world):
     assert [s.static_data['eval.trial_index'] for s in stops] == [0, 1]
     assert all(s.static_data[keys.TASK] == 'stack' for s in stops)
     assert len(stops) == 2
-    assert all(s.static_data['eval.terminated'] is False for s in stops)
+    assert all(s.static_data[keys.EVAL_TERMINATED] is False for s in stops)
     assert policy.reset_calls == 2
 
 
@@ -955,7 +955,7 @@ def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
 
     stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data['eval.terminated'] is False
+    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
     # The post-deadline chunk must not reach the drivers: the only non-empty emissions are the homing
     # Reset / home grip from the startup home and the timeout FINISH.
     assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -217,7 +217,7 @@ class _CountdownAdapter(EnvAdapter):
         return {}
 
     def terminal(self, result):
-        return {'eval.success': True} if result['done'] else None
+        return {keys.EVAL_SUCCESS: True} if result['done'] else None
 
 
 @pytest.mark.timeout(60.0)
@@ -276,7 +276,7 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
     episode = ds[0]
-    assert episode.static['eval.terminated'] is False
+    assert episode.static[keys.EVAL_TERMINATED] is False
     assert episode.static['eval.universe'] == 'sim'
     assert episode.static['eval.embodiment'] == 'remote.mujoco.franka'
     assert episode.static['scene_xml'].startswith('<mujoco')

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -56,4 +56,4 @@ class LiberoAdapter(WireCommandAdapter):
         return {'sim_state': raw_obs['sim_state']}
 
     def terminal(self, result: dict[str, Any]) -> dict[str, Any] | None:
-        return {'eval.success': True} if result['done'] else None
+        return {keys.EVAL_SUCCESS: True} if result['done'] else None

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -60,4 +60,4 @@ class RobolabAdapter(WireCommandAdapter):
     def terminal(self, result: dict[str, Any]) -> dict[str, Any] | None:
         # ``done`` covers termination and truncation, so the trial ends either way; ``success`` is True only
         # when the task's success condition fired, keeping timeouts honest.
-        return {'eval.success': bool(result['success'])} if result['done'] else None
+        return {keys.EVAL_SUCCESS: bool(result['success'])} if result['done'] else None

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -88,7 +88,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     assert len(ds) == 2
 
     episode = ds[0]
-    assert episode.static['eval.terminated'] is False
+    assert episode.static[keys.EVAL_TERMINATED] is False
     assert episode.static['eval.trial_index'] == 0
     assert episode.static['eval.seed'] == 100
     assert episode.static['eval.universe'] == 'sim'
@@ -188,7 +188,7 @@ class _CountdownProducer(pimm.ControlSystem):
                 self._steps += 1
                 self._emit_obs()
                 if self._done_after is not None and self._steps >= self._done_after:
-                    self.done.emit({'eval.success': True})
+                    self.done.emit({keys.EVAL_SUCCESS: True})
                     self._active = False
 
 
@@ -297,8 +297,8 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
     episode = ds[0]
-    assert episode.static['eval.terminated'] is True
-    assert episode.static['eval.success'] is True  # the delivered ``done`` payload lands in static data
+    assert episode.static[keys.EVAL_TERMINATED] is True
+    assert episode.static[keys.EVAL_SUCCESS] is True  # the delivered ``done`` payload lands in static data
     assert episode.static['eval.embodiment'] == 'test.countdown'
     # The terminal frame (the step where ``done`` fired) is recorded, not dropped by STOP closing the writer.
     values = [v for v, _ in episode.signals['value']]

--- a/utilities/plot_eval.py
+++ b/utilities/plot_eval.py
@@ -2,7 +2,7 @@
 Script to generate evaluation plots from a dataset.
 
 Usage:
-    uv run --locked utilities/plot_eval.py --dataset=@positronic.cfg.analysis.sim_episodes --output=eval_plots.html
+    uv run --locked utilities/plot_eval.py --dataset=@positronic.cfg.analysis.stacking_episodes --output=eval_plots.html
 """
 
 from collections import defaultdict
@@ -18,13 +18,13 @@ import positronic.cfg.analysis
 from positronic.dataset import Dataset
 
 
-@cfn.config(dataset=positronic.cfg.analysis.sim_episodes, output='eval_plots.html')
+@cfn.config(dataset=positronic.cfg.analysis.stacking_episodes, output='eval_plots.html')
 def main(dataset: Dataset, output: str):  # noqa: C901
     """
     Generate evaluation plots for a given dataset.
 
     Args:
-        dataset: The dataset to evaluate. Defaults to sim_episodes config.
+        dataset: The dataset to evaluate. Defaults to stacking_episodes config.
         output: Path to the output HTML file.
     """
     print(f'Loading dataset with {len(dataset)} episodes...')


### PR DESCRIPTION
## Why

Two conversations this month landed on the same gap. Runway's engineer built his own MolmoSpaces/RoboCasa integration and called it "a research branch, not very healthy nor very clean"; mimic's CTO has been building a robolab stack to validate policies on droid-like setups. Both were doing work this repository has already done, and neither could tell that from `docs/evaluation.md` — its first step is "serve your own model", so there is no way to judge the harness before committing to it.

## What changes

- **A ten-minute path with no checkpoint of your own.** `docker compose run --rm --service-ports openpi-server libero` serves the public `pi05_libero` (openpi fetches it from `gs://openpi-assets/checkpoints/pi05_libero`, nothing to mount), `positronic eval run --eval=.sim.libero.object` scores it, and `positronic_server` opens the recordings. `pi05_libero`'s 21/21 through this path, against its published ~97%, is stated as the faithfulness check — so a reader can verify the loop before trusting it with their own model.
- **The simulator list names what people call it** — LIBERO (40 tasks), RoboLab (Isaac Lab, 120 DROID tasks), MuJoCo, MolmoSpaces landing next — and states the property the list only implied: an endpoint that runs against a sim target runs against the rig unchanged.
- **A third way to start**: we run the sim on our GPUs, for teams who would rather not provision Isaac. It already happens; it was not written down.

## Notes for review

- Docs only, no code touched, so no rules check was run — a prose change to a single document.
- Two claims worth a second pair of eyes: the 21/21 figure, taken from the 6 July announcement in the Runway channel, and MolmoSpaces described as landing next rather than shipped.