### PR TITLE
Ship the platform wire contract as `client/`, with `positronic submit` over it

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1278,16 +1278,6 @@
                 }
             }
         ],
-        "./positronic/cli/__init__.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./positronic/data_collection.py": [
             {
                 "code": "reportOptionalOperand",

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -67,7 +67,7 @@ jobs:
       # against the PR base sha for the same reason as the ratchet below.
       env:
         RATCHET_BASE: ${{ env.BASE_SHA }}
-      run: python3 utilities/check_client_version_bump.py
+      run: uv run --locked python3 utilities/check_client_version_bump.py
     - name: Check basedpyright baseline ratchet
       # Runs unconditionally: cheap, and fast-passes when no baseline file grew. RATCHET_BASE is the
       # PR base sha ($BASE_SHA); the script diffs against its merge-base with HEAD, since origin/main

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -61,6 +61,13 @@ jobs:
       # .basedpyright/baseline.json. The fresh dev-only venv above is the canonical
       # env the baseline is generated against, so no `--exact` is needed here.
       run: uv run --locked basedpyright
+    - name: Check the client version and the root's pin on it
+      # The release publishes the client with `skip-existing`, so a change to `client/` that reuses
+      # its version silently keeps the old wheel and the root then ships depending on it. Judged
+      # against the PR base sha for the same reason as the ratchet below.
+      env:
+        RATCHET_BASE: ${{ env.BASE_SHA }}
+      run: python3 utilities/check_client_version_bump.py
     - name: Check basedpyright baseline ratchet
       # Runs unconditionally: cheap, and fast-passes when no baseline file grew. RATCHET_BASE is the
       # PR base sha ($BASE_SHA); the script diffs against its merge-base with HEAD, since origin/main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,39 @@ permissions:
   contents: read
 
 jobs:
+  # `positronic` requires `positronic-platform-client`, so the client is on the index before the
+  # release that depends on it. It carries its own version and usually has not moved, which is what
+  # `skip-existing` is for: republishing an unchanged client is a no-op, not a failed release.
+  publish-client-pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable uv (with cache)
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Build sdist and wheel
+        working-directory: client
+        run: |
+          rm -rf dist/
+          uvx --from build pyproject-build --sdist --wheel
+
+      - name: Twine check
+        run: uvx twine check client/dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: client/dist
+          skip-existing: true
+
   publish-pypi:
     runs-on: ubuntu-latest
+    needs: publish-client-pypi
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,11 +9,41 @@ permissions:
   contents: read
 
 jobs:
+  # Every publish gate that does not need a build, run once and BEFORE anything is published: a
+  # release to PyPI cannot be withdrawn, so a release this workflow would go on to reject must not
+  # put a distribution on the index first.
+  verify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify the tag matches the version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            echo "Error: no release tag — this workflow publishes a published release, not a dispatch" >&2
+            exit 1
+          fi
+          TAG="${TAG#v}"
+          FILE_VER=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "Tag: $TAG | pyproject.toml: $FILE_VER"
+          if [ "$TAG" != "$FILE_VER" ]; then
+            echo "Error: tag ($TAG) does not match project.version ($FILE_VER)" >&2
+            exit 1
+          fi
+
   # `positronic` requires `positronic-platform-client`, so the client is on the index before the
   # release that depends on it. It carries its own version and usually has not moved, which is what
   # `skip-existing` is for: republishing an unchanged client is a no-op, not a failed release.
   publish-client-pypi:
     runs-on: ubuntu-latest
+    needs: verify-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +71,7 @@ jobs:
 
   publish-pypi:
     runs-on: ubuntu-latest
-    needs: publish-client-pypi
+    needs: [verify-release, publish-client-pypi]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,17 +93,6 @@ jobs:
 
       - name: Twine check
         run: uvx twine check dist/*
-
-      - name: Verify version matches tag
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          TAG="${TAG#v}"
-          FILE_VER=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          echo "Tag: $TAG | pyproject.toml: $FILE_VER"
-          if [ "$TAG" != "$FILE_VER" ]; then
-            echo "Error: tag ($TAG) does not match project.version ($FILE_VER)" >&2
-            exit 1
-          fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         name: a changed client declares a new version, and the root pins it
         # Reads git and both manifests, so takes no filenames. Scoped to the paths that can put the
         # three out of step: the shipped client, its manifest, and the root's pin.
-        entry: python3 utilities/check_client_version_bump.py
+        entry: uv run --locked python3 utilities/check_client_version_bump.py
         language: system
         files: '^(client/.*|pyproject\.toml)$'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,15 @@ repos:
         files: '^(uv\.lock|stubs/mujoco/.*|utilities/generate_mujoco_stubs\.py)$'
         pass_filenames: false
         stages: [pre-commit]
+      - id: client-version-bump
+        name: a changed client declares a new version, and the root pins it
+        # Reads git and both manifests, so takes no filenames. Scoped to the paths that can put the
+        # three out of step: the shipped client, its manifest, and the root's pin.
+        entry: python3 utilities/check_client_version_bump.py
+        language: system
+        files: '^(client/.*|pyproject\.toml)$'
+        pass_filenames: false
+        stages: [pre-commit]
       - id: basedpyright-baseline-ratchet
         name: basedpyright baseline is a one-way ratchet
         # Reads the baseline and git directly, so takes no filenames; scoped to fire only when

--- a/client/README.md
+++ b/client/README.md
@@ -5,14 +5,14 @@ and response models, id and enum types, the error envelope, and one `PlatformCli
 endpoint.
 
 > **Alpha, under rapid development.** Names, fields, endpoints and behaviour change without notice,
-> and nothing here is covered by a backwards-compatibility guarantee. Pin the exact revision you
+> and nothing here is covered by a backwards-compatibility guarantee. Pin the exact version you
 > tested against, and expect to edit your code when you move off it.
 
 The library depends on `pydantic` and `httpx` and nothing else, so a service that only speaks to the
-platform installs this subdirectory on its own:
+platform installs it on its own, at the exact version it was written against:
 
 ```bash
-uv add "git+https://github.com/Positronic-Robotics/positronic@main#subdirectory=client"
+uv add "positronic-platform-client==0.2.0"
 ```
 
 `platform_client` never imports `positronic`. The commands a user drives it with — `positronic eval

--- a/client/README.md
+++ b/client/README.md
@@ -48,9 +48,9 @@ Calls go to `https://platform.positronic.ro` with nothing set. The environment c
 | `POSITRONIC_PLATFORM_API_KEY` | the key `register` mints — read from the environment only, so it never reaches a process listing |
 | `POSITRONIC_PLATFORM_CREDENTIAL` | the identity `register` registers with — read the same way, for the same reason |
 
-Boards have no command yet — `PlatformClient.list_boards` and `.rankings` read them from Python.
-Both take the key when one is set and work without: a public board is readable by anyone, a tenant's
-board only by its members.
+Boards have no command yet — `PlatformClient.list_boards` and `.rankings` read them from Python, the
+latter taking a `BoardRef` (`platform_client.boards`). Both take the key when one is set and work
+without: a public board is readable by anyone, a tenant's board only by its members.
 
 A board row reads `<display name>#<tag>`. The name is an alias and is not unique — a board may hide
 it altogether — so the tag is what tells two rows apart, and it is how you find your own: it is the

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,87 @@
+# positronic-platform-client
+
+The wire contract for the Positronic evaluation platform, and a thin HTTP client over it: request
+and response models, id and enum types, the error envelope, and one `PlatformClient` method per API
+endpoint.
+
+> **Alpha, under rapid development.** Names, fields, endpoints and behaviour change without notice,
+> and nothing here is covered by a backwards-compatibility guarantee. Pin the exact revision you
+> tested against, and expect to edit your code when you move off it.
+
+The library depends on `pydantic` and `httpx` and nothing else, so a service that only speaks to the
+platform installs this subdirectory on its own:
+
+```bash
+uv add "git+https://github.com/Positronic-Robotics/positronic@main#subdirectory=client"
+```
+
+`platform_client` never imports `positronic`. The commands a user drives it with — `positronic eval
+run` and `positronic account` — ship with `positronic`, which depends on this package rather
+than the other way round.
+
+## From the command line
+
+Nothing here has a command of its own. The user-facing side is `positronic`, and from a checkout it
+needs no installation step at all. `eval run` runs an eval here when given a policy, and on the
+platform when given a policy image:
+
+```bash
+export POSITRONIC_PLATFORM_CREDENTIAL=<the identity to register with>
+uv run positronic account register --alias=<display name>
+export POSITRONIC_PLATFORM_API_KEY=<the key printed above>
+
+uv run positronic eval run --eval=<name> --policy-image=org/policy@sha256:…
+uv run positronic eval status --submission-id=<hex id>
+uv run positronic eval list
+uv run positronic eval cancel --submission-id=<hex id>
+```
+
+`positronic/cli/examples/` runs the whole flow end to end.
+
+## Configuration
+
+Calls go to `https://platform.positronic.ro` with nothing set. The environment carries the rest:
+
+| Variable | Holds |
+|---|---|
+| `POSITRONIC_PLATFORM_URL` | a platform other than the default one, overridden per call by `--platform-url` |
+| `POSITRONIC_PLATFORM_API_KEY` | the key `register` mints — read from the environment only, so it never reaches a process listing |
+| `POSITRONIC_PLATFORM_CREDENTIAL` | the identity `register` registers with — read the same way, for the same reason |
+
+Boards have no command yet — `PlatformClient.list_boards` and `.rankings` read them from Python.
+Both take the key when one is set and work without: a public board is readable by anyone, a tenant's
+board only by its members.
+
+A board row reads `<display name>#<tag>`. The name is an alias and is not unique — a board may hide
+it altogether — so the tag is what tells two rows apart, and it is how you find your own: it is the
+same on every board you appear on.
+
+## From Python
+
+```python
+from platform_client.client import PlatformClient
+from platform_client.evals import EvalRef
+from platform_client.images import ImageRef
+from platform_client.requests import SubmissionCreateRequest
+
+with PlatformClient(api_key=key) as client:
+    created = client.create_submission(
+        SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('robolab.public_subset'))
+    )
+    view = client.get_submission(created.submission_id)
+```
+
+An **eval** is the whole of what a submission chooses: it names a task suite and the embodiment that
+runs it — one simulator, or one real robot — so there is no second axis to get wrong. The platform
+owns the set of names; asking for one it does not offer raises a `PlatformError` whose `evals`
+carries the ones it does.
+
+Ids are 64-bit ints in Python and bare lowercase hex on the wire; closed sets are `IntEnum`s carried
+as slugs. A non-2xx response raises `PlatformError`, which carries the parsed error envelope: `code`
+for a program, `message` for a human, `reason_code` where a terminal caller fault has one, `quota`
+where a 429 names the rule that refused the request, and `evals` where the eval asked for is not one
+of them.
+
+`users.me` reports the plan's rules as a list of `QuotaLimit`, each with its own key, window and
+subject; `MeResponse.quota_for(QUOTA_SUBMISSIONS_DAY)` reads one by key, from the keys the package
+publishes beside `QuotaLimit`.

--- a/client/README.md
+++ b/client/README.md
@@ -61,12 +61,12 @@ same on every board you appear on.
 ```python
 from platform_client.client import PlatformClient
 from platform_client.evals import EvalRef
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import SubmissionCreateRequest
 
 with PlatformClient(api_key=key) as client:
     created = client.create_submission(
-        SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('robolab.public_subset'))
+        SubmissionCreateRequest(policy_image=PolicyImage('org/policy:v1'), eval=EvalRef('robolab.public_subset'))
     )
     view = client.get_submission(created.submission_id)
 ```

--- a/client/platform_client/boards.py
+++ b/client/platform_client/boards.py
@@ -1,0 +1,25 @@
+"""Board references — the slug a ranking board is read by.
+
+The platform owns the set of slugs. This type refuses only what could never be one, so a board
+this client has never heard of still reaches the server, which answers with what it can see.
+"""
+
+from __future__ import annotations
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+
+class BoardRef(str):
+    """The slug of a board the platform publishes, as a validated `str`."""
+
+    __slots__ = ()
+
+    def __new__(cls, value: str) -> BoardRef:
+        if not value or any(c.isspace() for c in value):
+            raise ValueError(f'not a board slug: {value!r}')
+        return super().__new__(cls, value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())

--- a/client/platform_client/boards.py
+++ b/client/platform_client/boards.py
@@ -1,7 +1,6 @@
-"""Board references — the slug a ranking board is read by.
+"""The slug a ranking board is read by: `BoardRef('nebius-2026/robolab.smoke')`.
 
-The platform owns the set of slugs. This type refuses only what could never be one, so a board
-this client has never heard of still reaches the server, which answers with what it can see.
+The platform owns the set, so a board this client has never heard of still reaches the server.
 """
 
 from __future__ import annotations

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -163,9 +163,9 @@ class PlatformClient:
     def cancel_submission(self, request: CancelRequest) -> CancelResponse:
         return self._post(routes.SUBMISSIONS_CANCEL, request, CancelResponse)
 
-    def rankings(self, *, board: BoardRef, eval_version: str | None = None) -> RankingsResponse:
-        """One board by slug. An explicit `eval_version` pins a past board; otherwise the current one."""
-        query = RankingsQuery(board=board, eval_version=eval_version)
+    def rankings(self, *, board: BoardRef) -> RankingsResponse:
+        """One board by slug."""
+        query = RankingsQuery(board=board)
         return self._get(routes.RANKINGS_GET, RankingsResponse, query=query, auth=Auth.OPTIONAL)
 
     def list_boards(self) -> BoardListResponse:

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -109,15 +109,26 @@ class PlatformClient:
             client = httpx.Client(base_url=resolve_base_url(base_url), timeout=timeout)
         elif base_url is not None:
             raise ValueError('a client of your own already carries its base URL; pass one or the other')
-        elif not str(client.base_url):
-            # Every endpoint below sends a path relative to the client's own base URL, so one
-            # without it resolves against nothing and the request never leaves for a host.
-            raise ValueError('the supplied client carries no base_url; set httpx.Client(base_url=...) to the platform')
+        elif not client.base_url.is_absolute_url:
+            # Every endpoint below sends a path relative to the client's own base URL, so one that
+            # names no host — empty, or a bare path — resolves against nothing and the request never
+            # leaves for a platform.
+            raise ValueError(
+                f'the supplied client carries base_url {str(client.base_url)!r}; set '
+                f'httpx.Client(base_url=...) to an absolute URL, scheme and host, naming the platform'
+            )
         elif AUTH_HEADER in client.headers:
             # httpx MERGES client-level headers into every request, so a default here would reach
             # `users.register`, which this module declares unauthenticated and the gateway reads as
             # a registration by whoever that credential names.
             raise ValueError(f'the supplied client carries a default {AUTH_HEADER} header; pass the key as api_key')
+        elif client.auth is not None:
+            # An auth flow reaches the same requests by another route: httpx runs it on every one,
+            # so it would sign `users.register` too.
+            raise ValueError(
+                f'the supplied client carries an auth flow, which sets {AUTH_HEADER} on every '
+                f'request including `users.register`; pass the key as api_key'
+            )
         self._client = client
         self.api_key = resolve_api_key(api_key)
 

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -64,6 +64,19 @@ def resolve_api_key(api_key: ApiKey | None = None) -> ApiKey | None:
     return ApiKey(from_env) if from_env else None
 
 
+def require_absolute_url(url: str | httpx.URL, source: str) -> None:
+    """Refuse a base URL that names no host, naming the value and what it has to be.
+
+    Every endpoint sends a path relative to the client's base URL, so one that names no host — empty,
+    or a bare path — resolves against nothing and the request never leaves for a platform.
+    """
+    if httpx.URL(url).is_absolute_url:
+        return
+    raise ValueError(
+        f'{source} is {str(url)!r}, which names no host: give an absolute URL, scheme and host, naming the platform'
+    )
+
+
 def resolve_base_url(base_url: str | None = None) -> str:
     """The platform to talk to: what the caller passed, else the environment, else the default."""
     for value, source in ((base_url, 'base_url'), (os.environ.get(API_URL_ENV), API_URL_ENV)):
@@ -73,6 +86,7 @@ def resolve_base_url(base_url: str | None = None) -> str:
         # platform the caller named, and falling through would send that run to the production one.
         if not value.strip():
             raise ValueError(f'{source} is empty; name a platform, or leave it unset for {DEFAULT_PLATFORM_URL}')
+        require_absolute_url(value, source)
         return value
     return DEFAULT_PLATFORM_URL
 
@@ -104,28 +118,22 @@ class PlatformClient:
         self._owns_client = client is None
         if client is None:
             client = httpx.Client(base_url=resolve_base_url(base_url), timeout=timeout)
-        elif base_url is not None:
-            raise ValueError('a client of your own already carries its base URL; pass one or the other')
-        elif not client.base_url.is_absolute_url:
-            # Every endpoint below sends a path relative to the client's own base URL, so one that
-            # names no host — empty, or a bare path — resolves against nothing and the request never
-            # leaves for a platform.
-            raise ValueError(
-                f'the supplied client carries base_url {str(client.base_url)!r}; set '
-                f'httpx.Client(base_url=...) to an absolute URL, scheme and host, naming the platform'
-            )
-        elif AUTH_HEADER in client.headers:
-            # httpx MERGES client-level headers into every request, so a default here would reach
-            # `users.register`, which this module declares unauthenticated and the gateway reads as
-            # a registration by whoever that credential names.
-            raise ValueError(f'the supplied client carries a default {AUTH_HEADER} header; pass the key as api_key')
-        elif client.auth is not None:
-            # An auth flow reaches the same requests by another route: httpx runs it on every one,
-            # so it would sign `users.register` too.
-            raise ValueError(
-                f'the supplied client carries an auth flow, which sets {AUTH_HEADER} on every '
-                f'request including `users.register`; pass the key as api_key'
-            )
+        else:
+            if base_url is not None:
+                raise ValueError('a client of your own already carries its base URL; pass one or the other')
+            require_absolute_url(client.base_url, "the supplied client's base_url")
+            if AUTH_HEADER in client.headers:
+                # httpx MERGES client-level headers into every request, so a default here would reach
+                # `users.register`, which this module declares unauthenticated and the gateway reads
+                # as a registration by whoever that credential names.
+                raise ValueError(f'the supplied client carries a default {AUTH_HEADER} header; pass the key as api_key')
+            if client.auth is not None:
+                # An auth flow reaches the same requests by another route: httpx runs it on every
+                # one, so it would sign `users.register` too.
+                raise ValueError(
+                    f'the supplied client carries an auth flow, which sets {AUTH_HEADER} on every '
+                    f'request including `users.register`; pass the key as api_key'
+                )
         self._client = client
         self.api_key = resolve_api_key(api_key)
 
@@ -199,7 +207,12 @@ class PlatformClient:
         # Not `>= 400`: httpx follows no redirect by default, so a 3xx arrives here with a body that
         # is not an envelope and would surface as a parse error instead of the promised PlatformError.
         if not 200 <= response.status_code < 300:
-            raise PlatformError.from_payload(response.status_code, _decode(response))
+            try:
+                payload: object = response.json()
+            except ValueError:
+                # A failure need not carry an envelope at all: a proxy's HTML 502 arrives here too.
+                payload = response.text
+            raise PlatformError.from_payload(response.status_code, payload)
         return response
 
     def close(self) -> None:
@@ -214,10 +227,3 @@ class PlatformClient:
         self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
     ) -> None:
         self.close()
-
-
-def _decode(response: httpx.Response) -> object:
-    try:
-        return response.json()
-    except ValueError:
-        return response.text

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -49,6 +49,10 @@ DEFAULT_PLATFORM_URL = 'https://platform.positronic.ro'
 
 # How a caller is configured. Both secrets are read from the environment and never taken as an
 # argument: a command line is readable by every process on the box and lands in shell history.
+# Named because three places agree on it: what an authenticated call sends, what an unauthenticated
+# one must not, and what a caller's own client may therefore not default.
+AUTH_HEADER = 'Authorization'
+
 API_URL_ENV = 'POSITRONIC_PLATFORM_URL'
 API_KEY_ENV = 'POSITRONIC_PLATFORM_API_KEY'
 CREDENTIAL_ENV = 'POSITRONIC_PLATFORM_CREDENTIAL'
@@ -94,6 +98,11 @@ class PlatformClient:
             client = httpx.Client(base_url=resolve_base_url(base_url), timeout=timeout)
         elif base_url is not None:
             raise ValueError('a client of your own already carries its base URL; pass one or the other')
+        elif AUTH_HEADER in client.headers:
+            # httpx MERGES client-level headers into every request, so a default here would reach
+            # `users.register`, which this module declares unauthenticated and the gateway reads as
+            # a registration by whoever that credential names.
+            raise ValueError(f'the supplied client carries a default {AUTH_HEADER} header; pass the key as api_key')
         self._client = client
         self.api_key = api_key
 
@@ -149,7 +158,7 @@ class PlatformClient:
         if auth is Auth.REQUIRED and self.api_key is None:
             raise ValueError(f'{path} needs an API key; set .api_key from a users.register response')
         if auth is not Auth.NONE and self.api_key is not None:
-            headers['Authorization'] = f'Bearer {self.api_key}'
+            headers[AUTH_HEADER] = f'Bearer {self.api_key}'
         response = self._client.request(method, path, headers=headers, **kwargs)
         # Not `>= 400`: httpx follows no redirect by default, so a 3xx arrives here with a body that
         # is not an envelope and would surface as a parse error instead of the promised PlatformError.

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -1,10 +1,12 @@
 """`PlatformClient` — one method per gateway endpoint, request model in, response model out.
 
-A response is validated from its raw bytes rather than from a decoded object: an id is hex text on
-the wire, and only the JSON schema enforces that — decoding first would take a number as well.
+    with PlatformClient() as client:
+        client.register(RegisterRequest(credential=..., alias=...))  # keeps the key it returns
+        client.create_submission(SubmissionCreateRequest(policy_image=..., eval=...))
 
-A non-2xx response raises `PlatformError` carrying the parsed error envelope. `api_key` is a plain
-attribute: `users.register` returns one, and every authenticated call sends whatever is set.
+The platform is `base_url`, else `POSITRONIC_PLATFORM_URL`, else production; the key is `api_key`,
+else `POSITRONIC_PLATFORM_API_KEY`, else whatever `register` came back with. A non-2xx raises
+`PlatformError` carrying the error envelope.
 """
 
 from __future__ import annotations
@@ -57,6 +59,14 @@ API_KEY_ENV = 'POSITRONIC_PLATFORM_API_KEY'
 CREDENTIAL_ENV = 'POSITRONIC_PLATFORM_CREDENTIAL'
 
 
+def resolve_api_key(api_key: ApiKey | None = None) -> ApiKey | None:
+    """The key to authenticate with: what the caller passed, else the environment, else none."""
+    if api_key is not None:
+        return api_key
+    from_env = os.environ.get(API_KEY_ENV)
+    return ApiKey(from_env) if from_env else None
+
+
 def resolve_base_url(base_url: str | None = None) -> str:
     """The platform to talk to: what the caller passed, else the environment, else the default."""
     for value, source in ((base_url, 'base_url'), (os.environ.get(API_URL_ENV), API_URL_ENV)):
@@ -82,10 +92,8 @@ class Auth(Enum):
 class PlatformClient:
     """A caller's handle on one platform.
 
-    With no `base_url` it reads `API_URL_ENV`, and falls back to `DEFAULT_PLATFORM_URL` — so a user
-    configures nothing, a developer exports one variable, and a caller with a URL of its own passes
-    it. Pass an `httpx.Client` instead when the transport matters (an in-process ASGI transport, a
-    custom retry or proxy configuration); it carries its own base URL.
+    Pass an `httpx.Client` instead of a `base_url` when the transport matters (an in-process ASGI
+    transport, a proxy, a retry policy); it carries its own base URL, so the two are exclusive.
     """
 
     def __init__(
@@ -111,13 +119,20 @@ class PlatformClient:
             # a registration by whoever that credential names.
             raise ValueError(f'the supplied client carries a default {AUTH_HEADER} header; pass the key as api_key')
         self._client = client
-        self.api_key = api_key
+        self.api_key = resolve_api_key(api_key)
 
     # --- endpoints ---------------------------------------------------------------------------
 
     def register(self, request: RegisterRequest) -> RegisterResponse:
-        """Create-or-return a user. A key comes back only on a first registration or a `rotate`."""
-        return self._post(routes.USERS_REGISTER, request, RegisterResponse, auth=Auth.NONE)
+        """Create-or-return a user, KEEPING any key it returns — the next call is authenticated.
+
+        A key comes back only on a first registration or a `rotate`; a repeat registration answers
+        `existing` with none, and the client goes on holding whatever it already had.
+        """
+        response = self._post(routes.USERS_REGISTER, request, RegisterResponse, auth=Auth.NONE)
+        if response.api_key is not None:
+            self.api_key = response.api_key
+        return response
 
     def me(self) -> MeResponse:
         return self._get(routes.USERS_ME, MeResponse)
@@ -151,6 +166,8 @@ class PlatformClient:
 
     # --- plumbing ----------------------------------------------------------------------------
 
+    # Validated from the raw bytes, never from a decoded object: an id is hex text on the wire and
+    # only the JSON schema enforces that, so decoding first would take a number as well.
     def _get(self, path: str, model: type[M], *, query: BaseModel | None = None, auth: Auth = Auth.REQUIRED) -> M:
         return model.model_validate_json(self._send('GET', path, query=query, auth=auth).content)
 
@@ -167,7 +184,7 @@ class PlatformClient:
             kwargs['params'] = query.model_dump(mode='json', exclude_none=True)
         headers: dict[str, str] = {}
         if auth is Auth.REQUIRED and self.api_key is None:
-            raise ValueError(f'{path} needs an API key; set .api_key from a users.register response')
+            raise ValueError(f'{path} needs an API key: pass api_key=, set {API_KEY_ENV}, or call register() first')
         if auth is not Auth.NONE and self.api_key is not None:
             headers[AUTH_HEADER] = f'Bearer {self.api_key}'
         response = self._client.request(method, path, headers=headers, **kwargs)

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -16,6 +16,7 @@ from typing import Any, Self, TypeVar
 
 import httpx
 from platform_client import routes
+from platform_client.boards import BoardRef
 from platform_client.errors import PlatformError
 from platform_client.ids import ApiKey, SubmissionId
 from platform_client.requests import (
@@ -129,7 +130,7 @@ class PlatformClient:
     def cancel_submission(self, request: CancelRequest) -> CancelResponse:
         return self._post(routes.SUBMISSIONS_CANCEL, request, CancelResponse)
 
-    def rankings(self, *, board: str, eval_version: str | None = None) -> RankingsResponse:
+    def rankings(self, *, board: BoardRef, eval_version: str | None = None) -> RankingsResponse:
         """One board by slug. An explicit `eval_version` pins a past board; otherwise the current one."""
         query = RankingsQuery(board=board, eval_version=eval_version)
         return self._get(routes.RANKINGS_GET, RankingsResponse, query=query, auth=Auth.OPTIONAL)

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -1,0 +1,178 @@
+"""`PlatformClient` — one method per gateway endpoint, request model in, response model out.
+
+A response is validated from its raw bytes rather than from a decoded object: an id is hex text on
+the wire, and only the JSON schema enforces that — decoding first would take a number as well.
+
+A non-2xx response raises `PlatformError` carrying the parsed error envelope. `api_key` is a plain
+attribute: `users.register` returns one, and every authenticated call sends whatever is set.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum, auto
+from types import TracebackType
+from typing import Any, Self, TypeVar
+
+import httpx
+from platform_client import routes
+from platform_client.errors import PlatformError
+from platform_client.ids import ApiKey, SubmissionId
+from platform_client.requests import (
+    CancelRequest,
+    RankingsQuery,
+    RegisterRequest,
+    SubmissionCreateRequest,
+    SubmissionGetQuery,
+)
+from platform_client.responses import (
+    BoardListResponse,
+    CancelResponse,
+    MeResponse,
+    RankingsResponse,
+    RegisterResponse,
+    SubmissionCreateResponse,
+    SubmissionListResponse,
+    SubmissionView,
+)
+from pydantic import BaseModel, TypeAdapter
+
+M = TypeVar('M', bound=BaseModel)
+
+_SUBMISSION_VIEW: TypeAdapter[SubmissionView] = TypeAdapter(SubmissionView)
+
+DEFAULT_TIMEOUT_S = 30.0
+
+# The platform a caller reaches with no configuration at all. A user should never have to know a
+# URL; the environment variable below is for a developer pointing at a gateway of their own.
+DEFAULT_PLATFORM_URL = 'https://platform.positronic.ro'
+
+# How a caller is configured. Both secrets are read from the environment and never taken as an
+# argument: a command line is readable by every process on the box and lands in shell history.
+API_URL_ENV = 'POSITRONIC_PLATFORM_URL'
+API_KEY_ENV = 'POSITRONIC_PLATFORM_API_KEY'
+CREDENTIAL_ENV = 'POSITRONIC_PLATFORM_CREDENTIAL'
+
+
+def resolve_base_url(base_url: str | None = None) -> str:
+    """The platform to talk to: what the caller passed, else the environment, else the default.
+
+    One owner for the precedence, so a command and a script that skip different steps of it cannot
+    end up talking to different platforms.
+    """
+    return base_url or os.environ.get(API_URL_ENV) or DEFAULT_PLATFORM_URL
+
+
+class Auth(Enum):
+    """What an endpoint does with the client's API key."""
+
+    REQUIRED = auto()
+    # Sent when one is set: a public board answers either way, a tenant's board only with a key.
+    OPTIONAL = auto()
+    NONE = auto()
+
+
+class PlatformClient:
+    """A caller's handle on one platform.
+
+    With no `base_url` it reads `API_URL_ENV`, and falls back to `DEFAULT_PLATFORM_URL` — so a user
+    configures nothing, a developer exports one variable, and a caller with a URL of its own passes
+    it. Pass an `httpx.Client` instead when the transport matters (an in-process ASGI transport, a
+    custom retry or proxy configuration); it carries its own base URL.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        api_key: ApiKey | None = None,
+        timeout: float = DEFAULT_TIMEOUT_S,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._owns_client = client is None
+        if client is None:
+            client = httpx.Client(base_url=resolve_base_url(base_url), timeout=timeout)
+        elif base_url is not None:
+            raise ValueError('a client of your own already carries its base URL; pass one or the other')
+        self._client = client
+        self.api_key = api_key
+
+    # --- endpoints ---------------------------------------------------------------------------
+
+    def register(self, request: RegisterRequest) -> RegisterResponse:
+        """Create-or-return a user. A key comes back only on a first registration or a `rotate`."""
+        return self._post(routes.USERS_REGISTER, request, RegisterResponse, auth=Auth.NONE)
+
+    def me(self) -> MeResponse:
+        return self._get(routes.USERS_ME, MeResponse)
+
+    def create_submission(self, request: SubmissionCreateRequest) -> SubmissionCreateResponse:
+        return self._post(routes.SUBMISSIONS_CREATE, request, SubmissionCreateResponse)
+
+    def list_submissions(self) -> SubmissionListResponse:
+        """The caller's own submissions — or every user's, for an admin or service principal."""
+        return self._get(routes.SUBMISSIONS_LIST, SubmissionListResponse)
+
+    def get_submission(self, submission_id: SubmissionId) -> SubmissionView:
+        query = SubmissionGetQuery(id=submission_id)
+        return _SUBMISSION_VIEW.validate_json(self._send('GET', routes.SUBMISSIONS_GET, query=query).content)
+
+    def cancel_submission(self, request: CancelRequest) -> CancelResponse:
+        return self._post(routes.SUBMISSIONS_CANCEL, request, CancelResponse)
+
+    def rankings(self, *, board: str, eval_version: str | None = None) -> RankingsResponse:
+        """One board by slug. An explicit `eval_version` pins a past board; otherwise the current one."""
+        query = RankingsQuery(board=board, eval_version=eval_version)
+        return self._get(routes.RANKINGS_GET, RankingsResponse, query=query, auth=Auth.OPTIONAL)
+
+    def list_boards(self) -> BoardListResponse:
+        """The boards this caller can read: the public ones, plus their tenant's once a key is set."""
+        return self._get(routes.RANKINGS_LIST, BoardListResponse, auth=Auth.OPTIONAL)
+
+    # --- plumbing ----------------------------------------------------------------------------
+
+    def _get(self, path: str, model: type[M], *, query: BaseModel | None = None, auth: Auth = Auth.REQUIRED) -> M:
+        return model.model_validate_json(self._send('GET', path, query=query, auth=auth).content)
+
+    def _post(self, path: str, request: BaseModel, model: type[M], *, auth: Auth = Auth.REQUIRED) -> M:
+        body = request.model_dump(mode='json')
+        return model.model_validate_json(self._send('POST', path, json=body, auth=auth).content)
+
+    def _send(
+        self, method: str, path: str, *, query: BaseModel | None = None, auth: Auth = Auth.REQUIRED, **kwargs: Any
+    ) -> httpx.Response:
+        # `exclude_none` is what makes an unset parameter absent from the URL rather than an empty
+        # value, which the gateway would have to tell apart from a caller that meant the empty string.
+        if query is not None:
+            kwargs['params'] = query.model_dump(mode='json', exclude_none=True)
+        headers: dict[str, str] = {}
+        if auth is Auth.REQUIRED and self.api_key is None:
+            raise ValueError(f'{path} needs an API key; set .api_key from a users.register response')
+        if auth is not Auth.NONE and self.api_key is not None:
+            headers['Authorization'] = f'Bearer {self.api_key}'
+        response = self._client.request(method, path, headers=headers, **kwargs)
+        # Not `>= 400`: httpx follows no redirect by default, so a 3xx arrives here with a body that
+        # is not an envelope and would surface as a parse error instead of the promised PlatformError.
+        if not 200 <= response.status_code < 300:
+            raise PlatformError.from_payload(response.status_code, _decode(response))
+        return response
+
+    def close(self) -> None:
+        """Close the underlying transport, unless the caller supplied its own client."""
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+    ) -> None:
+        self.close()
+
+
+def _decode(response: httpx.Response) -> object:
+    try:
+        return response.json()
+    except ValueError:
+        return response.text

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -44,14 +44,11 @@ M = TypeVar('M', bound=BaseModel)
 
 DEFAULT_TIMEOUT_S = 30.0
 
-# The platform a caller reaches with no configuration at all. A user should never have to know a
-# URL; the environment variable below is for a developer pointing at a gateway of their own.
+# The platform a caller reaches with no configuration at all.
 DEFAULT_PLATFORM_URL = 'https://platform.positronic.ro'
 
-# How a caller is configured. Both secrets are read from the environment and never taken as an
-# argument: a command line is readable by every process on the box and lands in shell history.
-# Named because three places agree on it: what an authenticated call sends, what an unauthenticated
-# one must not, and what a caller's own client may therefore not default.
+# What an authenticated call sends, what `users.register` must not, and what a caller's own client
+# may therefore not default — three places that have to agree.
 AUTH_HEADER = 'Authorization'
 
 API_URL_ENV = 'POSITRONIC_PLATFORM_URL'

--- a/client/platform_client/client.py
+++ b/client/platform_client/client.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 from enum import Enum, auto
 from types import TracebackType
-from typing import Any, Self, TypeVar
+from typing import Any, ClassVar, Self, TypeVar
 
 import httpx
 from platform_client import routes
@@ -40,8 +40,6 @@ from pydantic import BaseModel, TypeAdapter
 
 M = TypeVar('M', bound=BaseModel)
 
-_SUBMISSION_VIEW: TypeAdapter[SubmissionView] = TypeAdapter(SubmissionView)
-
 DEFAULT_TIMEOUT_S = 30.0
 
 # The platform a caller reaches with no configuration at all. A user should never have to know a
@@ -60,12 +58,16 @@ CREDENTIAL_ENV = 'POSITRONIC_PLATFORM_CREDENTIAL'
 
 
 def resolve_base_url(base_url: str | None = None) -> str:
-    """The platform to talk to: what the caller passed, else the environment, else the default.
-
-    One owner for the precedence, so a command and a script that skip different steps of it cannot
-    end up talking to different platforms.
-    """
-    return base_url or os.environ.get(API_URL_ENV) or DEFAULT_PLATFORM_URL
+    """The platform to talk to: what the caller passed, else the environment, else the default."""
+    for value, source in ((base_url, 'base_url'), (os.environ.get(API_URL_ENV), API_URL_ENV)):
+        if value is None:
+            continue
+        # Empty is a misconfiguration, not a request for the default: `--platform-url=` reads as a
+        # platform the caller named, and falling through would send that run to the production one.
+        if not value.strip():
+            raise ValueError(f'{source} is empty; name a platform, or leave it unset for {DEFAULT_PLATFORM_URL}')
+        return value
+    return DEFAULT_PLATFORM_URL
 
 
 class Auth(Enum):
@@ -99,6 +101,10 @@ class PlatformClient:
             client = httpx.Client(base_url=resolve_base_url(base_url), timeout=timeout)
         elif base_url is not None:
             raise ValueError('a client of your own already carries its base URL; pass one or the other')
+        elif not str(client.base_url):
+            # Every endpoint below sends a path relative to the client's own base URL, so one
+            # without it resolves against nothing and the request never leaves for a host.
+            raise ValueError('the supplied client carries no base_url; set httpx.Client(base_url=...) to the platform')
         elif AUTH_HEADER in client.headers:
             # httpx MERGES client-level headers into every request, so a default here would reach
             # `users.register`, which this module declares unauthenticated and the gateway reads as
@@ -123,9 +129,13 @@ class PlatformClient:
         """The caller's own submissions — or every user's, for an admin or service principal."""
         return self._get(routes.SUBMISSIONS_LIST, SubmissionListResponse)
 
+    # The view is a discriminated union rather than a model, so it validates through an adapter.
+    # Built once, because building one costs more than the validation it then does.
+    _SUBMISSION_VIEW: ClassVar[TypeAdapter[SubmissionView]] = TypeAdapter(SubmissionView)
+
     def get_submission(self, submission_id: SubmissionId) -> SubmissionView:
         query = SubmissionGetQuery(id=submission_id)
-        return _SUBMISSION_VIEW.validate_json(self._send('GET', routes.SUBMISSIONS_GET, query=query).content)
+        return self._SUBMISSION_VIEW.validate_json(self._send('GET', routes.SUBMISSIONS_GET, query=query).content)
 
     def cancel_submission(self, request: CancelRequest) -> CancelResponse:
         return self._post(routes.SUBMISSIONS_CANCEL, request, CancelResponse)

--- a/client/platform_client/enums.py
+++ b/client/platform_client/enums.py
@@ -1,8 +1,7 @@
 """The closed sets a caller sees: error codes, terminal reason codes, submission and key status.
 
-Every member carries an explicit value and `INVALID = 0` is the unset/parse-failure sentinel. The
-values are stored durably, so they are append-only forever: add members, never renumber or reuse.
-Caller-visible surfaces carry the slug (`name.lower()`) — see `platform_client.slug`.
+The values are stored durably, so members are append-only forever: add, never renumber or reuse.
+`INVALID = 0` is the unset/parse-failure sentinel; the wire form is the slug (`platform_client.slug`).
 """
 
 from __future__ import annotations

--- a/client/platform_client/enums.py
+++ b/client/platform_client/enums.py
@@ -1,0 +1,133 @@
+"""The closed sets a caller sees: error codes, terminal reason codes, submission and key status.
+
+Every member carries an explicit value and `INVALID = 0` is the unset/parse-failure sentinel. The
+values are stored durably, so they are append-only forever: add members, never renumber or reuse.
+Caller-visible surfaces carry the slug (`name.lower()`) — see `platform_client.slug`.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum, unique
+
+
+@unique
+class ErrorCode(IntEnum):
+    """The `code` in an error envelope — the outcome of a REQUEST.
+
+    A run that fails is reported through submission status plus a `ReasonCode`, never one of these.
+    """
+
+    INVALID = 0
+    bad_request = 1
+    unauthorized = 2
+    forbidden = 3
+    not_found = 4
+    quota_exceeded = 5
+    transaction_conflict = 6  # one transaction key, two different submissions
+    registry_unreachable = 7  # retryable: no submission row, no quota event
+    # Retryable 503: an upstream dependency (the identity provider, the orchestrator) timed out,
+    # 5xx'd or rate-limited — distinct from a real auth failure, which is a 401.
+    upstream_unavailable = 8
+    # The eval exists but is not accepting submissions; one that does not exist is a not_found,
+    # whose details carry the evals this platform does offer.
+    eval_unavailable = 9
+    internal_error = 10
+
+
+@unique
+class ReasonCode(IntEnum):
+    """Closed terminal-failure taxonomy for a submission.
+
+    Split by fault: a platform fault refunds the caller's quota, a caller fault charges it.
+    """
+
+    INVALID = 0
+
+    # caller faults (charged)
+    image_unpullable = 1
+    image_too_large = 2
+    invalid_flags = 3
+    policy_setup_crash = 4
+    policy_inference_crash = 5
+    policy_oom = 6
+    latency_budget_exceeded = 7
+    wall_clock_exceeded = 8
+
+    # platform / provider faults (refunded)
+    internal_error = 9
+    quota_exceeded = 10
+    provision_wedged = 11
+    runner_unresponsive = 12
+
+
+@unique
+class SubmissionStatus(IntEnum):
+    """The submission lifecycle: pending -> submitting -> running -> finished|errored|cancelled.
+
+    `submitting` is the internal claim state; the gateway reports it as `pending`, so it never
+    reaches a caller.
+    """
+
+    INVALID = 0
+    pending = 1
+    submitting = 2
+    running = 3
+    finished = 4
+    errored = 5
+    cancelled = 6
+
+
+@unique
+class KeyStatus(IntEnum):
+    """What `users.register` did with the caller's API key.
+
+    `existing` carries no key: the plaintext is unreconstructable, so a re-register without
+    `rotate` returns none.
+    """
+
+    INVALID = 0
+    created = 1
+    existing = 2
+    rotated = 3
+
+
+@unique
+class OnExhausted(IntEnum):
+    """What a quota rule does once its limit is spent: refuse the request, or admit it and bill it."""
+
+    INVALID = 0
+    block = 1
+    meter = 2
+
+
+@unique
+class QuotaSubject(IntEnum):
+    """Whose allowance a quota rule draws on."""
+
+    INVALID = 0
+    user = 1
+    tenant = 2
+
+
+@unique
+class BoardVisibility(IntEnum):
+    """Who may read a board: anyone, or the members of the tenant that owns it."""
+
+    INVALID = 0
+    public = 1
+    tenant = 2
+
+
+# Charged, undecided, still holding a concurrency slot.
+ACTIVE_STATUSES: frozenset[SubmissionStatus] = frozenset({
+    SubmissionStatus.pending,
+    SubmissionStatus.submitting,
+    SubmissionStatus.running,
+})
+
+# Decided and immutable.
+TERMINAL_STATUSES: frozenset[SubmissionStatus] = frozenset({
+    SubmissionStatus.finished,
+    SubmissionStatus.errored,
+    SubmissionStatus.cancelled,
+})

--- a/client/platform_client/enums.py
+++ b/client/platform_client/enums.py
@@ -131,3 +131,7 @@ TERMINAL_STATUSES: frozenset[SubmissionStatus] = frozenset({
     SubmissionStatus.errored,
     SubmissionStatus.cancelled,
 })
+
+# Decided, and there will never be a result to read. Derived, so a fourth terminal status joins it
+# by being terminal rather than by every caller remembering to name it.
+NO_RESULT_STATUSES: frozenset[SubmissionStatus] = TERMINAL_STATUSES - {SubmissionStatus.finished}

--- a/client/platform_client/errors.py
+++ b/client/platform_client/errors.py
@@ -1,9 +1,8 @@
-"""The error envelope every endpoint fails with, and the exception a client raises for it.
+"""The envelope every endpoint fails with, and the exception a client raises for it.
 
-Agents parse `code`; humans read `message`. `details` is open-ended per error — three keys have a
-fixed meaning: `reason_code`, carrying the terminal `ReasonCode` behind a caller-fault rejection;
-`quota`, carrying the `QuotaLimit` that refused a `quota_exceeded`; and `evals`, carrying the eval
-names this platform offers when the one asked for is not among them.
+Agents parse `code`, humans read `message`. `details` is open-ended per error, with three fixed
+keys: `reason_code` behind a caller-fault rejection, `quota` behind `quota_exceeded`, and `evals`
+carrying the names on offer when the one asked for is not among them.
 """
 
 from __future__ import annotations

--- a/client/platform_client/errors.py
+++ b/client/platform_client/errors.py
@@ -1,0 +1,103 @@
+"""The error envelope every endpoint fails with, and the exception a client raises for it.
+
+Agents parse `code`; humans read `message`. `details` is open-ended per error — three keys have a
+fixed meaning: `reason_code`, carrying the terminal `ReasonCode` behind a caller-fault rejection;
+`quota`, carrying the `QuotaLimit` that refused a `quota_exceeded`; and `evals`, carrying the eval
+names this platform offers when the one asked for is not among them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from platform_client.enums import ErrorCode, ReasonCode
+from platform_client.evals import EvalRef
+from platform_client.responses import QuotaLimit
+from platform_client.slug import Slugged, members_by_slug
+from pydantic import BaseModel, Field, ValidationError
+
+# The `details` keys the gateway writes and this module reads.
+REASON_CODE_DETAIL = 'reason_code'
+QUOTA_DETAIL = 'quota'
+EVALS_DETAIL = 'evals'
+
+
+class ApiErrorBody(BaseModel):
+    code: Slugged[ErrorCode]
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ErrorEnvelope(BaseModel):
+    error: ApiErrorBody
+
+
+class PlatformError(Exception):
+    """A non-2xx response from the platform, carrying the parsed envelope."""
+
+    def __init__(self, envelope: ErrorEnvelope, *, http_status: int) -> None:
+        super().__init__(f'{envelope.error.code.name}: {envelope.error.message}')
+        self.envelope = envelope
+        self.http_status = http_status
+
+    @property
+    def code(self) -> ErrorCode:
+        return self.envelope.error.code
+
+    @property
+    def message(self) -> str:
+        return self.envelope.error.message
+
+    @property
+    def details(self) -> dict[str, Any]:
+        return self.envelope.error.details
+
+    @property
+    def reason_code(self) -> ReasonCode | None:
+        """The terminal reason behind a caller fault, when the failure carries one.
+
+        `None` means the failure carries no reason. A reason this client cannot read is
+        `ReasonCode.INVALID` instead, so a gateway sending a code from a newer taxonomy — or a
+        malformed one — is distinguishable from one sending none at all.
+        """
+        if REASON_CODE_DETAIL not in self.details:
+            return None
+        raw = self.details[REASON_CODE_DETAIL]
+        return members_by_slug(ReasonCode).get(raw, ReasonCode.INVALID) if isinstance(raw, str) else ReasonCode.INVALID
+
+    @property
+    def quota(self) -> QuotaLimit | None:
+        """The rule that refused the request, when the failure carries one."""
+        raw = self.details.get(QUOTA_DETAIL)
+        return QuotaLimit.model_validate(raw) if isinstance(raw, dict) else None
+
+    @property
+    def evals(self) -> list[EvalRef] | None:
+        """The evals this platform offers, when the failure is that the one asked for is not one.
+
+        The set lives on the server, so a caller naming an eval it does not have learns the real
+        ones from the refusal itself rather than from a list this client would have to keep current.
+        """
+        raw = self.details.get(EVALS_DETAIL)
+        if not isinstance(raw, list):
+            return None
+        return [EvalRef(name) for name in raw if isinstance(name, str)]
+
+    @classmethod
+    def from_payload(cls, http_status: int, payload: object) -> PlatformError:
+        """Build from a decoded response body, synthesizing an envelope for anything unparseable.
+
+        A proxy or load balancer between the caller and the gateway answers in its own shape, so an
+        unparseable body must still raise the same exception rather than a decode error.
+        """
+        try:
+            envelope = ErrorEnvelope.model_validate(payload)
+        except ValidationError:
+            envelope = ErrorEnvelope(
+                error=ApiErrorBody(
+                    code=ErrorCode.internal_error,
+                    message=f'unparseable error response (HTTP {http_status})',
+                    details={'body': payload},
+                )
+            )
+        return cls(envelope, http_status=http_status)

--- a/client/platform_client/errors.py
+++ b/client/platform_client/errors.py
@@ -14,12 +14,14 @@ from platform_client.enums import ErrorCode, ReasonCode
 from platform_client.evals import EvalRef
 from platform_client.responses import QuotaLimit
 from platform_client.slug import Slugged, members_by_slug
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 # The `details` keys the gateway writes and this module reads.
 REASON_CODE_DETAIL = 'reason_code'
 QUOTA_DETAIL = 'quota'
 EVALS_DETAIL = 'evals'
+
+_EVAL_LIST: TypeAdapter[list[EvalRef]] = TypeAdapter(list[EvalRef])
 
 
 class ApiErrorBody(BaseModel):
@@ -67,9 +69,14 @@ class PlatformError(Exception):
 
     @property
     def quota(self) -> QuotaLimit | None:
-        """The rule that refused the request, when the failure carries one."""
-        raw = self.details.get(QUOTA_DETAIL)
-        return QuotaLimit.model_validate(raw) if isinstance(raw, dict) else None
+        """The rule that refused the request, when the failure carries one.
+
+        Absent means absent. A present value that is not a rule is a gateway defect, so it raises
+        rather than reading as no rule at all.
+        """
+        if QUOTA_DETAIL not in self.details:
+            return None
+        return QuotaLimit.model_validate(self.details[QUOTA_DETAIL])
 
     @property
     def evals(self) -> list[EvalRef] | None:
@@ -77,11 +84,12 @@ class PlatformError(Exception):
 
         The set lives on the server, so a caller naming an eval it does not have learns the real
         ones from the refusal itself rather than from a list this client would have to keep current.
+        A present value that is not a list of names raises: a short list is worse than none, since a
+        caller would pick from it believing it whole.
         """
-        raw = self.details.get(EVALS_DETAIL)
-        if not isinstance(raw, list):
+        if EVALS_DETAIL not in self.details:
             return None
-        return [EvalRef(name) for name in raw if isinstance(name, str)]
+        return _EVAL_LIST.validate_python(self.details[EVALS_DETAIL])
 
     @classmethod
     def from_payload(cls, http_status: int, payload: object) -> PlatformError:

--- a/client/platform_client/errors.py
+++ b/client/platform_client/errors.py
@@ -8,7 +8,7 @@ names this platform offers when the one asked for is not among them.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 from platform_client.enums import ErrorCode, ReasonCode
 from platform_client.evals import EvalRef
@@ -20,8 +20,6 @@ from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 REASON_CODE_DETAIL = 'reason_code'
 QUOTA_DETAIL = 'quota'
 EVALS_DETAIL = 'evals'
-
-_EVAL_LIST: TypeAdapter[list[EvalRef]] = TypeAdapter(list[EvalRef])
 
 
 class ApiErrorBody(BaseModel):
@@ -78,6 +76,10 @@ class PlatformError(Exception):
             return None
         return QuotaLimit.model_validate(self.details[QUOTA_DETAIL])
 
+    # A list is not a model, so it validates through an adapter. Built once, because building one
+    # costs more than the validation it then does.
+    _EVAL_LIST: ClassVar[TypeAdapter[list[EvalRef]]] = TypeAdapter(list[EvalRef])
+
     @property
     def evals(self) -> list[EvalRef] | None:
         """The evals this platform offers, when the failure is that the one asked for is not one.
@@ -89,7 +91,7 @@ class PlatformError(Exception):
         """
         if EVALS_DETAIL not in self.details:
             return None
-        return _EVAL_LIST.validate_python(self.details[EVALS_DETAIL])
+        return self._EVAL_LIST.validate_python(self.details[EVALS_DETAIL])
 
     @classmethod
     def from_payload(cls, http_status: int, payload: object) -> PlatformError:

--- a/client/platform_client/evals.py
+++ b/client/platform_client/evals.py
@@ -1,0 +1,29 @@
+"""Eval references — the one name a caller picks a run by.
+
+An eval names a task suite AND the embodiment that runs it: `franka.spoons` is the wooden-spoon
+task on a real Franka, and nothing else can run it. So the caller chooses one name and the platform
+resolves everything behind it; there is no second axis to get wrong.
+
+The platform owns the set of names. This type refuses only what could never be one, so a name this
+client has never heard of still reaches the server, which answers with the ones it offers.
+"""
+
+from __future__ import annotations
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+
+class EvalRef(str):
+    """The name of an eval the platform offers, as a validated `str`."""
+
+    __slots__ = ()
+
+    def __new__(cls, value: str) -> EvalRef:
+        if not value or any(c.isspace() for c in value):
+            raise ValueError(f'not an eval name: {value!r}')
+        return super().__new__(cls, value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())

--- a/client/platform_client/evals.py
+++ b/client/platform_client/evals.py
@@ -1,11 +1,7 @@
-"""Eval references — the one name a caller picks a run by.
+"""The one name a caller picks a run by: `EvalRef('franka.spoons')`.
 
-An eval names a task suite AND the embodiment that runs it: `franka.spoons` is the wooden-spoon
-task on a real Franka, and nothing else can run it. So the caller chooses one name and the platform
-resolves everything behind it; there is no second axis to get wrong.
-
-The platform owns the set of names. This type refuses only what could never be one, so a name this
-client has never heard of still reaches the server, which answers with the ones it offers.
+A name is a task suite AND the embodiment that runs it, so there is no second axis to get wrong.
+The platform owns the set, so a name this client has never heard of still reaches the server.
 """
 
 from __future__ import annotations

--- a/client/platform_client/ids.py
+++ b/client/platform_client/ids.py
@@ -1,12 +1,9 @@
 """Platform id types: 64-bit ints in Python, bare lowercase hex on the wire.
 
-- `Id64` is the base; `UserId` and `SubmissionId` are distinct subclasses, so a transposed argument
-  fails a typecheck rather than reaching the database. A service with ids of its own subclasses it
-  too — the platform's internal run id is one, and it is not part of this contract.
-- Range is `0 < value < 2**63`; 0 is reserved as the unset sentinel.
-- The wire form is the hex string, never a JSON number — a full int64 does not survive JavaScript's
-  2**53, and the API is called from anything.
-- `TransactionKey` / `ApiKey` are opaque tokens, not ids.
+`UserId` and `SubmissionId` are distinct `Id64` subclasses, so a transposed argument fails a
+typecheck rather than reaching the database; a service with ids of its own subclasses it too. Range
+is `0 < value < 2**63`, and the wire form is never a JSON number — a full int64 does not survive
+JavaScript's 2**53. `TransactionKey` / `ApiKey` are opaque tokens, not ids.
 """
 
 from __future__ import annotations

--- a/client/platform_client/ids.py
+++ b/client/platform_client/ids.py
@@ -1,0 +1,89 @@
+"""Platform id types: 64-bit ints in Python, bare lowercase hex on the wire.
+
+- `Id64` is the base; `UserId` and `SubmissionId` are distinct subclasses, so a transposed argument
+  fails a typecheck rather than reaching the database. A service with ids of its own subclasses it
+  too — the platform's internal run id is one, and it is not part of this contract.
+- Range is `0 < value < 2**63`; 0 is reserved as the unset sentinel.
+- The wire form is the hex string, never a JSON number — a full int64 does not survive JavaScript's
+  2**53, and the API is called from anything.
+- `TransactionKey` / `ApiKey` are opaque tokens, not ids.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, NewType, Self
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+# Exclusive upper bound: SQLite's INTEGER is signed 64-bit, so an id must fit a positive int64.
+ID_LIMIT = 2**63
+
+# The wire form, matched whole. `int(s, 16)` alone is too generous: it also takes a `0x` prefix, a
+# sign and embedded underscores, so three spellings would name one id.
+_HEX = re.compile(r'[0-9a-fA-F]+')
+
+
+class Id64(int):
+    """A platform id. Subclass it per resource; never use the base type in a signature."""
+
+    __slots__ = ()
+
+    def __new__(cls, value: int) -> Self:
+        # bool is an int subclass, and `Id64(True)` is always a caller bug rather than the id 1.
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f'{cls.__name__} takes an int; use {cls.__name__}.parse() for a hex string')
+        if not 0 < value < ID_LIMIT:
+            raise ValueError(f'{cls.__name__} out of range: {value} (expected 0 < value < 2**63)')
+        return super().__new__(cls, value)
+
+    @classmethod
+    def parse(cls, value: int | str) -> Self:
+        """Accept the wire form (case-insensitive hex, no prefix) or a raw int."""
+        if isinstance(value, str):
+            if not _HEX.fullmatch(value):
+                raise ValueError(f'{cls.__name__} must be bare hexadecimal: {value!r}')
+            value = int(value, 16)
+        return cls(value)
+
+    def to_str(self) -> str:
+        return format(int(self), 'x')
+
+    def __str__(self) -> str:
+        return self.to_str()
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}.parse({self.to_str()!r})'
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.json_or_python_schema(
+            # JSON carries the hex string only, so a server that emitted a number is a hard error here
+            # rather than a value silently truncated by whatever parsed it upstream.
+            json_schema=core_schema.no_info_after_validator_function(cls.parse, core_schema.str_schema()),
+            python_schema=core_schema.no_info_plain_validator_function(cls.parse),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                cls.to_str, return_schema=core_schema.str_schema(), when_used='always'
+            ),
+        )
+
+
+class UserId(Id64):
+    """A registered user."""
+
+    __slots__ = ()
+
+
+class SubmissionId(Id64):
+    """One user's run request, as the gateway records it."""
+
+    __slots__ = ()
+
+
+# A client-supplied dedup token, opaque to the platform: whatever the caller sends, echoed by nothing.
+# Two submissions under one key are one transaction — the second returns the first, and is not charged.
+TransactionKey = NewType('TransactionKey', str)
+
+# The plaintext API key, returned by `users.register` exactly once and stored only as a hash.
+ApiKey = NewType('ApiKey', str)

--- a/client/platform_client/images.py
+++ b/client/platform_client/images.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import re
+
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
+
+# `<algorithm>:<hex>`, matched whole. The length is the registry's business — what is checked here
+# is the shape a typo breaks: a missing half, or an encoding that is not hex.
+_DIGEST = re.compile(r'[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]+')
 
 
 class ImageRef(str):
@@ -18,6 +24,14 @@ class ImageRef(str):
         name, sep, digest = value.partition('@')
         if not name or any(c.isspace() for c in value) or (sep and not digest) or '@' in digest:
             raise ValueError(f'not an image reference: {value!r}')
+        # A tag or a digest with nothing behind it is a typo, and one the registry only refuses at
+        # submission time — where an unpullable image is a charged terminal submission.
+        if sep and not _DIGEST.fullmatch(digest):
+            raise ValueError(f'not a digest: {digest!r}')
+        # A trailing colon is an empty tag. A registry port (`reg.io:5000/org/policy`) is not one:
+        # what follows its colon is the rest of the path, so only an EMPTY remainder is the typo.
+        if name.rpartition(':')[1] and not name.rpartition(':')[2]:
+            raise ValueError(f'image reference has an empty tag: {value!r}')
         return super().__new__(cls, value)
 
     @classmethod

--- a/client/platform_client/images.py
+++ b/client/platform_client/images.py
@@ -24,8 +24,7 @@ class ImageRef(str):
         name, sep, digest = value.partition('@')
         if not name or any(c.isspace() for c in value) or (sep and not digest) or '@' in digest:
             raise ValueError(f'not an image reference: {value!r}')
-        # A tag or a digest with nothing behind it is a typo, and one the registry only refuses at
-        # submission time — where an unpullable image is a charged terminal submission.
+        # A digest, where present, matches the supported grammar.
         if sep and not _DIGEST.fullmatch(digest):
             raise ValueError(f'not a digest: {digest!r}')
         # A trailing colon is an empty tag. A registry port (`reg.io:5000/org/policy`) is not one:

--- a/client/platform_client/images.py
+++ b/client/platform_client/images.py
@@ -1,0 +1,38 @@
+"""Container-image references — the one type a caller and the platform pin a policy image with."""
+
+from __future__ import annotations
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+
+class ImageRef(str):
+    """A registry reference, `name[@digest]`, as a validated `str` — no serializer, no DB adapter.
+
+    `name` is everything before the digest (repository plus any tag); `digest` is what pins the bytes.
+    """
+
+    __slots__ = ()
+
+    def __new__(cls, value: str) -> ImageRef:
+        name, sep, digest = value.partition('@')
+        if not name or any(c.isspace() for c in value) or (sep and not digest) or '@' in digest:
+            raise ValueError(f'not an image reference: {value!r}')
+        return super().__new__(cls, value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())
+
+    @property
+    def name(self) -> str:
+        return self.partition('@')[0]
+
+    @property
+    def digest(self) -> str | None:
+        return self.partition('@')[2] or None
+
+    def pinned(self, digest: str) -> ImageRef:
+        """This reference bound to `digest`, REPLACING any digest it already carries — appending
+        instead would turn an already-pinned `repo@sha256:…` into an unpullable double digest."""
+        return ImageRef(f'{self.name}@{digest}')

--- a/client/platform_client/policy_images.py
+++ b/client/platform_client/policy_images.py
@@ -7,9 +7,18 @@ import re
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 
-# `<algorithm>:<hex>`, matched whole. The length is the registry's business — what is checked here
-# is the shape a typo breaks: a missing half, or an encoding that is not hex.
-_DIGEST = re.compile(r'[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]+')
+# The reference grammar a registry parses, in one expression, split up only for reading: an
+# optional host with an optional port, a lowercase repository path, an optional tag, an optional
+# digest. Piecemeal checks kept admitting the next typo — `org/policy:bad:tag` reads as a tag to a
+# rule that only rejects an empty one, and an unpullable image is a CHARGED terminal submission.
+_HOST = r'[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
+_DOMAIN = rf'{_HOST}(?:\.{_HOST})*(?::[0-9]+)?'
+_PATH = r'[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*'
+_TAG = r'[A-Za-z0-9_][A-Za-z0-9._-]{0,127}'
+# `<algorithm>:<hex>`. The length is the registry's business — what is checked is the shape a typo
+# breaks: a missing half, or an encoding that is not hex.
+_DIGEST = r'[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]+'
+_REFERENCE = re.compile(rf'(?:{_DOMAIN}/)?{_PATH}(?:/{_PATH})*(?::{_TAG})?(?:@{_DIGEST})?')
 
 
 class PolicyImage(str):
@@ -21,16 +30,8 @@ class PolicyImage(str):
     __slots__ = ()
 
     def __new__(cls, value: str) -> PolicyImage:
-        name, sep, digest = value.partition('@')
-        if not name or any(c.isspace() for c in value) or (sep and not digest) or '@' in digest:
+        if not _REFERENCE.fullmatch(value):
             raise ValueError(f'not an image reference: {value!r}')
-        # A digest, where present, matches the supported grammar.
-        if sep and not _DIGEST.fullmatch(digest):
-            raise ValueError(f'not a digest: {digest!r}')
-        # A trailing colon is an empty tag. A registry port (`reg.io:5000/org/policy`) is not one:
-        # what follows its colon is the rest of the path, so only an EMPTY remainder is the typo.
-        if name.rpartition(':')[1] and not name.rpartition(':')[2]:
-            raise ValueError(f'image reference has an empty tag: {value!r}')
         return super().__new__(cls, value)
 
     @classmethod

--- a/client/platform_client/policy_images.py
+++ b/client/platform_client/policy_images.py
@@ -7,10 +7,8 @@ import re
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 
-# The reference grammar a registry parses, in one expression, split up only for reading: an
-# optional host with an optional port, a lowercase repository path, an optional tag, an optional
-# digest. Piecemeal checks kept admitting the next typo — `org/policy:bad:tag` reads as a tag to a
-# rule that only rejects an empty one, and an unpullable image is a CHARGED terminal submission.
+# The reference grammar a registry parses: an optional host and port, a lowercase repository path,
+# an optional tag, an optional digest. A typo it admits is an unpullable image — terminal, and CHARGED.
 _HOST = r'[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
 _DOMAIN = rf'{_HOST}(?:\.{_HOST})*(?::[0-9]+)?'
 _PATH = r'[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*'

--- a/client/platform_client/policy_images.py
+++ b/client/platform_client/policy_images.py
@@ -1,4 +1,4 @@
-"""Container-image references — the one type a caller and the platform pin a policy image with."""
+"""Policy images — the container image a submission's policy is run from."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from pydantic_core import core_schema
 _DIGEST = re.compile(r'[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]+')
 
 
-class ImageRef(str):
+class PolicyImage(str):
     """A registry reference, `name[@digest]`, as a validated `str` — no serializer, no DB adapter.
 
     `name` is everything before the digest (repository plus any tag); `digest` is what pins the bytes.
@@ -20,7 +20,7 @@ class ImageRef(str):
 
     __slots__ = ()
 
-    def __new__(cls, value: str) -> ImageRef:
+    def __new__(cls, value: str) -> PolicyImage:
         name, sep, digest = value.partition('@')
         if not name or any(c.isspace() for c in value) or (sep and not digest) or '@' in digest:
             raise ValueError(f'not an image reference: {value!r}')
@@ -45,7 +45,7 @@ class ImageRef(str):
     def digest(self) -> str | None:
         return self.partition('@')[2] or None
 
-    def pinned(self, digest: str) -> ImageRef:
+    def pinned(self, digest: str) -> PolicyImage:
         """This reference bound to `digest`, REPLACING any digest it already carries — appending
         instead would turn an already-pinned `repo@sha256:…` into an unpullable double digest."""
-        return ImageRef(f'{self.name}@{digest}')
+        return PolicyImage(f'{self.name}@{digest}')

--- a/client/platform_client/requests.py
+++ b/client/platform_client/requests.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from platform_client.boards import BoardRef
 from platform_client.evals import EvalRef
 from platform_client.ids import SubmissionId, TransactionKey
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from pydantic import BaseModel, ConfigDict, Field
 
 _FORBID_EXTRA = ConfigDict(extra='forbid')
@@ -34,9 +34,9 @@ class SubmissionCreateRequest(BaseModel):
 
     model_config = _FORBID_EXTRA
 
-    # An `ImageRef`, so a reference the registry could never resolve is refused in the caller's own
+    # A `PolicyImage`, so a reference the registry could never resolve is refused in the caller's own
     # process instead of spending a round trip to learn it.
-    policy_image: ImageRef
+    policy_image: PolicyImage
     # The whole of what the caller chooses: the eval names its own embodiment, and the platform
     # answers an unknown name with the ones it offers.
     eval: EvalRef

--- a/client/platform_client/requests.py
+++ b/client/platform_client/requests.py
@@ -1,0 +1,71 @@
+"""What a caller sends: the POST bodies, and the query models the GET endpoints take.
+
+Both halves are models so that pydantic owns the field names on both sides of the wire, and a GET's
+parameters are built by dumping one rather than by assembling a dict beside the path. A parameter
+left unset is dumped away (`exclude_none`) and is absent from the URL, never an empty value.
+
+Every model rejects unknown fields: a typo'd field is a 422, not a silently dropped input that would
+change what the submission means without the caller knowing.
+"""
+
+from __future__ import annotations
+
+from platform_client.evals import EvalRef
+from platform_client.ids import SubmissionId, TransactionKey
+from platform_client.images import ImageRef
+from pydantic import BaseModel, ConfigDict, Field
+
+_FORBID_EXTRA = ConfigDict(extra='forbid')
+
+
+class RegisterRequest(BaseModel):
+    """`users.register` — create-or-return, keyed on the external identity behind `credential`."""
+
+    model_config = _FORBID_EXTRA
+
+    credential: str
+    alias: str | None = None
+    rotate: bool = False
+
+
+class SubmissionCreateRequest(BaseModel):
+    """`submissions.create` — the run-defining fields, exactly as sent."""
+
+    model_config = _FORBID_EXTRA
+
+    # An `ImageRef`, so a reference the registry could never resolve is refused in the caller's own
+    # process instead of spending a round trip to learn it.
+    policy_image: ImageRef
+    # The whole of what the caller chooses: the eval names its own embodiment, and the platform
+    # answers an unknown name with the ones it offers.
+    eval: EvalRef
+    alias: str | None = None
+    # A present key must be non-empty: an empty string is a client bug, not "no key", and accepting
+    # it would silently drop the caller's dedup guarantee.
+    transaction_key: TransactionKey | None = Field(default=None, min_length=1)
+
+
+class CancelRequest(BaseModel):
+    """`submissions.cancel`."""
+
+    model_config = _FORBID_EXTRA
+
+    id: SubmissionId
+
+
+class SubmissionGetQuery(BaseModel):
+    """`submissions.get` — the id travels in the query string, in its hex wire form."""
+
+    model_config = _FORBID_EXTRA
+
+    id: SubmissionId
+
+
+class RankingsQuery(BaseModel):
+    """`rankings.get` — one board by slug. An `eval_version` pins a past board; omitting it asks for
+    the board as it stands."""
+
+    model_config = _FORBID_EXTRA
+
+    board: str
+    eval_version: str | None = None

--- a/client/platform_client/requests.py
+++ b/client/platform_client/requests.py
@@ -1,7 +1,7 @@
 """What a caller sends: the POST bodies, and the query models the GET endpoints take.
 
 Unknown fields are rejected, so a typo'd field is a 422 rather than a silently dropped input that
-would change what the submission means. A parameter left unset is absent from the URL, never empty.
+would change what the submission means.
 """
 
 from __future__ import annotations
@@ -59,10 +59,8 @@ class SubmissionGetQuery(BaseModel):
 
 
 class RankingsQuery(BaseModel):
-    """`rankings.get` — one board by slug. An `eval_version` pins a past board; omitting it asks for
-    the board as it stands."""
+    """`rankings.get` — one board by slug."""
 
     model_config = _FORBID_EXTRA
 
     board: BoardRef
-    eval_version: str | None = None

--- a/client/platform_client/requests.py
+++ b/client/platform_client/requests.py
@@ -1,11 +1,7 @@
 """What a caller sends: the POST bodies, and the query models the GET endpoints take.
 
-Both halves are models so that pydantic owns the field names on both sides of the wire, and a GET's
-parameters are built by dumping one rather than by assembling a dict beside the path. A parameter
-left unset is dumped away (`exclude_none`) and is absent from the URL, never an empty value.
-
-Every model rejects unknown fields: a typo'd field is a 422, not a silently dropped input that would
-change what the submission means without the caller knowing.
+Unknown fields are rejected, so a typo'd field is a 422 rather than a silently dropped input that
+would change what the submission means. A parameter left unset is absent from the URL, never empty.
 """
 
 from __future__ import annotations

--- a/client/platform_client/requests.py
+++ b/client/platform_client/requests.py
@@ -10,6 +10,7 @@ change what the submission means without the caller knowing.
 
 from __future__ import annotations
 
+from platform_client.boards import BoardRef
 from platform_client.evals import EvalRef
 from platform_client.ids import SubmissionId, TransactionKey
 from platform_client.images import ImageRef
@@ -67,5 +68,5 @@ class RankingsQuery(BaseModel):
 
     model_config = _FORBID_EXTRA
 
-    board: str
+    board: BoardRef
     eval_version: str | None = None

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -132,7 +132,6 @@ class SubmissionCreateResponse(_ReasonBearing):
 
     submission_id: SubmissionId
     policy_image_digest: str | None = None
-    eval_version: str | None = None
 
 
 class SubmissionListRow(_ReasonBearing):
@@ -277,7 +276,6 @@ class BoardSummary(BaseModel):
     board: BoardRef
     title: str
     eval: EvalRef
-    eval_version: str
     primary_metric: str
     visibility: Slugged[BoardVisibility]
 
@@ -298,6 +296,5 @@ class RankingsResponse(BaseModel):
 
     board: BoardRef
     eval: EvalRef
-    eval_version: str
     primary_metric: str
     rankings: list[RankingRow] = Field(default_factory=list)

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -56,9 +56,7 @@ class QuotaLimit(BaseModel):
     key: str  # the rule's identity, one of the published keys above — what a 429 names
     meter: str  # open set: a plan may declare one. 'submissions' | 'credits'
     unit: str  # the display unit, open for the same reason
-    # Meter units per display unit (credits: 6, submissions: 1). Consumers divide by it, so a
-    # zero would validate here and raise ZeroDivisionError in the caller instead.
-    scale: int = Field(gt=0)
+    scale: int = Field(gt=0)  # meter units per display unit (credits: 6, submissions: 1), always positive
     window: str  # a display label: 'day', '24 Jul – 23 Aug', 'concurrent'
     subject: Slugged[QuotaSubject]
     scope: list[str] = Field(default_factory=list)  # tags this rule counts; empty counts the whole meter
@@ -211,11 +209,8 @@ class CancelledSubmissionView(_TaggedView):
     status: Slugged[SubmissionStatus] = SubmissionStatus.cancelled
 
 
-# The discriminator's field name, and the fields a consumer rendering a view puts in its own header
-# line rather than in the body — named here so a model rename cannot leave a consumer excluding a
-# field that no longer exists.
+# The field the view union discriminates on, named so a rename moves the discriminator with it.
 STATUS_FIELD = 'status'
-VIEW_HEADER_FIELDS = frozenset({'id', STATUS_FIELD})
 
 
 def _status_tag(value: Any) -> str | None:

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -13,7 +13,7 @@ from platform_client.boards import BoardRef
 from platform_client.enums import BoardVisibility, KeyStatus, OnExhausted, QuotaSubject, ReasonCode, SubmissionStatus
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId, UserId
-from platform_client.slug import Slugged
+from platform_client.slug import Slugged, slug_of
 from pydantic import AfterValidator, AwareDatetime, BaseModel, Discriminator, Field, Tag, model_validator
 
 
@@ -231,16 +231,18 @@ def _status_tag(value: Any) -> str | None:
     """
     raw = value.get(STATUS_FIELD) if isinstance(value, dict) else getattr(value, STATUS_FIELD, None)
     if isinstance(raw, SubmissionStatus):
-        return raw.name.lower()
+        return slug_of(raw)
     return raw if isinstance(raw, str) else None
 
 
+# Each tag is the slug of the status its variant declares, taken from the enum rather than spelled:
+# the wire vocabulary is the enum's, so a member renamed there renames the discriminator with it.
 SubmissionView = Annotated[
-    Annotated[PendingSubmissionView, Tag('pending')]
-    | Annotated[RunningSubmissionView, Tag('running')]
-    | Annotated[ErroredSubmissionView, Tag('errored')]
-    | Annotated[FinishedSubmissionView, Tag('finished')]
-    | Annotated[CancelledSubmissionView, Tag('cancelled')],
+    Annotated[PendingSubmissionView, Tag(slug_of(SubmissionStatus.pending))]
+    | Annotated[RunningSubmissionView, Tag(slug_of(SubmissionStatus.running))]
+    | Annotated[ErroredSubmissionView, Tag(slug_of(SubmissionStatus.errored))]
+    | Annotated[FinishedSubmissionView, Tag(slug_of(SubmissionStatus.finished))]
+    | Annotated[CancelledSubmissionView, Tag(slug_of(SubmissionStatus.cancelled))],
     Discriminator(_status_tag),
 ]
 

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -39,10 +39,8 @@ class Scores(BaseModel):
     unscored: int = 0
 
 
-# The rule keys this platform's plans declare. Published because a caller matches on them: a 429
-# names one in its `details`, and `MeResponse.quota_for` takes one. Renaming a key is a contract
-# change; a plan declaring a NEW rule is not, so a key absent from this list is not an error.
-# An engagement's own rules are not published here — its words are its own (test_vocabulary).
+# The rule keys a caller matches on: a 429 names one in its `details`, and `quota_for` takes one.
+# A key absent from this list is a plan declaring its own rule, not an error.
 QUOTA_SUBMISSIONS_DAY = 'submissions.day'
 QUOTA_SUBMISSIONS_CONCURRENT = 'submissions.concurrent'
 

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -151,6 +151,14 @@ class SubmissionListResponse(BaseModel):
     submissions: list[SubmissionListRow] = Field(default_factory=list)
 
 
+# The field the view union discriminates on, named so a rename moves the discriminator with it.
+STATUS_FIELD = 'status'
+
+# The field every view identifies a submission by, named for the same reason: a renderer that
+# excludes it by a stale literal prints it twice.
+ID_FIELD = 'id'
+
+
 class _TaggedView(BaseModel):
     """One `submissions.get` variant. Its `status` default IS the tag the union selects it by, so a
     payload carrying any other status belongs to a different variant and is refused rather than
@@ -162,7 +170,7 @@ class _TaggedView(BaseModel):
 
     @model_validator(mode='after')
     def _the_status_is_this_variants_tag(self) -> Self:
-        tag = type(self).model_fields['status'].default
+        tag = type(self).model_fields[STATUS_FIELD].default
         if self.status is not tag:
             raise ValueError(f'{type(self).__name__} carries status {self.status.name}, not {tag.name}')
         return self
@@ -213,14 +221,6 @@ class CancelledSubmissionView(_TaggedView):
     id: SubmissionId
     cancelled_at: AwareDatetime | None = None
     status: Slugged[SubmissionStatus] = SubmissionStatus.cancelled
-
-
-# The field the view union discriminates on, named so a rename moves the discriminator with it.
-STATUS_FIELD = 'status'
-
-# The field every view identifies a submission by, named for the same reason: a renderer that
-# excludes it by a stale literal prints it twice.
-ID_FIELD = 'id'
 
 
 def _status_tag(value: Any) -> str | None:

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -20,9 +20,7 @@ from pydantic import AfterValidator, AwareDatetime, BaseModel, Discriminator, Fi
 
 
 def _public(status: SubmissionStatus) -> SubmissionStatus:
-    """A status as a CALLER may see it. `submitting` is the gateway's internal claim state, which it
-    reports as `pending`; a payload carrying it is a gateway that forgot, and is refused here rather
-    than left for every consumer to normalise."""
+    """A status as a CALLER may see it: `submitting` is an internal claim state, reported as `pending`."""
     if status is SubmissionStatus.submitting:
         raise ValueError(f'{status.name} is an internal state and never reaches a caller')
     return status
@@ -117,13 +115,7 @@ class MeResponse(BaseModel):
 
 
 class _ReasonBearing(BaseModel):
-    """A flat submission row carrying the terminal-failure taxonomy.
-
-    `ReasonCode` says why a run FAILED, so it belongs to `errored` and to no other status. Holding
-    the two fields together here is what refuses a `pending` payload carrying `image_unpullable` —
-    which would otherwise validate and be reported as an accepted submission. The `submissions.get`
-    variants state the same rule by giving `reason_code` only to `ErroredSubmissionView`.
-    """
+    """A flat submission row whose `reason_code` is absent unless `status` is `errored`."""
 
     status: PublicStatus
     reason_code: Slugged[ReasonCode] | None = None
@@ -227,6 +219,10 @@ class CancelledSubmissionView(_TaggedView):
 
 # The field the view union discriminates on, named so a rename moves the discriminator with it.
 STATUS_FIELD = 'status'
+
+# The field every view identifies a submission by, named for the same reason: a renderer that
+# excludes it by a stale literal prints it twice.
+ID_FIELD = 'id'
 
 
 def _status_tag(value: Any) -> str | None:

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Self
 
+from platform_client.boards import BoardRef
 from platform_client.enums import BoardVisibility, KeyStatus, OnExhausted, QuotaSubject, ReasonCode, SubmissionStatus
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId, UserId
@@ -115,7 +116,26 @@ class MeResponse(BaseModel):
         return next((limit for limit in self.quota if limit.key == key), None)
 
 
-class SubmissionCreateResponse(BaseModel):
+class _ReasonBearing(BaseModel):
+    """A flat submission row carrying the terminal-failure taxonomy.
+
+    `ReasonCode` says why a run FAILED, so it belongs to `errored` and to no other status. Holding
+    the two fields together here is what refuses a `pending` payload carrying `image_unpullable` —
+    which would otherwise validate and be reported as an accepted submission. The `submissions.get`
+    variants state the same rule by giving `reason_code` only to `ErroredSubmissionView`.
+    """
+
+    status: PublicStatus
+    reason_code: Slugged[ReasonCode] | None = None
+
+    @model_validator(mode='after')
+    def _a_reason_means_it_errored(self) -> Self:
+        if self.reason_code is not None and self.status is not SubmissionStatus.errored:
+            raise ValueError(f'reason_code {self.reason_code.name} on a {self.status.name} submission')
+        return self
+
+
+class SubmissionCreateResponse(_ReasonBearing):
     """`submissions.create` — covers a fresh create, an idempotent replay, and an unpullable image.
 
     An unpullable image is a caller fault: the submission is terminal and charged, so it comes
@@ -123,22 +143,18 @@ class SubmissionCreateResponse(BaseModel):
     """
 
     submission_id: SubmissionId
-    status: PublicStatus
     policy_image_digest: str | None = None
     eval_version: str | None = None
-    reason_code: Slugged[ReasonCode] | None = None
 
 
-class SubmissionListRow(BaseModel):
+class SubmissionListRow(_ReasonBearing):
     """One row of `submissions.list`. `user_id` attributes it — an admin listing spans users."""
 
     id: SubmissionId
     user_id: UserId
     alias: str | None = None
-    status: PublicStatus
     eval: EvalRef
     received_at: AwareDatetime
-    reason_code: Slugged[ReasonCode] | None = None
 
 
 class SubmissionListResponse(BaseModel):
@@ -264,7 +280,7 @@ class RankingRow(BaseModel):
 class BoardSummary(BaseModel):
     """One board of `rankings.list`. `board` is the slug `rankings.get` takes."""
 
-    board: str
+    board: BoardRef
     title: str
     eval: EvalRef
     eval_version: str
@@ -286,7 +302,7 @@ class RankingsResponse(BaseModel):
     guaranteed to name a field of `Scores`.
     """
 
-    board: str
+    board: BoardRef
     eval: EvalRef
     eval_version: str
     primary_metric: str

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -1,0 +1,284 @@
+"""Response models for every gateway endpoint — the typed shape both sides bind to.
+
+- Timestamps are aware UTC datetimes; the wire form is ISO 8601.
+- Ids are hex strings on the wire (`platform_client.ids`), closed sets are slugs
+  (`platform_client.slug`).
+- Locations stay plain strings: to a caller they are opaque locators.
+- `submissions.get` answers one of five variants, discriminated on the status slug.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Self
+
+from platform_client.enums import BoardVisibility, KeyStatus, OnExhausted, QuotaSubject, ReasonCode, SubmissionStatus
+from platform_client.evals import EvalRef
+from platform_client.ids import ApiKey, SubmissionId, UserId
+from platform_client.slug import Slugged
+from pydantic import AwareDatetime, BaseModel, Discriminator, Field, Tag, model_validator
+
+
+class Scores(BaseModel):
+    """The scorer's output for a finished run. `primary` is the value a board ranks on."""
+
+    primary: float | None = None
+    success_rate: float | None = None
+    per_task: dict[str, float] = Field(default_factory=dict)
+    episodes: int = 0
+    unscored: int = 0
+
+
+# The rule keys this platform's plans declare. Published because a caller matches on them: a 429
+# names one in its `details`, and `MeResponse.quota_for` takes one. Renaming a key is a contract
+# change; a plan declaring a NEW rule is not, so a key absent from this list is not an error.
+# An engagement's own rules are not published here — its words are its own (test_vocabulary).
+QUOTA_SUBMISSIONS_DAY = 'submissions.day'
+QUOTA_SUBMISSIONS_CONCURRENT = 'submissions.concurrent'
+
+
+class QuotaLimit(BaseModel):
+    """One rule of the caller's plan, and what is left of it at the moment of the read."""
+
+    key: str  # the rule's identity, one of the published keys above — what a 429 names
+    meter: str  # open set: a plan may declare one. 'submissions' | 'credits'
+    unit: str  # the display unit, open for the same reason
+    scale: int  # meter units per display unit (credits: 6, submissions: 1)
+    window: str  # a display label: 'day', '24 Jul – 23 Aug', 'concurrent'
+    subject: Slugged[QuotaSubject]
+    scope: list[str] = Field(default_factory=list)  # tags this rule counts; empty counts the whole meter
+    limit: int  # meter units
+    used: int  # meter units; may exceed limit under on_exhausted=meter
+    resets_at: AwareDatetime | None
+    on_exhausted: Slugged[OnExhausted]
+
+    @property
+    def remaining(self) -> int:
+        """Meter units left, clamped at 0."""
+        return max(self.limit - self.used, 0)
+
+
+class ArtifactRefs(BaseModel):
+    """Where a finished submission's outputs are readable."""
+
+    result: str
+
+
+# The outcomes that mint a key. `existing` is the one that does not.
+_MINTING_OUTCOMES = frozenset({KeyStatus.created, KeyStatus.rotated})
+
+
+class RegisterResponse(BaseModel):
+    """`users.register`. `api_key` is present exactly when a key was minted: `created` or `rotated`."""
+
+    user_id: UserId
+    artifact_location: str
+    api_key: ApiKey | None = None
+    key_status: Slugged[KeyStatus]
+
+    @model_validator(mode='after')
+    def _the_key_and_the_outcome_agree(self) -> Self:
+        # Held here so no consumer has to infer the outcome from the key's presence: a `created`
+        # response missing its key would otherwise read as `existing` and prompt a needless rotate.
+        minted = self.key_status in _MINTING_OUTCOMES
+        if minted and self.api_key is None:
+            raise ValueError(f'key_status is {self.key_status.name} but no api_key came with it')
+        if not minted and self.api_key is not None:
+            raise ValueError(f'key_status is {self.key_status.name}, which mints no key, yet an api_key is present')
+        return self
+
+
+class MeResponse(BaseModel):
+    """`users.me`."""
+
+    user_id: UserId
+    alias: str | None = None
+    tenant: str
+    plan: str
+    quota: list[QuotaLimit]
+
+    def quota_for(self, key: str) -> QuotaLimit | None:
+        """The limit under a rule key (`QUOTA_SUBMISSIONS_DAY` and friends), or None where the plan
+        carries no such rule."""
+        return next((limit for limit in self.quota if limit.key == key), None)
+
+
+class SubmissionCreateResponse(BaseModel):
+    """`submissions.create` — covers a fresh create, an idempotent replay, and an unpullable image.
+
+    An unpullable image is a caller fault: the submission is terminal and charged, so it comes
+    back `errored` with a `reason_code` rather than as an error envelope.
+    """
+
+    submission_id: SubmissionId
+    status: Slugged[SubmissionStatus]
+    policy_image_digest: str | None = None
+    eval_version: str | None = None
+    reason_code: Slugged[ReasonCode] | None = None
+
+
+class SubmissionListRow(BaseModel):
+    """One row of `submissions.list`. `user_id` attributes it — an admin listing spans users."""
+
+    id: SubmissionId
+    user_id: UserId
+    alias: str | None = None
+    status: Slugged[SubmissionStatus]
+    eval: EvalRef
+    received_at: AwareDatetime
+    reason_code: Slugged[ReasonCode] | None = None
+
+
+class SubmissionListResponse(BaseModel):
+    submissions: list[SubmissionListRow] = Field(default_factory=list)
+
+
+class _TaggedView(BaseModel):
+    """One `submissions.get` variant. Its `status` default IS the tag the union selects it by, so a
+    payload carrying any other status belongs to a different variant and is refused rather than
+    validated into this one — which is what stops an internal state the union has no variant for,
+    `submitting`, from arriving dressed as a pending view.
+    """
+
+    status: Slugged[SubmissionStatus]
+
+    @model_validator(mode='after')
+    def _the_status_is_this_variants_tag(self) -> Self:
+        tag = type(self).model_fields['status'].default
+        if self.status is not tag:
+            raise ValueError(f'{type(self).__name__} carries status {self.status.name}, not {tag.name}')
+        return self
+
+
+class PendingSubmissionView(_TaggedView):
+    """Queued, not yet running. `queue_position` is 1-based by arrival and computed on read."""
+
+    id: SubmissionId
+    alias: str | None = None
+    received_at: AwareDatetime
+    queued_at: AwareDatetime
+    queue_position: int = Field(gt=0)
+    status: Slugged[SubmissionStatus] = SubmissionStatus.pending
+
+
+class RunningSubmissionView(_TaggedView):
+    """Executing. `stage` names the orchestrator stage; `stage_detail` decorates it for display."""
+
+    id: SubmissionId
+    running_since: AwareDatetime
+    stage: str | None = None
+    stage_detail: str | None = None
+    status: Slugged[SubmissionStatus] = SubmissionStatus.running
+
+
+class ErroredSubmissionView(_TaggedView):
+    """Terminal failure. `reason_code` is the machine-readable taxonomy; `reason` is for humans."""
+
+    id: SubmissionId
+    reason_code: Slugged[ReasonCode] | None = None
+    reason: str | None = None
+    status: Slugged[SubmissionStatus] = SubmissionStatus.errored
+
+
+class FinishedSubmissionView(_TaggedView):
+    """Terminal success."""
+
+    id: SubmissionId
+    scores: Scores = Field(default_factory=Scores)
+    artifacts: ArtifactRefs
+    status: Slugged[SubmissionStatus] = SubmissionStatus.finished
+
+
+class CancelledSubmissionView(_TaggedView):
+    """Terminal, cancelled by the caller."""
+
+    id: SubmissionId
+    cancelled_at: AwareDatetime | None = None
+    status: Slugged[SubmissionStatus] = SubmissionStatus.cancelled
+
+
+# The discriminator's field name, and the fields a consumer rendering a view puts in its own header
+# line rather than in the body — named here so a model rename cannot leave a consumer excluding a
+# field that no longer exists.
+STATUS_FIELD = 'status'
+VIEW_HEADER_FIELDS = frozenset({'id', STATUS_FIELD})
+
+
+def _status_tag(value: Any) -> str | None:
+    """The status slug a `submissions.get` payload selects its variant by.
+
+    Reads the raw input, so it runs before validation and must handle both a decoded JSON mapping
+    and an already-built model.
+    """
+    raw = value.get(STATUS_FIELD) if isinstance(value, dict) else getattr(value, STATUS_FIELD, None)
+    if isinstance(raw, SubmissionStatus):
+        return raw.name.lower()
+    return raw if isinstance(raw, str) else None
+
+
+SubmissionView = Annotated[
+    Annotated[PendingSubmissionView, Tag('pending')]
+    | Annotated[RunningSubmissionView, Tag('running')]
+    | Annotated[ErroredSubmissionView, Tag('errored')]
+    | Annotated[FinishedSubmissionView, Tag('finished')]
+    | Annotated[CancelledSubmissionView, Tag('cancelled')],
+    Discriminator(_status_tag),
+]
+
+
+class CancelResponse(BaseModel):
+    """`submissions.cancel`. `refunded` is false once the run started — started work is charged."""
+
+    status: Slugged[SubmissionStatus]
+    refunded: bool
+
+
+class RankingRow(BaseModel):
+    """One row of a board: a user's best submission on it.
+
+    `display_name` is what the board shows — the user's alias, or a placeholder where a board is
+    anonymous or the user set none. It is NOT an identifier: aliases are not unique, so two rows may
+    carry the same one. `tag` is what tells them apart, and is what lets a user find their own row;
+    it is stable for a user across boards. Render them together (`ateam#0ddba7`).
+
+    The value the board ranks on is `scores.primary`, which `Scores` already defines as exactly that;
+    a second copy beside it is a number the gateway can contradict itself with.
+    """
+
+    rank: int
+    display_name: str
+    tag: str
+    scores: Scores = Field(default_factory=Scores)
+    submission_id: SubmissionId
+    submitted_at: AwareDatetime
+
+
+class BoardSummary(BaseModel):
+    """One board of `rankings.list`. `board` is the slug `rankings.get` takes."""
+
+    board: str
+    title: str
+    eval: EvalRef
+    eval_version: str
+    primary_metric: str
+    visibility: Slugged[BoardVisibility]
+
+
+class BoardListResponse(BaseModel):
+    """`rankings.list` — the boards the caller can see. A board they cannot see is absent, not refused."""
+
+    boards: list[BoardSummary] = Field(default_factory=list)
+
+
+class RankingsResponse(BaseModel):
+    """`rankings.get` for one board.
+
+    `primary_metric` NAMES the metric the board sorts on — `scores.primary`, whatever the eval calls
+    it. It is a label for a reader, never a key: nothing looks a value up by it, and it is not
+    guaranteed to name a field of `Scores`.
+    """
+
+    board: str
+    eval: EvalRef
+    eval_version: str
+    primary_metric: str
+    rankings: list[RankingRow] = Field(default_factory=list)

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -15,7 +15,21 @@ from platform_client.enums import BoardVisibility, KeyStatus, OnExhausted, Quota
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId, UserId
 from platform_client.slug import Slugged
-from pydantic import AwareDatetime, BaseModel, Discriminator, Field, Tag, model_validator
+from pydantic import AfterValidator, AwareDatetime, BaseModel, Discriminator, Field, Tag, model_validator
+
+
+def _public(status: SubmissionStatus) -> SubmissionStatus:
+    """A status as a CALLER may see it. `submitting` is the gateway's internal claim state, which it
+    reports as `pending`; a payload carrying it is a gateway that forgot, and is refused here rather
+    than left for every consumer to normalise."""
+    if status is SubmissionStatus.submitting:
+        raise ValueError(f'{status.name} is an internal state and never reaches a caller')
+    return status
+
+
+# Every status a caller-facing model may carry. The five `submissions.get` variants pin their own
+# tag instead (`_TaggedView`), which is the same rule stated per variant.
+PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 
 
 class Scores(BaseModel):
@@ -42,7 +56,9 @@ class QuotaLimit(BaseModel):
     key: str  # the rule's identity, one of the published keys above — what a 429 names
     meter: str  # open set: a plan may declare one. 'submissions' | 'credits'
     unit: str  # the display unit, open for the same reason
-    scale: int  # meter units per display unit (credits: 6, submissions: 1)
+    # Meter units per display unit (credits: 6, submissions: 1). Consumers divide by it, so a
+    # zero would validate here and raise ZeroDivisionError in the caller instead.
+    scale: int = Field(gt=0)
     window: str  # a display label: 'day', '24 Jul – 23 Aug', 'concurrent'
     subject: Slugged[QuotaSubject]
     scope: list[str] = Field(default_factory=list)  # tags this rule counts; empty counts the whole meter
@@ -77,8 +93,7 @@ class RegisterResponse(BaseModel):
 
     @model_validator(mode='after')
     def _the_key_and_the_outcome_agree(self) -> Self:
-        # Held here so no consumer has to infer the outcome from the key's presence: a `created`
-        # response missing its key would otherwise read as `existing` and prompt a needless rotate.
+        # The outcome and the key are one fact, held together here rather than inferred apart.
         minted = self.key_status in _MINTING_OUTCOMES
         if minted and self.api_key is None:
             raise ValueError(f'key_status is {self.key_status.name} but no api_key came with it')
@@ -110,7 +125,7 @@ class SubmissionCreateResponse(BaseModel):
     """
 
     submission_id: SubmissionId
-    status: Slugged[SubmissionStatus]
+    status: PublicStatus
     policy_image_digest: str | None = None
     eval_version: str | None = None
     reason_code: Slugged[ReasonCode] | None = None
@@ -122,7 +137,7 @@ class SubmissionListRow(BaseModel):
     id: SubmissionId
     user_id: UserId
     alias: str | None = None
-    status: Slugged[SubmissionStatus]
+    status: PublicStatus
     eval: EvalRef
     received_at: AwareDatetime
     reason_code: Slugged[ReasonCode] | None = None
@@ -228,7 +243,7 @@ SubmissionView = Annotated[
 class CancelResponse(BaseModel):
     """`submissions.cancel`. `refunded` is false once the run started — started work is charged."""
 
-    status: Slugged[SubmissionStatus]
+    status: PublicStatus
     refunded: bool
 
 
@@ -240,8 +255,7 @@ class RankingRow(BaseModel):
     carry the same one. `tag` is what tells them apart, and is what lets a user find their own row;
     it is stable for a user across boards. Render them together (`ateam#0ddba7`).
 
-    The value the board ranks on is `scores.primary`, which `Scores` already defines as exactly that;
-    a second copy beside it is a number the gateway can contradict itself with.
+    The value the board ranks on is `scores.primary`.
     """
 
     rank: int

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -1,10 +1,8 @@
-"""Response models for every gateway endpoint — the typed shape both sides bind to.
+"""What every gateway endpoint answers with — the typed shape both sides bind to.
 
-- Timestamps are aware UTC datetimes; the wire form is ISO 8601.
-- Ids are hex strings on the wire (`platform_client.ids`), closed sets are slugs
-  (`platform_client.slug`).
-- Locations stay plain strings: to a caller they are opaque locators.
-- `submissions.get` answers one of five variants, discriminated on the status slug.
+Timestamps are aware UTC, ids are hex strings (`platform_client.ids`), closed sets are slugs
+(`platform_client.slug`), and locations are opaque. `submissions.get` answers one of five variants,
+discriminated on the status slug.
 """
 
 from __future__ import annotations

--- a/client/platform_client/routes.py
+++ b/client/platform_client/routes.py
@@ -1,8 +1,7 @@
 """The gateway's paths — one definition the client and the server both bind to.
 
-Every write is a POST, every read a GET, all under `/v1`. Only the paths live here: a POST body and
-a GET's query parameters are both models in `requests`, so pydantic owns every field name on both
-sides of the wire and no parameter is spelled out a second time as a string.
+Every write is a POST, every read a GET, all under `/v1`. Field names live in `requests`, so no
+parameter is spelled out here a second time as a string.
 """
 
 from __future__ import annotations

--- a/client/platform_client/routes.py
+++ b/client/platform_client/routes.py
@@ -1,0 +1,19 @@
+"""The gateway's paths — one definition the client and the server both bind to.
+
+Every write is a POST, every read a GET, all under `/v1`. Only the paths live here: a POST body and
+a GET's query parameters are both models in `requests`, so pydantic owns every field name on both
+sides of the wire and no parameter is spelled out a second time as a string.
+"""
+
+from __future__ import annotations
+
+API_PREFIX = '/v1'
+
+USERS_REGISTER = f'{API_PREFIX}/users.register'
+USERS_ME = f'{API_PREFIX}/users.me'
+SUBMISSIONS_CREATE = f'{API_PREFIX}/submissions.create'
+SUBMISSIONS_LIST = f'{API_PREFIX}/submissions.list'
+SUBMISSIONS_GET = f'{API_PREFIX}/submissions.get'
+SUBMISSIONS_CANCEL = f'{API_PREFIX}/submissions.cancel'
+RANKINGS_GET = f'{API_PREFIX}/rankings.get'
+RANKINGS_LIST = f'{API_PREFIX}/rankings.list'

--- a/client/platform_client/slug.py
+++ b/client/platform_client/slug.py
@@ -1,8 +1,7 @@
 """`Slugged[E]` — an `IntEnum` stored as an int and carried as its slug on the wire.
 
-Validation maps slug -> member and REJECTS an unknown slug, so the API boundary answers 422 rather
-than silently landing on the `INVALID` sentinel. Serialization maps member -> slug in both dump
-modes, so a JSON payload never leaks the stored integer.
+An unknown slug is REFUSED at the boundary (422) rather than landing on the `INVALID` sentinel, and
+neither dump mode leaks the stored integer.
 """
 
 from __future__ import annotations

--- a/client/platform_client/slug.py
+++ b/client/platform_client/slug.py
@@ -1,0 +1,58 @@
+"""`Slugged[E]` — an `IntEnum` stored as an int and carried as its slug on the wire.
+
+Validation maps slug -> member and REJECTS an unknown slug, so the API boundary answers 422 rather
+than silently landing on the `INVALID` sentinel. Serialization maps member -> slug in both dump
+modes, so a JSON payload never leaks the stored integer.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Annotated, Any, TypeVar
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+E = TypeVar('E', bound=IntEnum)
+
+
+def slug_of(member: IntEnum) -> str:
+    return member.name.lower()
+
+
+def members_by_slug(enum_cls: type[E]) -> dict[str, E]:
+    """The wire vocabulary. `INVALID` is an in-memory sentinel and is deliberately absent."""
+    return {m.name.lower(): m for m in enum_cls if m.value != 0}
+
+
+class _SlugCodec:
+    """The `Annotated` metadata behind `Slugged`; one instance serves every enum."""
+
+    def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        enum_cls: type[IntEnum] = source_type
+        by_slug = members_by_slug(enum_cls)
+
+        def from_slug(value: str) -> IntEnum:
+            return by_slug[value]
+
+        def reject_sentinel(value: IntEnum) -> IntEnum:
+            if value.value == 0:
+                raise ValueError(f'{enum_cls.__name__}.{value.name} is an unset sentinel, not a wire value')
+            return value
+
+        # A literal schema over the slugs both rejects an unknown one and renders as a string enum in
+        # the generated OpenAPI, which a plain validator function cannot do.
+        parse_slug = core_schema.no_info_after_validator_function(from_slug, core_schema.literal_schema(list(by_slug)))
+        return core_schema.json_or_python_schema(
+            json_schema=parse_slug,
+            python_schema=core_schema.union_schema([
+                core_schema.no_info_after_validator_function(reject_sentinel, core_schema.is_instance_schema(enum_cls)),
+                parse_slug,
+            ]),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                slug_of, return_schema=core_schema.str_schema(), when_used='always'
+            ),
+        )
+
+
+Slugged = Annotated[E, _SlugCodec()]

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -8,7 +8,14 @@ import httpx
 import pytest
 from platform_client import routes
 from platform_client.boards import BoardRef
-from platform_client.client import API_URL_ENV, DEFAULT_PLATFORM_URL, PlatformClient, resolve_base_url
+from platform_client.client import (
+    API_KEY_ENV,
+    API_URL_ENV,
+    DEFAULT_PLATFORM_URL,
+    PlatformClient,
+    resolve_api_key,
+    resolve_base_url,
+)
 from platform_client.enums import (
     BoardVisibility,
     ErrorCode,
@@ -96,6 +103,29 @@ def test_register_carries_back_a_minted_key():
     response = make_client(gateway, api_key=None).register(RegisterRequest(credential='token'))
     assert response.api_key == 'pk_live_new'
     assert response.key_status is KeyStatus.created
+
+
+def test_register_keeps_the_key_it_is_given_so_the_next_call_is_authenticated():
+    gateway = Gateway(
+        200,
+        {'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'api_key': 'pk_live_new', 'key_status': 'created'},
+    )
+    client = make_client(gateway, api_key=None)
+
+    client.register(RegisterRequest(credential='token'))
+
+    assert client.api_key == 'pk_live_new'
+
+
+def test_a_registration_that_carries_no_key_leaves_the_one_already_held():
+    # A repeat registration answers `existing` with no key: the caller's working key is not a thing
+    # to clear, and clearing it would break the very next authenticated call.
+    gateway = Gateway(200, {'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'key_status': 'existing'})
+    client = make_client(gateway)
+
+    client.register(RegisterRequest(credential='token'))
+
+    assert client.api_key == KEY
 
 
 def test_me_sends_the_bearer_token_and_parses_every_limit():
@@ -330,6 +360,16 @@ def test_the_url_precedence_is_argument_then_environment_then_the_default(monkey
     assert resolve_base_url() == 'http://from.env'
     monkeypatch.delenv(API_URL_ENV)
     assert resolve_base_url() == DEFAULT_PLATFORM_URL
+
+
+def test_the_key_precedence_is_argument_then_environment_then_none(monkeypatch):
+    # Same shape as the URL above: a caller that exported the key its registration printed is
+    # configured, and passing it a second time through every construction site is not the contract.
+    monkeypatch.setenv(API_KEY_ENV, 'pk_live_env')
+    assert resolve_api_key(ApiKey('pk_live_argument')) == 'pk_live_argument'
+    assert resolve_api_key() == 'pk_live_env'
+    monkeypatch.delenv(API_KEY_ENV)
+    assert resolve_api_key() is None
 
 
 @pytest.mark.parametrize('empty', ['', '   '])

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -11,6 +11,7 @@ from platform_client.boards import BoardRef
 from platform_client.client import (
     API_KEY_ENV,
     API_URL_ENV,
+    AUTH_HEADER,
     DEFAULT_PLATFORM_URL,
     PlatformClient,
     resolve_api_key,
@@ -461,8 +462,8 @@ def test_a_failure_that_names_no_evals_is_told_apart_from_one_that_names_none():
 def test_a_supplied_client_carrying_an_authorization_default_is_refused():
     # httpx merges client-level headers into every request, so a default here would reach
     # `users.register` — which this module declares unauthenticated.
-    with pytest.raises(ValueError, match='Authorization'):
-        PlatformClient(client=httpx.Client(base_url=BASE, headers={'Authorization': 'Bearer leaked'}))
+    with pytest.raises(ValueError, match=AUTH_HEADER):
+        PlatformClient(client=httpx.Client(base_url=BASE, headers={AUTH_HEADER: 'Bearer leaked'}))
 
 
 def test_a_supplied_client_carrying_an_auth_flow_is_refused():

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -250,13 +250,12 @@ def test_cancel_submission_posts_the_id():
     assert gateway.body() == {'id': '1f'}
 
 
-def rankings_gateway(eval_version: str = 'smoke@0123456789ab') -> Gateway:
+def rankings_gateway() -> Gateway:
     return Gateway(
         200,
         {
             'board': 'smoke',
             'eval': 'fake.smoke',
-            'eval_version': eval_version,
             'primary_metric': 'success_rate',
             'rankings': [
                 {
@@ -272,7 +271,7 @@ def rankings_gateway(eval_version: str = 'smoke@0123456789ab') -> Gateway:
     )
 
 
-def test_rankings_names_the_board_and_omits_an_unset_version():
+def test_rankings_names_the_board_in_the_query_string():
     gateway = rankings_gateway()
 
     response = make_client(gateway, api_key=None).rankings(board=BoardRef('smoke'))
@@ -282,12 +281,6 @@ def test_rankings_names_the_board_and_omits_an_unset_version():
     assert response.rankings[0].scores.primary == 0.75
     assert dict(gateway.request().url.params) == {'board': 'smoke'}
     assert 'authorization' not in gateway.request().headers
-
-
-def test_rankings_pins_a_past_board_when_a_version_is_given():
-    gateway = rankings_gateway('smoke@old')
-    make_client(gateway, api_key=None).rankings(board=BoardRef('smoke'), eval_version='smoke@old')
-    assert dict(gateway.request().url.params)['eval_version'] == 'smoke@old'
 
 
 def test_a_board_read_sends_the_key_when_one_is_set():
@@ -305,7 +298,6 @@ def test_list_boards_asks_without_a_key_and_parses_every_board():
                     'board': 'smoke',
                     'title': 'Smoke',
                     'eval': 'fake.smoke',
-                    'eval_version': 'smoke@0123456789ab',
                     'primary_metric': 'success_rate',
                     'visibility': 'public',
                 }

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -393,6 +393,19 @@ def test_a_supplied_client_whose_base_url_names_no_host_is_refused(base_url: str
         PlatformClient(client=httpx.Client(base_url=base_url))
 
 
+@pytest.mark.parametrize('base_url', ['/gateway', '//gateway/api'])
+def test_a_base_url_that_names_no_host_is_refused_however_it_arrives(monkeypatch, base_url: str):
+    # httpx takes a relative base URL, so the client the caller does not supply is built from one
+    # just as happily — the same dead request, reached through the argument or the environment.
+    monkeypatch.delenv(API_URL_ENV, raising=False)
+    with pytest.raises(ValueError, match='absolute URL'):
+        PlatformClient(base_url)
+
+    monkeypatch.setenv(API_URL_ENV, base_url)
+    with pytest.raises(ValueError, match='absolute URL'):
+        PlatformClient()
+
+
 def test_closing_leaves_a_caller_supplied_client_open():
     supplied = httpx.Client(base_url=BASE, transport=httpx.MockTransport(Gateway(200, {})))
     PlatformClient(client=supplied).close()

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -21,7 +21,7 @@ from platform_client.enums import (
 from platform_client.errors import EVALS_DETAIL, REASON_CODE_DETAIL, PlatformError
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import CancelRequest, RegisterRequest, SubmissionCreateRequest
 from platform_client.responses import (
     QUOTA_SUBMISSIONS_DAY,
@@ -139,7 +139,7 @@ def test_create_submission_sends_the_run_defining_fields():
     client = make_client(gateway)
 
     response = client.create_submission(
-        SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('fake.smoke'))
+        SubmissionCreateRequest(policy_image=PolicyImage('org/policy:v1'), eval=EvalRef('fake.smoke'))
     )
 
     assert isinstance(response, SubmissionCreateResponse)
@@ -153,7 +153,7 @@ def test_create_submission_sends_the_run_defining_fields():
 def test_create_submission_reports_a_terminal_unpullable_image_as_a_response():
     gateway = Gateway(200, {'submission_id': '1f', 'status': 'errored', 'reason_code': 'image_unpullable'})
     response = make_client(gateway).create_submission(
-        SubmissionCreateRequest(policy_image=ImageRef('nope'), eval=EvalRef('fake.smoke'))
+        SubmissionCreateRequest(policy_image=PolicyImage('nope'), eval=EvalRef('fake.smoke'))
     )
     assert response.status is SubmissionStatus.errored
     assert response.reason_code is ReasonCode.image_unpullable
@@ -206,7 +206,7 @@ def test_a_numeric_id_is_refused_at_the_boundary():
     gateway = Gateway(200, {'submission_id': 31, 'status': 'pending'})
     with pytest.raises(ValidationError):
         make_client(gateway).create_submission(
-            SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('fake.smoke'))
+            SubmissionCreateRequest(policy_image=PolicyImage('org/policy:v1'), eval=EvalRef('fake.smoke'))
         )
 
 
@@ -303,7 +303,7 @@ def test_an_error_envelope_becomes_the_typed_exception():
     )
     with pytest.raises(PlatformError) as raised:
         make_client(gateway).create_submission(
-            SubmissionCreateRequest(policy_image=ImageRef('nope'), eval=EvalRef('fake.smoke'))
+            SubmissionCreateRequest(policy_image=PolicyImage('nope'), eval=EvalRef('fake.smoke'))
         )
 
     assert raised.value.code is ErrorCode.bad_request
@@ -383,7 +383,7 @@ def test_an_unknown_eval_comes_back_carrying_the_ones_on_offer():
     )
     with pytest.raises(PlatformError) as caught:
         make_client(gateway).create_submission(
-            SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('fake.smokey'))
+            SubmissionCreateRequest(policy_image=PolicyImage('org/policy:v1'), eval=EvalRef('fake.smokey'))
         )
     assert caught.value.evals == ['fake.smoke', 'robolab.public_subset']
 

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -392,10 +392,12 @@ def test_a_client_of_your_own_carries_its_own_base_url():
         PlatformClient(BASE, client=httpx.Client())
 
 
-def test_a_supplied_client_with_no_base_url_is_refused():
-    # Every endpoint sends a path relative to it, so without one the request reaches no host at all.
-    with pytest.raises(ValueError, match='no base_url'):
-        PlatformClient(client=httpx.Client())
+@pytest.mark.parametrize('base_url', ['', '/gateway', '//gateway/api'])
+def test_a_supplied_client_whose_base_url_names_no_host_is_refused(base_url: str):
+    # Every endpoint sends a path relative to it, so a base URL that names no host — unset, or a
+    # bare path — resolves against nothing and the request reaches no platform at all.
+    with pytest.raises(ValueError, match='absolute URL'):
+        PlatformClient(client=httpx.Client(base_url=base_url))
 
 
 def test_closing_leaves_a_caller_supplied_client_open():
@@ -461,6 +463,13 @@ def test_a_supplied_client_carrying_an_authorization_default_is_refused():
     # `users.register` — which this module declares unauthenticated.
     with pytest.raises(ValueError, match='Authorization'):
         PlatformClient(client=httpx.Client(base_url=BASE, headers={'Authorization': 'Bearer leaked'}))
+
+
+def test_a_supplied_client_carrying_an_auth_flow_is_refused():
+    # The same header by another route: httpx runs a client-level `auth` on every request, so an
+    # unauthenticated `users.register` would go out signed by whoever that flow names.
+    with pytest.raises(ValueError, match='auth flow'):
+        PlatformClient(client=httpx.Client(base_url=BASE, auth=('user', 'password')))
 
 
 def test_a_malformed_eval_list_raises_rather_than_reading_as_no_list():

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -332,9 +332,30 @@ def test_the_url_precedence_is_argument_then_environment_then_the_default(monkey
     assert resolve_base_url() == DEFAULT_PLATFORM_URL
 
 
+@pytest.mark.parametrize('empty', ['', '   '])
+def test_a_url_supplied_but_empty_is_refused_rather_than_read_as_unset(monkeypatch, empty):
+    # `--platform-url=` names a platform, so falling through would send that run to the default —
+    # the production platform — which is the one place it was least meant to go.
+    monkeypatch.setenv(API_URL_ENV, 'http://from.env')
+    with pytest.raises(ValueError, match='base_url is empty'):
+        resolve_base_url(empty)
+    with pytest.raises(ValueError, match='base_url is empty'):
+        PlatformClient(empty)
+
+    monkeypatch.setenv(API_URL_ENV, empty)
+    with pytest.raises(ValueError, match=f'{API_URL_ENV} is empty'):
+        resolve_base_url()
+
+
 def test_a_client_of_your_own_carries_its_own_base_url():
     with pytest.raises(ValueError, match='one or the other'):
         PlatformClient(BASE, client=httpx.Client())
+
+
+def test_a_supplied_client_with_no_base_url_is_refused():
+    # Every endpoint sends a path relative to it, so without one the request reaches no host at all.
+    with pytest.raises(ValueError, match='no base_url'):
+        PlatformClient(client=httpx.Client())
 
 
 def test_closing_leaves_a_caller_supplied_client_open():

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -23,6 +23,7 @@ from platform_client.ids import ApiKey, SubmissionId
 from platform_client.images import ImageRef
 from platform_client.requests import CancelRequest, RegisterRequest, SubmissionCreateRequest
 from platform_client.responses import (
+    QUOTA_SUBMISSIONS_DAY,
     BoardListResponse,
     CancelResponse,
     MeResponse,
@@ -106,7 +107,7 @@ def test_me_sends_the_bearer_token_and_parses_every_limit():
             'plan': 'nebius_competition_2026',
             'quota': [
                 {
-                    'key': 'submissions.day',
+                    'key': QUOTA_SUBMISSIONS_DAY,
                     'meter': 'submissions',
                     'unit': 'submission',
                     'scale': 1,
@@ -125,7 +126,7 @@ def test_me_sends_the_bearer_token_and_parses_every_limit():
 
     assert isinstance(response, MeResponse)
     assert response.tenant == 'nebius-2026'
-    limit = response.quota_for('submissions.day')
+    limit = response.quota_for(QUOTA_SUBMISSIONS_DAY)
     assert limit is not None
     assert (limit.remaining, limit.subject, limit.on_exhausted) == (1, QuotaSubject.user, OnExhausted.block)
     assert gateway.request().url.path == routes.USERS_ME
@@ -391,3 +392,27 @@ def test_a_failure_that_names_no_evals_is_told_apart_from_one_that_names_none():
     with pytest.raises(PlatformError) as caught:
         make_client(gateway).list_submissions()
     assert caught.value.evals is None
+
+
+def test_a_supplied_client_carrying_an_authorization_default_is_refused():
+    # httpx merges client-level headers into every request, so a default here would reach
+    # `users.register` — which this module declares unauthenticated.
+    with pytest.raises(ValueError, match='Authorization'):
+        PlatformClient(client=httpx.Client(base_url=BASE, headers={'Authorization': 'Bearer leaked'}))
+
+
+def test_a_malformed_eval_list_raises_rather_than_reading_as_no_list():
+    # A short list is worse than none: a caller would pick from it believing it whole.
+    gateway = Gateway(404, {'error': {'code': 'not_found', 'message': 'x', 'details': {EVALS_DETAIL: 'fake.smoke'}}})
+    with pytest.raises(PlatformError) as caught:
+        make_client(gateway).list_submissions()
+    with pytest.raises(ValidationError):
+        _ = caught.value.evals
+
+
+def test_a_malformed_quota_detail_raises_rather_than_reading_as_no_rule():
+    gateway = Gateway(429, {'error': {'code': 'quota_exceeded', 'message': 'x', 'details': {'quota': 'all of it'}}})
+    with pytest.raises(PlatformError) as caught:
+        make_client(gateway).list_submissions()
+    with pytest.raises(ValidationError):
+        _ = caught.value.quota

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -7,6 +7,7 @@ import json
 import httpx
 import pytest
 from platform_client import routes
+from platform_client.boards import BoardRef
 from platform_client.client import API_URL_ENV, DEFAULT_PLATFORM_URL, PlatformClient, resolve_base_url
 from platform_client.enums import (
     BoardVisibility,
@@ -243,7 +244,7 @@ def rankings_gateway(eval_version: str = 'smoke@0123456789ab') -> Gateway:
 def test_rankings_names_the_board_and_omits_an_unset_version():
     gateway = rankings_gateway()
 
-    response = make_client(gateway, api_key=None).rankings(board='smoke')
+    response = make_client(gateway, api_key=None).rankings(board=BoardRef('smoke'))
 
     assert isinstance(response, RankingsResponse)
     assert response.board == 'smoke'
@@ -254,13 +255,13 @@ def test_rankings_names_the_board_and_omits_an_unset_version():
 
 def test_rankings_pins_a_past_board_when_a_version_is_given():
     gateway = rankings_gateway('smoke@old')
-    make_client(gateway, api_key=None).rankings(board='smoke', eval_version='smoke@old')
+    make_client(gateway, api_key=None).rankings(board=BoardRef('smoke'), eval_version='smoke@old')
     assert dict(gateway.request().url.params)['eval_version'] == 'smoke@old'
 
 
 def test_a_board_read_sends_the_key_when_one_is_set():
     gateway = rankings_gateway()
-    make_client(gateway).rankings(board='nebius-2026/robolab/public_subset')
+    make_client(gateway).rankings(board=BoardRef('nebius-2026/robolab/public_subset'))
     assert gateway.request().headers['authorization'] == f'Bearer {KEY}'
 
 

--- a/client/platform_client/tests/test_client.py
+++ b/client/platform_client/tests/test_client.py
@@ -1,0 +1,393 @@
+"""PlatformClient: one method per endpoint, over a stub transport."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from platform_client import routes
+from platform_client.client import API_URL_ENV, DEFAULT_PLATFORM_URL, PlatformClient, resolve_base_url
+from platform_client.enums import (
+    BoardVisibility,
+    ErrorCode,
+    KeyStatus,
+    OnExhausted,
+    QuotaSubject,
+    ReasonCode,
+    SubmissionStatus,
+)
+from platform_client.errors import EVALS_DETAIL, REASON_CODE_DETAIL, PlatformError
+from platform_client.evals import EvalRef
+from platform_client.ids import ApiKey, SubmissionId
+from platform_client.images import ImageRef
+from platform_client.requests import CancelRequest, RegisterRequest, SubmissionCreateRequest
+from platform_client.responses import (
+    BoardListResponse,
+    CancelResponse,
+    MeResponse,
+    PendingSubmissionView,
+    RankingsResponse,
+    RegisterResponse,
+    SubmissionCreateResponse,
+    SubmissionListResponse,
+)
+from pydantic import ValidationError
+
+BASE = 'http://gateway.test'
+KEY = ApiKey('pk_live_secret')
+AT = '2026-03-04T05:06:07Z'
+
+
+class Gateway:
+    """Records the request it was handed and answers a canned payload."""
+
+    def __init__(self, status: int, payload: object) -> None:
+        self.status = status
+        self.payload = payload
+        self.seen: httpx.Request | None = None
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.seen = request
+        return httpx.Response(self.status, json=self.payload)
+
+    def request(self) -> httpx.Request:
+        assert self.seen is not None, 'no request reached the gateway'
+        return self.seen
+
+    def body(self) -> dict:
+        return json.loads(self.request().content)
+
+
+def make_client(gateway: Gateway, *, api_key: ApiKey | None = KEY) -> PlatformClient:
+    transport = httpx.MockTransport(gateway)
+    return PlatformClient(client=httpx.Client(base_url=BASE, transport=transport), api_key=api_key)
+
+
+def test_register_posts_the_body_unauthenticated_and_parses_the_response():
+    gateway = Gateway(200, {'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'key_status': 'existing'})
+    client = make_client(gateway, api_key=None)
+
+    response = client.register(RegisterRequest(credential='token', alias='demo'))
+
+    assert isinstance(response, RegisterResponse)
+    assert response.user_id == 0xA0
+    assert response.key_status is KeyStatus.existing
+    assert response.api_key is None
+    assert gateway.request().url.path == routes.USERS_REGISTER
+    assert gateway.request().method == 'POST'
+    assert 'authorization' not in gateway.request().headers
+    assert gateway.body() == {'credential': 'token', 'alias': 'demo', 'rotate': False}
+
+
+def test_register_sends_no_key_even_when_the_client_holds_one():
+    gateway = Gateway(200, {'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'key_status': 'existing'})
+    make_client(gateway).register(RegisterRequest(credential='token'))
+    assert 'authorization' not in gateway.request().headers
+
+
+def test_register_carries_back_a_minted_key():
+    gateway = Gateway(
+        200,
+        {'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'api_key': 'pk_live_new', 'key_status': 'created'},
+    )
+    response = make_client(gateway, api_key=None).register(RegisterRequest(credential='token'))
+    assert response.api_key == 'pk_live_new'
+    assert response.key_status is KeyStatus.created
+
+
+def test_me_sends_the_bearer_token_and_parses_every_limit():
+    gateway = Gateway(
+        200,
+        {
+            'user_id': 'a0',
+            'alias': 'demo',
+            'tenant': 'nebius-2026',
+            'plan': 'nebius_competition_2026',
+            'quota': [
+                {
+                    'key': 'submissions.day',
+                    'meter': 'submissions',
+                    'unit': 'submission',
+                    'scale': 1,
+                    'window': 'day',
+                    'subject': 'user',
+                    'scope': [],
+                    'limit': 2,
+                    'used': 1,
+                    'resets_at': AT,
+                    'on_exhausted': 'block',
+                }
+            ],
+        },
+    )
+    response = make_client(gateway).me()
+
+    assert isinstance(response, MeResponse)
+    assert response.tenant == 'nebius-2026'
+    limit = response.quota_for('submissions.day')
+    assert limit is not None
+    assert (limit.remaining, limit.subject, limit.on_exhausted) == (1, QuotaSubject.user, OnExhausted.block)
+    assert gateway.request().url.path == routes.USERS_ME
+    assert gateway.request().headers['authorization'] == f'Bearer {KEY}'
+
+
+def test_create_submission_sends_the_run_defining_fields():
+    gateway = Gateway(200, {'submission_id': '1f', 'status': 'pending', 'policy_image_digest': 'sha256:abc'})
+    client = make_client(gateway)
+
+    response = client.create_submission(
+        SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('fake.smoke'))
+    )
+
+    assert isinstance(response, SubmissionCreateResponse)
+    assert response.submission_id == 0x1F
+    assert response.status is SubmissionStatus.pending
+    assert gateway.request().url.path == routes.SUBMISSIONS_CREATE
+    assert gateway.body()['policy_image'] == 'org/policy:v1'
+    assert gateway.body()['transaction_key'] is None
+
+
+def test_create_submission_reports_a_terminal_unpullable_image_as_a_response():
+    gateway = Gateway(200, {'submission_id': '1f', 'status': 'errored', 'reason_code': 'image_unpullable'})
+    response = make_client(gateway).create_submission(
+        SubmissionCreateRequest(policy_image=ImageRef('nope'), eval=EvalRef('fake.smoke'))
+    )
+    assert response.status is SubmissionStatus.errored
+    assert response.reason_code is ReasonCode.image_unpullable
+
+
+def test_list_submissions_parses_every_row():
+    gateway = Gateway(
+        200,
+        {
+            'submissions': [
+                {
+                    'id': '1f',
+                    'user_id': 'a0',
+                    'alias': None,
+                    'status': 'finished',
+                    'eval': 'fake.smoke',
+                    'received_at': AT,
+                    'reason_code': None,
+                }
+            ]
+        },
+    )
+    response = make_client(gateway).list_submissions()
+
+    assert isinstance(response, SubmissionListResponse)
+    assert response.submissions[0].status is SubmissionStatus.finished
+    assert gateway.request().url.path == routes.SUBMISSIONS_LIST
+
+
+def test_get_submission_sends_the_hex_id_and_resolves_the_variant():
+    gateway = Gateway(200, {'id': '1f', 'received_at': AT, 'queued_at': AT, 'queue_position': 2, 'status': 'pending'})
+    view = make_client(gateway).get_submission(SubmissionId(0x1F))
+
+    assert isinstance(view, PendingSubmissionView)
+    assert view.queue_position == 2
+    assert gateway.request().url.path == routes.SUBMISSIONS_GET
+    assert dict(gateway.request().url.params) == {'id': '1f'}
+
+
+def test_a_redirect_is_a_failure_rather_than_a_body_to_parse():
+    # httpx follows no redirect by default, so a 3xx arrives here with a body that is not an envelope.
+    gateway = Gateway(302, {'error': {'code': 'not_found', 'message': 'moved'}})
+    with pytest.raises(PlatformError) as raised:
+        make_client(gateway).me()
+    assert raised.value.http_status == 302
+
+
+def test_a_numeric_id_is_refused_at_the_boundary():
+    # The wire contract is hex text. Decoding the body first would have taken the number.
+    gateway = Gateway(200, {'submission_id': 31, 'status': 'pending'})
+    with pytest.raises(ValidationError):
+        make_client(gateway).create_submission(
+            SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('fake.smoke'))
+        )
+
+
+def test_cancel_submission_posts_the_id():
+    gateway = Gateway(200, {'status': 'cancelled', 'refunded': True})
+    response = make_client(gateway).cancel_submission(CancelRequest(id=SubmissionId(0x1F)))
+
+    assert isinstance(response, CancelResponse)
+    assert response.refunded is True
+    assert gateway.body() == {'id': '1f'}
+
+
+def rankings_gateway(eval_version: str = 'smoke@0123456789ab') -> Gateway:
+    return Gateway(
+        200,
+        {
+            'board': 'smoke',
+            'eval': 'fake.smoke',
+            'eval_version': eval_version,
+            'primary_metric': 'success_rate',
+            'rankings': [
+                {
+                    'rank': 1,
+                    'display_name': 'demo',
+                    'tag': '0ddba7',
+                    'scores': {'primary': 0.75},
+                    'submission_id': '1f',
+                    'submitted_at': AT,
+                }
+            ],
+        },
+    )
+
+
+def test_rankings_names_the_board_and_omits_an_unset_version():
+    gateway = rankings_gateway()
+
+    response = make_client(gateway, api_key=None).rankings(board='smoke')
+
+    assert isinstance(response, RankingsResponse)
+    assert response.board == 'smoke'
+    assert response.rankings[0].scores.primary == 0.75
+    assert dict(gateway.request().url.params) == {'board': 'smoke'}
+    assert 'authorization' not in gateway.request().headers
+
+
+def test_rankings_pins_a_past_board_when_a_version_is_given():
+    gateway = rankings_gateway('smoke@old')
+    make_client(gateway, api_key=None).rankings(board='smoke', eval_version='smoke@old')
+    assert dict(gateway.request().url.params)['eval_version'] == 'smoke@old'
+
+
+def test_a_board_read_sends_the_key_when_one_is_set():
+    gateway = rankings_gateway()
+    make_client(gateway).rankings(board='nebius-2026/robolab/public_subset')
+    assert gateway.request().headers['authorization'] == f'Bearer {KEY}'
+
+
+def test_list_boards_asks_without_a_key_and_parses_every_board():
+    gateway = Gateway(
+        200,
+        {
+            'boards': [
+                {
+                    'board': 'smoke',
+                    'title': 'Smoke',
+                    'eval': 'fake.smoke',
+                    'eval_version': 'smoke@0123456789ab',
+                    'primary_metric': 'success_rate',
+                    'visibility': 'public',
+                }
+            ]
+        },
+    )
+
+    response = make_client(gateway, api_key=None).list_boards()
+
+    assert isinstance(response, BoardListResponse)
+    assert response.boards[0].visibility is BoardVisibility.public
+    assert gateway.request().url.path == routes.RANKINGS_LIST
+    assert 'authorization' not in gateway.request().headers
+
+
+def test_an_error_envelope_becomes_the_typed_exception():
+    gateway = Gateway(
+        400,
+        {
+            'error': {
+                'code': 'bad_request',
+                'message': 'image not pullable',
+                'details': {REASON_CODE_DETAIL: 'image_unpullable'},
+            }
+        },
+    )
+    with pytest.raises(PlatformError) as raised:
+        make_client(gateway).create_submission(
+            SubmissionCreateRequest(policy_image=ImageRef('nope'), eval=EvalRef('fake.smoke'))
+        )
+
+    assert raised.value.code is ErrorCode.bad_request
+    assert raised.value.reason_code is ReasonCode.image_unpullable
+    assert raised.value.http_status == 400
+
+
+def test_an_authenticated_call_without_a_key_fails_before_the_request():
+    gateway = Gateway(200, {})
+    with pytest.raises(ValueError, match='API key'):
+        make_client(gateway, api_key=None).me()
+    assert gateway.seen is None
+
+
+def test_a_client_given_nothing_reaches_the_default_platform(monkeypatch):
+    # A user should never have to know a URL, so an unconfigured client is the ordinary case.
+    monkeypatch.delenv(API_URL_ENV, raising=False)
+    assert str(PlatformClient()._client.base_url) == DEFAULT_PLATFORM_URL
+
+
+def test_the_url_precedence_is_argument_then_environment_then_the_default(monkeypatch):
+    monkeypatch.setenv(API_URL_ENV, 'http://from.env')
+    assert resolve_base_url('http://from.argument') == 'http://from.argument'
+    assert resolve_base_url() == 'http://from.env'
+    monkeypatch.delenv(API_URL_ENV)
+    assert resolve_base_url() == DEFAULT_PLATFORM_URL
+
+
+def test_a_client_of_your_own_carries_its_own_base_url():
+    with pytest.raises(ValueError, match='one or the other'):
+        PlatformClient(BASE, client=httpx.Client())
+
+
+def test_closing_leaves_a_caller_supplied_client_open():
+    supplied = httpx.Client(base_url=BASE, transport=httpx.MockTransport(Gateway(200, {})))
+    PlatformClient(client=supplied).close()
+    assert not supplied.is_closed
+
+    owned = PlatformClient(BASE)
+    owned.close()
+    assert owned._client.is_closed
+
+
+def test_every_endpoint_has_exactly_one_method():
+    # A route is a path under the prefix, which `routes` also holds query-parameter names beside.
+    declared = {
+        name
+        for name, value in vars(routes).items()
+        if name != 'API_PREFIX' and isinstance(value, str) and value.startswith(routes.API_PREFIX)
+    }
+    methods = {
+        'register',
+        'me',
+        'create_submission',
+        'list_submissions',
+        'get_submission',
+        'cancel_submission',
+        'rankings',
+        'list_boards',
+    }
+    assert len(declared) == len(methods)
+    assert methods <= set(vars(PlatformClient))
+
+
+def test_an_unknown_eval_comes_back_carrying_the_ones_on_offer():
+    # The platform owns the set, so a caller who names one it does not have learns the real names
+    # from the refusal rather than from a list this client would have to keep current.
+    gateway = Gateway(
+        404,
+        {
+            'error': {
+                'code': 'not_found',
+                'message': "unknown eval 'fake.smokey'",
+                'details': {EVALS_DETAIL: ['fake.smoke', 'robolab.public_subset']},
+            }
+        },
+    )
+    with pytest.raises(PlatformError) as caught:
+        make_client(gateway).create_submission(
+            SubmissionCreateRequest(policy_image=ImageRef('org/policy:v1'), eval=EvalRef('fake.smokey'))
+        )
+    assert caught.value.evals == ['fake.smoke', 'robolab.public_subset']
+
+
+def test_a_failure_that_names_no_evals_is_told_apart_from_one_that_names_none():
+    gateway = Gateway(403, {'error': {'code': 'forbidden', 'message': 'no', 'details': {}}})
+    with pytest.raises(PlatformError) as caught:
+        make_client(gateway).list_submissions()
+    assert caught.value.evals is None

--- a/client/platform_client/tests/test_enums.py
+++ b/client/platform_client/tests/test_enums.py
@@ -1,0 +1,101 @@
+"""The persisted enum values are pinned.
+
+Every value here is stored durably, so this test is the ratchet: adding a member is expected and
+updates the map below; changing or reusing a value silently re-reads every existing row as
+something else, and that is what must fail.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+import pytest
+from platform_client.enums import (
+    ACTIVE_STATUSES,
+    TERMINAL_STATUSES,
+    BoardVisibility,
+    ErrorCode,
+    KeyStatus,
+    OnExhausted,
+    QuotaSubject,
+    ReasonCode,
+    SubmissionStatus,
+)
+
+ERROR_CODE_VALUES = {
+    'INVALID': 0,
+    'bad_request': 1,
+    'unauthorized': 2,
+    'forbidden': 3,
+    'not_found': 4,
+    'quota_exceeded': 5,
+    'transaction_conflict': 6,
+    'registry_unreachable': 7,
+    'upstream_unavailable': 8,
+    'eval_unavailable': 9,
+    'internal_error': 10,
+}
+
+REASON_CODE_VALUES = {
+    'INVALID': 0,
+    'image_unpullable': 1,
+    'image_too_large': 2,
+    'invalid_flags': 3,
+    'policy_setup_crash': 4,
+    'policy_inference_crash': 5,
+    'policy_oom': 6,
+    'latency_budget_exceeded': 7,
+    'wall_clock_exceeded': 8,
+    'internal_error': 9,
+    'quota_exceeded': 10,
+    'provision_wedged': 11,
+    'runner_unresponsive': 12,
+}
+
+SUBMISSION_STATUS_VALUES = {
+    'INVALID': 0,
+    'pending': 1,
+    'submitting': 2,
+    'running': 3,
+    'finished': 4,
+    'errored': 5,
+    'cancelled': 6,
+}
+
+KEY_STATUS_VALUES = {'INVALID': 0, 'created': 1, 'existing': 2, 'rotated': 3}
+
+ON_EXHAUSTED_VALUES = {'INVALID': 0, 'block': 1, 'meter': 2}
+
+QUOTA_SUBJECT_VALUES = {'INVALID': 0, 'user': 1, 'tenant': 2}
+
+BOARD_VISIBILITY_VALUES = {'INVALID': 0, 'public': 1, 'tenant': 2}
+
+PERSISTED_ENUMS: list[tuple[type[IntEnum], dict[str, int]]] = [
+    (ErrorCode, ERROR_CODE_VALUES),
+    (ReasonCode, REASON_CODE_VALUES),
+    (SubmissionStatus, SUBMISSION_STATUS_VALUES),
+    (KeyStatus, KEY_STATUS_VALUES),
+    (OnExhausted, ON_EXHAUSTED_VALUES),
+    (QuotaSubject, QUOTA_SUBJECT_VALUES),
+    (BoardVisibility, BOARD_VISIBILITY_VALUES),
+]
+
+
+@pytest.mark.parametrize(('enum_cls', 'expected'), PERSISTED_ENUMS, ids=lambda p: getattr(p, '__name__', ''))
+def test_the_name_to_value_mapping_is_pinned(enum_cls: type[IntEnum], expected: dict[str, int]):
+    assert {m.name: m.value for m in enum_cls} == expected
+
+
+@pytest.mark.parametrize(('enum_cls', 'expected'), PERSISTED_ENUMS, ids=lambda p: getattr(p, '__name__', ''))
+def test_zero_is_the_unset_sentinel(enum_cls: type[IntEnum], expected: dict[str, int]):
+    assert enum_cls(0).name == 'INVALID'
+
+
+@pytest.mark.parametrize(('enum_cls', 'expected'), PERSISTED_ENUMS, ids=lambda p: getattr(p, '__name__', ''))
+def test_no_value_is_reused(enum_cls: type[IntEnum], expected: dict[str, int]):
+    assert len(set(expected.values())) == len(expected)
+
+
+def test_the_status_sets_partition_the_decided_from_the_undecided():
+    assert ACTIVE_STATUSES & TERMINAL_STATUSES == frozenset()
+    assert ACTIVE_STATUSES | TERMINAL_STATUSES == set(SubmissionStatus) - {SubmissionStatus.INVALID}

--- a/client/platform_client/tests/test_evals.py
+++ b/client/platform_client/tests/test_evals.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from platform_client.evals import EvalRef
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import SubmissionCreateRequest
 from pydantic import ValidationError
 
@@ -37,9 +37,9 @@ def test_the_boundary_refuses_an_empty_eval():
 def test_an_image_reference_a_registry_could_never_resolve_is_refused_here(value: str):
     # An unpullable image is a CHARGED terminal submission, so a typo caught locally is quota saved.
     with pytest.raises(ValueError):
-        ImageRef(value)
+        PolicyImage(value)
 
 
 @pytest.mark.parametrize('value', ['org/policy', 'org/policy:v1', 'org/policy@sha256:abc', 'reg.io:5000/org/p:v1'])
 def test_a_reference_a_registry_can_resolve_is_kept(value: str):
-    assert ImageRef(value) == value
+    assert PolicyImage(value) == value

--- a/client/platform_client/tests/test_evals.py
+++ b/client/platform_client/tests/test_evals.py
@@ -1,9 +1,10 @@
-"""EvalRef: the one name a submission chooses by."""
+"""The two validated references a submission carries: the eval it runs, and the image it runs."""
 
 from __future__ import annotations
 
 import pytest
 from platform_client.evals import EvalRef
+from platform_client.images import ImageRef
 from platform_client.requests import SubmissionCreateRequest
 from pydantic import ValidationError
 
@@ -30,3 +31,15 @@ def test_a_name_this_client_has_never_heard_of_still_reaches_the_platform():
 def test_the_boundary_refuses_an_empty_eval():
     with pytest.raises(ValidationError):
         SubmissionCreateRequest.model_validate({'policy_image': 'org/policy:v1', 'eval': ''})
+
+
+@pytest.mark.parametrize('value', ['org/policy:', 'org/policy@sha256:', 'org/policy@nope', 'org/policy@sha256:zz'])
+def test_an_image_reference_a_registry_could_never_resolve_is_refused_here(value: str):
+    # An unpullable image is a CHARGED terminal submission, so a typo caught locally is quota saved.
+    with pytest.raises(ValueError):
+        ImageRef(value)
+
+
+@pytest.mark.parametrize('value', ['org/policy', 'org/policy:v1', 'org/policy@sha256:abc', 'reg.io:5000/org/p:v1'])
+def test_a_reference_a_registry_can_resolve_is_kept(value: str):
+    assert ImageRef(value) == value

--- a/client/platform_client/tests/test_evals.py
+++ b/client/platform_client/tests/test_evals.py
@@ -1,10 +1,9 @@
-"""The two validated references a submission carries: the eval it runs, and the image it runs."""
+"""The eval reference a submission names."""
 
 from __future__ import annotations
 
 import pytest
 from platform_client.evals import EvalRef
-from platform_client.policy_images import PolicyImage
 from platform_client.requests import SubmissionCreateRequest
 from pydantic import ValidationError
 
@@ -31,15 +30,3 @@ def test_a_name_this_client_has_never_heard_of_still_reaches_the_platform():
 def test_the_boundary_refuses_an_empty_eval():
     with pytest.raises(ValidationError):
         SubmissionCreateRequest.model_validate({'policy_image': 'org/policy:v1', 'eval': ''})
-
-
-@pytest.mark.parametrize('value', ['org/policy:', 'org/policy@sha256:', 'org/policy@nope', 'org/policy@sha256:zz'])
-def test_an_image_reference_a_registry_could_never_resolve_is_refused_here(value: str):
-    # An unpullable image is a CHARGED terminal submission, so a typo caught locally is quota saved.
-    with pytest.raises(ValueError):
-        PolicyImage(value)
-
-
-@pytest.mark.parametrize('value', ['org/policy', 'org/policy:v1', 'org/policy@sha256:abc', 'reg.io:5000/org/p:v1'])
-def test_a_reference_a_registry_can_resolve_is_kept(value: str):
-    assert PolicyImage(value) == value

--- a/client/platform_client/tests/test_evals.py
+++ b/client/platform_client/tests/test_evals.py
@@ -1,0 +1,32 @@
+"""EvalRef: the one name a submission chooses by."""
+
+from __future__ import annotations
+
+import pytest
+from platform_client.evals import EvalRef
+from platform_client.requests import SubmissionCreateRequest
+from pydantic import ValidationError
+
+
+def test_an_eval_name_is_a_str_carrying_its_type():
+    ref = EvalRef('robolab.public_subset')
+    assert ref == 'robolab.public_subset'
+    assert isinstance(ref, str)
+
+
+@pytest.mark.parametrize('value', ['', ' ', 'two words', 'trailing '])
+def test_a_value_that_could_never_name_an_eval_is_refused_here(value: str):
+    with pytest.raises(ValueError):
+        EvalRef(value)
+
+
+def test_a_name_this_client_has_never_heard_of_still_reaches_the_platform():
+    # The set lives on the server; a client that curated its own copy would refuse a newly offered
+    # eval until someone remembered to release it.
+    payload = {'policy_image': 'org/policy:v1', 'eval': 'an.eval.shipped.this.morning'}
+    assert SubmissionCreateRequest.model_validate(payload).eval == 'an.eval.shipped.this.morning'
+
+
+def test_the_boundary_refuses_an_empty_eval():
+    with pytest.raises(ValidationError):
+        SubmissionCreateRequest.model_validate({'policy_image': 'org/policy:v1', 'eval': ''})

--- a/client/platform_client/tests/test_ids.py
+++ b/client/platform_client/tests/test_ids.py
@@ -1,0 +1,129 @@
+"""Id64: the range invariant, the hex wire form, and the pydantic round trip."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from platform_client.ids import ID_LIMIT, Id64, SubmissionId, UserId
+from pydantic import BaseModel, ValidationError
+
+
+class ServiceId(Id64):
+    """An id declared outside this package — what a service with ids of its own does with `Id64`."""
+
+    __slots__ = ()
+
+
+class Holder(BaseModel):
+    user_id: UserId
+    other_id: ServiceId | None = None
+
+
+def test_an_id_is_an_int_carrying_its_subclass():
+    uid = UserId(255)
+    assert uid == 255
+    assert isinstance(uid, int)
+    assert type(uid) is UserId
+
+
+def test_the_wire_form_is_bare_lowercase_hex():
+    assert UserId(255).to_str() == 'ff'
+    assert str(UserId(255)) == 'ff'
+    assert SubmissionId(ID_LIMIT - 1).to_str() == '7fffffffffffffff'
+    assert not UserId(255).to_str().startswith(('0x', 'usr_'))
+
+
+def test_parse_accepts_an_int_or_case_insensitive_hex():
+    assert UserId.parse(255) == 255
+    assert UserId.parse('ff') == 255
+    assert UserId.parse('FF') == 255
+    assert type(UserId.parse('ff')) is UserId
+
+
+def test_parse_round_trips_through_the_wire_form():
+    for value in (1, 255, 4096, ID_LIMIT - 1):
+        assert SubmissionId.parse(SubmissionId(value).to_str()) == value
+
+
+def test_repr_is_evaluable():
+    uid = UserId(255)
+    assert repr(uid) == "UserId.parse('ff')"
+    assert eval(repr(uid)) == uid  # noqa: S307 - the repr contract is that it rebuilds the value
+
+
+@pytest.mark.parametrize('value', [0, -1, ID_LIMIT, ID_LIMIT + 1, 2**64])
+def test_out_of_range_is_rejected(value: int):
+    with pytest.raises(ValueError):
+        UserId(value)
+    with pytest.raises(ValueError):
+        UserId.parse(value)
+
+
+def test_a_bool_is_not_an_id():
+    with pytest.raises(TypeError):
+        UserId(True)
+
+
+def test_a_hex_string_needs_parse_not_the_constructor():
+    with pytest.raises(TypeError):
+        UserId('ff')  # pyright: ignore[reportArgumentType] - the refusal under test is of the wrong type
+
+
+@pytest.mark.parametrize('value', ['', 'zz', '0xff', '+ff', '-ff', 'f_f', 'ff ff', 'usr_ff', '12.5'])
+def test_a_non_hex_string_is_rejected(value: str):
+    with pytest.raises(ValueError):
+        UserId.parse(value)
+
+
+def test_zero_is_rejected_in_both_forms():
+    with pytest.raises(ValueError):
+        UserId.parse('0')
+    with pytest.raises(ValueError):
+        UserId.parse(0)
+
+
+def test_the_subclasses_are_distinct_types():
+    assert {type(UserId(1)), type(SubmissionId(1)), type(ServiceId(1))} == {UserId, SubmissionId, ServiceId}
+    assert not isinstance(UserId(1), SubmissionId)
+    assert issubclass(UserId, Id64)
+
+
+def test_pydantic_validates_an_int_or_a_hex_string_into_the_subclass():
+    from_hex = Holder.model_validate({'user_id': 'ff'}).user_id
+    from_int = Holder.model_validate({'user_id': 255}).user_id
+    assert type(from_hex) is type(from_int) is UserId
+    assert from_hex == from_int == 255
+
+
+def test_pydantic_serializes_to_hex_in_both_dump_modes():
+    holder = Holder(user_id=UserId(255), other_id=ServiceId(16))
+    assert holder.model_dump(mode='json') == {'user_id': 'ff', 'other_id': '10'}
+    assert holder.model_dump() == {'user_id': 'ff', 'other_id': '10'}
+
+
+def test_the_json_payload_never_carries_a_number():
+    payload = json.loads(Holder(user_id=UserId(ID_LIMIT - 1)).model_dump_json())
+    assert payload['user_id'] == '7fffffffffffffff'
+    assert isinstance(payload['user_id'], str)
+
+
+def test_json_input_must_be_the_hex_string():
+    assert Holder.model_validate_json('{"user_id": "ff"}').user_id == 255
+    # A full int64 does not survive a JavaScript JSON parser, so a number is a server bug, not input.
+    with pytest.raises(ValidationError):
+        Holder.model_validate_json('{"user_id": 255}')
+
+
+def test_pydantic_rejects_an_out_of_range_or_unparseable_id():
+    with pytest.raises(ValidationError):
+        Holder.model_validate({'user_id': 0})
+    with pytest.raises(ValidationError):
+        Holder.model_validate({'user_id': ID_LIMIT})
+    with pytest.raises(ValidationError):
+        Holder.model_validate({'user_id': 'nope'})
+
+
+def test_a_model_round_trips_through_its_json_form():
+    holder = Holder(user_id=UserId(1234), other_id=ServiceId(4321))
+    assert Holder.model_validate(holder.model_dump(mode='json')) == holder

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -105,7 +105,7 @@ MODELS: list[BaseModel] = [
     ),
     CancelRequest(id=SUB),
     SubmissionGetQuery(id=SUB),
-    RankingsQuery(board=BoardRef('smoke'), eval_version='smoke@0123456789ab'),
+    RankingsQuery(board=BoardRef('smoke')),
     RegisterResponse(
         user_id=USER,
         artifact_location='s3://pp-artifacts/users/a0/',
@@ -114,12 +114,7 @@ MODELS: list[BaseModel] = [
     ),
     RegisterResponse(user_id=USER, artifact_location='s3://pp-artifacts/users/a0/', key_status=KeyStatus.existing),
     MeResponse(user_id=USER, alias='demo', tenant='nebius-2026', plan='nebius_competition_2026', quota=[DAILY]),
-    SubmissionCreateResponse(
-        submission_id=SUB,
-        status=SubmissionStatus.pending,
-        policy_image_digest='sha256:abc',
-        eval_version='smoke@0123456789ab',
-    ),
+    SubmissionCreateResponse(submission_id=SUB, status=SubmissionStatus.pending, policy_image_digest='sha256:abc'),
     SubmissionCreateResponse(
         submission_id=SUB, status=SubmissionStatus.errored, reason_code=ReasonCode.image_unpullable
     ),
@@ -145,7 +140,6 @@ MODELS: list[BaseModel] = [
     RankingsResponse(
         board=BoardRef('smoke'),
         eval=EvalRef('fake.smoke'),
-        eval_version='smoke@0123456789ab',
         primary_metric='success_rate',
         rankings=[
             RankingRow(rank=1, display_name='demo', tag='0ddba7', scores=SCORES, submission_id=SUB, submitted_at=AT)
@@ -158,7 +152,6 @@ MODELS: list[BaseModel] = [
                 board=BoardRef('smoke'),
                 title='Smoke',
                 eval=EvalRef('fake.smoke'),
-                eval_version='smoke@0123456789ab',
                 primary_metric='success_rate',
                 visibility=BoardVisibility.public,
             )
@@ -274,22 +267,12 @@ def test_a_board_slug_arrives_as_its_own_type_on_both_sides():
                 'board': 'smoke',
                 'title': 'Smoke',
                 'eval': 'fake.smoke',
-                'eval_version': 'smoke@0123456789ab',
                 'primary_metric': 'success_rate',
                 'visibility': 'public',
             }
         ]
     })
     assert isinstance(listed.boards[0].board, BoardRef)
-
-
-def test_an_unset_query_parameter_is_absent_from_the_url_rather_than_empty():
-    assert RankingsQuery(board=BoardRef('smoke')).model_dump(mode='json', exclude_none=True) == {'board': 'smoke'}
-
-
-def test_a_pinned_query_carries_its_version():
-    query = RankingsQuery(board=BoardRef('smoke'), eval_version='smoke@old')
-    assert query.model_dump(mode='json', exclude_none=True) == {'board': 'smoke', 'eval_version': 'smoke@old'}
 
 
 def test_an_id_reaches_the_query_string_in_its_hex_wire_form():

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -57,7 +57,7 @@ USER = UserId(0xA0)
 SCORES = Scores(primary=0.75, success_rate=0.5, per_task={'banana_in_bowl': 0.75}, episodes=4, unscored=0)
 
 DAILY = QuotaLimit(
-    key='submissions.day',
+    key=QUOTA_SUBMISSIONS_DAY,
     meter='submissions',
     unit='submission',
     scale=1,
@@ -380,7 +380,7 @@ def test_the_published_keys_are_the_ones_a_caller_looks_up():
 def test_a_limit_is_found_by_its_rule_key():
     me = MeResponse(user_id=USER, tenant='nebius-2026', plan='nebius_competition_2026', quota=[DAILY, CREDITS])
     assert me.quota_for('credits.period') is CREDITS
-    assert me.quota_for('submissions.concurrent') is None
+    assert me.quota_for(QUOTA_SUBMISSIONS_CONCURRENT) is None
 
 
 def test_a_quota_refusal_carries_the_whole_rule_that_refused_it():
@@ -392,7 +392,7 @@ def test_a_quota_refusal_carries_the_whole_rule_that_refused_it():
                 'message': 'daily submission quota exhausted',
                 'details': {
                     QUOTA_DETAIL: {
-                        'key': 'submissions.day',
+                        'key': QUOTA_SUBMISSIONS_DAY,
                         'meter': 'submissions',
                         'unit': 'submission',
                         'scale': 1,
@@ -409,7 +409,7 @@ def test_a_quota_refusal_carries_the_whole_rule_that_refused_it():
         },
     )
     assert err.quota is not None
-    assert err.quota.key == 'submissions.day'
+    assert err.quota.key == QUOTA_SUBMISSIONS_DAY
     assert err.quota.remaining == 0
     assert err.quota.on_exhausted is OnExhausted.block
     assert err.quota.resets_at == datetime(2026, 8, 12, tzinfo=UTC)
@@ -418,3 +418,29 @@ def test_a_quota_refusal_carries_the_whole_rule_that_refused_it():
 def test_an_error_without_a_quota_detail_reports_none():
     err = PlatformError.from_payload(400, {'error': {'code': 'bad_request', 'message': 'nope'}})
     assert err.quota is None
+
+
+def test_a_scale_of_zero_is_refused_at_the_boundary():
+    # Consumers divide by it, so a zero would validate here and raise ZeroDivisionError there.
+    payload = DAILY.model_dump(mode='json') | {'scale': 0}
+    with pytest.raises(ValidationError):
+        QuotaLimit.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    'model, payload',
+    [
+        (SubmissionCreateResponse, {'submission_id': 'ff', 'status': 'submitting'}),
+        (CancelResponse, {'status': 'submitting', 'refunded': False}),
+    ],
+)
+def test_the_internal_claim_state_never_reaches_a_caller(model: type[BaseModel], payload: dict):
+    # The enum says the gateway reports `submitting` as `pending`; a payload carrying it is a
+    # gateway that forgot, refused here rather than left for every consumer to normalise.
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+@pytest.mark.parametrize('status', ['pending', 'running', 'finished', 'errored', 'cancelled'])
+def test_every_status_a_caller_can_see_is_kept(status: str):
+    assert SubmissionCreateResponse.model_validate({'submission_id': 'ff', 'status': status}).status.name == status

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -27,8 +27,10 @@ from platform_client.requests import (
     SubmissionGetQuery,
 )
 from platform_client.responses import (
+    ID_FIELD,
     QUOTA_SUBMISSIONS_CONCURRENT,
     QUOTA_SUBMISSIONS_DAY,
+    STATUS_FIELD,
     ArtifactRefs,
     BoardListResponse,
     BoardSummary,
@@ -316,6 +318,22 @@ def test_an_empty_transaction_key_is_a_client_bug_not_an_absent_one():
 )
 def test_the_status_slug_selects_the_view_variant(payload: dict, expected: type[BaseModel]):
     assert type(SUBMISSION_VIEWS.validate_python(payload)) is expected
+
+
+@pytest.mark.parametrize(
+    'variant',
+    [
+        PendingSubmissionView,
+        RunningSubmissionView,
+        ErroredSubmissionView,
+        FinishedSubmissionView,
+        CancelledSubmissionView,
+    ],
+)
+def test_the_published_field_names_are_ones_every_variant_declares(variant: type[BaseModel]):
+    # `positronic eval status` prints these two on its header line and excludes them from the body
+    # by these names, so a name that outlived its field would print it twice.
+    assert {ID_FIELD, STATUS_FIELD} <= set(variant.model_fields)
 
 
 def test_a_view_refuses_a_status_that_is_not_its_own_tag():

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pytest
+from platform_client.boards import BoardRef
 from platform_client.enums import (
     BoardVisibility,
     ErrorCode,
@@ -100,7 +101,7 @@ MODELS: list[BaseModel] = [
     ),
     CancelRequest(id=SUB),
     SubmissionGetQuery(id=SUB),
-    RankingsQuery(board='smoke', eval_version='smoke@0123456789ab'),
+    RankingsQuery(board=BoardRef('smoke'), eval_version='smoke@0123456789ab'),
     RegisterResponse(
         user_id=USER,
         artifact_location='s3://pp-artifacts/users/a0/',
@@ -138,7 +139,7 @@ MODELS: list[BaseModel] = [
     CancelledSubmissionView(id=SUB, cancelled_at=AT),
     CancelResponse(status=SubmissionStatus.cancelled, refunded=True),
     RankingsResponse(
-        board='smoke',
+        board=BoardRef('smoke'),
         eval=EvalRef('fake.smoke'),
         eval_version='smoke@0123456789ab',
         primary_metric='success_rate',
@@ -150,7 +151,7 @@ MODELS: list[BaseModel] = [
     BoardListResponse(
         boards=[
             BoardSummary(
-                board='smoke',
+                board=BoardRef('smoke'),
                 title='Smoke',
                 eval=EvalRef('fake.smoke'),
                 eval_version='smoke@0123456789ab',
@@ -218,12 +219,72 @@ def test_a_digest_pinned_image_is_taken_whole_and_parsed():
     assert request.policy_image.digest == 'sha256:abc'
 
 
+def test_a_reason_code_is_refused_on_a_status_that_did_not_fail():
+    # `ReasonCode` says why a run FAILED. A pending payload carrying one is a malformed response,
+    # and validating it would report a submission as accepted while naming the reason it was not.
+    with pytest.raises(ValidationError):
+        SubmissionCreateResponse.model_validate({
+            'submission_id': '1f',
+            'status': 'pending',
+            'reason_code': 'image_unpullable',
+        })
+
+
+def test_a_listed_row_refuses_the_same_pairing():
+    with pytest.raises(ValidationError):
+        SubmissionListRow.model_validate({
+            'id': '1f',
+            'user_id': 'a0',
+            'status': 'finished',
+            'eval': 'fake.smoke',
+            'received_at': '2026-08-13T10:00:00Z',
+            'reason_code': 'policy_oom',
+        })
+
+
+def test_an_errored_row_keeps_its_reason_and_a_clean_one_needs_none():
+    # The boundary of the rule above: it constrains the PAIRING, not either field on its own.
+    errored = SubmissionCreateResponse.model_validate({
+        'submission_id': '1f',
+        'status': 'errored',
+        'reason_code': 'image_unpullable',
+    })
+    assert errored.reason_code is ReasonCode.image_unpullable
+    assert SubmissionCreateResponse.model_validate({'submission_id': '1f', 'status': 'pending'}).reason_code is None
+    # An errored submission need not say why — the taxonomy is optional, the pairing is not.
+    assert SubmissionCreateResponse.model_validate({'submission_id': '1f', 'status': 'errored'}).reason_code is None
+
+
+def test_a_board_slug_that_could_never_be_one_is_refused():
+    with pytest.raises(ValidationError):
+        RankingsQuery.model_validate({'board': '   '})
+    with pytest.raises(ValidationError):
+        RankingsQuery.model_validate({'board': ''})
+
+
+def test_a_board_slug_arrives_as_its_own_type_on_both_sides():
+    assert isinstance(RankingsQuery(board=BoardRef('smoke')).board, BoardRef)
+    listed = BoardListResponse.model_validate({
+        'boards': [
+            {
+                'board': 'smoke',
+                'title': 'Smoke',
+                'eval': 'fake.smoke',
+                'eval_version': 'smoke@0123456789ab',
+                'primary_metric': 'success_rate',
+                'visibility': 'public',
+            }
+        ]
+    })
+    assert isinstance(listed.boards[0].board, BoardRef)
+
+
 def test_an_unset_query_parameter_is_absent_from_the_url_rather_than_empty():
-    assert RankingsQuery(board='smoke').model_dump(mode='json', exclude_none=True) == {'board': 'smoke'}
+    assert RankingsQuery(board=BoardRef('smoke')).model_dump(mode='json', exclude_none=True) == {'board': 'smoke'}
 
 
 def test_a_pinned_query_carries_its_version():
-    query = RankingsQuery(board='smoke', eval_version='smoke@old')
+    query = RankingsQuery(board=BoardRef('smoke'), eval_version='smoke@old')
     assert query.model_dump(mode='json', exclude_none=True) == {'board': 'smoke', 'eval_version': 'smoke@old'}
 
 

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import get_args
 
 import pytest
 from platform_client.boards import BoardRef
@@ -51,7 +52,8 @@ from platform_client.responses import (
     SubmissionListRow,
     SubmissionView,
 )
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from platform_client.slug import slug_of
+from pydantic import BaseModel, Tag, TypeAdapter, ValidationError
 
 AT = datetime(2026, 3, 4, 5, 6, 7, tzinfo=UTC)
 SUB = SubmissionId(0x1F)
@@ -348,6 +350,17 @@ def test_a_view_refuses_a_status_that_is_not_its_own_tag():
 def test_a_view_keeps_its_own_tag():
     view = PendingSubmissionView(id=SUB, received_at=AT, queued_at=AT, queue_position=1)
     assert view.status is SubmissionStatus.pending
+
+
+def test_every_variant_is_tagged_with_the_slug_of_the_status_it_declares():
+    # The discriminator computes a tag from the payload's slug, so a tag spelled any other way names
+    # a wire value nothing produces and the variant becomes unreachable.
+    variants = get_args(get_args(SubmissionView)[0])
+    assert len(variants) == 5
+    for variant in variants:
+        model, tag = get_args(variant)
+        assert isinstance(tag, Tag)
+        assert tag.tag == slug_of(model.model_fields[STATUS_FIELD].default)
 
 
 def test_a_minted_outcome_without_its_key_is_refused():

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -1,0 +1,420 @@
+"""Every request and response model survives its own JSON form, and the status union routes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from platform_client.enums import (
+    BoardVisibility,
+    ErrorCode,
+    KeyStatus,
+    OnExhausted,
+    QuotaSubject,
+    ReasonCode,
+    SubmissionStatus,
+)
+from platform_client.errors import QUOTA_DETAIL, REASON_CODE_DETAIL, ApiErrorBody, ErrorEnvelope, PlatformError
+from platform_client.evals import EvalRef
+from platform_client.ids import ApiKey, SubmissionId, TransactionKey, UserId
+from platform_client.images import ImageRef
+from platform_client.requests import (
+    CancelRequest,
+    RankingsQuery,
+    RegisterRequest,
+    SubmissionCreateRequest,
+    SubmissionGetQuery,
+)
+from platform_client.responses import (
+    QUOTA_SUBMISSIONS_CONCURRENT,
+    QUOTA_SUBMISSIONS_DAY,
+    ArtifactRefs,
+    BoardListResponse,
+    BoardSummary,
+    CancelledSubmissionView,
+    CancelResponse,
+    ErroredSubmissionView,
+    FinishedSubmissionView,
+    MeResponse,
+    PendingSubmissionView,
+    QuotaLimit,
+    RankingRow,
+    RankingsResponse,
+    RegisterResponse,
+    RunningSubmissionView,
+    Scores,
+    SubmissionCreateResponse,
+    SubmissionListResponse,
+    SubmissionListRow,
+    SubmissionView,
+)
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+AT = datetime(2026, 3, 4, 5, 6, 7, tzinfo=UTC)
+SUB = SubmissionId(0x1F)
+USER = UserId(0xA0)
+
+SCORES = Scores(primary=0.75, success_rate=0.5, per_task={'banana_in_bowl': 0.75}, episodes=4, unscored=0)
+
+DAILY = QuotaLimit(
+    key='submissions.day',
+    meter='submissions',
+    unit='submission',
+    scale=1,
+    window='day',
+    subject=QuotaSubject.user,
+    limit=2,
+    used=1,
+    resets_at=AT,
+    on_exhausted=OnExhausted.block,
+)
+
+CREDITS = QuotaLimit(
+    key='credits.period',
+    meter='credits',
+    unit='credit',
+    scale=6,
+    window='24 Jul – 23 Aug',
+    subject=QuotaSubject.tenant,
+    scope=['real'],
+    limit=600,
+    used=630,
+    resets_at=None,
+    on_exhausted=OnExhausted.meter,
+)
+
+SUBMISSION_VIEWS = TypeAdapter(SubmissionView)
+
+MODELS: list[BaseModel] = [
+    Scores(),
+    SCORES,
+    DAILY,
+    CREDITS,
+    ArtifactRefs(result='s3://pp-artifacts/users/a0/submissions/1f/result.json'),
+    RegisterRequest(credential='token', alias='demo', rotate=True),
+    SubmissionCreateRequest(
+        policy_image=ImageRef('org/policy:v1'),
+        eval=EvalRef('fake.smoke'),
+        alias='demo',
+        transaction_key=TransactionKey('key-1'),
+    ),
+    CancelRequest(id=SUB),
+    SubmissionGetQuery(id=SUB),
+    RankingsQuery(board='smoke', eval_version='smoke@0123456789ab'),
+    RegisterResponse(
+        user_id=USER,
+        artifact_location='s3://pp-artifacts/users/a0/',
+        api_key=ApiKey('pk_live_secret'),
+        key_status=KeyStatus.created,
+    ),
+    RegisterResponse(user_id=USER, artifact_location='s3://pp-artifacts/users/a0/', key_status=KeyStatus.existing),
+    MeResponse(user_id=USER, alias='demo', tenant='nebius-2026', plan='nebius_competition_2026', quota=[DAILY]),
+    SubmissionCreateResponse(
+        submission_id=SUB,
+        status=SubmissionStatus.pending,
+        policy_image_digest='sha256:abc',
+        eval_version='smoke@0123456789ab',
+    ),
+    SubmissionCreateResponse(
+        submission_id=SUB, status=SubmissionStatus.errored, reason_code=ReasonCode.image_unpullable
+    ),
+    SubmissionListResponse(),
+    SubmissionListResponse(
+        submissions=[
+            SubmissionListRow(
+                id=SUB,
+                user_id=USER,
+                alias='demo',
+                status=SubmissionStatus.running,
+                eval=EvalRef('fake.smoke'),
+                received_at=AT,
+            )
+        ]
+    ),
+    PendingSubmissionView(id=SUB, alias='demo', received_at=AT, queued_at=AT, queue_position=1),
+    RunningSubmissionView(id=SUB, running_since=AT, stage='evaluating', stage_detail='task 2/10'),
+    ErroredSubmissionView(id=SUB, reason_code=ReasonCode.policy_oom, reason='policy ran out of memory'),
+    FinishedSubmissionView(id=SUB, scores=SCORES, artifacts=ArtifactRefs(result='s3://b/result.json')),
+    CancelledSubmissionView(id=SUB, cancelled_at=AT),
+    CancelResponse(status=SubmissionStatus.cancelled, refunded=True),
+    RankingsResponse(
+        board='smoke',
+        eval=EvalRef('fake.smoke'),
+        eval_version='smoke@0123456789ab',
+        primary_metric='success_rate',
+        rankings=[
+            RankingRow(rank=1, display_name='demo', tag='0ddba7', scores=SCORES, submission_id=SUB, submitted_at=AT)
+        ],
+    ),
+    BoardListResponse(),
+    BoardListResponse(
+        boards=[
+            BoardSummary(
+                board='smoke',
+                title='Smoke',
+                eval=EvalRef('fake.smoke'),
+                eval_version='smoke@0123456789ab',
+                primary_metric='success_rate',
+                visibility=BoardVisibility.public,
+            )
+        ]
+    ),
+    ErrorEnvelope(error=ApiErrorBody(code=ErrorCode.quota_exceeded, message='daily quota spent')),
+]
+
+
+@pytest.mark.parametrize('model', MODELS, ids=lambda m: type(m).__name__)
+def test_a_model_round_trips_through_its_json_form(model: BaseModel):
+    assert type(model).model_validate(model.model_dump(mode='json')) == model
+
+
+@pytest.mark.parametrize('model', MODELS, ids=lambda m: type(m).__name__)
+def test_a_model_round_trips_through_a_real_json_string(model: BaseModel):
+    assert type(model).model_validate_json(model.model_dump_json()) == model
+
+
+def test_ids_and_statuses_leave_as_wire_values():
+    payload = SubmissionListResponse(
+        submissions=[
+            SubmissionListRow(
+                id=SUB,
+                user_id=USER,
+                status=SubmissionStatus.errored,
+                eval=EvalRef('fake.smoke'),
+                received_at=AT,
+                reason_code=ReasonCode.image_unpullable,
+            )
+        ]
+    ).model_dump(mode='json')
+    row = payload['submissions'][0]
+    assert row['id'] == '1f'
+    assert row['user_id'] == 'a0'
+    assert row['status'] == 'errored'
+    assert row['reason_code'] == 'image_unpullable'
+    assert row['received_at'].startswith('2026-03-04T05:06:07')
+
+
+def test_a_request_rejects_an_unknown_field():
+    with pytest.raises(ValidationError):
+        SubmissionCreateRequest.model_validate({
+            'policy_image': 'i',
+            'eval': 'fake.smoke',
+            'evals': 'fake.smoke',  # a plausible typo of eval
+        })
+
+
+def test_a_policy_image_the_registry_could_never_resolve_is_refused_here():
+    with pytest.raises(ValidationError):
+        SubmissionCreateRequest.model_validate({
+            'policy_image': 'org/policy@',  # a digest separator with nothing behind it
+            'eval': 'fake.smoke',
+        })
+
+
+def test_a_digest_pinned_image_is_taken_whole_and_parsed():
+    request = SubmissionCreateRequest(policy_image=ImageRef('org/policy@sha256:abc'), eval=EvalRef('fake.smoke'))
+    assert isinstance(request.policy_image, ImageRef)
+    assert request.policy_image.name == 'org/policy'
+    assert request.policy_image.digest == 'sha256:abc'
+
+
+def test_an_unset_query_parameter_is_absent_from_the_url_rather_than_empty():
+    assert RankingsQuery(board='smoke').model_dump(mode='json', exclude_none=True) == {'board': 'smoke'}
+
+
+def test_a_pinned_query_carries_its_version():
+    query = RankingsQuery(board='smoke', eval_version='smoke@old')
+    assert query.model_dump(mode='json', exclude_none=True) == {'board': 'smoke', 'eval_version': 'smoke@old'}
+
+
+def test_an_id_reaches_the_query_string_in_its_hex_wire_form():
+    assert SubmissionGetQuery(id=SUB).model_dump(mode='json') == {'id': SUB.to_str()}
+
+
+def test_an_empty_transaction_key_is_a_client_bug_not_an_absent_one():
+    with pytest.raises(ValidationError):
+        SubmissionCreateRequest.model_validate({'policy_image': 'i', 'eval': 'fake.smoke', 'transaction_key': ''})
+
+
+@pytest.mark.parametrize(
+    ('payload', 'expected'),
+    [
+        (
+            {'id': '1f', 'received_at': AT, 'queued_at': AT, 'queue_position': 3, 'status': 'pending'},
+            PendingSubmissionView,
+        ),
+        ({'id': '1f', 'running_since': AT, 'stage': 'evaluating', 'status': 'running'}, RunningSubmissionView),
+        ({'id': '1f', 'reason_code': 'policy_oom', 'reason': 'oom', 'status': 'errored'}, ErroredSubmissionView),
+        (
+            {'id': '1f', 'scores': {}, 'artifacts': {'result': 's3://b/result.json'}, 'status': 'finished'},
+            FinishedSubmissionView,
+        ),
+        ({'id': '1f', 'cancelled_at': AT, 'status': 'cancelled'}, CancelledSubmissionView),
+    ],
+    ids=['pending', 'running', 'errored', 'finished', 'cancelled'],
+)
+def test_the_status_slug_selects_the_view_variant(payload: dict, expected: type[BaseModel]):
+    assert type(SUBMISSION_VIEWS.validate_python(payload)) is expected
+
+
+def test_a_view_refuses_a_status_that_is_not_its_own_tag():
+    # `submitting` is an internal state the union has no variant for; a gateway building a pending
+    # view from such a record must fail here rather than emit a tag no caller can route.
+    with pytest.raises(ValidationError):
+        PendingSubmissionView(
+            id=SUB, received_at=AT, queued_at=AT, queue_position=1, status=SubmissionStatus.submitting
+        )
+
+
+def test_a_view_keeps_its_own_tag():
+    view = PendingSubmissionView(id=SUB, received_at=AT, queued_at=AT, queue_position=1)
+    assert view.status is SubmissionStatus.pending
+
+
+def test_a_minted_outcome_without_its_key_is_refused():
+    with pytest.raises(ValidationError):
+        RegisterResponse(user_id=USER, artifact_location='s3://b/', key_status=KeyStatus.created)
+
+
+def test_an_existing_registration_carrying_a_key_is_refused():
+    with pytest.raises(ValidationError):
+        RegisterResponse(user_id=USER, artifact_location='s3://b/', api_key=ApiKey('pk'), key_status=KeyStatus.existing)
+
+
+def test_each_outcome_paired_with_its_own_key_state_is_kept():
+    minted = RegisterResponse(
+        user_id=USER, artifact_location='s3://b/', api_key=ApiKey('pk'), key_status=KeyStatus.rotated
+    )
+    existing = RegisterResponse(user_id=USER, artifact_location='s3://b/', key_status=KeyStatus.existing)
+    assert minted.api_key is not None and existing.api_key is None
+
+
+def test_an_unknown_status_does_not_resolve_to_a_variant():
+    with pytest.raises(ValidationError):
+        SUBMISSION_VIEWS.validate_python({'id': '1f', 'status': 'submitting'})
+
+
+def test_a_view_round_trips_back_to_its_own_variant():
+    view = RunningSubmissionView(id=SUB, running_since=AT, stage='scoring')
+    assert SUBMISSION_VIEWS.validate_python(SUBMISSION_VIEWS.dump_python(view, mode='json')) == view
+
+
+def test_the_error_exception_exposes_the_envelope_and_the_reason_code():
+    payload = {
+        'error': {
+            'code': 'bad_request',
+            'message': 'image not pullable',
+            'details': {REASON_CODE_DETAIL: 'image_unpullable'},
+        }
+    }
+    err = PlatformError.from_payload(400, payload)
+    assert err.code is ErrorCode.bad_request
+    assert err.message == 'image not pullable'
+    assert err.reason_code is ReasonCode.image_unpullable
+    assert err.http_status == 400
+
+
+def test_an_unparseable_error_body_still_raises_the_same_exception():
+    err = PlatformError.from_payload(502, '<html>bad gateway</html>')
+    assert err.code is ErrorCode.internal_error
+    assert err.http_status == 502
+    assert err.details['body'] == '<html>bad gateway</html>'
+
+
+def test_a_reason_code_this_client_cannot_read_is_invalid_rather_than_absent():
+    err = PlatformError.from_payload(
+        400,
+        {'error': {'code': 'bad_request', 'message': 'm', 'details': {REASON_CODE_DETAIL: 'from_a_newer_taxonomy'}}},
+    )
+    assert err.reason_code is ReasonCode.INVALID
+
+
+def test_a_failure_carrying_no_reason_reports_none():
+    err = PlatformError.from_payload(400, {'error': {'code': 'bad_request', 'message': 'm'}})
+    assert err.reason_code is None
+
+
+def test_a_defect_inside_validation_surfaces_instead_of_becoming_an_unparseable_body(monkeypatch):
+    def boom(_payload: object) -> ErrorEnvelope:
+        raise RuntimeError('a validator bug, not a malformed payload')
+
+    monkeypatch.setattr(ErrorEnvelope, 'model_validate', staticmethod(boom))
+    with pytest.raises(RuntimeError):
+        PlatformError.from_payload(500, {'error': {'code': 'internal_error', 'message': 'm'}})
+
+
+def test_a_queue_position_below_one_is_refused():
+    with pytest.raises(ValidationError):
+        PendingSubmissionView(id=SUB, received_at=AT, queued_at=AT, queue_position=0)
+
+
+def test_the_first_place_in_the_queue_is_kept():
+    assert PendingSubmissionView(id=SUB, received_at=AT, queued_at=AT, queue_position=1).queue_position == 1
+
+
+def test_an_error_without_a_reason_code_reports_none():
+    err = PlatformError.from_payload(429, {'error': {'code': 'quota_exceeded', 'message': 'spent'}})
+    assert err.reason_code is None
+
+
+def test_a_quota_limit_leaves_with_its_slugs_and_an_empty_scope():
+    payload = DAILY.model_dump(mode='json')
+    assert payload['on_exhausted'] == 'block'
+    assert payload['subject'] == 'user'
+    assert payload['scope'] == []
+    assert CREDITS.model_dump(mode='json')['scope'] == ['real']
+
+
+def test_remaining_is_computed_and_never_negative():
+    assert DAILY.remaining == 1
+    assert CREDITS.remaining == 0
+    assert 'remaining' not in DAILY.model_dump(mode='json')
+
+
+def test_the_published_keys_are_the_ones_a_caller_looks_up():
+    me = MeResponse(user_id=USER, tenant='t', plan='p', quota=[DAILY])
+    assert me.quota_for(QUOTA_SUBMISSIONS_DAY) is DAILY
+    assert me.quota_for(QUOTA_SUBMISSIONS_CONCURRENT) is None  # a plan need not declare every rule
+
+
+def test_a_limit_is_found_by_its_rule_key():
+    me = MeResponse(user_id=USER, tenant='nebius-2026', plan='nebius_competition_2026', quota=[DAILY, CREDITS])
+    assert me.quota_for('credits.period') is CREDITS
+    assert me.quota_for('submissions.concurrent') is None
+
+
+def test_a_quota_refusal_carries_the_whole_rule_that_refused_it():
+    err = PlatformError.from_payload(
+        429,
+        {
+            'error': {
+                'code': 'quota_exceeded',
+                'message': 'daily submission quota exhausted',
+                'details': {
+                    QUOTA_DETAIL: {
+                        'key': 'submissions.day',
+                        'meter': 'submissions',
+                        'unit': 'submission',
+                        'scale': 1,
+                        'window': 'day',
+                        'subject': 'user',
+                        'scope': [],
+                        'limit': 2,
+                        'used': 2,
+                        'resets_at': '2026-08-12T00:00:00Z',
+                        'on_exhausted': 'block',
+                    }
+                },
+            }
+        },
+    )
+    assert err.quota is not None
+    assert err.quota.key == 'submissions.day'
+    assert err.quota.remaining == 0
+    assert err.quota.on_exhausted is OnExhausted.block
+    assert err.quota.resets_at == datetime(2026, 8, 12, tzinfo=UTC)
+
+
+def test_an_error_without_a_quota_detail_reports_none():
+    err = PlatformError.from_payload(400, {'error': {'code': 'bad_request', 'message': 'nope'}})
+    assert err.quota is None

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -18,7 +18,7 @@ from platform_client.enums import (
 from platform_client.errors import QUOTA_DETAIL, REASON_CODE_DETAIL, ApiErrorBody, ErrorEnvelope, PlatformError
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId, TransactionKey, UserId
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import (
     CancelRequest,
     RankingsQuery,
@@ -94,7 +94,7 @@ MODELS: list[BaseModel] = [
     ArtifactRefs(result='s3://pp-artifacts/users/a0/submissions/1f/result.json'),
     RegisterRequest(credential='token', alias='demo', rotate=True),
     SubmissionCreateRequest(
-        policy_image=ImageRef('org/policy:v1'),
+        policy_image=PolicyImage('org/policy:v1'),
         eval=EvalRef('fake.smoke'),
         alias='demo',
         transaction_key=TransactionKey('key-1'),
@@ -213,8 +213,8 @@ def test_a_policy_image_the_registry_could_never_resolve_is_refused_here():
 
 
 def test_a_digest_pinned_image_is_taken_whole_and_parsed():
-    request = SubmissionCreateRequest(policy_image=ImageRef('org/policy@sha256:abc'), eval=EvalRef('fake.smoke'))
-    assert isinstance(request.policy_image, ImageRef)
+    request = SubmissionCreateRequest(policy_image=PolicyImage('org/policy@sha256:abc'), eval=EvalRef('fake.smoke'))
+    assert isinstance(request.policy_image, PolicyImage)
     assert request.policy_image.name == 'org/policy'
     assert request.policy_image.digest == 'sha256:abc'
 

--- a/client/platform_client/tests/test_policy_images.py
+++ b/client/platform_client/tests/test_policy_images.py
@@ -1,0 +1,77 @@
+"""The image reference a submission carries."""
+
+from __future__ import annotations
+
+import pytest
+from platform_client.policy_images import PolicyImage
+from pydantic import BaseModel, ValidationError
+
+
+def test_a_reference_splits_into_its_name_and_its_digest():
+    unpinned = PolicyImage('org/policy:v1')
+    assert (unpinned.name, unpinned.digest) == ('org/policy:v1', None)
+    pinned = PolicyImage('org/policy:v1@sha256:abc123')
+    assert (pinned.name, pinned.digest) == ('org/policy:v1', 'sha256:abc123')
+
+
+def test_pinning_replaces_a_digest_rather_than_appending_one():
+    assert PolicyImage('org/policy:v1').pinned('sha256:abc') == 'org/policy:v1@sha256:abc'
+    # An already-pinned reference re-pins to the resolved digest — never `repo@sha256:…@sha256:…`.
+    repinned = PolicyImage('org/policy@sha256:aaa').pinned('sha256:bbb')
+    assert repinned == 'org/policy@sha256:bbb' and repinned.count('@') == 1
+    assert isinstance(repinned, PolicyImage)
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        '',
+        '@sha256:abc',
+        'org/ policy',
+        'org/policy@',
+        'org/policy@nope',
+        'org/policy@sha256:zz',
+        'org/policy@sha256:a@sha256:b',
+        'org/policy:',
+        'org/policy:bad:tag',
+        'org/policy:v1 ',
+        'org//policy',
+        'org/policy:-v1',
+    ],
+)
+def test_a_reference_no_registry_could_resolve_is_refused_here(value: str):
+    # The gateway resolves this reference against a registry, and an unpullable image is a CHARGED
+    # terminal submission — so the shapes a typo makes are refused here rather than billed later.
+    with pytest.raises(ValueError):
+        PolicyImage(value)
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        'policy',
+        'org/policy',
+        'org/policy:v1',
+        'org/policy@sha256:abc',
+        'org/team/policy:v1',
+        'org/policy:v1.2_beta-3',
+        'reg.io/org/p:v1',
+        'reg.io:5000/org/p:v1',
+        'reg.io:5000/org/p:v1@sha256:abc',
+    ],
+)
+def test_a_reference_a_registry_can_resolve_is_kept(value: str):
+    # `reg.io:5000/...` is a registry PORT, and a tag carries dots, underscores and hyphens of its
+    # own — the grammar that refuses `org/policy:bad:tag` must admit all of these unchanged.
+    assert PolicyImage(value) == value
+
+
+def test_references_are_plain_strings_on_the_wire():
+    class M(BaseModel):
+        image: PolicyImage
+
+    parsed = M.model_validate({'image': 'org/policy:v1@sha256:abc'})
+    assert isinstance(parsed.image, PolicyImage) and parsed.image.digest == 'sha256:abc'
+    assert parsed.model_dump() == {'image': 'org/policy:v1@sha256:abc'}
+    with pytest.raises(ValidationError):
+        M.model_validate({'image': '@sha256:abc'})

--- a/client/platform_client/tests/test_slug.py
+++ b/client/platform_client/tests/test_slug.py
@@ -1,0 +1,67 @@
+"""Slugged: slug in, member out, unknown rejected — the 422 the API boundary owes a bad value."""
+
+from __future__ import annotations
+
+import pytest
+from platform_client.enums import ReasonCode, SubmissionStatus
+from platform_client.slug import Slugged, members_by_slug, slug_of
+from pydantic import BaseModel, ValidationError
+
+
+class Holder(BaseModel):
+    status: Slugged[SubmissionStatus]
+    reason_code: Slugged[ReasonCode] | None = None
+
+
+def test_a_slug_validates_into_the_member():
+    assert Holder.model_validate({'status': 'running'}).status is SubmissionStatus.running
+    holder = Holder.model_validate({'status': 'pending', 'reason_code': 'policy_oom'})
+    assert holder.reason_code is ReasonCode.policy_oom
+
+
+def test_a_member_passes_through():
+    assert Holder(status=SubmissionStatus.finished).status is SubmissionStatus.finished
+
+
+def test_serialization_carries_the_slug_not_the_int():
+    holder = Holder(status=SubmissionStatus.finished, reason_code=ReasonCode.wall_clock_exceeded)
+    assert holder.model_dump(mode='json') == {'status': 'finished', 'reason_code': 'wall_clock_exceeded'}
+    assert holder.model_dump() == {'status': 'finished', 'reason_code': 'wall_clock_exceeded'}
+
+
+@pytest.mark.parametrize('value', ['nonsense', 'Running', 'RUNNING', 'run', '', ' running'])
+def test_an_unknown_slug_is_rejected(value: str):
+    with pytest.raises(ValidationError):
+        Holder.model_validate({'status': value})
+
+
+def test_the_sentinel_is_not_a_wire_value():
+    with pytest.raises(ValidationError):
+        Holder.model_validate({'status': 'invalid'})
+    with pytest.raises(ValidationError):
+        Holder(status=SubmissionStatus.INVALID)
+
+
+def test_the_stored_int_is_not_accepted_as_input():
+    # The wire vocabulary is slugs; an int here means a caller bypassed the boundary.
+    with pytest.raises(ValidationError):
+        Holder.model_validate({'status': 3})
+
+
+def test_a_holder_round_trips_through_its_json_form():
+    holder = Holder(status=SubmissionStatus.errored, reason_code=ReasonCode.image_unpullable)
+    assert Holder.model_validate(holder.model_dump(mode='json')) == holder
+
+
+def test_the_wire_vocabulary_excludes_the_sentinel():
+    assert 'invalid' not in members_by_slug(SubmissionStatus)
+    assert set(members_by_slug(SubmissionStatus)) == {m.name for m in SubmissionStatus} - {'INVALID'}
+
+
+def test_slug_of_is_the_lowercased_name():
+    assert slug_of(ReasonCode.policy_setup_crash) == 'policy_setup_crash'
+
+
+def test_the_generated_schema_advertises_the_slugs():
+    schema = Holder.model_json_schema()['properties']['status']
+    assert set(schema.get('enum', [])) == set(members_by_slug(SubmissionStatus))

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "positronic-platform-client"
+version = "0.1.0"
+description = "Typed wire contract and HTTP client for the Positronic evaluation platform API"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+# Nothing else, ever: a service that only speaks to the platform installs this subdirectory alone
+# (`git+…#subdirectory=client`) and must not pull the robotics stack in behind it.
+dependencies = [
+    "pydantic>=2.7",
+    "httpx>=0.27",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# `platform_client` carries no `__init__.py`; hatchling ships the named directory verbatim.
+packages = ["platform_client"]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -17,5 +17,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-# `platform_client` carries no `__init__.py`; hatchling ships the named directory verbatim.
+# `platform_client` carries no `__init__.py`; hatchling ships the named directory verbatim, py.typed
+# among them — without it a type checker treats an INSTALLED copy as untyped and ignores every
+# annotation this package exists to publish (PEP 561).
 packages = ["platform_client"]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "positronic-platform-client"
-version = "0.1.0"
+version = "0.2.0"
 description = "Typed wire contract and HTTP client for the Positronic evaluation platform API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -6,7 +6,10 @@ import configuronic as cfn
 @cfn.config()
 def placeholder():
     # Lets ``--eval=.sim.positronic.stack_cubes`` resolve relative to this package; never instantiated.
-    raise SystemExit('--eval is required, e.g. --eval=.sim.positronic.stack_cubes')
+    raise SystemExit(
+        '--eval is required: a config to run here (--eval=.sim.positronic.stack_cubes), '
+        'or the name of one the platform offers (--eval=robolab.public_subset, with --policy-image)'
+    )
 
 
 def build_trials(seed: int | None, trial_count: int, scenes: list[dict] | None = None) -> list[dict]:

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -10,6 +10,14 @@ from positronic.utils import nebius
 
 
 @cfn.config()
+def unset():
+    """No policy chosen: what `positronic eval run` holds when the run goes to the platform, which
+    pulls an image instead. It lives here so a relative `--policy=.act` still resolves against this
+    package, and returns None so a local run can name the omission itself."""
+    return None
+
+
+@cfn.config()
 def placeholder():
     raise RuntimeError(
         'This config is not supposed to be instantiated, '

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -11,9 +11,8 @@ from positronic.utils import nebius
 
 @cfn.config()
 def unset():
-    """No policy chosen: what `positronic eval run` holds when the run goes to the platform, which
-    pulls an image instead. It lives here so a relative `--policy=.act` still resolves against this
-    package, and returns None so a local run can name the omission itself."""
+    """No policy. It lives in this package so a relative `--policy=.act` still resolves against it,
+    and instantiates to None rather than raising, so the absence is a value a caller can act on."""
     return None
 
 

--- a/positronic/cli/__init__.py
+++ b/positronic/cli/__init__.py
@@ -1,6 +1,7 @@
 import configuronic as cfn
 import pos3
 
+from positronic.cli.account import commands as account_commands
 from positronic.cli.eval import commands as eval_commands
 from positronic.utils.logging import init_logging
 
@@ -8,7 +9,7 @@ from positronic.utils.logging import init_logging
 @pos3.with_mirror()
 def _internal_main():
     init_logging()
-    cfn.cli({'eval': eval_commands})
+    cfn.cli({'eval': eval_commands, 'account': account_commands})
 
 
 if __name__ == '__main__':

--- a/positronic/cli/account/__init__.py
+++ b/positronic/cli/account/__init__.py
@@ -1,0 +1,7 @@
+from configuronic.cli import CommandTree
+
+from positronic.cli.account.register import register
+
+# Subcommands of `positronic account`: what the platform knows about you rather than about any one
+# run. Running an eval on it, and reading back what a run did, are `positronic eval`.
+commands: CommandTree = {'register': register}

--- a/positronic/cli/account/gateway.py
+++ b/positronic/cli/account/gateway.py
@@ -13,7 +13,28 @@ from platform_client.client import API_KEY_ENV, API_URL_ENV, CREDENTIAL_ENV, Pla
 from platform_client.errors import PlatformError
 from platform_client.ids import ApiKey, SubmissionId
 
-__all__ = ['API_KEY_ENV', 'API_URL_ENV', 'CREDENTIAL_ENV', 'credential', 'gateway', 'parse_submission_id']
+__all__ = [
+    'API_KEY_ENV',
+    'API_URL_ENV',
+    'CREDENTIAL_ENV',
+    'credential',
+    'gateway',
+    'parse_submission_id',
+    'refusing_bad_input',
+]
+
+
+@contextmanager
+def refusing_bad_input() -> Iterator[None]:
+    """Report a value the wire types refuse as a CLI refusal, not a traceback.
+
+    Every one of them — a platform URL, an image reference, an eval name, a request model — raises
+    `ValueError` naming the value it would not take, which is already the sentence a user needs.
+    """
+    try:
+        yield
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 @contextmanager
@@ -22,12 +43,9 @@ def gateway(platform_url: str | None = None, *, key_required: bool = True) -> It
     key = os.environ.get(API_KEY_ENV)
     if key_required and not key:
         raise SystemExit(f'no API key: set {API_KEY_ENV} to the one `positronic account register` printed')
-    try:
+    # A misconfigured platform — an empty `--platform-url`, or one the client cannot reach.
+    with refusing_bad_input():
         client_ = PlatformClient(platform_url, api_key=ApiKey(key) if key else None)
-    except ValueError as exc:
-        # A misconfigured platform — an empty `--platform-url` or `POSITRONIC_PLATFORM_URL`. To a
-        # user that is a refusal to read, not a traceback out of the constructor.
-        raise SystemExit(str(exc)) from exc
     with client_ as client:
         try:
             yield client

--- a/positronic/cli/account/gateway.py
+++ b/positronic/cli/account/gateway.py
@@ -1,0 +1,54 @@
+"""The plumbing every platform command shares: a configured client, and refusals a user can read.
+
+The URL's precedence — argument, then environment, then the default platform — belongs to the
+client, so a script and a command cannot resolve it differently. A key or a credential is never an
+argument: a command line is readable by every process on the box and lands in shell history.
+"""
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from platform_client.client import API_KEY_ENV, API_URL_ENV, CREDENTIAL_ENV, PlatformClient
+from platform_client.errors import PlatformError
+from platform_client.ids import ApiKey, SubmissionId
+
+__all__ = ['API_KEY_ENV', 'API_URL_ENV', 'CREDENTIAL_ENV', 'credential', 'gateway', 'parse_submission_id']
+
+
+@contextmanager
+def gateway(platform_url: str | None = None, *, key_required: bool = True) -> Iterator[PlatformClient]:
+    """A client on the configured platform, reporting a refusal by it as a CLI failure."""
+    key = os.environ.get(API_KEY_ENV)
+    if key_required and not key:
+        raise SystemExit(f'no API key: set {API_KEY_ENV} to the one `positronic account register` printed')
+    with PlatformClient(platform_url, api_key=ApiKey(key) if key else None) as client:
+        try:
+            yield client
+        except PlatformError as exc:
+            lines = [f'{exc.code.name}: {exc.message}']
+            # The platform owns the set of evals, so a name it does not know is answered with the
+            # names it does — print them rather than making the user guess a second time.
+            if exc.evals is not None:
+                lines.append(f'evals on offer: {", ".join(exc.evals)}')
+            raise SystemExit('\n'.join(lines)) from exc
+
+
+def credential() -> str:
+    """The identity to register with, from the environment."""
+    value = os.environ.get(CREDENTIAL_ENV)
+    if not value:
+        raise SystemExit(f'no credential: set {CREDENTIAL_ENV} to the identity to register with')
+    return value
+
+
+def parse_submission_id(token: object) -> SubmissionId:
+    """One submission id off the command line."""
+    # CLI values are literal-evaluated, so an all-digit id arrives as an int, and reading that as
+    # decimal would name a different submission. Such an id needs inner quotes to stay text.
+    if not isinstance(token, str):
+        raise SystemExit(f'submission id is hexadecimal; quote one that reads as a number: \'"{token}"\'')
+    try:
+        return SubmissionId.parse(token)
+    except ValueError as exc:
+        raise SystemExit(f'not a submission id: {exc}') from exc

--- a/positronic/cli/account/gateway.py
+++ b/positronic/cli/account/gateway.py
@@ -22,7 +22,13 @@ def gateway(platform_url: str | None = None, *, key_required: bool = True) -> It
     key = os.environ.get(API_KEY_ENV)
     if key_required and not key:
         raise SystemExit(f'no API key: set {API_KEY_ENV} to the one `positronic account register` printed')
-    with PlatformClient(platform_url, api_key=ApiKey(key) if key else None) as client:
+    try:
+        client_ = PlatformClient(platform_url, api_key=ApiKey(key) if key else None)
+    except ValueError as exc:
+        # A misconfigured platform — an empty `--platform-url` or `POSITRONIC_PLATFORM_URL`. To a
+        # user that is a refusal to read, not a traceback out of the constructor.
+        raise SystemExit(str(exc)) from exc
+    with client_ as client:
         try:
             yield client
         except PlatformError as exc:

--- a/positronic/cli/account/register.py
+++ b/positronic/cli/account/register.py
@@ -5,7 +5,7 @@ import shlex
 import configuronic as cfn
 from platform_client.requests import RegisterRequest
 
-from positronic.cli.account.gateway import API_KEY_ENV, credential, gateway
+from positronic.cli.account.gateway import API_KEY_ENV, credential, gateway, refusing_bad_input
 
 
 @cfn.config()
@@ -14,7 +14,8 @@ def register(alias: str | None = None, rotate: bool = False, platform_url: str |
 
     Reads the credential from the environment, never an argument.
     """
-    request = RegisterRequest(credential=credential(), alias=alias, rotate=rotate)
+    with refusing_bad_input():
+        request = RegisterRequest(credential=credential(), alias=alias, rotate=rotate)
     with gateway(platform_url, key_required=False) as client:
         response = client.register(request)
     print(f'user {response.user_id} ({response.key_status.name})')

--- a/positronic/cli/account/register.py
+++ b/positronic/cli/account/register.py
@@ -1,0 +1,26 @@
+"""`positronic account register` — the account this platform knows you by."""
+
+import shlex
+
+import configuronic as cfn
+from platform_client.requests import RegisterRequest
+
+from positronic.cli.account.gateway import API_KEY_ENV, credential, gateway
+
+
+@cfn.config()
+def register(alias: str | None = None, rotate: bool = False, platform_url: str | None = None):
+    """Register with the platform, or rotate an existing registration's API key.
+
+    Reads the credential from the environment, never an argument.
+    """
+    request = RegisterRequest(credential=credential(), alias=alias, rotate=rotate)
+    with gateway(platform_url, key_required=False) as client:
+        response = client.register(request)
+    print(f'user {response.user_id} ({response.key_status.name})')
+    if response.api_key is None:
+        print('no key issued: one is minted on a first registration, or by --rotate')
+    else:
+        # The key is opaque, so it may hold whitespace or shell metacharacters; an unquoted export
+        # line would either mangle it or run the rest of it.
+        print(f'export {API_KEY_ENV}={shlex.quote(response.api_key)}')

--- a/positronic/cli/account/tests/test_register.py
+++ b/positronic/cli/account/tests/test_register.py
@@ -1,0 +1,57 @@
+"""`positronic account register`, over a stub platform transport."""
+
+import shlex
+
+import pytest
+from platform_client import routes
+
+from positronic.cli.account import gateway as gateway_module
+from positronic.cli.account.register import register
+
+
+def test_register_prints_the_export_line_for_a_minted_key(platform, run_command, capsys):
+    platform.answer({
+        'user_id': 'a0',
+        'artifact_location': 's3://b/users/a0/',
+        'api_key': 'pk_new',
+        'key_status': 'created',
+    })
+
+    run_command(register, alias='demo')
+
+    assert platform.request.url.path == routes.USERS_REGISTER
+    assert 'authorization' not in platform.request.headers
+    assert platform.body == {'credential': 'token', 'alias': 'demo', 'rotate': False}
+    out = capsys.readouterr().out
+    assert 'user a0 (created)' in out
+    assert f'export {gateway_module.API_KEY_ENV}=pk_new' in out
+
+
+def test_an_export_line_survives_a_key_holding_shell_characters(platform, run_command, capsys):
+    # The key is opaque; pasting an unquoted export line would run the `;` and drop the rest.
+    platform.answer({
+        'user_id': 'a0',
+        'artifact_location': 's3://b/users/a0/',
+        'api_key': 'pk a$b;rm -rf /',
+        'key_status': 'created',
+    })
+
+    run_command(register)
+
+    line = next(ln for ln in capsys.readouterr().out.splitlines() if ln.startswith('export '))
+    assert shlex.split(line)[1] == f'{gateway_module.API_KEY_ENV}=pk a$b;rm -rf /'
+
+
+def test_register_refuses_when_no_credential_is_in_the_environment(platform, run_command, monkeypatch):
+    monkeypatch.delenv(gateway_module.CREDENTIAL_ENV)
+    with pytest.raises(SystemExit) as raised:
+        run_command(register)
+    assert gateway_module.CREDENTIAL_ENV in str(raised.value)
+
+
+def test_register_says_no_key_came_back_for_an_existing_registration(platform, run_command, capsys):
+    platform.answer({'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'key_status': 'existing'})
+
+    run_command(register)
+
+    assert 'no key issued' in capsys.readouterr().out

--- a/positronic/cli/account/tests/test_register.py
+++ b/positronic/cli/account/tests/test_register.py
@@ -49,6 +49,15 @@ def test_register_refuses_when_no_credential_is_in_the_environment(platform, run
     assert gateway_module.CREDENTIAL_ENV in str(raised.value)
 
 
+def test_an_alias_the_request_model_refuses_is_a_refusal_naming_the_field(platform, run_command):
+    # configuronic literal-evaluates a CLI value, so `--alias=5` arrives as an int, which the model
+    # refuses — a refusal to read rather than a traceback out of the constructor.
+    with pytest.raises(SystemExit) as raised:
+        run_command(register, alias=5)
+    assert 'alias' in str(raised.value)
+    assert platform.seen is None
+
+
 def test_register_says_no_key_came_back_for_an_existing_registration(platform, run_command, capsys):
     platform.answer({'user_id': 'a0', 'artifact_location': 's3://b/users/a0/', 'key_status': 'existing'})
 

--- a/positronic/cli/conftest.py
+++ b/positronic/cli/conftest.py
@@ -1,0 +1,75 @@
+"""A stub platform for the commands that talk to one.
+
+Shared by `positronic account` and `positronic eval`, which drive the same client: the
+transport is stubbed and everything above it — request shaping, auth headers, response parsing — is
+the real thing.
+"""
+
+import json
+
+import configuronic as cfn
+import httpx
+import pytest
+from platform_client.client import PlatformClient
+from platform_client.ids import ApiKey
+
+from positronic.cli.account import gateway as gateway_module
+
+BASE = 'http://gateway.test'
+KEY = 'pk_live_secret'
+ID = '5f3a91c2b7d40e18'
+AT = '2026-03-04T05:06:07Z'
+
+
+class StubPlatform:
+    """Records what a command sent, and the URL and key it was sent with, and answers a canned payload."""
+
+    def __init__(self):
+        self.status = 200
+        self.payload: object = {}
+        self.seen: httpx.Request | None = None
+        self.base_url: str | None = None
+        self.api_key: ApiKey | None = None
+
+    def answer(self, payload: object, *, status: int = 200) -> None:
+        self.payload, self.status = payload, status
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.seen = request
+        return httpx.Response(self.status, json=self.payload)
+
+    @property
+    def request(self) -> httpx.Request:
+        assert self.seen is not None, 'no request reached the platform'
+        return self.seen
+
+    @property
+    def body(self) -> dict:
+        return json.loads(self.request.content)
+
+
+@pytest.fixture
+def platform(monkeypatch):
+    """A configured environment whose client rides a stub transport."""
+    stub = StubPlatform()
+
+    def build(base_url: str | None = None, *, api_key: ApiKey | None = None) -> PlatformClient:
+        stub.base_url, stub.api_key = base_url, api_key
+        transport = httpx.MockTransport(stub)
+        return PlatformClient(client=httpx.Client(base_url=base_url or BASE, transport=transport), api_key=api_key)
+
+    monkeypatch.setattr(gateway_module, 'PlatformClient', build)
+    monkeypatch.setenv(gateway_module.API_URL_ENV, BASE)
+    monkeypatch.setenv(gateway_module.API_KEY_ENV, KEY)
+    monkeypatch.setenv(gateway_module.CREDENTIAL_ENV, 'token')
+    return stub
+
+
+@pytest.fixture
+def run_command():
+    """Run one command as the CLI does: parsed arguments overridden onto its config, then instantiated."""
+
+    def run(command: cfn.Config, **kwargs):
+        return command.override(**kwargs).instantiate()
+
+    return run

--- a/positronic/cli/eval/__init__.py
+++ b/positronic/cli/eval/__init__.py
@@ -1,5 +1,15 @@
+from configuronic.cli import CommandTree
+
 from positronic.cli.eval.run import run
+from positronic.cli.eval.submissions import cancel, list_submissions, status
 from positronic.cli.eval.timing_report import timing_report
 
-# Subcommands of `positronic eval`.
-commands = {'run': run, 'timing-report': timing_report}
+# Subcommands of `positronic eval`. `run` executes an eval — here, or on the platform when it is
+# given a policy image — and the rest read back what a platform run is doing.
+commands: CommandTree = {
+    'run': run,
+    'status': status,
+    'list': list_submissions,
+    'cancel': cancel,
+    'timing-report': timing_report,
+}

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -13,6 +13,7 @@ import pimm
 import positronic.cfg.policy as policy_cfg
 from positronic import telemetry, telemetry_keys, utils, wire
 from positronic.cfg.eval import placeholder
+from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.eval import Embodiment, Eval, Task
@@ -210,14 +211,49 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
         policy.close()
 
 
-@cfn.config(eval=placeholder, policy=policy_cfg.placeholder)
-def run(eval: Eval, policy, output_dir=None, inference_latency=False, timing=False):
+@cfn.config(eval=placeholder, policy=policy_cfg.unset)
+def run(
+    eval: Eval | str,
+    policy,
+    output_dir=None,
+    inference_latency=False,
+    timing=False,
+    policy_image: str | None = None,
+    alias: str | None = None,
+    transaction_key: str | None = None,
+    platform_url: str | None = None,
+):
     """Run a selected eval (embodiment + task + its trial sweep) through the shared inference harness.
+
+    Here by default: ``--eval`` is an eval config and ``--policy`` the policy that drives it.
+    ``--policy-image`` instead sends the run to the platform, which pulls that image and runs the
+    eval of that NAME on the embodiment the eval names — ``--eval=robolab.public_subset``, not a
+    config, since the platform owns the evals it offers. What comes back is a submission id, which
+    ``positronic eval status`` reads.
 
     ``timing`` records wall-clock telemetry sidecars under ``output_dir`` (spans + machine-load stats) for a
     simulated eval; reduce them with ``positronic eval timing-report``.
     """
-    # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob
-    # (sim inference-cost simulation). Overlay it onto every trial context, then self-drive the eval.
-    eval = replace(eval, trials=[{**trial, 'inference_latency': inference_latency} for trial in eval.trials])
-    main(policy=policy, evals=[eval], output_dir=output_dir, timing=timing)
+    if policy_image is None:
+        if policy is None:
+            raise SystemExit('--policy is required to run here; --policy-image runs it on the platform instead')
+        if not isinstance(eval, Eval):
+            raise SystemExit(f'--eval={eval!r} is a name, not a config: pass --policy-image to run it on the platform')
+        # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob
+        # (sim inference-cost simulation). Overlay it onto every trial context, then self-drive the eval.
+        eval = replace(eval, trials=[{**trial, 'inference_latency': inference_latency} for trial in eval.trials])
+        main(policy=policy, evals=[eval], output_dir=output_dir, timing=timing)
+        return
+
+    if policy is not None:
+        raise SystemExit('--policy runs the eval here and --policy-image runs it on the platform; pass one')
+    if not isinstance(eval, str):
+        raise SystemExit('the platform names its own evals: pass --eval=<name>, e.g. --eval=robolab.public_subset')
+    # The platform owns its own trial sweep, its own output and its own telemetry, so these mean
+    # nothing there; dropping them silently would hand back a run the caller believes they shaped.
+    # Every "not asked for" value is falsy, which is what makes the test the value itself.
+    local_only = {'--output-dir': output_dir, '--inference-latency': inference_latency, '--timing': timing}
+    asked = sorted(flag for flag, value in local_only.items() if value)
+    if asked:
+        raise SystemExit(f'a platform run has no {", ".join(asked)}')
+    submit(eval, policy_image, alias=alias, transaction_key=transaction_key, platform_url=platform_url)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -211,6 +211,17 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
         policy.close()
 
 
+def _refuse(inapplicable: dict[str, object], where: str) -> None:
+    """Stop on an argument the chosen half of `run` cannot honour.
+
+    Dropping one silently hands back a run the caller believes they shaped. Every "not asked for"
+    value is falsy, which is what makes the test the value itself.
+    """
+    asked = sorted(flag for flag, value in inapplicable.items() if value)
+    if asked:
+        raise SystemExit(f'a {where} run has no {", ".join(asked)}')
+
+
 @cfn.config(eval=placeholder, policy=policy_cfg.unset)
 def run(
     eval: Eval | str,
@@ -237,6 +248,7 @@ def run(
     if policy_image is None:
         if policy is None:
             raise SystemExit('--policy is required to run here; --policy-image runs it on the platform instead')
+        _refuse({'--alias': alias, '--transaction-key': transaction_key, '--platform-url': platform_url}, 'local')
         if not isinstance(eval, Eval):
             raise SystemExit(f'--eval={eval!r} is a name, not a config: pass --policy-image to run it on the platform')
         # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import configuronic as cfn
 import pos3
+from platform_client.responses import SubmissionCreateResponse
 
 import pimm
 import positronic.cfg.policy as policy_cfg
@@ -233,7 +234,7 @@ def run(
     alias: str | None = None,
     transaction_key: str | None = None,
     platform_url: str | None = None,
-):
+) -> SubmissionCreateResponse | None:
     """Run a selected eval (embodiment + task + its trial sweep) through the shared inference harness.
 
     Here by default: ``--eval`` is an eval config and ``--policy`` the policy that drives it.
@@ -244,6 +245,9 @@ def run(
 
     ``timing`` records wall-clock telemetry sidecars under ``output_dir`` (spans + machine-load stats) for a
     simulated eval; reduce them with ``positronic eval timing-report``.
+
+    A platform run returns what the platform created, so a caller holding this function has the
+    submission id without parsing what was printed. A local run's result is the dataset it wrote.
     """
     if policy_image is None:
         if policy is None:
@@ -255,17 +259,12 @@ def run(
         # (sim inference-cost simulation). Overlay it onto every trial context, then self-drive the eval.
         eval = replace(eval, trials=[{**trial, 'inference_latency': inference_latency} for trial in eval.trials])
         main(policy=policy, evals=[eval], output_dir=output_dir, timing=timing)
-        return
+        return None
 
     if policy is not None:
         raise SystemExit('--policy runs the eval here and --policy-image runs it on the platform; pass one')
     if not isinstance(eval, str):
         raise SystemExit('the platform names its own evals: pass --eval=<name>, e.g. --eval=robolab.public_subset')
-    # The platform owns its own trial sweep, its own output and its own telemetry, so these mean
-    # nothing there; dropping them silently would hand back a run the caller believes they shaped.
-    # Every "not asked for" value is falsy, which is what makes the test the value itself.
-    local_only = {'--output-dir': output_dir, '--inference-latency': inference_latency, '--timing': timing}
-    asked = sorted(flag for flag, value in local_only.items() if value)
-    if asked:
-        raise SystemExit(f'a platform run has no {", ".join(asked)}')
-    submit(eval, policy_image, alias=alias, transaction_key=transaction_key, platform_url=platform_url)
+    # The platform owns its own trial sweep, its own output and its own telemetry.
+    _refuse({'--output-dir': output_dir, '--inference-latency': inference_latency, '--timing': timing}, 'platform')
+    return submit(eval, policy_image, alias=alias, transaction_key=transaction_key, platform_url=platform_url)

--- a/positronic/cli/eval/submissions.py
+++ b/positronic/cli/eval/submissions.py
@@ -2,9 +2,13 @@
 
 import configuronic as cfn
 from platform_client.requests import CancelRequest
-from platform_client.responses import VIEW_HEADER_FIELDS
+from platform_client.responses import STATUS_FIELD
 
 from positronic.cli.account.gateway import gateway, parse_submission_id
+
+# What `status` prints on its header line, so the body below it does not repeat them. Field names
+# rather than literals, so a model rename cannot leave this excluding a field that no longer exists.
+_HEADER_FIELDS = frozenset({'id', STATUS_FIELD})
 
 
 @cfn.config()
@@ -14,7 +18,7 @@ def status(submission_id: str, platform_url: str | None = None):
     with gateway(platform_url) as client:
         view = client.get_submission(wanted)
     print(f'{view.id} {view.status.name}')
-    for name, value in view.model_dump(mode='json', exclude=set(VIEW_HEADER_FIELDS)).items():
+    for name, value in view.model_dump(mode='json', exclude=set(_HEADER_FIELDS)).items():
         print(f'  {name}: {value}')
 
 

--- a/positronic/cli/eval/submissions.py
+++ b/positronic/cli/eval/submissions.py
@@ -1,0 +1,37 @@
+"""`positronic eval status|list|cancel` — what the runs you sent to the platform are doing."""
+
+import configuronic as cfn
+from platform_client.requests import CancelRequest
+from platform_client.responses import VIEW_HEADER_FIELDS
+
+from positronic.cli.account.gateway import gateway, parse_submission_id
+
+
+@cfn.config()
+def status(submission_id: str, platform_url: str | None = None):
+    """Report what one submission is doing, and what it produced once it is done."""
+    wanted = parse_submission_id(submission_id)
+    with gateway(platform_url) as client:
+        view = client.get_submission(wanted)
+    print(f'{view.id} {view.status.name}')
+    for name, value in view.model_dump(mode='json', exclude=set(VIEW_HEADER_FIELDS)).items():
+        print(f'  {name}: {value}')
+
+
+@cfn.config()
+def list_submissions(platform_url: str | None = None):
+    """List the submissions this API key can see."""
+    with gateway(platform_url) as client:
+        response = client.list_submissions()
+    for row in response.submissions:
+        alias = f' {row.alias}' if row.alias else ''
+        print(f'{row.id} {row.received_at:%Y-%m-%d %H:%M} {row.status.name} {row.eval}{alias}')
+
+
+@cfn.config()
+def cancel(submission_id: str, platform_url: str | None = None):
+    """Cancel a submission that has not reached a terminal status."""
+    request = CancelRequest(id=parse_submission_id(submission_id))
+    with gateway(platform_url) as client:
+        result = client.cancel_submission(request)
+    print(f'{result.status.name}, quota {"refunded" if result.refunded else "charged"}')

--- a/positronic/cli/eval/submissions.py
+++ b/positronic/cli/eval/submissions.py
@@ -2,13 +2,13 @@
 
 import configuronic as cfn
 from platform_client.requests import CancelRequest
-from platform_client.responses import STATUS_FIELD
+from platform_client.responses import ID_FIELD, STATUS_FIELD
 
 from positronic.cli.account.gateway import gateway, parse_submission_id
 
 # What `status` prints on its header line, so the body below it does not repeat them. Field names
 # rather than literals, so a model rename cannot leave this excluding a field that no longer exists.
-_HEADER_FIELDS = frozenset({'id', STATUS_FIELD})
+_HEADER_FIELDS = frozenset({ID_FIELD, STATUS_FIELD})
 
 
 @cfn.config()

--- a/positronic/cli/eval/submissions.py
+++ b/positronic/cli/eval/submissions.py
@@ -4,7 +4,7 @@ import configuronic as cfn
 from platform_client.requests import CancelRequest
 from platform_client.responses import ID_FIELD, STATUS_FIELD
 
-from positronic.cli.account.gateway import gateway, parse_submission_id
+from positronic.cli.account.gateway import gateway, parse_submission_id, refusing_bad_input
 
 # What `status` prints on its header line, so the body below it does not repeat them. Field names
 # rather than literals, so a model rename cannot leave this excluding a field that no longer exists.
@@ -35,7 +35,8 @@ def list_submissions(platform_url: str | None = None):
 @cfn.config()
 def cancel(submission_id: str, platform_url: str | None = None):
     """Cancel a submission that has not reached a terminal status."""
-    request = CancelRequest(id=parse_submission_id(submission_id))
+    with refusing_bad_input():
+        request = CancelRequest(id=parse_submission_id(submission_id))
     with gateway(platform_url) as client:
         result = client.cancel_submission(request)
     print(f'{result.status.name}, quota {"refunded" if result.refunded else "charged"}')

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -39,8 +39,7 @@ def submit(
     print(f'submission {created.submission_id} ({created.status.name})')
     if created.policy_image_digest is not None:
         print(f'digest {created.policy_image_digest}')
-    # Terminal with no result coming — rejected at the door, or a replay of a submission since
-    # cancelled. A zero exit would let a script treat a run that never happened as one that did.
+    # These terminal statuses can never carry a result, so the submission fails rather than returns.
     if created.status in NO_RESULT_STATUSES:
         reason = created.reason_code.name if created.reason_code is not None else created.status.name
         raise SystemExit(f'rejected: {reason}')

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -8,6 +8,7 @@ from platform_client.evals import EvalRef
 from platform_client.ids import TransactionKey
 from platform_client.images import ImageRef
 from platform_client.requests import SubmissionCreateRequest
+from platform_client.responses import SubmissionCreateResponse
 
 from positronic.cli.account.gateway import gateway
 
@@ -19,8 +20,8 @@ def submit(
     alias: str | None = None,
     transaction_key: str | None = None,
     platform_url: str | None = None,
-) -> None:
-    """Submit one policy image against one eval, and print what came back.
+) -> SubmissionCreateResponse:
+    """Submit one policy image against one eval, print what came back, and return it.
 
     The eval names the embodiment it runs on, so it is the whole of the choice; naming one the
     platform does not offer answers with the ones it does. An image pinned by digest runs the bytes
@@ -43,3 +44,4 @@ def submit(
     if created.status is SubmissionStatus.errored:
         reason = created.reason_code.name if created.reason_code is not None else 'unknown'
         raise SystemExit(f'rejected: {reason}')
+    return created

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -6,7 +6,7 @@ Not a command of its own: running an eval is one act, and where it runs is an ar
 from platform_client.enums import NO_RESULT_STATUSES
 from platform_client.evals import EvalRef
 from platform_client.ids import TransactionKey
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import SubmissionCreateRequest
 from platform_client.responses import SubmissionCreateResponse
 
@@ -29,7 +29,7 @@ def submit(
     `transaction_key` returns the original instead of spending another day's quota.
     """
     request = SubmissionCreateRequest(
-        policy_image=ImageRef(policy_image),
+        policy_image=PolicyImage(policy_image),
         eval=EvalRef(eval_name),
         alias=alias,
         transaction_key=TransactionKey(transaction_key) if transaction_key is not None else None,

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -10,7 +10,7 @@ from platform_client.policy_images import PolicyImage
 from platform_client.requests import SubmissionCreateRequest
 from platform_client.responses import SubmissionCreateResponse
 
-from positronic.cli.account.gateway import gateway
+from positronic.cli.account.gateway import gateway, refusing_bad_input
 
 
 def submit(
@@ -28,12 +28,13 @@ def submit(
     you tested, while a mutable tag is resolved at submission time. Repeating a submission under one
     `transaction_key` returns the original instead of spending another day's quota.
     """
-    request = SubmissionCreateRequest(
-        policy_image=PolicyImage(policy_image),
-        eval=EvalRef(eval_name),
-        alias=alias,
-        transaction_key=TransactionKey(transaction_key) if transaction_key is not None else None,
-    )
+    with refusing_bad_input():
+        request = SubmissionCreateRequest(
+            policy_image=PolicyImage(policy_image),
+            eval=EvalRef(eval_name),
+            alias=alias,
+            transaction_key=TransactionKey(transaction_key) if transaction_key is not None else None,
+        )
     with gateway(platform_url) as client:
         submission = client.create_submission(request)
     print(f'submission {submission.submission_id} ({submission.status.name})')

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -1,0 +1,41 @@
+"""The half of `positronic eval run` that hands the run to the platform instead of running it here.
+
+Not a command of its own: running an eval is one act, and where it runs is an argument to it.
+"""
+
+from platform_client.evals import EvalRef
+from platform_client.ids import TransactionKey
+from platform_client.images import ImageRef
+from platform_client.requests import SubmissionCreateRequest
+
+from positronic.cli.account.gateway import gateway
+
+
+def submit(
+    eval_name: str,
+    policy_image: str,
+    *,
+    alias: str | None = None,
+    transaction_key: str | None = None,
+    platform_url: str | None = None,
+) -> None:
+    """Submit one policy image against one eval, and print what came back.
+
+    The eval names the embodiment it runs on, so it is the whole of the choice; naming one the
+    platform does not offer answers with the ones it does. An image pinned by digest runs the bytes
+    you tested, while a mutable tag is resolved at submission time. Repeating a submission under one
+    `transaction_key` returns the original instead of spending another day's quota.
+    """
+    request = SubmissionCreateRequest(
+        policy_image=ImageRef(policy_image),
+        eval=EvalRef(eval_name),
+        alias=alias,
+        transaction_key=TransactionKey(transaction_key) if transaction_key is not None else None,
+    )
+    with gateway(platform_url) as client:
+        created = client.create_submission(request)
+    print(f'submission {created.submission_id} ({created.status.name})')
+    if created.policy_image_digest is not None:
+        print(f'digest {created.policy_image_digest}')
+    if created.reason_code is not None:
+        print(f'rejected: {created.reason_code.name}')

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -3,7 +3,7 @@
 Not a command of its own: running an eval is one act, and where it runs is an argument to it.
 """
 
-from platform_client.enums import SubmissionStatus
+from platform_client.enums import NO_RESULT_STATUSES
 from platform_client.evals import EvalRef
 from platform_client.ids import TransactionKey
 from platform_client.images import ImageRef
@@ -39,9 +39,9 @@ def submit(
     print(f'submission {created.submission_id} ({created.status.name})')
     if created.policy_image_digest is not None:
         print(f'digest {created.policy_image_digest}')
-    # Terminal at the door, and charged. A zero exit would let a script treat a run that never
-    # happened as one that did.
-    if created.status is SubmissionStatus.errored:
-        reason = created.reason_code.name if created.reason_code is not None else 'unknown'
+    # Terminal with no result coming — rejected at the door, or a replay of a submission since
+    # cancelled. A zero exit would let a script treat a run that never happened as one that did.
+    if created.status in NO_RESULT_STATUSES:
+        reason = created.reason_code.name if created.reason_code is not None else created.status.name
         raise SystemExit(f'rejected: {reason}')
     return created

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -35,12 +35,12 @@ def submit(
         transaction_key=TransactionKey(transaction_key) if transaction_key is not None else None,
     )
     with gateway(platform_url) as client:
-        created = client.create_submission(request)
-    print(f'submission {created.submission_id} ({created.status.name})')
-    if created.policy_image_digest is not None:
-        print(f'digest {created.policy_image_digest}')
+        submission = client.create_submission(request)
+    print(f'submission {submission.submission_id} ({submission.status.name})')
+    if submission.policy_image_digest is not None:
+        print(f'digest {submission.policy_image_digest}')
     # These terminal statuses can never carry a result, so the submission fails rather than returns.
-    if created.status in NO_RESULT_STATUSES:
-        reason = created.reason_code.name if created.reason_code is not None else created.status.name
+    if submission.status in NO_RESULT_STATUSES:
+        reason = submission.reason_code.name if submission.reason_code is not None else submission.status.name
         raise SystemExit(f'rejected: {reason}')
-    return created
+    return submission

--- a/positronic/cli/eval/submit.py
+++ b/positronic/cli/eval/submit.py
@@ -3,6 +3,7 @@
 Not a command of its own: running an eval is one act, and where it runs is an argument to it.
 """
 
+from platform_client.enums import SubmissionStatus
 from platform_client.evals import EvalRef
 from platform_client.ids import TransactionKey
 from platform_client.images import ImageRef
@@ -37,5 +38,8 @@ def submit(
     print(f'submission {created.submission_id} ({created.status.name})')
     if created.policy_image_digest is not None:
         print(f'digest {created.policy_image_digest}')
-    if created.reason_code is not None:
-        print(f'rejected: {created.reason_code.name}')
+    # Terminal at the door, and charged. A zero exit would let a script treat a run that never
+    # happened as one that did.
+    if created.status is SubmissionStatus.errored:
+        reason = created.reason_code.name if created.reason_code is not None else 'unknown'
+        raise SystemExit(f'rejected: {reason}')

--- a/positronic/cli/eval/tests/test_run_on_the_platform.py
+++ b/positronic/cli/eval/tests/test_run_on_the_platform.py
@@ -28,12 +28,14 @@ def test_a_policy_image_sends_the_run_to_the_platform(platform, run_command, cap
     assert 'digest sha256:abc' in out
 
 
-def test_an_image_rejected_at_the_door_is_reported(platform, run_command, capsys):
+def test_an_image_rejected_at_the_door_fails_the_command(platform, run_command, capsys):
+    # Terminal at the door and charged: a zero exit would let a script read it as a run that happened.
     platform.answer({'submission_id': ID, 'status': 'errored', 'reason_code': 'image_unpullable'})
 
-    run_command(run, eval='fake.smoke', policy_image='org/p:v1')
+    with pytest.raises(SystemExit, match='rejected: image_unpullable'):
+        run_command(run, eval='fake.smoke', policy_image='org/p:v1')
 
-    assert 'rejected: image_unpullable' in capsys.readouterr().out
+    assert f'submission {ID} (errored)' in capsys.readouterr().out
 
 
 def test_an_eval_the_platform_does_not_offer_is_answered_with_the_ones_it_does(platform, run_command):
@@ -58,6 +60,16 @@ def test_an_eval_the_platform_does_not_offer_is_answered_with_the_ones_it_does(p
 def test_an_image_reference_the_registry_could_never_resolve_is_refused_here(platform, run_command):
     with pytest.raises(ValueError):
         run_command(run, eval='fake.smoke', policy_image='org/policy@')
+    assert platform.seen is None
+
+
+@pytest.mark.parametrize(
+    'platform_only', [{'alias': 'demo'}, {'transaction_key': 'k'}, {'platform_url': 'http://x.test'}]
+)
+def test_a_local_run_refuses_what_only_a_platform_run_can_mean(platform, run_command, platform_only: dict):
+    # The mirror of the check below it: neither half may drop the other's arguments in silence.
+    with pytest.raises(SystemExit, match='a local run has no'):
+        run_command(run, eval='fake.smoke', policy='a policy', **platform_only)
     assert platform.seen is None
 
 

--- a/positronic/cli/eval/tests/test_run_on_the_platform.py
+++ b/positronic/cli/eval/tests/test_run_on_the_platform.py
@@ -1,0 +1,93 @@
+"""`positronic eval run` with a policy image: the run goes to the platform, over a stub transport."""
+
+import sys
+
+import configuronic as cfn
+import pytest
+from platform_client import routes
+
+from positronic.cli.conftest import ID, KEY
+from positronic.cli.eval.run import run
+
+
+def test_a_policy_image_sends_the_run_to_the_platform(platform, run_command, capsys):
+    platform.answer({'submission_id': ID, 'status': 'pending', 'policy_image_digest': 'sha256:abc'})
+
+    run_command(run, eval='fake.smoke', policy_image='org/p:v1', transaction_key='retry-1')
+
+    assert platform.request.url.path == routes.SUBMISSIONS_CREATE
+    assert platform.request.headers['authorization'] == f'Bearer {KEY}'
+    assert platform.body == {
+        'policy_image': 'org/p:v1',
+        'eval': 'fake.smoke',
+        'alias': None,
+        'transaction_key': 'retry-1',
+    }
+    out = capsys.readouterr().out
+    assert f'submission {ID} (pending)' in out
+    assert 'digest sha256:abc' in out
+
+
+def test_an_image_rejected_at_the_door_is_reported(platform, run_command, capsys):
+    platform.answer({'submission_id': ID, 'status': 'errored', 'reason_code': 'image_unpullable'})
+
+    run_command(run, eval='fake.smoke', policy_image='org/p:v1')
+
+    assert 'rejected: image_unpullable' in capsys.readouterr().out
+
+
+def test_an_eval_the_platform_does_not_offer_is_answered_with_the_ones_it_does(platform, run_command):
+    # The set lives on the server, so the refusal is where a caller learns the real names.
+    platform.answer(
+        {
+            'error': {
+                'code': 'not_found',
+                'message': "unknown eval 'fake.smokey'",
+                'details': {'evals': ['fake.smoke', 'robolab.public_subset']},
+            }
+        },
+        status=404,
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        run_command(run, eval='fake.smokey', policy_image='org/p:v1')
+
+    assert 'evals on offer: fake.smoke, robolab.public_subset' in str(exit_info.value)
+
+
+def test_an_image_reference_the_registry_could_never_resolve_is_refused_here(platform, run_command):
+    with pytest.raises(ValueError):
+        run_command(run, eval='fake.smoke', policy_image='org/policy@')
+    assert platform.seen is None
+
+
+def test_a_run_with_neither_a_policy_nor_an_image_says_which_it_wants(platform, run_command):
+    with pytest.raises(SystemExit, match='--policy is required'):
+        run_command(run, eval='fake.smoke')
+    assert platform.seen is None
+
+
+def test_a_run_cannot_be_both_here_and_there(platform, run_command):
+    with pytest.raises(SystemExit, match='pass one'):
+        run_command(run, eval='fake.smoke', policy='a policy', policy_image='org/p:v1')
+    assert platform.seen is None
+
+
+@pytest.mark.parametrize('local_only', [{'timing': True}, {'output_dir': '/tmp/x'}, {'inference_latency': True}])
+def test_a_platform_run_refuses_what_only_a_local_run_can_mean(platform, run_command, local_only: dict):
+    # The platform owns its own trial sweep, output and telemetry, so silently dropping these would
+    # hand back a run the caller believes they configured.
+    with pytest.raises(SystemExit, match='a platform run has no'):
+        run_command(run, eval='fake.smoke', policy_image='org/p:v1', **local_only)
+    assert platform.seen is None
+
+
+def test_the_eval_group_walks_to_run(platform, capsys, monkeypatch):
+    platform.answer({'submission_id': ID, 'status': 'pending'})
+    argv = ['positronic', 'eval', 'run', '--eval=fake.smoke', '--policy-image=org/p:v1']
+    monkeypatch.setattr(sys, 'argv', argv)
+
+    cfn.cli({'eval': {'run': run}})
+
+    assert platform.request.url.path == routes.SUBMISSIONS_CREATE
+    assert f'submission {ID} (pending)' in capsys.readouterr().out

--- a/positronic/cli/eval/tests/test_run_on_the_platform.py
+++ b/positronic/cli/eval/tests/test_run_on_the_platform.py
@@ -41,6 +41,24 @@ def test_an_image_rejected_at_the_door_fails_the_command(platform, run_command, 
     assert f'submission {ID} (errored)' in capsys.readouterr().out
 
 
+def test_a_replay_of_a_cancelled_submission_fails_the_command(platform, run_command):
+    # An idempotent replay returns the original, which may since have been cancelled. It will never
+    # produce a result, so it exits like any other terminal-without-a-result.
+    platform.answer({'submission_id': ID, 'status': 'cancelled'})
+
+    with pytest.raises(SystemExit, match='rejected: cancelled'):
+        run_command(run, eval='fake.smoke', policy_image='org/p:v1', transaction_key='retry-1')
+
+
+def test_a_replay_of_a_finished_submission_succeeds(platform, run_command, capsys):
+    # The boundary of the rule above: terminal is not the test, a missing result is.
+    platform.answer({'submission_id': ID, 'status': 'finished'})
+
+    run_command(run, eval='fake.smoke', policy_image='org/p:v1', transaction_key='retry-1')
+
+    assert f'submission {ID} (finished)' in capsys.readouterr().out
+
+
 def test_an_eval_the_platform_does_not_offer_is_answered_with_the_ones_it_does(platform, run_command):
     # The set lives on the server, so the refusal is where a caller learns the real names.
     platform.answer(

--- a/positronic/cli/eval/tests/test_run_on_the_platform.py
+++ b/positronic/cli/eval/tests/test_run_on_the_platform.py
@@ -5,6 +5,7 @@ import sys
 import configuronic as cfn
 import pytest
 from platform_client import routes
+from platform_client.ids import SubmissionId
 
 from positronic.cli.conftest import ID, KEY
 from positronic.cli.eval.run import run
@@ -13,8 +14,10 @@ from positronic.cli.eval.run import run
 def test_a_policy_image_sends_the_run_to_the_platform(platform, run_command, capsys):
     platform.answer({'submission_id': ID, 'status': 'pending', 'policy_image_digest': 'sha256:abc'})
 
-    run_command(run, eval='fake.smoke', policy_image='org/p:v1', transaction_key='retry-1')
+    created = run_command(run, eval='fake.smoke', policy_image='org/p:v1', transaction_key='retry-1')
 
+    # Returned as well as printed, so a caller holding the function has the id without scraping stdout.
+    assert created.submission_id == SubmissionId.parse(ID)
     assert platform.request.url.path == routes.SUBMISSIONS_CREATE
     assert platform.request.headers['authorization'] == f'Bearer {KEY}'
     assert platform.body == {

--- a/positronic/cli/eval/tests/test_run_on_the_platform.py
+++ b/positronic/cli/eval/tests/test_run_on_the_platform.py
@@ -78,9 +78,23 @@ def test_an_eval_the_platform_does_not_offer_is_answered_with_the_ones_it_does(p
     assert 'evals on offer: fake.smoke, robolab.public_subset' in str(exit_info.value)
 
 
-def test_an_image_reference_the_registry_could_never_resolve_is_refused_here(platform, run_command):
-    with pytest.raises(ValueError):
-        run_command(run, eval='fake.smoke', policy_image='org/policy@')
+@pytest.mark.parametrize(
+    ('typo', 'named'),
+    [
+        ({'policy_image': 'org/policy@'}, 'org/policy@'),
+        ({'eval': 'fake smoke'}, 'fake smoke'),
+        ({'transaction_key': ''}, 'transaction_key'),
+    ],
+    ids=['image', 'eval', 'transaction-key'],
+)
+def test_a_value_the_wire_types_refuse_is_a_refusal_naming_it_rather_than_a_traceback(
+    platform, run_command, typo: dict, named: str
+):
+    # These are refused in the caller's own process, before anything is sent, so the user learns
+    # which value they typed wrong instead of reading a stack trace out of a constructor.
+    with pytest.raises(SystemExit) as exit_info:
+        run_command(run, **{'eval': 'fake.smoke', 'policy_image': 'org/p:v1', **typo})
+    assert named in str(exit_info.value)
     assert platform.seen is None
 
 

--- a/positronic/cli/eval/tests/test_submissions.py
+++ b/positronic/cli/eval/tests/test_submissions.py
@@ -1,0 +1,91 @@
+"""`positronic eval status|list|cancel`: reading back what a platform run did, over a stub transport.
+
+The gateway plumbing every command shares — the key, the URL, a refusal — is checked here, on the
+commands that require a key.
+"""
+
+import pytest
+from platform_client import routes
+
+from positronic.cli.account import gateway as gateway_module
+from positronic.cli.conftest import AT, ID
+from positronic.cli.eval.submissions import cancel, list_submissions, status
+
+
+def test_status_prints_the_fields_of_the_variant_it_got(platform, run_command, capsys):
+    platform.answer({'id': ID, 'status': 'pending', 'received_at': AT, 'queued_at': AT, 'queue_position': 3})
+
+    run_command(status, submission_id=ID)
+
+    assert platform.request.url.path == routes.SUBMISSIONS_GET
+    assert platform.request.url.params['id'] == ID
+    out = capsys.readouterr().out.splitlines()
+    assert out[0] == f'{ID} pending'
+    assert '  queue_position: 3' in out
+
+
+def test_list_prints_a_line_per_submission(platform, run_command, capsys):
+    platform.answer({
+        'submissions': [
+            {'id': ID, 'user_id': 'a0', 'alias': 'demo', 'status': 'running', 'eval': 'fake.smoke', 'received_at': AT}
+        ]
+    })
+
+    run_command(list_submissions)
+
+    assert platform.request.url.path == routes.SUBMISSIONS_LIST
+    assert capsys.readouterr().out.strip() == f'{ID} 2026-03-04 05:06 running fake.smoke demo'
+
+
+def test_cancel_reports_whether_the_quota_came_back(platform, run_command, capsys):
+    platform.answer({'status': 'cancelled', 'refunded': True})
+
+    run_command(cancel, submission_id=ID)
+
+    assert platform.request.url.path == routes.SUBMISSIONS_CANCEL
+    assert platform.body == {'id': ID}
+    assert 'cancelled, quota refunded' in capsys.readouterr().out
+
+
+def test_a_submission_id_the_parser_read_as_a_number_is_refused(platform, run_command):
+    with pytest.raises(SystemExit, match='hexadecimal'):
+        run_command(status, submission_id=1234567890123456)
+
+
+def test_a_submission_id_that_is_not_hexadecimal_is_refused(platform, run_command):
+    with pytest.raises(SystemExit, match='not a submission id'):
+        run_command(cancel, submission_id='zz')
+
+
+def test_a_refusal_by_the_platform_exits_with_its_message(platform, run_command):
+    platform.answer({'error': {'code': 'quota_exceeded', 'message': 'no submissions left today'}}, status=429)
+
+    with pytest.raises(SystemExit) as exit_info:
+        run_command(list_submissions)
+
+    assert str(exit_info.value) == 'quota_exceeded: no submissions left today'
+
+
+def test_a_command_needing_a_key_names_the_variable_that_holds_it(platform, run_command, monkeypatch):
+    monkeypatch.delenv(gateway_module.API_KEY_ENV)
+
+    with pytest.raises(SystemExit, match=gateway_module.API_KEY_ENV):
+        run_command(list_submissions)
+
+
+def test_an_unconfigured_url_leaves_the_client_on_its_default_platform(platform, run_command, monkeypatch):
+    # A user should never have to know a URL: with nothing set, the client reaches the platform.
+    monkeypatch.delenv(gateway_module.API_URL_ENV)
+    platform.answer({'submissions': []})
+
+    run_command(list_submissions)
+
+    assert platform.base_url is None
+
+
+def test_the_platform_url_argument_overrides_the_environment(platform, run_command):
+    platform.answer({'submissions': []})
+
+    run_command(list_submissions, platform_url='http://other.test')
+
+    assert platform.base_url == 'http://other.test'

--- a/positronic/cli/eval/tests/test_submissions.py
+++ b/positronic/cli/eval/tests/test_submissions.py
@@ -22,6 +22,8 @@ def test_status_prints_the_fields_of_the_variant_it_got(platform, run_command, c
     out = capsys.readouterr().out.splitlines()
     assert out[0] == f'{ID} pending'
     assert '  queue_position: 3' in out
+    # The header carries the id and the status, so the body below it repeats neither.
+    assert [line for line in out[1:] if line.startswith(('  id:', '  status:'))] == []
 
 
 def test_list_prints_a_line_per_submission(platform, run_command, capsys):

--- a/positronic/cli/examples/README.md
+++ b/positronic/cli/examples/README.md
@@ -1,0 +1,42 @@
+# Examples
+
+Runnable walkthroughs of the evaluation platform. Everything here runs through `uv` from a
+checkout, so nothing has to be installed first — `uv run` builds the environment it needs.
+
+| Script | What it shows |
+|---|---|
+| `walkthrough.py` | The whole flow through `PlatformClient`: register, submit, read quota, poll to a terminal status. |
+| `nebius_competition/submit_sample.py` | Submitting to one engagement's eval with a transaction key, and waiting for what it scored. |
+
+## From the command line
+
+The same flow, with no Python of your own:
+
+```bash
+export POSITRONIC_PLATFORM_CREDENTIAL=<the identity to register with>
+uv run positronic account register --alias=<display name>
+export POSITRONIC_PLATFORM_API_KEY=<the key printed above>
+
+uv run positronic eval run --eval=<name> --policy-image=org/policy@sha256:…
+uv run positronic eval status --submission-id=<hex id>
+```
+
+`eval run` is the same command that runs an eval on the machine in front of you; a policy image in
+place of a policy is what sends it to the platform.
+
+An eval names the embodiment it runs on — a task suite belongs to a simulator or to one real robot,
+never to both — so the eval is the whole of the choice. The platform owns the list, and naming one
+it does not offer answers with the ones it does.
+
+## From Python
+
+```bash
+POSITRONIC_PLATFORM_CREDENTIAL=<token> uv run positronic/cli/examples/walkthrough.py
+```
+
+Both scripts talk to `https://platform.positronic.ro` unless `--platform-url` says otherwise; the
+walkthrough defaults to the `fake.smoke` eval, which a platform started with no cloud and no GPU
+still runs.
+
+Engagement-specific material lives in its own subdirectory, and
+`positronic/cli/tests/test_vocabulary.py` holds everything outside it to that.

--- a/positronic/cli/examples/nebius_competition/README.md
+++ b/positronic/cli/examples/nebius_competition/README.md
@@ -1,0 +1,17 @@
+# Nebius competition
+
+Walkthroughs for the competition's sim qualifier, on top of the same client every other caller uses.
+
+- `submit_sample.py` — submit a policy image to the `robolab.public_subset` eval, wait for it to
+  finish, and report what it scored.
+
+Three things about the competition flow that the generic walkthrough does not cover:
+
+- **Pin your image by digest.** The platform resolves the reference to a digest at submission time
+  and runs those exact bytes; submitting a mutable tag means the run may not be the build you
+  tested.
+- **Reuse a transaction key on a retry.** A retry with the same key returns the original
+  submission; a retry without one spends another day's quota. The key is yours to choose, and
+  reusing it with a *different* request is a conflict rather than a silent swap.
+- **A board is per eval version.** A rotation changes the version and starts a new board, so scores
+  from before it are never mixed with scores from after.

--- a/positronic/cli/examples/nebius_competition/README.md
+++ b/positronic/cli/examples/nebius_competition/README.md
@@ -5,7 +5,7 @@ Walkthroughs for the competition's sim qualifier, on top of the same client ever
 - `submit_sample.py` — submit a policy image to the `robolab.public_subset` eval, wait for it to
   finish, and report what it scored.
 
-Three things about the competition flow that the generic walkthrough does not cover:
+What the generic walkthrough does not cover:
 
 - **Pin your image by digest.** The platform resolves the reference to a digest at submission time
   and runs those exact bytes; submitting a mutable tag means the run may not be the build you

--- a/positronic/cli/examples/nebius_competition/README.md
+++ b/positronic/cli/examples/nebius_competition/README.md
@@ -13,5 +13,3 @@ What the generic walkthrough does not cover:
 - **Reuse a transaction key on a retry.** A retry with the same key returns the original
   submission; a retry without one spends another day's quota. The key is yours to choose, and
   reusing it with a *different* request is a conflict rather than a silent swap.
-- **A board is per eval version.** A rotation changes the version and starts a new board, so scores
-  from before it are never mixed with scores from after.

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -25,7 +25,7 @@ from platform_client.enums import NO_RESULT_STATUSES, TERMINAL_STATUSES, ReasonC
 from platform_client.errors import PlatformError
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId, TransactionKey
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import SubmissionCreateRequest
 from platform_client.responses import FinishedSubmissionView, SubmissionCreateResponse, SubmissionView
 
@@ -34,7 +34,7 @@ EVAL = EvalRef('robolab.public_subset')
 
 
 def submit(
-    client: PlatformClient, *, policy_image: ImageRef, alias: str | None, transaction_key: TransactionKey | None
+    client: PlatformClient, *, policy_image: PolicyImage, alias: str | None, transaction_key: TransactionKey | None
 ) -> SubmissionCreateResponse:
     """Create the submission, and report the exact image and eval version it was pinned to."""
     created = client.create_submission(
@@ -75,7 +75,7 @@ def main() -> None:
         try:
             created = submit(
                 client,
-                policy_image=ImageRef(args.policy_image),
+                policy_image=PolicyImage(args.policy_image),
                 alias=args.alias,
                 transaction_key=TransactionKey(args.transaction_key) if args.transaction_key else None,
             )

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -85,8 +85,7 @@ def main() -> None:
                     reason += ' — check the reference and its visibility'
                 raise SystemExit(f'terminal at the door: {reason}')
             view = poll_until_terminal(client, created.submission_id, timeout_s=args.timeout)
-            # A qualifier that failed reports the same way whenever it failed — at the door or an
-            # hour in — so a script cannot read one as a run that produced something.
+            # A terminal view that is not finished carries no result, so there is no score to report.
             if not isinstance(view, FinishedSubmissionView):
                 raise SystemExit(f'finished as {view.status.name}, with no result to read')
             print(f'finished as {view.status.name}')

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -21,7 +21,7 @@ import os
 import time
 
 from platform_client.client import API_KEY_ENV, PlatformClient
-from platform_client.enums import TERMINAL_STATUSES, ReasonCode, SubmissionStatus
+from platform_client.enums import NO_RESULT_STATUSES, TERMINAL_STATUSES, ReasonCode
 from platform_client.errors import PlatformError
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId, TransactionKey
@@ -79,15 +79,18 @@ def main() -> None:
                 alias=args.alias,
                 transaction_key=TransactionKey(args.transaction_key) if args.transaction_key else None,
             )
-            if created.status is SubmissionStatus.errored:
-                reason = created.reason_code.name if created.reason_code else 'unknown'
+            if created.status in NO_RESULT_STATUSES:
+                reason = created.reason_code.name if created.reason_code else created.status.name
                 if created.reason_code is ReasonCode.image_unpullable:
                     reason += ' — check the reference and its visibility'
                 raise SystemExit(f'terminal at the door: {reason}')
             view = poll_until_terminal(client, created.submission_id, timeout_s=args.timeout)
+            # A qualifier that failed reports the same way whenever it failed — at the door or an
+            # hour in — so a script cannot read one as a run that produced something.
+            if not isinstance(view, FinishedSubmissionView):
+                raise SystemExit(f'finished as {view.status.name}, with no result to read')
             print(f'finished as {view.status.name}')
-            if isinstance(view, FinishedSubmissionView):
-                print(f'primary {view.scores.primary} over {view.scores.episodes} episodes')
+            print(f'primary {view.scores.primary} over {view.scores.episodes} episodes')
         except PlatformError as exc:
             offered = f'\nevals on offer: {", ".join(exc.evals)}' if exc.evals is not None else ''
             raise SystemExit(f'{exc.code.name}: {exc.message}{offered}') from exc

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -1,0 +1,97 @@
+"""Submit a sample policy to the competition's eval and print what it scored.
+
+    uv run positronic/cli/examples/nebius_competition/submit_sample.py \
+        --policy-image=<registry>/<you>/policy@sha256:...
+
+`uv run` builds the environment this needs from the checkout, so nothing has to be installed first.
+The key comes from POSITRONIC_PLATFORM_API_KEY: a secret passed as an argument lands in your shell
+history and in every process listing on the box.
+
+Assumes a key you already hold; `../walkthrough.py` covers registration. Re-running with the same
+`--transaction-key` returns the original submission rather than spending quota twice.
+
+The command-line equivalent is `positronic eval run --eval=robolab.public_subset
+--policy-image=...`, then `positronic eval status --submission-id=...`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+
+from platform_client.client import API_KEY_ENV, PlatformClient
+from platform_client.enums import TERMINAL_STATUSES, ReasonCode, SubmissionStatus
+from platform_client.errors import PlatformError
+from platform_client.evals import EvalRef
+from platform_client.ids import ApiKey, SubmissionId, TransactionKey
+from platform_client.images import ImageRef
+from platform_client.requests import SubmissionCreateRequest
+from platform_client.responses import FinishedSubmissionView, SubmissionCreateResponse, SubmissionView
+
+# The eval names the embodiment it runs on, so it is the whole of what a submission chooses.
+EVAL = EvalRef('robolab.public_subset')
+
+
+def submit(
+    client: PlatformClient, *, policy_image: ImageRef, alias: str | None, transaction_key: TransactionKey | None
+) -> SubmissionCreateResponse:
+    """Create the submission, and report the exact image and eval version it was pinned to."""
+    created = client.create_submission(
+        SubmissionCreateRequest(policy_image=policy_image, eval=EVAL, alias=alias, transaction_key=transaction_key)
+    )
+    print(f'submission {created.submission_id} — {created.status.name}')
+    print(f'pinned image {created.policy_image_digest} against eval {created.eval_version}')
+    return created
+
+
+def poll_until_terminal(
+    client: PlatformClient, submission_id: SubmissionId, *, timeout_s: float, poll_s: float = 5.0
+) -> SubmissionView:
+    """Poll one submission until it is decided, or give up and say how to follow it by hand."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        view = client.get_submission(submission_id)
+        if view.status in TERMINAL_STATUSES:
+            return view
+        time.sleep(poll_s)
+    raise SystemExit(f'still running after {timeout_s:.0f}s — `positronic eval status` follows it')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--platform-url', default=None, help='a platform other than the default one')
+    parser.add_argument('--policy-image', required=True, help='a digest-pinned reference the platform can pull')
+    parser.add_argument('--alias', default=None, help='a per-submission label; the board shows your user alias')
+    parser.add_argument('--transaction-key', default=None, help='reuse it to retry without a second charge')
+    parser.add_argument('--timeout', type=float, default=3600.0, help='seconds to wait for a terminal status')
+    args = parser.parse_args()
+
+    key = os.environ.get(API_KEY_ENV)
+    if not key:
+        raise SystemExit(f'set {API_KEY_ENV} to the key `positronic account register` printed')
+
+    with PlatformClient(args.platform_url, api_key=ApiKey(key)) as client:
+        try:
+            created = submit(
+                client,
+                policy_image=ImageRef(args.policy_image),
+                alias=args.alias,
+                transaction_key=TransactionKey(args.transaction_key) if args.transaction_key else None,
+            )
+            if created.status is SubmissionStatus.errored:
+                reason = created.reason_code.name if created.reason_code else 'unknown'
+                if created.reason_code is ReasonCode.image_unpullable:
+                    reason += ' — check the reference and its visibility'
+                raise SystemExit(f'terminal at the door: {reason}')
+            view = poll_until_terminal(client, created.submission_id, timeout_s=args.timeout)
+            print(f'finished as {view.status.name}')
+            if isinstance(view, FinishedSubmissionView):
+                print(f'primary {view.scores.primary} over {view.scores.episodes} episodes')
+        except PlatformError as exc:
+            offered = f'\nevals on offer: {", ".join(exc.evals)}' if exc.evals is not None else ''
+            raise SystemExit(f'{exc.code.name}: {exc.message}{offered}') from exc
+
+
+if __name__ == '__main__':
+    main()

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -37,12 +37,12 @@ def submit(
     client: PlatformClient, *, policy_image: PolicyImage, alias: str | None, transaction_key: TransactionKey | None
 ) -> SubmissionCreateResponse:
     """Create the submission, and report the exact image and eval version it was pinned to."""
-    created = client.create_submission(
+    submission = client.create_submission(
         SubmissionCreateRequest(policy_image=policy_image, eval=EVAL, alias=alias, transaction_key=transaction_key)
     )
-    print(f'submission {created.submission_id} — {created.status.name}')
-    print(f'pinned image {created.policy_image_digest} against eval {created.eval_version}')
-    return created
+    print(f'submission {submission.submission_id} — {submission.status.name}')
+    print(f'pinned image {submission.policy_image_digest} against eval {submission.eval_version}')
+    return submission
 
 
 def poll_until_terminal(
@@ -73,18 +73,18 @@ def main() -> None:
 
     with PlatformClient(args.platform_url, api_key=ApiKey(key)) as client:
         try:
-            created = submit(
+            submission = submit(
                 client,
                 policy_image=PolicyImage(args.policy_image),
                 alias=args.alias,
                 transaction_key=TransactionKey(args.transaction_key) if args.transaction_key else None,
             )
-            if created.status in NO_RESULT_STATUSES:
-                reason = created.reason_code.name if created.reason_code else created.status.name
-                if created.reason_code is ReasonCode.image_unpullable:
+            if submission.status in NO_RESULT_STATUSES:
+                reason = submission.reason_code.name if submission.reason_code else submission.status.name
+                if submission.reason_code is ReasonCode.image_unpullable:
                     reason += ' — check the reference and its visibility'
                 raise SystemExit(f'terminal at the door: {reason}')
-            view = poll_until_terminal(client, created.submission_id, timeout_s=args.timeout)
+            view = poll_until_terminal(client, submission.submission_id, timeout_s=args.timeout)
             # A terminal view that is not finished carries no result, so there is no score to report.
             if not isinstance(view, FinishedSubmissionView):
                 raise SystemExit(f'finished as {view.status.name}, with no result to read')

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -36,12 +36,12 @@ EVAL = EvalRef('robolab.public_subset')
 def submit(
     client: PlatformClient, *, policy_image: PolicyImage, alias: str | None, transaction_key: TransactionKey | None
 ) -> SubmissionCreateResponse:
-    """Create the submission, and report the exact image and eval version it was pinned to."""
+    """Create the submission, and report the exact image it was pinned to."""
     submission = client.create_submission(
         SubmissionCreateRequest(policy_image=policy_image, eval=EVAL, alias=alias, transaction_key=transaction_key)
     )
     print(f'submission {submission.submission_id} — {submission.status.name}')
-    print(f'pinned image {submission.policy_image_digest} against eval {submission.eval_version}')
+    print(f'pinned image {submission.policy_image_digest} against eval {EVAL}')
     return submission
 
 

--- a/positronic/cli/examples/walkthrough.py
+++ b/positronic/cli/examples/walkthrough.py
@@ -1,0 +1,128 @@
+"""Drive one submission from registration to a board, against any platform.
+
+    POSITRONIC_PLATFORM_CREDENTIAL=<token> uv run positronic/cli/examples/walkthrough.py
+
+`uv run` builds the environment this needs from the checkout, so nothing has to be installed first.
+The credential is read from the environment rather than taken as an argument: a command line is
+readable by every process on the box and lands in shell history.
+
+Every call goes through `PlatformClient`, so each response is a typed model rather than a dict. The
+same flow from the command line is `positronic account register`, `positronic eval run` and
+`positronic eval status`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+
+from platform_client.client import CREDENTIAL_ENV, PlatformClient
+from platform_client.enums import TERMINAL_STATUSES, KeyStatus, SubmissionStatus
+from platform_client.errors import PlatformError
+from platform_client.evals import EvalRef
+from platform_client.ids import ApiKey, SubmissionId
+from platform_client.images import ImageRef
+from platform_client.requests import RegisterRequest, SubmissionCreateRequest
+from platform_client.responses import ErroredSubmissionView, FinishedSubmissionView, SubmissionView
+
+
+def mint_api_key(client: PlatformClient, *, credential: str, alias: str) -> ApiKey:
+    """Register this identity and come back with a usable key, rotating if it is already registered.
+
+    Registration is create-or-return, and a key's plaintext is stored only as a hash, so a second
+    registration reports `existing` and carries no key. Rotating issues a fresh one and retires the
+    old one.
+    """
+    registration = client.register(RegisterRequest(credential=credential, alias=alias))
+    print(f'   user {registration.user_id} ({registration.key_status.name})')
+    if registration.api_key is None:
+        registration = client.register(RegisterRequest(credential=credential, alias=alias, rotate=True))
+        print(f'   rotated ({registration.key_status.name})')
+    assert registration.api_key is not None, f'expected a key after {KeyStatus.rotated.name}'
+    return registration.api_key
+
+
+def poll_until_terminal(
+    client: PlatformClient, submission_id: SubmissionId, *, timeout_s: float, poll_s: float = 0.2
+) -> SubmissionView:
+    """Poll one submission to a terminal status, printing each distinct status on the way."""
+    deadline = time.monotonic() + timeout_s
+    seen: list[str] = []
+    while time.monotonic() < deadline:
+        view = client.get_submission(submission_id)
+        if not seen or seen[-1] != view.status.name:
+            seen.append(view.status.name)
+            print(f'   status: {view.status.name}')
+        if view.status in TERMINAL_STATUSES:
+            return view
+        time.sleep(poll_s)
+    raise TimeoutError(f'submission {submission_id} never reached a terminal status (saw {seen})')
+
+
+def print_quota(client: PlatformClient) -> None:
+    """What the caller's plan allows, and what is left of it right now."""
+    me = client.me()
+    print(f'   {me.tenant} on {me.plan}')
+    for limit in me.quota:
+        remaining, allowed = limit.remaining / limit.scale, limit.limit / limit.scale
+        print(f'   {limit.key} ({limit.window}): {remaining:g} of {allowed:g} {limit.unit} left')
+
+
+def walkthrough(
+    client: PlatformClient, *, credential: str, alias: str, eval_ref: EvalRef, policy_image: ImageRef, timeout_s: float
+) -> None:
+    print('1. register')
+    client.api_key = mint_api_key(client, credential=credential, alias=alias)
+
+    print('2. submit')
+    # The eval is the whole of the choice: it names the embodiment its tasks run on, and asking for
+    # one the platform does not offer comes back with the names it does, under `PlatformError.evals`.
+    created = client.create_submission(SubmissionCreateRequest(policy_image=policy_image, eval=eval_ref))
+    print(f'   submission {created.submission_id} ({created.status.name})')
+    if created.status is SubmissionStatus.errored:
+        print(f'   terminal at the door: {created.reason_code.name if created.reason_code else "unknown"}')
+        return
+
+    print('3. quota')
+    print_quota(client)
+
+    print('4. poll until terminal')
+    view = poll_until_terminal(client, created.submission_id, timeout_s=timeout_s)
+    if isinstance(view, FinishedSubmissionView):
+        print(f'   primary {view.scores.primary} over {view.scores.episodes} episodes')
+        print(f'   result  {view.artifacts.result}')
+    elif isinstance(view, ErroredSubmissionView):
+        print(f'   failed: {view.reason_code.name if view.reason_code else "unknown"} — {view.reason}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--platform-url', default=None, help='a platform other than the default one')
+    parser.add_argument('--alias', default='demo', help='the name a board displays you by')
+    parser.add_argument('--eval', default='fake.smoke', help='the eval to run; the platform lists the ones it offers')
+    parser.add_argument('--policy-image', default='org/policy:v1', help='the image the platform pulls and runs')
+    parser.add_argument('--timeout', type=float, default=60.0, help='seconds to wait for a terminal status')
+    args = parser.parse_args()
+
+    credential = os.environ.get(CREDENTIAL_ENV)
+    if not credential:
+        raise SystemExit(f'set {CREDENTIAL_ENV} to the token the platform verifies you by')
+
+    with PlatformClient(args.platform_url) as client:
+        try:
+            walkthrough(
+                client,
+                credential=credential,
+                alias=args.alias,
+                eval_ref=EvalRef(args.eval),
+                policy_image=ImageRef(args.policy_image),
+                timeout_s=args.timeout,
+            )
+        except PlatformError as exc:
+            offered = f'\nevals on offer: {", ".join(exc.evals)}' if exc.evals is not None else ''
+            raise SystemExit(f'{exc.code.name}: {exc.message}{offered}') from exc
+
+
+if __name__ == '__main__':
+    main()

--- a/positronic/cli/examples/walkthrough.py
+++ b/positronic/cli/examples/walkthrough.py
@@ -22,7 +22,7 @@ from platform_client.enums import NO_RESULT_STATUSES, TERMINAL_STATUSES, KeyStat
 from platform_client.errors import PlatformError
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId
-from platform_client.images import ImageRef
+from platform_client.policy_images import PolicyImage
 from platform_client.requests import RegisterRequest, SubmissionCreateRequest
 from platform_client.responses import ErroredSubmissionView, FinishedSubmissionView, SubmissionView
 
@@ -70,7 +70,13 @@ def print_quota(client: PlatformClient) -> None:
 
 
 def walkthrough(
-    client: PlatformClient, *, credential: str, alias: str, eval_ref: EvalRef, policy_image: ImageRef, timeout_s: float
+    client: PlatformClient,
+    *,
+    credential: str,
+    alias: str,
+    eval_ref: EvalRef,
+    policy_image: PolicyImage,
+    timeout_s: float,
 ) -> None:
     print('1. register')
     client.api_key = mint_api_key(client, credential=credential, alias=alias)
@@ -119,7 +125,7 @@ def main() -> None:
                 credential=credential,
                 alias=args.alias,
                 eval_ref=EvalRef(args.eval),
-                policy_image=ImageRef(args.policy_image),
+                policy_image=PolicyImage(args.policy_image),
                 timeout_s=args.timeout,
             )
         except PlatformError as exc:

--- a/positronic/cli/examples/walkthrough.py
+++ b/positronic/cli/examples/walkthrough.py
@@ -18,7 +18,7 @@ import os
 import time
 
 from platform_client.client import CREDENTIAL_ENV, PlatformClient
-from platform_client.enums import TERMINAL_STATUSES, KeyStatus, SubmissionStatus
+from platform_client.enums import NO_RESULT_STATUSES, TERMINAL_STATUSES, KeyStatus
 from platform_client.errors import PlatformError
 from platform_client.evals import EvalRef
 from platform_client.ids import ApiKey, SubmissionId
@@ -80,20 +80,23 @@ def walkthrough(
     # one the platform does not offer comes back with the names it does, under `PlatformError.evals`.
     created = client.create_submission(SubmissionCreateRequest(policy_image=policy_image, eval=eval_ref))
     print(f'   submission {created.submission_id} ({created.status.name})')
-    if created.status is SubmissionStatus.errored:
-        print(f'   terminal at the door: {created.reason_code.name if created.reason_code else "unknown"}')
-        return
+    if created.status in NO_RESULT_STATUSES:
+        reason = created.reason_code.name if created.reason_code else created.status.name
+        raise SystemExit(f'   terminal at the door: {reason}')
 
     print('3. quota')
     print_quota(client)
 
     print('4. poll until terminal')
     view = poll_until_terminal(client, created.submission_id, timeout_s=timeout_s)
-    if isinstance(view, FinishedSubmissionView):
-        print(f'   primary {view.scores.primary} over {view.scores.episodes} episodes')
-        print(f'   result  {view.artifacts.result}')
-    elif isinstance(view, ErroredSubmissionView):
-        print(f'   failed: {view.reason_code.name if view.reason_code else "unknown"} — {view.reason}')
+    if isinstance(view, ErroredSubmissionView):
+        raise SystemExit(f'   failed: {view.reason_code.name if view.reason_code else "unknown"} — {view.reason}')
+    # Run as a command, and a test reads the exit code, so a run that produced nothing must not
+    # leave one saying it did.
+    if not isinstance(view, FinishedSubmissionView):
+        raise SystemExit(f'   {view.status.name}, with no result to read')
+    print(f'   primary {view.scores.primary} over {view.scores.episodes} episodes')
+    print(f'   result  {view.artifacts.result}')
 
 
 def main() -> None:

--- a/positronic/cli/examples/walkthrough.py
+++ b/positronic/cli/examples/walkthrough.py
@@ -97,8 +97,7 @@ def walkthrough(
     view = poll_until_terminal(client, created.submission_id, timeout_s=timeout_s)
     if isinstance(view, ErroredSubmissionView):
         raise SystemExit(f'   failed: {view.reason_code.name if view.reason_code else "unknown"} — {view.reason}')
-    # Run as a command, and a test reads the exit code, so a run that produced nothing must not
-    # leave one saying it did.
+    # A terminal view that is not finished carries no result, so there is no score to report.
     if not isinstance(view, FinishedSubmissionView):
         raise SystemExit(f'   {view.status.name}, with no result to read')
     print(f'   primary {view.scores.primary} over {view.scores.episodes} episodes')

--- a/positronic/cli/examples/walkthrough.py
+++ b/positronic/cli/examples/walkthrough.py
@@ -21,26 +21,25 @@ from platform_client.client import CREDENTIAL_ENV, PlatformClient
 from platform_client.enums import NO_RESULT_STATUSES, TERMINAL_STATUSES, KeyStatus
 from platform_client.errors import PlatformError
 from platform_client.evals import EvalRef
-from platform_client.ids import ApiKey, SubmissionId
+from platform_client.ids import SubmissionId
 from platform_client.policy_images import PolicyImage
 from platform_client.requests import RegisterRequest, SubmissionCreateRequest
 from platform_client.responses import ErroredSubmissionView, FinishedSubmissionView, SubmissionView
 
 
-def mint_api_key(client: PlatformClient, *, credential: str, alias: str) -> ApiKey:
-    """Register this identity and come back with a usable key, rotating if it is already registered.
+def authenticate(client: PlatformClient, *, credential: str, alias: str) -> None:
+    """Leave the client holding a usable key, rotating if this identity is already registered.
 
-    Registration is create-or-return, and a key's plaintext is stored only as a hash, so a second
-    registration reports `existing` and carries no key. Rotating issues a fresh one and retires the
-    old one.
+    `register` keeps whatever key it is given. A key's plaintext is stored only as a hash, so a
+    second registration reports `existing` and carries none; rotating issues a fresh one and
+    retires the old.
     """
     registration = client.register(RegisterRequest(credential=credential, alias=alias))
     print(f'   user {registration.user_id} ({registration.key_status.name})')
     if registration.api_key is None:
         registration = client.register(RegisterRequest(credential=credential, alias=alias, rotate=True))
         print(f'   rotated ({registration.key_status.name})')
-    assert registration.api_key is not None, f'expected a key after {KeyStatus.rotated.name}'
-    return registration.api_key
+    assert client.api_key is not None, f'expected a key after {KeyStatus.rotated.name}'
 
 
 def poll_until_terminal(
@@ -79,22 +78,22 @@ def walkthrough(
     timeout_s: float,
 ) -> None:
     print('1. register')
-    client.api_key = mint_api_key(client, credential=credential, alias=alias)
+    authenticate(client, credential=credential, alias=alias)
 
     print('2. submit')
     # The eval is the whole of the choice: it names the embodiment its tasks run on, and asking for
     # one the platform does not offer comes back with the names it does, under `PlatformError.evals`.
-    created = client.create_submission(SubmissionCreateRequest(policy_image=policy_image, eval=eval_ref))
-    print(f'   submission {created.submission_id} ({created.status.name})')
-    if created.status in NO_RESULT_STATUSES:
-        reason = created.reason_code.name if created.reason_code else created.status.name
+    submission = client.create_submission(SubmissionCreateRequest(policy_image=policy_image, eval=eval_ref))
+    print(f'   submission {submission.submission_id} ({submission.status.name})')
+    if submission.status in NO_RESULT_STATUSES:
+        reason = submission.reason_code.name if submission.reason_code else submission.status.name
         raise SystemExit(f'   terminal at the door: {reason}')
 
     print('3. quota')
     print_quota(client)
 
     print('4. poll until terminal')
-    view = poll_until_terminal(client, created.submission_id, timeout_s=timeout_s)
+    view = poll_until_terminal(client, submission.submission_id, timeout_s=timeout_s)
     if isinstance(view, ErroredSubmissionView):
         raise SystemExit(f'   failed: {view.reason_code.name if view.reason_code else "unknown"} — {view.reason}')
     # A terminal view that is not finished carries no result, so there is no score to report.

--- a/positronic/cli/tests/test_fresh_install.py
+++ b/positronic/cli/tests/test_fresh_install.py
@@ -1,0 +1,214 @@
+"""Every documented command runs from a bare `uv`, against a platform that answers everything.
+
+The commands and the example scripts are what a new user types first, so what is checked here is
+the whole of that first experience: a checkout, no installation step, no packages on the path, and
+the exact invocation the READMEs cite. A subprocess with `VIRTUAL_ENV` and `PYTHONPATH` scrubbed is
+what makes that claim honest — `uv run` has to build the environment itself or the command fails.
+
+The platform is a fake that answers 200 to every route, so a failure here is the invocation or the
+environment, never the platform.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from platform_client import routes
+from platform_client.client import API_KEY_ENV, API_URL_ENV, CREDENTIAL_ENV
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBMISSION = '5f3a91c2b7d40e18'
+AT = '2026-03-04T05:06:07Z'
+
+# One canned answer per route, each the shape its response model requires. A submission is finished
+# the first time it is read, so a polling example terminates on its first pass.
+ANSWERS: dict[str, object] = {
+    routes.USERS_REGISTER: {
+        'user_id': 'a0',
+        'artifact_location': 's3://bucket/users/a0/',
+        'api_key': 'pk_live_fake',
+        'key_status': 'created',
+    },
+    routes.USERS_ME: {
+        'user_id': 'a0',
+        'alias': 'demo',
+        'tenant': 'demo-tenant',
+        'plan': 'demo-plan',
+        'quota': [
+            {
+                'key': 'submissions.day',
+                'meter': 'submissions',
+                'unit': 'submission',
+                'scale': 1,
+                'window': 'day',
+                'subject': 'user',
+                'scope': [],
+                'limit': 2,
+                'used': 1,
+                'resets_at': AT,
+                'on_exhausted': 'block',
+            }
+        ],
+    },
+    routes.SUBMISSIONS_CREATE: {
+        'submission_id': SUBMISSION,
+        'status': 'pending',
+        'policy_image_digest': 'sha256:abc',
+        'eval_version': 'fake.smoke@0123456789ab',
+    },
+    routes.SUBMISSIONS_GET: {
+        'id': SUBMISSION,
+        'status': 'finished',
+        'scores': {'primary': 0.5, 'episodes': 4},
+        'artifacts': {'result': 's3://bucket/result.json'},
+    },
+    routes.SUBMISSIONS_LIST: {
+        'submissions': [
+            {'id': SUBMISSION, 'user_id': 'a0', 'status': 'finished', 'eval': 'fake.smoke', 'received_at': AT}
+        ]
+    },
+    routes.SUBMISSIONS_CANCEL: {'status': 'cancelled', 'refunded': True},
+    routes.RANKINGS_GET: {
+        'board': 'fake.smoke',
+        'eval': 'fake.smoke',
+        'eval_version': 'fake.smoke@0123456789ab',
+        'primary_metric': 'success_rate',
+        'rankings': [
+            {
+                'rank': 1,
+                'display_name': 'demo',
+                'tag': '0ddba7',
+                'scores': {'primary': 0.5, 'episodes': 4},
+                'submission_id': SUBMISSION,
+                'submitted_at': AT,
+            }
+        ],
+    },
+    routes.RANKINGS_LIST: {
+        'boards': [
+            {
+                'board': 'fake.smoke',
+                'title': 'Fake smoke',
+                'eval': 'fake.smoke',
+                'eval_version': 'fake.smoke@0123456789ab',
+                'primary_metric': 'success_rate',
+                'visibility': 'public',
+            }
+        ]
+    },
+}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def _answer(self) -> None:
+        path = self.path.split('?', 1)[0]
+        payload = ANSWERS.get(path)
+        if payload is None:
+            self.send_error(404, f'no canned answer for {path}')
+            return
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = _answer
+    do_POST = _answer
+
+    def log_message(self, format: str, *args: object) -> None:  # the test reports failures itself
+        pass
+
+
+@pytest.fixture(scope='module')
+def platform_url() -> Iterator[str]:
+    server = ThreadingHTTPServer(('127.0.0.1', 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f'http://127.0.0.1:{server.server_port}'
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def run_from_a_clean_environment(command: list[str], *, platform_url: str) -> subprocess.CompletedProcess:
+    """Run one documented command as a user with nothing installed would."""
+    # An inherited interpreter or import path would let the command succeed on packages `uv run`
+    # never had to provide, which is exactly the claim under test.
+    env = {
+        'PATH': os.environ['PATH'],
+        'HOME': os.environ['HOME'],
+        API_URL_ENV: platform_url,
+        API_KEY_ENV: 'pk_live_fake',
+        CREDENTIAL_ENV: 'token',
+    }
+    return subprocess.run(command, cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=1800)
+
+
+DOCUMENTED_COMMANDS = {
+    'account-register': ['uv', 'run', 'positronic', 'account', 'register', '--alias=demo'],
+    'eval-run-on-platform': [
+        'uv',
+        'run',
+        'positronic',
+        'eval',
+        'run',
+        '--eval=fake.smoke',
+        '--policy-image=org/policy:v1',
+    ],
+    'eval-status': ['uv', 'run', 'positronic', 'eval', 'status', f'--submission-id={SUBMISSION}'],
+    'eval-list': ['uv', 'run', 'positronic', 'eval', 'list'],
+    'eval-cancel': ['uv', 'run', 'positronic', 'eval', 'cancel', f'--submission-id={SUBMISSION}'],
+    'walkthrough': ['uv', 'run', 'positronic/cli/examples/walkthrough.py'],
+    'submit-sample': [
+        'uv',
+        'run',
+        'positronic/cli/examples/nebius_competition/submit_sample.py',
+        '--policy-image=org/policy@sha256:abc',
+    ],
+}
+
+
+@pytest.mark.skipif(shutil.which('uv') is None, reason='the documented commands are uv commands')
+@pytest.mark.parametrize('command', DOCUMENTED_COMMANDS.values(), ids=DOCUMENTED_COMMANDS.keys())
+def test_a_documented_command_runs_with_nothing_installed(command: list[str], platform_url: str):
+    result = run_from_a_clean_environment(command, platform_url=platform_url)
+    assert result.returncode == 0, f'{" ".join(command)} failed:\n{result.stdout}\n{result.stderr}'
+
+
+README_FILES = (REPO_ROOT / 'client' / 'README.md', REPO_ROOT / 'positronic' / 'cli' / 'examples' / 'README.md')
+
+
+def cited_commands() -> set[tuple[str, ...]]:
+    """Every `uv run …` line in the READMEs, cut to the words before its first placeholder."""
+    cited = set()
+    for path in README_FILES:
+        for line in path.read_text().splitlines():
+            stripped = line.strip().removeprefix('$ ')
+            if not stripped.startswith('uv run '):
+                continue
+            # A cited line carries placeholders (`--board=<board slug>`), which are neither words
+            # nor runnable; everything from the first one on is the reader's to fill in.
+            cited.add(_words(stripped.split('<', 1)[0]))
+    return cited
+
+
+def _words(command: str | list[str]) -> tuple[str, ...]:
+    """A command without its options — what identifies it, whatever arguments a citation carries."""
+    tokens = command.split() if isinstance(command, str) else command
+    return tuple(token for token in tokens if not token.startswith('--'))
+
+
+def test_every_uv_command_the_readmes_cite_is_one_this_test_runs():
+    # What is documented and what is checked drift apart silently otherwise: a command renamed in a
+    # README goes on passing here under its old name, and the first person to hit it is a new user.
+    run_here = {_words(command) for command in DOCUMENTED_COMMANDS.values()}
+    assert cited_commands() <= run_here, f'cited but never run: {sorted(cited_commands() - run_here)}'

--- a/positronic/cli/tests/test_fresh_install.py
+++ b/positronic/cli/tests/test_fresh_install.py
@@ -60,12 +60,7 @@ ANSWERS: dict[str, object] = {
             }
         ],
     },
-    routes.SUBMISSIONS_CREATE: {
-        'submission_id': SUBMISSION,
-        'status': 'pending',
-        'policy_image_digest': 'sha256:abc',
-        'eval_version': 'fake.smoke@0123456789ab',
-    },
+    routes.SUBMISSIONS_CREATE: {'submission_id': SUBMISSION, 'status': 'pending', 'policy_image_digest': 'sha256:abc'},
     routes.SUBMISSIONS_GET: {
         'id': SUBMISSION,
         'status': 'finished',
@@ -81,7 +76,6 @@ ANSWERS: dict[str, object] = {
     routes.RANKINGS_GET: {
         'board': 'fake.smoke',
         'eval': 'fake.smoke',
-        'eval_version': 'fake.smoke@0123456789ab',
         'primary_metric': 'success_rate',
         'rankings': [
             {
@@ -100,7 +94,6 @@ ANSWERS: dict[str, object] = {
                 'board': 'fake.smoke',
                 'title': 'Fake smoke',
                 'eval': 'fake.smoke',
-                'eval_version': 'fake.smoke@0123456789ab',
                 'primary_metric': 'success_rate',
                 'visibility': 'public',
             }

--- a/positronic/cli/tests/test_fresh_install.py
+++ b/positronic/cli/tests/test_fresh_install.py
@@ -131,6 +131,19 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 @pytest.fixture(scope='module')
+def uv() -> str:
+    """The `uv` every documented command runs through — a dependency, never a skip.
+
+    Skipping on a missing one would report a first-run experience as checked on a box where nothing
+    ran, and say so in the same words whether the commands passed or never executed. This repo is a
+    uv project, so an absent `uv` is a broken environment and fails like one.
+    """
+    found = shutil.which('uv')
+    assert found is not None, 'uv is not on PATH, and these are its commands — install it to run this suite'
+    return found
+
+
+@pytest.fixture(scope='module')
 def platform_url() -> Iterator[str]:
     server = ThreadingHTTPServer(('127.0.0.1', 0), _Handler)
     threading.Thread(target=server.serve_forever, daemon=True).start()
@@ -179,10 +192,11 @@ DOCUMENTED_COMMANDS = {
 }
 
 
-@pytest.mark.skipif(shutil.which('uv') is None, reason='the documented commands are uv commands')
 @pytest.mark.parametrize('command', DOCUMENTED_COMMANDS.values(), ids=DOCUMENTED_COMMANDS.keys())
-def test_a_documented_command_runs_with_nothing_installed(command: list[str], platform_url: str):
-    result = run_from_a_clean_environment(command, platform_url=platform_url)
+def test_a_documented_command_runs_with_nothing_installed(command: list[str], platform_url: str, uv: str):
+    # Through the resolved `uv`, so what ran is the one the fixture found rather than whatever a
+    # subprocess PATH would have picked.
+    result = run_from_a_clean_environment([uv, *command[1:]], platform_url=platform_url)
     assert result.returncode == 0, f'{" ".join(command)} failed:\n{result.stdout}\n{result.stderr}'
 
 

--- a/positronic/cli/tests/test_fresh_install.py
+++ b/positronic/cli/tests/test_fresh_install.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -23,6 +24,7 @@ from pathlib import Path
 import pytest
 from platform_client import routes
 from platform_client.client import API_KEY_ENV, API_URL_ENV, CREDENTIAL_ENV
+from platform_client.responses import QUOTA_SUBMISSIONS_DAY
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SUBMISSION = '5f3a91c2b7d40e18'
@@ -44,7 +46,7 @@ ANSWERS: dict[str, object] = {
         'plan': 'demo-plan',
         'quota': [
             {
-                'key': 'submissions.day',
+                'key': QUOTA_SUBMISSIONS_DAY,
                 'meter': 'submissions',
                 'unit': 'submission',
                 'scale': 1,
@@ -188,27 +190,30 @@ README_FILES = (REPO_ROOT / 'client' / 'README.md', REPO_ROOT / 'positronic' / '
 
 
 def cited_commands() -> set[tuple[str, ...]]:
-    """Every `uv run …` line in the READMEs, cut to the words before its first placeholder."""
+    """Every `uv run …` line in the READMEs, as its command path and its option NAMES."""
     cited = set()
     for path in README_FILES:
         for line in path.read_text().splitlines():
             stripped = line.strip().removeprefix('$ ')
-            if not stripped.startswith('uv run '):
-                continue
-            # A cited line carries placeholders (`--board=<board slug>`), which are neither words
-            # nor runnable; everything from the first one on is the reader's to fill in.
-            cited.add(_words(stripped.split('<', 1)[0]))
+            if stripped.startswith('uv run '):
+                # A placeholder may hold a space (`--alias=<display name>`), so it goes before the
+                # split rather than being filtered out of the words afterwards.
+                cited.add(_shape(re.sub(r'<[^>]*>', '', stripped).split()))
     return cited
 
 
-def _words(command: str | list[str]) -> tuple[str, ...]:
-    """A command without its options — what identifies it, whatever arguments a citation carries."""
-    tokens = command.split() if isinstance(command, str) else command
-    return tuple(token for token in tokens if not token.startswith('--'))
+def _shape(command: list[str]) -> tuple[str, ...]:
+    """A command's path and the NAMES of its options, with every value dropped.
+
+    The values differ by construction — a README carries `--submission-id=<hex id>` where this test
+    runs a real one — but the names must not, or a README could rename an option to something the
+    CLI does not accept and this check would go on passing.
+    """
+    return tuple(token.split('=', 1)[0] for token in command)
 
 
 def test_every_uv_command_the_readmes_cite_is_one_this_test_runs():
     # What is documented and what is checked drift apart silently otherwise: a command renamed in a
     # README goes on passing here under its old name, and the first person to hit it is a new user.
-    run_here = {_words(command) for command in DOCUMENTED_COMMANDS.values()}
+    run_here = {_shape(command) for command in DOCUMENTED_COMMANDS.values()}
     assert cited_commands() <= run_here, f'cited but never run: {sorted(cited_commands() - run_here)}'

--- a/positronic/cli/tests/test_vocabulary.py
+++ b/positronic/cli/tests/test_vocabulary.py
@@ -34,6 +34,7 @@ SCANNED_ROOTS = (
     REPO_ROOT / 'client',
     CLI_ROOT / 'account',
     CLI_ROOT / 'examples',
+    CLI_ROOT / 'eval' / 'run.py',
     CLI_ROOT / 'eval' / 'submit.py',
     CLI_ROOT / 'eval' / 'submissions.py',
 )

--- a/positronic/cli/tests/test_vocabulary.py
+++ b/positronic/cli/tests/test_vocabulary.py
@@ -1,0 +1,88 @@
+"""The platform's vocabulary is customer-neutral: one engagement's words stay in its own directory.
+
+Both trees the platform's users read are held to it — the wire contract in `client/`, and the
+commands and examples here — since a word that leaks into either is a word every other customer
+reads about themselves.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# The words that name a role or a period in one engagement rather than anything the platform has.
+# What the contract says instead is `user` for the account and `caller` for whoever is asking.
+ENGAGEMENT_WORDS = (
+    'competition',
+    'participant',
+    'contestant',
+    'season',
+    'qualifier',
+    'prize',
+    'entrant',
+    'leaderboard',
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI_ROOT = REPO_ROOT / 'positronic' / 'cli'
+# Every surface a platform user reads: the wire contract, the commands that drive it, the examples.
+# The rest of `positronic/cli` is robotics, whose own words are none of this rule's business — and
+# the last test below is what keeps that line honest as commands move between the two.
+SCANNED_ROOTS = (
+    REPO_ROOT / 'client',
+    CLI_ROOT / 'account',
+    CLI_ROOT / 'examples',
+    CLI_ROOT / 'eval' / 'submit.py',
+    CLI_ROOT / 'eval' / 'submissions.py',
+)
+ENGAGEMENT_DIR = REPO_ROOT / 'positronic' / 'cli' / 'examples' / 'nebius_competition'
+TEXT_SUFFIXES = frozenset({'.py', '.md', '.toml'})
+
+# No trailing boundary, so a plural is caught too. A leading one spares the engagement directory's
+# own name where a path names it.
+_ENGAGEMENT_WORD = re.compile(r'\b(' + '|'.join(ENGAGEMENT_WORDS) + ')', re.IGNORECASE)
+
+
+def scanned_files() -> list[Path]:
+    return sorted(
+        path
+        for root in SCANNED_ROOTS
+        for path in ([root] if root.is_file() else root.rglob('*'))
+        if path.suffix in TEXT_SUFFIXES and ENGAGEMENT_DIR not in path.parents and path != Path(__file__).resolve()
+    )
+
+
+@pytest.mark.parametrize('path', scanned_files(), ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_a_file_outside_the_engagement_directory_uses_none_of_its_words(path: Path):
+    hits = [
+        f'{path.relative_to(REPO_ROOT)}:{number}: {line.strip()}'
+        for number, line in enumerate(path.read_text().splitlines(), 1)
+        if _ENGAGEMENT_WORD.search(line)
+    ]
+    assert not hits, 'engagement vocabulary outside its directory:\n' + '\n'.join(hits)
+
+
+def test_the_scan_reaches_both_trees_and_stops_at_the_engagement_directory():
+    scanned = scanned_files()
+    assert REPO_ROOT / 'client' / 'platform_client' / 'responses.py' in scanned
+    assert CLI_ROOT / 'eval' / 'submissions.py' in scanned
+    assert CLI_ROOT / 'examples' / 'walkthrough.py' in scanned
+    assert ENGAGEMENT_DIR / 'submit_sample.py' not in scanned
+
+
+def test_every_command_that_speaks_to_the_platform_is_scanned():
+    # The roots above are a list, and a command moving between `eval` and `platform` would silently
+    # leave it. What identifies a platform-facing module is that it imports the contract.
+    speaks_to_the_platform = {
+        path
+        for path in CLI_ROOT.rglob('*.py')
+        # Test support is exempt for the same reason the scan skips this file, and the engagement's
+        # own directory is the one place its words belong.
+        if 'platform_client' in path.read_text()
+        and 'tests' not in path.parts
+        and path.name != 'conftest.py'
+        and ENGAGEMENT_DIR not in path.parents
+    }
+    assert speaks_to_the_platform <= set(scanned_files())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     # openpi-client: optional, see [project.optional-dependencies] openpi
     "plotly>=6.5.0",
     "pos3>=0.3.1",
+    # The platform's wire contract, which `positronic eval submit` and `positronic platform` speak.
+    # A workspace member in a clone (see [tool.uv.sources]); a released `positronic` resolves it
+    # from the index, so the client is published first (.github/workflows/release.yaml).
+    "positronic-platform-client",
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",
@@ -129,6 +133,11 @@ dev = [
     "positronic[telemetry]",  # the telemetry tests exercise the SDK and the samplers
 ]
 
+[tool.uv.workspace]
+# `client/` builds the standalone `positronic-platform-client` distribution, which stays installable
+# on its own — it may depend on nothing in this repo.
+members = ["client"]
+
 [tool.uv]
 # lerobot_0_3_3 extra pulls in lerobot==0.3.3 which declares rerun-sdk<0.23,
 # but our usage of lerobot doesn't need rerun — override to unblock resolution.
@@ -172,6 +181,7 @@ pos3 = false
 positronic-franka = false
 
 [tool.uv.sources]
+positronic-platform-client = { workspace = true }
 # ZED SDK ships one ABI-specific wheel per CPython version; pick by interpreter.
 pyzed = [
     { url = "https://download.stereolabs.com/zedsdk/5.0/whl/linux_x86_64/pyzed-5.0-cp311-cp311-linux_x86_64.whl", marker = "python_full_version < '3.12'" },
@@ -183,10 +193,11 @@ i2rt = { git = "https://github.com/i2rt-robotics/i2rt.git", rev = "5d47b358bafb3
 
 [tool.pytest.ini_options]
 # Search roots, not a list of suites, so a new `tests/` directory is collected without being registered
-testpaths = ["pimm", "positronic", "utilities"]
+testpaths = ["client", "pimm", "positronic", "utilities"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = [
     "--cov=pimm",
+    "--cov=platform_client",
     "--cov=positronic",
     "--cov-report=term-missing",
     # Needs the `libero` extra and OSMesa; `libero-e2e.yaml` runs it by path, which `--ignore` allows.
@@ -201,7 +212,7 @@ markers = [
 
 [tool.coverage.run]
 branch = true
-source = ["pimm", "positronic"]
+source = ["pimm", "platform_client", "positronic"]
 
 [tool.coverage.report]
 show_missing = true
@@ -248,7 +259,7 @@ skip-magic-trailing-comma = true
 # .basedpyright/baseline.json; only NEW errors fail. Modules are strictened incrementally.
 typeCheckingMode = "standard"
 pythonVersion = "3.11"
-include = ["pimm", "positronic"]
+include = ["client", "pimm", "positronic"]
 # mujoco ships no `.pyi` and re-exports from binary extension modules, so its whole API reads as
 # attribute errors without these. Regenerate with utilities/generate_mujoco_stubs.py.
 stubPath = "stubs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,13 @@ dependencies = [
     # openpi-client: optional, see [project.optional-dependencies] openpi
     "plotly>=6.5.0",
     "pos3>=0.3.1",
-    # The platform's wire contract, which `positronic eval submit` and `positronic platform` speak.
-    # A workspace member in a clone (see [tool.uv.sources]); a released `positronic` resolves it
-    # from the index, so the client is published first (.github/workflows/release.yaml).
-    "positronic-platform-client",
+    # The platform's wire contract, which `positronic eval run --policy-image` and
+    # `positronic account` speak. A workspace member in a clone (see [tool.uv.sources]); a released
+    # `positronic` resolves it from the index, so the client is published first
+    # (.github/workflows/release.yaml). Pinned exactly, because that package guarantees no
+    # backwards compatibility: a floating requirement would let a fresh install of THIS release
+    # resolve a contract it was never built against.
+    "positronic-platform-client==0.1.0",
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # (.github/workflows/release.yaml). Pinned exactly, because that package guarantees no
     # backwards compatibility: a floating requirement would let a fresh install of THIS release
     # resolve a contract it was never built against.
-    "positronic-platform-client==0.1.0",
+    "positronic-platform-client==0.2.0",
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",

--- a/utilities/check_client_version_bump.py
+++ b/utilities/check_client_version_bump.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import subprocess
 import sys
 import tomllib
@@ -61,8 +60,6 @@ DISTRIBUTION = 'positronic-platform-client'
 # Changes that cannot reach the installed wheel. A test is NOT here: it ships inside the package
 # directory, and a reader comparing two revisions may expect the same code behind the same version.
 EXEMPT_SUFFIXES = ('.md',)
-
-_VERSION_LINE = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']', re.M)
 
 
 def run_git(*args: str) -> str | None:
@@ -103,10 +100,25 @@ def is_later_version(was: str, is_now: str) -> bool:
         raise SystemExit(f'ERROR - {CLIENT_MANIFEST} version is not PEP 440: {exc}') from exc
 
 
-def declared_version(text: str) -> str | None:
-    """The `version` a pyproject declares, or None where it declares none this can read."""
-    match = _VERSION_LINE.search(text)
-    return match.group(1) if match else None
+def declared_version(text: str, *, guarded: str | None = None) -> str | None:
+    """The `version` a pyproject declares under `[project]`, or None where it declares none.
+
+    Parsed out of TOML rather than scanned for as text, like the pin below: to a scan a `version`
+    line under any other table — a tool's own section — reads as the project's own.
+
+    `guarded` names the file where this repository's own copy is being read, whose corruption is a
+    misconfiguration to fail on; a base-side manifest is one the gate merely cannot judge, so it
+    abstains and the caller skips.
+    """
+    try:
+        manifest = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        if guarded is None:
+            return None
+        raise SystemExit(f'ERROR - {guarded} is not readable TOML: {exc}') from exc
+    project = manifest.get('project')
+    version = project.get('version') if isinstance(project, dict) else None
+    return version if isinstance(version, str) else None
 
 
 def pinned_version(text: str) -> str | None:
@@ -164,7 +176,7 @@ def shipped_changes(paths: list[str]) -> list[str]:
 def check(base: str) -> list[str]:
     """Every way this change leaves the client, its version and the root's pin out of step."""
     failures: list[str] = []
-    now = declared_version((REPO_ROOT / CLIENT_MANIFEST).read_text())
+    now = declared_version((REPO_ROOT / CLIENT_MANIFEST).read_text(), guarded=CLIENT_MANIFEST)
     if now is None:
         raise SystemExit(f'ERROR - {CLIENT_MANIFEST} declares no readable `version`, so the gate cannot judge it.')
 

--- a/utilities/check_client_version_bump.py
+++ b/utilities/check_client_version_bump.py
@@ -146,9 +146,11 @@ def pinned_version(text: str) -> str | None:
             continue
         if canonicalize_name(requirement.name) != canonicalize_name(DISTRIBUTION):
             continue
-        # Only `==<version>` alone is a pin: anything else resolves to whatever the index offers.
+        # Only `==<version>` alone, and unconditionally, is a pin: anything else resolves to whatever
+        # the index offers, and a marker (`; python_version < '3'`) leaves the client uninstalled on
+        # every interpreter this project supports, where the CLI imports `platform_client` regardless.
         specifiers = list(requirement.specifier)
-        if len(specifiers) == 1 and specifiers[0].operator == '==':
+        if requirement.marker is None and len(specifiers) == 1 and specifiers[0].operator == '==':
             return specifiers[0].version
     return None
 

--- a/utilities/check_client_version_bump.py
+++ b/utilities/check_client_version_bump.py
@@ -25,8 +25,9 @@ Fails open (exit 0, note on stderr) where it cannot judge — an unresolvable ba
 CI, which always has the base sha, is where the gate holds. A manifest that is present and
 unreadable fails closed: that is a corrupt guarded file, not an absence.
 
-It runs under `uv run` rather than a bare interpreter, because it compares versions by PEP 440 and
-that ordering is `packaging`'s to own, not this file's to approximate.
+It runs under `uv run` rather than a bare interpreter, because it reads the root's pin as a
+requirement and compares versions by PEP 440 — both `packaging`'s to own, not this file's to
+approximate.
 
 The git plumbing below is this module's own rather than shared with the other `utilities/check_*`
 scripts: they run as `python3 utilities/<script>.py`, where the repository root is not on `sys.path`
@@ -40,8 +41,11 @@ import os
 import re
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -59,7 +63,6 @@ DISTRIBUTION = 'positronic-platform-client'
 EXEMPT_SUFFIXES = ('.md',)
 
 _VERSION_LINE = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']', re.M)
-_PIN = re.compile(rf'{re.escape(DISTRIBUTION)}\s*==\s*([0-9][^"\',\s]*)')
 
 
 def run_git(*args: str) -> str | None:
@@ -84,7 +87,7 @@ def resolve_merge_base(ref: str) -> str | None:
     return run_git('rev-parse', ref) or None
 
 
-def increases(was: str, is_now: str) -> bool:
+def is_later_version(was: str, is_now: str) -> bool:
     """Whether `is_now` is a LATER version than `was`, by the ordering the index will use.
 
     PEP 440 through `packaging`, not a hand-rolled tuple: the index resolves these versions by that
@@ -107,9 +110,35 @@ def declared_version(text: str) -> str | None:
 
 
 def pinned_version(text: str) -> str | None:
-    """The version the root manifest pins the client at, or None where it pins none."""
-    match = _PIN.search(text)
-    return match.group(1) if match else None
+    """The version the root manifest pins the client at, or None where it pins none.
+
+    Read as a requirement out of parsed TOML rather than scanned for as text: to a scan a
+    commented-out line reads as a live pin, so a dependency deleted the way one usually is — its
+    line left behind under a `#` — passes the missing-dependency case this gate exists to refuse.
+    """
+    try:
+        manifest = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        # A guarded file that is present and unparseable is corrupt, not absent.
+        raise SystemExit(f'ERROR - {ROOT_MANIFEST} is not readable TOML: {exc}') from exc
+    project = manifest.get('project')
+    dependencies = project.get('dependencies') if isinstance(project, dict) else None
+    if not isinstance(dependencies, list):
+        return None
+    for entry in dependencies:
+        if not isinstance(entry, str):
+            continue
+        try:
+            requirement = Requirement(entry)
+        except InvalidRequirement:
+            continue
+        if canonicalize_name(requirement.name) != canonicalize_name(DISTRIBUTION):
+            continue
+        # Only `==<version>` alone is a pin: anything else resolves to whatever the index offers.
+        specifiers = list(requirement.specifier)
+        if len(specifiers) == 1 and specifiers[0].operator == '==':
+            return specifiers[0].version
+    return None
 
 
 def changed_paths(base: str) -> list[str] | None:
@@ -175,7 +204,7 @@ def check(base: str) -> list[str]:
     if was is None:
         print(f'NOTE - {base}:{CLIENT_MANIFEST} declares no readable `version`; skipping.', file=sys.stderr)
         return failures
-    if not increases(was, now):
+    if not is_later_version(was, now):
         moved = 'still' if was == now else f'moved BACKWARDS from {was} to'
         failures.append(
             f'{len(edited)} file(s) changed under {CLIENT_DIR}/ with `version` {moved} {now}. '

--- a/utilities/check_client_version_bump.py
+++ b/utilities/check_client_version_bump.py
@@ -1,0 +1,198 @@
+"""Keep the published client, its version, and the root's pin on it in step.
+
+`positronic` requires `positronic-platform-client==<version>`, and the release workflow publishes
+the client first with `skip-existing`. That flag is what makes republishing an unchanged client a
+no-op rather than a failed release, and it is also the hole: if `client/` changes and its version
+does not, PyPI keeps the old wheel, the publish step reports success, and the root release then goes
+out depending on a version whose bytes are not the ones in this repository. Nothing fails — a fresh
+install just gets the old client, which is why this is caught here rather than at release time.
+
+Two things are checked, and it takes both to close it:
+
+1. A change under `client/` bumps `client/pyproject.toml`'s `version`. Without this the new code
+   never reaches the index, because `skip-existing` skips a version already published.
+2. The root's `positronic-platform-client==` pin names exactly that version. Without this the
+   client publishes fine and the root ships depending on the previous one.
+
+The version must INCREASE, not merely differ: a version already published under other code is worse
+than no bump at all, since the index will keep whichever bytes got there first.
+
+Judged against `--base` (else `$RATCHET_BASE`, else `origin/main`), at the merge-base, so a bump that
+landed on the base side meanwhile is not this change's to claim.
+
+Fails open (exit 0, note on stderr) where it cannot judge — an unresolvable base, or a base with no
+`client/pyproject.toml` (the client's own first commit) — so an offline commit is never blocked and
+CI, which always has the base sha, is where the gate holds. A manifest that is present and
+unreadable fails closed: that is a corrupt guarded file, not an absence.
+
+The git plumbing below is this module's own rather than shared with the other `utilities/check_*`
+scripts: they run as `python3 utilities/<script>.py`, where the repository root is not on `sys.path`
+and a `utilities.` import cannot resolve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BASE_REV_ENV = 'RATCHET_BASE'
+
+# The directory the distribution ships, its manifest, and the name the root pins it by.
+CLIENT_DIR = 'client'
+CLIENT_MANIFEST = 'client/pyproject.toml'
+ROOT_MANIFEST = 'pyproject.toml'
+DISTRIBUTION = 'positronic-platform-client'
+
+# Changes that cannot reach the installed wheel. A test is NOT here: it ships inside the package
+# directory, and a reader comparing two revisions may expect the same code behind the same version.
+EXEMPT_SUFFIXES = ('.md',)
+
+_VERSION_LINE = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']', re.M)
+_PIN = re.compile(rf'{re.escape(DISTRIBUTION)}\s*==\s*([0-9][^"\',\s]*)')
+
+
+def run_git(*args: str) -> str | None:
+    try:
+        result = subprocess.run(['git', *args], cwd=REPO_ROOT, capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def resolve_base_ref(arg: str | None, env: str | None) -> str:
+    """Pick the base ref: an explicit `--base` wins, then `$RATCHET_BASE`, else `origin/main`."""
+    return arg or env or 'origin/main'
+
+
+def resolve_merge_base(ref: str) -> str | None:
+    """The commit this change is judged from, or None where the ref does not resolve at all."""
+    merge_base = run_git('merge-base', 'HEAD', ref)
+    if merge_base:
+        return merge_base
+    # No merge-base (shallow history, an unrelated ref): use the ref itself where it resolves.
+    return run_git('rev-parse', ref) or None
+
+
+def _ordered(version: str, parts: int) -> tuple:
+    """`version` as something two of them compare by, padded to `parts` components.
+
+    Numeric parts compare as numbers, so `0.10.0` does not read as older than `0.9.0`. Both sides
+    pad to the same width, so `1.0` and `1.0.0` compare EQUAL — packaging treats them as one
+    version, and reading the extra zero as a bump would accept a release that ships as its
+    predecessor. A non-numeric part sorts after the numbers, so a pre-release suffix orders
+    consistently instead of crashing the gate.
+    """
+    read = [(0, int(p)) if p.isdigit() else (1, p) for p in version.replace('-', '.').split('.')]
+    return tuple(read + [(0, 0)] * (parts - len(read)))
+
+
+def increases(was: str, is_now: str) -> bool:
+    """Whether `is_now` is a LATER version than `was`, both read to the same number of parts."""
+    width = max(len(was.replace('-', '.').split('.')), len(is_now.replace('-', '.').split('.')))
+    return _ordered(is_now, width) > _ordered(was, width)
+
+
+def declared_version(text: str) -> str | None:
+    """The `version` a pyproject declares, or None where it declares none this can read."""
+    match = _VERSION_LINE.search(text)
+    return match.group(1) if match else None
+
+
+def pinned_version(text: str) -> str | None:
+    """The version the root manifest pins the client at, or None where it pins none."""
+    match = _PIN.search(text)
+    return match.group(1) if match else None
+
+
+def changed_paths(base: str) -> list[str] | None:
+    """Every path this change touches against `base` — working tree, index, and new files.
+
+    A brand-new module is what a `diff` alone misses, and it is exactly what a wire change looks
+    like: until it is staged, git reports it only as untracked.
+    """
+    tracked = run_git('diff', '--name-only', base, '--')
+    if tracked is None:
+        return None
+    staged = run_git('diff', '--name-only', '--cached', base, '--') or ''
+    untracked = run_git('ls-files', '--others', '--exclude-standard') or ''
+    return sorted({p for p in (tracked + '\n' + staged + '\n' + untracked).splitlines() if p.strip()})
+
+
+def shipped_changes(paths: list[str]) -> list[str]:
+    """The changed paths under `client/` that could alter what an install runs."""
+    prefix = f'{CLIENT_DIR}/'
+    return [p for p in paths if p.startswith(prefix) and not p.endswith(EXEMPT_SUFFIXES)]
+
+
+def check(base: str) -> list[str]:
+    """Every way this change leaves the client, its version and the root's pin out of step."""
+    failures: list[str] = []
+    now = declared_version((REPO_ROOT / CLIENT_MANIFEST).read_text())
+    if now is None:
+        raise SystemExit(f'ERROR - {CLIENT_MANIFEST} declares no readable `version`, so the gate cannot judge it.')
+
+    # 2. The pin travels with the version whether or not this change touched the client, so it is
+    #    checked first and unconditionally: a bump that forgets the pin is the same stale install.
+    pinned = pinned_version((REPO_ROOT / ROOT_MANIFEST).read_text())
+    if pinned is None:
+        print(f'NOTE - {ROOT_MANIFEST} pins no {DISTRIBUTION}=={{version}}; skipping the pin check.', file=sys.stderr)
+    elif pinned != now:
+        failures.append(
+            f'{ROOT_MANIFEST} pins {DISTRIBUTION}=={pinned} while {CLIENT_MANIFEST} declares {now}. '
+            f'A release would publish the client as {now} and then publish the root depending on '
+            f'{pinned} — the previous wheel. Move the pin to {now}.'
+        )
+
+    paths = changed_paths(base)
+    if paths is None:
+        print(f'NOTE - could not diff against {base}; skipping the version-bump gate.', file=sys.stderr)
+        return failures
+    edited = shipped_changes(paths)
+    if not edited:
+        return failures
+
+    # 1. Changed code needs a version the index has never seen, or `skip-existing` keeps the old one.
+    before = run_git('show', f'{base}:{CLIENT_MANIFEST}')
+    if before is None:
+        print(f'NOTE - {base} carries no {CLIENT_MANIFEST}; skipping the version-bump gate.', file=sys.stderr)
+        return failures
+    was = declared_version(before)
+    if was is None:
+        print(f'NOTE - {base}:{CLIENT_MANIFEST} declares no readable `version`; skipping.', file=sys.stderr)
+        return failures
+    if not increases(was, now):
+        moved = 'still' if was == now else f'moved BACKWARDS from {was} to'
+        failures.append(
+            f'{len(edited)} file(s) changed under {CLIENT_DIR}/ with `version` {moved} {now}. '
+            f'Bump it in {CLIENT_MANIFEST} (and the root pin with it): the release publishes with '
+            f'`skip-existing`, so republishing {now} is a silent no-op and the root would ship '
+            f'depending on bytes this repository no longer contains. First changed file: {edited[0]}'
+        )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--base', default=None, help=f'the ref this change is judged against (else ${BASE_REV_ENV})')
+    parser.add_argument('filenames', nargs='*', help='ignored; the gate reads git, not the hook filter')
+    args = parser.parse_args(argv)
+
+    ref = resolve_base_ref(args.base, os.environ.get(BASE_REV_ENV))
+    base = resolve_merge_base(ref)
+    if base is None:
+        print(f'NOTE - {ref} does not resolve; skipping the client version gate.', file=sys.stderr)
+        return 0
+    failures = check(base)
+    for failure in failures:
+        print(f'ERROR - {failure}', file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/utilities/check_client_version_bump.py
+++ b/utilities/check_client_version_bump.py
@@ -25,6 +25,9 @@ Fails open (exit 0, note on stderr) where it cannot judge — an unresolvable ba
 CI, which always has the base sha, is where the gate holds. A manifest that is present and
 unreadable fails closed: that is a corrupt guarded file, not an absence.
 
+It runs under `uv run` rather than a bare interpreter, because it compares versions by PEP 440 and
+that ordering is `packaging`'s to own, not this file's to approximate.
+
 The git plumbing below is this module's own rather than shared with the other `utilities/check_*`
 scripts: they run as `python3 utilities/<script>.py`, where the repository root is not on `sys.path`
 and a `utilities.` import cannot resolve.
@@ -38,6 +41,8 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -79,23 +84,20 @@ def resolve_merge_base(ref: str) -> str | None:
     return run_git('rev-parse', ref) or None
 
 
-def _ordered(version: str, parts: int) -> tuple:
-    """`version` as something two of them compare by, padded to `parts` components.
-
-    Numeric parts compare as numbers, so `0.10.0` does not read as older than `0.9.0`. Both sides
-    pad to the same width, so `1.0` and `1.0.0` compare EQUAL — packaging treats them as one
-    version, and reading the extra zero as a bump would accept a release that ships as its
-    predecessor. A non-numeric part sorts after the numbers, so a pre-release suffix orders
-    consistently instead of crashing the gate.
-    """
-    read = [(0, int(p)) if p.isdigit() else (1, p) for p in version.replace('-', '.').split('.')]
-    return tuple(read + [(0, 0)] * (parts - len(read)))
-
-
 def increases(was: str, is_now: str) -> bool:
-    """Whether `is_now` is a LATER version than `was`, both read to the same number of parts."""
-    width = max(len(was.replace('-', '.').split('.')), len(is_now.replace('-', '.').split('.')))
-    return _ordered(is_now, width) > _ordered(was, width)
+    """Whether `is_now` is a LATER version than `was`, by the ordering the index will use.
+
+    PEP 440 through `packaging`, not a hand-rolled tuple: the index resolves these versions by that
+    ordering, so a gate that ranks them any other way guards something other than what ships. It is
+    the pre-releases a hand-rolled comparison gets backwards — `1.0rc1` precedes `1.0`, and `1.0rc10`
+    follows `1.0rc2` — and it is also what makes `1.0` and `1.0.0` compare EQUAL, so a padded zero is
+    not read as a bump and cannot pass off a re-release as its successor.
+    """
+    try:
+        return Version(is_now) > Version(was)
+    except InvalidVersion as exc:
+        # Fails closed, and says which value the index would have refused too.
+        raise SystemExit(f'ERROR - {CLIENT_MANIFEST} version is not PEP 440: {exc}') from exc
 
 
 def declared_version(text: str) -> str | None:
@@ -141,7 +143,14 @@ def check(base: str) -> list[str]:
     #    checked first and unconditionally: a bump that forgets the pin is the same stale install.
     pinned = pinned_version((REPO_ROOT / ROOT_MANIFEST).read_text())
     if pinned is None:
-        print(f'NOTE - {ROOT_MANIFEST} pins no {DISTRIBUTION}=={{version}}; skipping the pin check.', file=sys.stderr)
+        # Not an absence to skip past: the CLI imports `platform_client`, so a root that no longer
+        # names an exact version resolves whatever the index offers — the same stale-or-incompatible
+        # install this gate exists to refuse, reached by deleting the pin instead of by lagging it.
+        failures.append(
+            f'{ROOT_MANIFEST} declares no `{DISTRIBUTION}=={{version}}`, yet the CLI imports '
+            f'`platform_client`. A release would resolve whatever the index offers. Pin it at {now}, '
+            f'or drop this gate along with the dependency.'
+        )
     elif pinned != now:
         failures.append(
             f'{ROOT_MANIFEST} pins {DISTRIBUTION}=={pinned} while {CLIENT_MANIFEST} declares {now}. '

--- a/utilities/tests/test_check_client_version_bump.py
+++ b/utilities/tests/test_check_client_version_bump.py
@@ -1,5 +1,7 @@
 """The gate that keeps the client's code, its version, and the root's pin on it in step."""
 
+import pytest
+
 from utilities import check_client_version_bump as gate
 
 
@@ -21,6 +23,20 @@ def test_a_padded_zero_is_the_same_version():
     assert not gate.increases('1.0.0', '1.0')
 
 
+def test_pre_releases_order_the_way_the_index_orders_them():
+    # PEP 440, which a hand-rolled tuple gets backwards in both directions: a release candidate
+    # PRECEDES its release, and rc10 FOLLOWS rc2.
+    assert gate.increases('1.0rc1', '1.0')
+    assert not gate.increases('1.0', '1.0rc1')
+    assert gate.increases('1.0rc2', '1.0rc10')
+    assert not gate.increases('1.0rc10', '1.0rc2')
+
+
+def test_a_version_the_index_could_not_read_fails_closed():
+    with pytest.raises(SystemExit):
+        gate.increases('0.1.0', 'not-a-version')
+
+
 def test_the_declared_version_is_read_from_a_manifest():
     assert gate.declared_version('[project]\nname = "x"\nversion = "0.3.1"\n') == '0.3.1'
     assert gate.declared_version("version = '0.3.1'") == '0.3.1'
@@ -32,10 +48,12 @@ def test_the_root_pin_is_read_from_a_dependency_list():
     assert gate.pinned_version('    "positronic-platform-client==2.10.3",\n') == '2.10.3'
 
 
-def test_a_root_that_pins_no_client_reads_as_no_pin():
-    # Not a failure: the gate says so on stderr and leaves the pin check alone.
+def test_a_relaxed_or_absent_pin_reads_as_no_pin():
+    # Read as absent, and `check` treats that as a FAILURE rather than a reason to skip: deleting
+    # the pin reaches the same stale-or-incompatible install as letting it lag.
     assert gate.pinned_version('dependencies = ["httpx", "pydantic>=2"]') is None
     assert gate.pinned_version('dependencies = ["positronic-platform-client"]') is None
+    assert gate.pinned_version('dependencies = ["positronic-platform-client>=0.1.0"]') is None
 
 
 def test_only_shipped_paths_under_the_client_demand_a_bump():

--- a/utilities/tests/test_check_client_version_bump.py
+++ b/utilities/tests/test_check_client_version_bump.py
@@ -5,36 +5,36 @@ import pytest
 from utilities import check_client_version_bump as gate
 
 
-def test_a_later_version_increases():
-    assert gate.increases('0.1.0', '0.2.0')
-    assert gate.increases('0.1.0', '0.1.1')
-    assert gate.increases('0.9.0', '0.10.0')  # numeric, so 10 is not read as older than 9
+def test_a_later_version_is_later():
+    assert gate.is_later_version('0.1.0', '0.2.0')
+    assert gate.is_later_version('0.1.0', '0.1.1')
+    assert gate.is_later_version('0.9.0', '0.10.0')  # numeric, so 10 is not read as older than 9
 
 
-def test_an_unchanged_or_backwards_version_does_not_increase():
-    assert not gate.increases('0.2.0', '0.2.0')
-    assert not gate.increases('0.2.0', '0.1.0')
+def test_an_unchanged_or_backwards_version_is_not_later():
+    assert not gate.is_later_version('0.2.0', '0.2.0')
+    assert not gate.is_later_version('0.2.0', '0.1.0')
 
 
 def test_a_padded_zero_is_the_same_version():
     # packaging reads 1.0 and 1.0.0 as one version, so a release "bumped" that way ships as its
     # predecessor and `skip-existing` skips it.
-    assert not gate.increases('1.0', '1.0.0')
-    assert not gate.increases('1.0.0', '1.0')
+    assert not gate.is_later_version('1.0', '1.0.0')
+    assert not gate.is_later_version('1.0.0', '1.0')
 
 
 def test_pre_releases_order_the_way_the_index_orders_them():
     # PEP 440, which a hand-rolled tuple gets backwards in both directions: a release candidate
     # PRECEDES its release, and rc10 FOLLOWS rc2.
-    assert gate.increases('1.0rc1', '1.0')
-    assert not gate.increases('1.0', '1.0rc1')
-    assert gate.increases('1.0rc2', '1.0rc10')
-    assert not gate.increases('1.0rc10', '1.0rc2')
+    assert gate.is_later_version('1.0rc1', '1.0')
+    assert not gate.is_later_version('1.0', '1.0rc1')
+    assert gate.is_later_version('1.0rc2', '1.0rc10')
+    assert not gate.is_later_version('1.0rc10', '1.0rc2')
 
 
 def test_a_version_the_index_could_not_read_fails_closed():
     with pytest.raises(SystemExit):
-        gate.increases('0.1.0', 'not-a-version')
+        gate.is_later_version('0.1.0', 'not-a-version')
 
 
 def test_the_declared_version_is_read_from_a_manifest():
@@ -43,17 +43,40 @@ def test_the_declared_version_is_read_from_a_manifest():
     assert gate.declared_version('[project]\nname = "x"\n') is None
 
 
+def manifest(*dependencies: str, trailing: str = '') -> str:
+    """A root manifest declaring these dependencies, and whatever else the case needs after them."""
+    listed = ''.join(f'    "{entry}",\n' for entry in dependencies)
+    return f'[project]\nname = "positronic"\nversion = "0.2.1"\ndependencies = [\n{listed}{trailing}]\n'
+
+
 def test_the_root_pin_is_read_from_a_dependency_list():
-    assert gate.pinned_version('dependencies = ["positronic-platform-client==0.1.0", "httpx"]') == '0.1.0'
-    assert gate.pinned_version('    "positronic-platform-client==2.10.3",\n') == '2.10.3'
+    assert gate.pinned_version(manifest('positronic-platform-client==0.1.0', 'httpx')) == '0.1.0'
+    assert gate.pinned_version(manifest('httpx', 'positronic-platform-client == 2.10.3')) == '2.10.3'
+    # The name is matched as a distribution, so the spelling variants an index treats as one match.
+    assert gate.pinned_version(manifest('Positronic_Platform_Client==0.1.0')) == '0.1.0'
 
 
 def test_a_relaxed_or_absent_pin_reads_as_no_pin():
     # Read as absent, and `check` treats that as a FAILURE rather than a reason to skip: deleting
     # the pin reaches the same stale-or-incompatible install as letting it lag.
-    assert gate.pinned_version('dependencies = ["httpx", "pydantic>=2"]') is None
-    assert gate.pinned_version('dependencies = ["positronic-platform-client"]') is None
-    assert gate.pinned_version('dependencies = ["positronic-platform-client>=0.1.0"]') is None
+    assert gate.pinned_version(manifest('httpx', 'pydantic>=2')) is None
+    assert gate.pinned_version(manifest('positronic-platform-client')) is None
+    assert gate.pinned_version(manifest('positronic-platform-client>=0.1.0')) is None
+    assert gate.pinned_version(manifest('positronic-platform-client>=0.1.0,==0.1.0')) is None
+
+
+def test_a_deleted_dependency_left_behind_as_a_comment_is_no_pin():
+    # The shape a deletion actually leaves: the line commented out rather than removed. Scanned as
+    # text it reads as a live pin, which passes the missing-dependency case this gate exists to
+    # refuse — so the dependency list is parsed, where a comment does not exist at all.
+    left_behind = manifest('httpx', trailing='    # "positronic-platform-client==0.1.0",\n')
+    assert gate.pinned_version(left_behind) is None
+
+
+def test_a_manifest_that_does_not_parse_fails_closed():
+    # Present and unreadable is a corrupt guarded file, not an absence to skip past.
+    with pytest.raises(SystemExit):
+        gate.pinned_version('[project\nname = "positronic"\n')
 
 
 def test_only_shipped_paths_under_the_client_demand_a_bump():

--- a/utilities/tests/test_check_client_version_bump.py
+++ b/utilities/tests/test_check_client_version_bump.py
@@ -80,6 +80,14 @@ def test_a_relaxed_or_absent_pin_reads_as_no_pin():
     assert gate.pinned_version(manifest('positronic-platform-client>=0.1.0,==0.1.0')) is None
 
 
+def test_a_conditional_pin_is_no_pin():
+    # A marker that is false on every supported interpreter installs the client nowhere, while the
+    # CLI imports `platform_client` unconditionally — so a fresh install fails at startup.
+    assert gate.pinned_version(manifest("positronic-platform-client==0.2.0; python_version < '3'")) is None
+    assert gate.pinned_version(manifest("positronic-platform-client==0.2.0; python_version >= '3'")) is None
+    assert gate.pinned_version(manifest('positronic-platform-client==0.2.0')) == '0.2.0'
+
+
 def test_a_deleted_dependency_left_behind_as_a_comment_is_no_pin():
     # The shape a deletion actually leaves: the line commented out rather than removed. Scanned as
     # text it reads as a live pin, which passes the missing-dependency case this gate exists to

--- a/utilities/tests/test_check_client_version_bump.py
+++ b/utilities/tests/test_check_client_version_bump.py
@@ -39,8 +39,23 @@ def test_a_version_the_index_could_not_read_fails_closed():
 
 def test_the_declared_version_is_read_from_a_manifest():
     assert gate.declared_version('[project]\nname = "x"\nversion = "0.3.1"\n') == '0.3.1'
-    assert gate.declared_version("version = '0.3.1'") == '0.3.1'
     assert gate.declared_version('[project]\nname = "x"\n') is None
+    # Parsed, so only `[project].version` is the project's own: a version under a tool's section is
+    # that tool's, and to a text scan both read the same.
+    assert gate.declared_version('[project]\nname = "x"\n\n[tool.bumper]\nversion = "9.9.9"\n') is None
+
+
+def test_a_base_side_manifest_that_does_not_parse_abstains():
+    # The base's copy is one this gate cannot judge, and an unjudgeable base has never blocked a
+    # commit: `check` prints a NOTE and skips, so an offline or shallow checkout stays workable.
+    assert gate.declared_version('[project\nname = "x"\n') is None
+
+
+def test_this_repositorys_own_manifest_that_does_not_parse_fails_closed():
+    # Named as guarded, it is the file the gate protects: present and unreadable is corrupt, not
+    # absent, and reading it as "no version declared" would skip the bump check on a broken client.
+    with pytest.raises(SystemExit):
+        gate.declared_version('[project\nname = "x"\n', guarded=gate.CLIENT_MANIFEST)
 
 
 def manifest(*dependencies: str, trailing: str = '') -> str:

--- a/utilities/tests/test_check_client_version_bump.py
+++ b/utilities/tests/test_check_client_version_bump.py
@@ -1,0 +1,57 @@
+"""The gate that keeps the client's code, its version, and the root's pin on it in step."""
+
+from utilities import check_client_version_bump as gate
+
+
+def test_a_later_version_increases():
+    assert gate.increases('0.1.0', '0.2.0')
+    assert gate.increases('0.1.0', '0.1.1')
+    assert gate.increases('0.9.0', '0.10.0')  # numeric, so 10 is not read as older than 9
+
+
+def test_an_unchanged_or_backwards_version_does_not_increase():
+    assert not gate.increases('0.2.0', '0.2.0')
+    assert not gate.increases('0.2.0', '0.1.0')
+
+
+def test_a_padded_zero_is_the_same_version():
+    # packaging reads 1.0 and 1.0.0 as one version, so a release "bumped" that way ships as its
+    # predecessor and `skip-existing` skips it.
+    assert not gate.increases('1.0', '1.0.0')
+    assert not gate.increases('1.0.0', '1.0')
+
+
+def test_the_declared_version_is_read_from_a_manifest():
+    assert gate.declared_version('[project]\nname = "x"\nversion = "0.3.1"\n') == '0.3.1'
+    assert gate.declared_version("version = '0.3.1'") == '0.3.1'
+    assert gate.declared_version('[project]\nname = "x"\n') is None
+
+
+def test_the_root_pin_is_read_from_a_dependency_list():
+    assert gate.pinned_version('dependencies = ["positronic-platform-client==0.1.0", "httpx"]') == '0.1.0'
+    assert gate.pinned_version('    "positronic-platform-client==2.10.3",\n') == '2.10.3'
+
+
+def test_a_root_that_pins_no_client_reads_as_no_pin():
+    # Not a failure: the gate says so on stderr and leaves the pin check alone.
+    assert gate.pinned_version('dependencies = ["httpx", "pydantic>=2"]') is None
+    assert gate.pinned_version('dependencies = ["positronic-platform-client"]') is None
+
+
+def test_only_shipped_paths_under_the_client_demand_a_bump():
+    paths = [
+        'client/platform_client/responses.py',
+        'client/README.md',
+        'positronic/cli/eval/submit.py',
+        'pyproject.toml',
+    ]
+    # The README ships in the wheel but cannot change what an install runs; the two paths outside
+    # `client/` belong to the root distribution, which carries its own version.
+    assert gate.shipped_changes(paths) == ['client/platform_client/responses.py']
+
+
+def test_a_client_test_counts_as_shipped():
+    # It sits inside the package directory, so two revisions behind one version would differ.
+    assert gate.shipped_changes(['client/platform_client/tests/test_models.py']) == [
+        'client/platform_client/tests/test_models.py'
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -68,6 +68,10 @@ positronic = false
 positronic-franka = false
 
 [manifest]
+members = [
+    "positronic",
+    "positronic-platform-client",
+]
 constraints = [
     { name = "cmake", specifier = "<4.3" },
     { name = "evdev", specifier = "<1.9" },
@@ -4853,6 +4857,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "plotly" },
     { name = "pos3" },
+    { name = "positronic-platform-client" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyturbojpeg" },
@@ -4971,6 +4976,7 @@ requires-dist = [
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pos3", specifier = ">=0.3.1" },
     { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.7.0" },
+    { name = "positronic-platform-client", editable = "client" },
     { name = "protobuf", marker = "extra == 'molmoact2'" },
     { name = "psutil", marker = "extra == 'telemetry'" },
     { name = "pyarrow" },
@@ -5030,6 +5036,21 @@ dependencies = [
     { name = "requests", marker = "sys_platform == 'linux' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-yam') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-yam') or (extra == 'extra-10-positronic-molmoact2' and extra == 'extra-10-positronic-yam')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/45/029c72cffe797d8265328405552f3f4d7dae76ee900ca811095200e471f4/positronic_franka-0.7.0.tar.gz", hash = "sha256:b9381ffa52d9fa9c998619bc40bb568733ceb2b7bd86d5c407483ae29ec08c2e", size = 1809759, upload-time = "2026-08-03T22:29:36.532Z" }
+
+[[package]]
+name = "positronic-platform-client"
+version = "0.1.0"
+source = { editable = "client" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pydantic", specifier = ">=2.7" },
+]
 
 [[package]]
 name = "prometheus-client"

--- a/uv.lock
+++ b/uv.lock
@@ -5039,7 +5039,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/45/029c72cffe797d826
 
 [[package]]
 name = "positronic-platform-client"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

`client/` is a new distribution, `positronic-platform-client`: the evaluation platform's wire
contract — request and response models, id and enum types, the error envelope — plus
`PlatformClient`, one method per endpoint.

The commands are `positronic`'s own: **`eval run` runs an eval — here given `--policy`, on the
platform given `--policy-image`** — `eval status`/`list`/`cancel` read back what a platform run did,
and **`account register`** is what the platform knows you as. No second command line.

## Why

**Running an eval is one act.** Where it runs is a property of the run, not a different verb, so
the arguments say which and each mode refuses the other's by name: a platform run given `--timing`
or `--output-dir` stops, because the platform owns its own sweep, output and telemetry.

**Nothing is installed to use it.** Every invocation the READMEs cite is a bare `uv run` from a
checkout, and a test runs each in a subprocess with `VIRTUAL_ENV` and `PYTHONPATH` scrubbed.

**One eval, not a backend and an eval set.** A submission chose both, and the pair could be wrong in
a way neither half was: a task suite belongs to a simulator or to one real robot, so `robolab` × the
wooden-spoon set names a run nothing can execute. The contract carries one axis — `eval`, an
`EvalRef`, naming suite and embodiment together; a name this client never heard of still reaches
the platform, which refuses it with the ones it does offer.

**A release cannot ship a root pinned to stale client bytes.** `release.yaml` publishes the client
first with `skip-existing`, which is also the hole: a change under `client/` reusing its version
leaves the old wheel on the index and the root ships depending on it. So
`utilities/check_client_version_bump.py` makes changed client code declare a greater version and
the root's pin name exactly it, at review time — reading both out of parsed TOML, so a line left
behind under a `#` is neither a version nor a pin.

Smaller decisions a reader could argue:

- The key is a construction argument falling back to `POSITRONIC_PLATFORM_API_KEY`, and `register`
  KEEPS a key it is handed — the call that mints a credential should not make the caller install it.
  A repeat registration answers `existing` with none and leaves the one already held.
- Every wire reference is a validated `str` subclass: `EvalRef`, `BoardRef`, and `PolicyImage`,
  refused against the grammar a registry itself parses — an unpullable image is a charged run.
- A value the wire types refuse — a platform URL naming no host, a malformed image or eval — is a
  CLI refusal naming it rather than a traceback, since falling through would have sent that run to
  the production platform.
- `idempotency_key` → `transaction_key`: two submissions under one key are one transaction, and a
  terminal one with no result exits nonzero everywhere it is reported.
- A submission and a board name an `eval` and nothing else — there is no version field on the wire.
  What identifies a set of trials is the eval string itself.
- Ids are hex on the wire and typed ints in Python: a full int64 does not survive JavaScript's
  `2**53`. Secrets come from the environment only.
- The README says what it is: **alpha, no backwards-compatibility guarantee**.

## Map

`client/platform_client/` is the contract — types, models, error envelope, routes, HTTP client.
`positronic/cli/eval/` runs and reads back and `positronic/cli/account/` registers, both over
`account/gateway.py`; `positronic/cli/examples/` writes the same flow out.

## Verification

`uv run pytest client positronic/cli utilities` — 517 passed, including fresh-install runs of every documented command; the same suite with `uv` off `PATH` fails naming it. The version gate is driven
against a scratch repository both ways.

## Refs

`internal#77`, `internal#345`, `internal#376`. The platform side is `platform#18`.

<!-- opened-by: posi-agent -->