### PR TITLE
Skip a command pose present only as a null rename alias

### DIFF
--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -543,11 +543,9 @@ class ChangeEEFrame(Codec):
                     'episode a codec already moved would train on a frame the checkpoint does not declare'
                 )
             derived: dict[str, Any] = {obs_keys.EE_FRAME: FromValue(codec._transform.as_vector(_QUAT))}
-            # Membership alone is not enough: a joint-only dataset carries no legacy pose to rename, and the
-            # backfill (``cfg.ds.internal._RENAME_ROBOT_COMMAND``) surfaces that absence as a present key holding
-            # ``None``. Wrapping it would defer the failure to whoever dereferences the signal.
-            present = (key for key in codec._keys if key in episode and episode[key] is not None)
-            derived.update({key: partial(self._derive_pose, key) for key in present})
+            # ``cfg.ds.internal._RENAME_ROBOT_COMMAND`` backfills an absent pose as ``None``, not as a missing key.
+            keys_with_poses = (key for key in codec._keys if key in episode and episode[key] is not None)
+            derived.update({key: partial(self._derive_pose, key) for key in keys_with_poses})
             return Group(Derive(**derived), Identity())(episode)
 
         @property

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -543,7 +543,11 @@ class ChangeEEFrame(Codec):
                     'episode a codec already moved would train on a frame the checkpoint does not declare'
                 )
             derived: dict[str, Any] = {obs_keys.EE_FRAME: FromValue(codec._transform.as_vector(_QUAT))}
-            derived.update({key: partial(self._derive_pose, key) for key in codec._keys if key in episode})
+            # Membership alone is not enough: a joint-only dataset carries no legacy pose to rename, and the
+            # backfill (``cfg.ds.internal._RENAME_ROBOT_COMMAND``) surfaces that absence as a present key holding
+            # ``None``. Wrapping it would defer the failure to whoever dereferences the signal.
+            present = (key for key in codec._keys if key in episode and episode[key] is not None)
+            derived.update({key: partial(self._derive_pose, key) for key in present})
             return Group(Derive(**derived), Identity())(episode)
 
         @property

--- a/positronic/policy/tests/test_change_ee_frame.py
+++ b/positronic/policy/tests/test_change_ee_frame.py
@@ -194,3 +194,25 @@ def test_training_encoder_skips_absent_command_pose():
     assert keys.TARGET_EE_POSE not in list(out), 'absent command pose must not be materialized'
     np.testing.assert_allclose(out[keys.EE_POSE][0][0], (obs_pose * TO_DROID).as_vector(QUAT), atol=1e-9)
     assert keys.TARGET_JOINTS in out
+
+
+def test_training_encoder_skips_a_command_pose_present_only_as_a_null_alias():
+    """``cfg.ds.internal._RENAME_ROBOT_COMMAND`` backfills the canonical command pose from the legacy plural
+    name, so a joint-only dataset that has neither carries the key with a ``None`` value. Converting that
+    yields a signal that raises on dereference, which surfaces far from here."""
+    obs_pose = _pose([0.3, 0.1, 0.4], [0.2, -0.3, 0.5])
+    ts = [1000, 2000]
+    episode = EpisodeContainer(
+        data={
+            keys.URDF: URDF,
+            keys.CONTROL_FRAME: DEFAULT_FRAME,
+            keys.EE_POSE: DummySignal(ts, np.stack([obs_pose.as_vector(QUAT)] * 2)),
+            keys.TARGET_JOINTS: DummySignal(ts, np.zeros((2, 7), dtype=np.float32)),
+            keys.TARGET_EE_POSE: None,
+        }
+    )
+
+    out = ChangeEEFrame(TO_DROID).training_encoder(episode)
+
+    assert out[keys.TARGET_EE_POSE] is None, 'a null alias must pass through, not become a broken signal'
+    np.testing.assert_allclose(out[keys.EE_POSE][0][0], (obs_pose * TO_DROID).as_vector(QUAT), atol=1e-9)


### PR DESCRIPTION
`ChangeEEFrame`'s episode transform converts only the pose keys the episode carries a signal for, rather than every key present in it. A key present with a `None` value passes through untouched.

## Why

`cfg.ds.internal._RENAME_ROBOT_COMMAND` backfills the canonical `robot_command.pose` from the legacy plural name with `Get('robot_commands.pose', None)`, so a dataset carrying neither name still holds the key — with `None` under it. Membership was the whole guard, so the transform wrapped that `None` in an `Elementwise` and handed back a signal with nothing inside. The failure then surfaced at the first dereference, as `TypeError: object of type 'NoneType' has no len()`, with nothing in the traceback naming either this transform or the rename.

Two other shapes are arguable:

- **Raise here rather than skip.** Absence already has a meaning in this transform: a key missing outright is skipped, which `test_training_encoder_skips_absent_command_pose` pins. The backfill's `None` is that same absence in a different spelling, so raising would make one spelling of "no command pose" fatal and the other benign.
- **Fix the backfill so absence stays absent** — drop the key instead of setting it to `None`. That is the narrower defect, with a wider blast radius: the alias is read by every consumer of `REAL_ROBOT_TRANSFORM` and `SIM_ROBOT_TRANSFORM`, so changing what it emits is a change to the dataset-transform contract. The guard here holds whoever produced the `None`.

What it does not cover: the null alias still reaches every other consumer of those transforms. This makes the frame codec tolerant of it, nothing more.

## Verification

The new test fails on the unguarded code with the `TypeError` above and passes with the guard. Full suite `uv run --locked pytest --no-cov` — 1038 passed, 8 skipped. `basedpyright` 0 errors, baseline ratchet clean, `ruff check` and `ruff format --check` clean.

## Refs

`Positronic-Robotics/internal#330`

<!-- opened-by: posi-agent -->