### PR TITLE
Park the Franka at its home pose in the driver's teardown

### DIFF
--- a/pimm/README.md
+++ b/pimm/README.md
@@ -184,6 +184,16 @@ to use regular Python. Emitters (`ControlSystemEmitter`) and receivers
 (`ControlSystemReceiver`) are just fields on the object; they keep track of their
 owner so the world can wire them correctly.
 
+**Wait by yielding, never by sleeping.** A `yield pimm.Sleep(seconds)` hands the wait to whatever
+is running the loop; a `time.sleep` takes it. In the main-process group the difference is the whole
+schedule — `interleave` advances every other control system while one of them sleeps, so a blocking
+call there stalls the peers, not just its own loop. A control system that only ever runs as its own
+background process gets away with it, which is exactly why it turns up in drivers: the code works,
+until the day it is scheduled in the foreground or a test drives it directly, and then it stops the
+world instead of pausing itself. Yielding also makes the wait visible — a test can drive the loop
+and see what it asked for. This holds during teardown too: the wrapper keeps advancing the
+generator after the stop signal, so a driver parking its hardware yields like any other.
+
 The `World` runtime plays three roles:
 
 1. **Connection planner.** Each call to `world.connect(emitter, receiver, ...)`

--- a/pimm/README.md
+++ b/pimm/README.md
@@ -184,15 +184,11 @@ to use regular Python. Emitters (`ControlSystemEmitter`) and receivers
 (`ControlSystemReceiver`) are just fields on the object; they keep track of their
 owner so the world can wire them correctly.
 
-**Wait by yielding, never by sleeping.** A `yield pimm.Sleep(seconds)` hands the wait to whatever
-is running the loop; a `time.sleep` takes it. In the main-process group the difference is the whole
-schedule — `interleave` advances every other control system while one of them sleeps, so a blocking
-call there stalls the peers, not just its own loop. A control system that only ever runs as its own
-background process gets away with it, which is exactly why it turns up in drivers: the code works,
-until the day it is scheduled in the foreground or a test drives it directly, and then it stops the
-world instead of pausing itself. Yielding also makes the wait visible — a test can drive the loop
-and see what it asked for. This holds during teardown too: the wrapper keeps advancing the
-generator after the stop signal, so a driver parking its hardware yields like any other.
+**Wait by yielding, never by sleeping.** `yield pimm.Sleep(seconds)` hands the wait to the runner;
+`time.sleep` takes it. In the main-process group `interleave` advances the peers while one loop
+sleeps, so a blocking call there stalls them all. It works in a background process, which is why it
+survives review and breaks the day that control system is scheduled in the foreground. Teardown is
+no exception: the runner keeps advancing the generator after the stop signal.
 
 The `World` runtime plays three roles:
 

--- a/pimm/README.md
+++ b/pimm/README.md
@@ -186,7 +186,7 @@ owner so the world can wire them correctly.
 
 **Don't use system libs for sleeping — `yield pimm.Sleep(secs)` instead.** In the main-process
 group `interleave` advances the peers while one loop sleeps, so a blocking call there stalls them
-all. `positronic/drivers/tests/test_no_blocking_sleep.py` enforces it.
+all.
 
 The `World` runtime plays three roles:
 

--- a/pimm/README.md
+++ b/pimm/README.md
@@ -184,11 +184,9 @@ to use regular Python. Emitters (`ControlSystemEmitter`) and receivers
 (`ControlSystemReceiver`) are just fields on the object; they keep track of their
 owner so the world can wire them correctly.
 
-**Wait by yielding, never by sleeping.** `yield pimm.Sleep(seconds)` hands the wait to the runner;
-`time.sleep` takes it. In the main-process group `interleave` advances the peers while one loop
-sleeps, so a blocking call there stalls them all. It works in a background process, which is why it
-survives review and breaks the day that control system is scheduled in the foreground. Teardown is
-no exception: the runner keeps advancing the generator after the stop signal.
+**Don't use system libs for sleeping — `yield pimm.Sleep(secs)` instead.** In the main-process
+group `interleave` advances the peers while one loop sleeps, so a blocking call there stalls them
+all. `positronic/drivers/tests/test_no_blocking_sleep.py` enforces it.
 
 The `World` runtime plays three roles:
 

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -499,9 +499,10 @@ class World:
 
         logging.info(f'Waiting for {len(self.background_processes)} background processes to terminate...')
         for process in self.background_processes:
-            # Control systems run teardown (with-blocks in run()) after the stop signal; hardware cleanup such as
-            # engaging robot brakes takes tens of seconds, so give it time before resorting to SIGTERM.
-            process.join(timeout=60)
+            # Control systems run teardown (with-blocks in run()) after the stop signal; hardware cleanup parks
+            # the arm under the driver's own bounded timeout and then engages brakes, which takes tens of
+            # seconds, so give it time before resorting to SIGTERM.
+            process.join(timeout=90)
             if process.is_alive():
                 logging.warning(f'Process {process.name} (pid {process.pid}) did not respond, terminating...')
                 process.terminate()

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -499,9 +499,8 @@ class World:
 
         logging.info(f'Waiting for {len(self.background_processes)} background processes to terminate...')
         for process in self.background_processes:
-            # Control systems run teardown (with-blocks in run()) after the stop signal; hardware cleanup parks
-            # the arm under the driver's own bounded timeout and then engages brakes, which takes tens of
-            # seconds, so give it time before resorting to SIGTERM.
+            # Control systems run teardown (with-blocks in run()) after the stop signal, and some drivers may
+            # need tens of seconds to park their hardware, so give them the time before resorting to SIGTERM.
             process.join(timeout=90)
             if process.is_alive():
                 logging.warning(f'Process {process.name} (pid {process.pid}) did not respond, terminating...')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -294,22 +294,12 @@ class Robot(pimm.ControlSystem):
         """Move the arm to the home pose, giving up after ``park_timeout_s``.
 
         Autonomous motion: bounded, at the configured dynamics factor, to the configured ``home_joints``
-        and nowhere else. Every failure — including a goal that stops advancing — reaches the log and no
-        further.
+        and nowhere else. An arm already there arrives immediately, so arrival is the controller's to
+        report rather than something to pre-check. Every failure — including a goal that stops advancing —
+        reaches the log and no further.
         """
-        SLACK_RAD = 0.05
-        STILL_RAD_PER_S = 0.01
         target = np.asarray(self._home_joints, dtype=np.float64)
-        # A reset lands anywhere inside home_joints_variation, so an arm within that spread is already parked.
-        tolerance = np.asarray(self._home_joints_variation, dtype=np.float64) + SLACK_RAD
         try:
-            state = robot.state()
-            at_home = np.all(np.abs(np.asarray(state.q, dtype=np.float64) - target) <= tolerance)
-            # An arm merely passing through the spread is still travelling somewhere else, and stopping there
-            # brakes it away from home.
-            still = np.all(np.abs(np.asarray(state.dq, dtype=np.float64)) <= STILL_RAD_PER_S)
-            if at_home and still:
-                return
             logging.info('Parking the arm at the home pose')
             robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = time.monotonic() + self._park_timeout_s

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -25,13 +25,17 @@ def _check_error(is_error, was_error):
     return is_error, is_error and not was_error
 
 
+DESK_USER_ENV = 'FRANKA_DESK_USER'
+DESK_PASSWORD_ENV = 'FRANKA_DESK_PASSWORD'
+
+
 def _read_desk_credentials() -> tuple[str, str]:
     """Franka Desk login and password from the environment. Credentials stay out of the config so they never reach
     the command line, which is recorded verbatim in every run's metadata."""
-    login, password = os.environ.get('FRANKA_DESK_USER'), os.environ.get('FRANKA_DESK_PASSWORD')
+    login, password = os.environ.get(DESK_USER_ENV), os.environ.get(DESK_PASSWORD_ENV)
     if not (login and password):
         missing = ' and '.join(
-            name for name, value in (('FRANKA_DESK_USER', login), ('FRANKA_DESK_PASSWORD', password)) if not value
+            name for name, value in ((DESK_USER_ENV, login), (DESK_PASSWORD_ENV, password)) if not value
         )
         raise RuntimeError(
             f'{missing} not set in the environment. The driver needs Desk credentials to open the brakes and '

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 import xml.etree.ElementTree as ET
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -222,13 +222,16 @@ class Robot(pimm.ControlSystem):
             robot.set_load(0.0, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
 
     @staticmethod
-    def _travel(robot, target) -> Iterator[None]:
+    def _travel(robot, target, keep_waiting: Callable[[], bool]) -> Iterator[None]:
         """Command ``target`` and yield once per poll until the arm arrives; raise if the goal stops advancing.
 
-        Yielding is the only wait: what a poll costs, and when to give up waiting, are the caller's.
+        Yielding is the only wait, so what a poll costs is the caller's. When to give up is the caller's too,
+        but it is asked HERE, before each poll, rather than in the loop body: the caller only regains control
+        after a poll has already happened, and a goal cancelled by the very event that ended the wait reports
+        failure — so a caller that gave up one poll too late would turn its own clean exit into a fault.
         """
         robot.set_target_joints(target)
-        while True:
+        while keep_waiting():
             goal = robot.goal()
             if goal.status == pf.GoalStatus.REACHED:
                 return
@@ -250,9 +253,7 @@ class Robot(pimm.ControlSystem):
             )
             target = target + variation
 
-        for _ in self._travel(robot, target):
-            if should_stop.value:
-                return
+        for _ in self._travel(robot, target, lambda: not should_stop.value):
             st = robot.state()
             robot_state.encode(st)
             robot_state._start_reset()  # `encode` clears RESETTING; the arm has not arrived
@@ -261,6 +262,8 @@ class Robot(pimm.ControlSystem):
                 robot.recover_from_errors()
             yield rate_limiter.wait()
 
+        if should_stop.value:  # the travel gave up on the stop rather than on arrival
+            return
         robot_state._finish_reset()
         self.state.emit(robot_state)
 
@@ -303,11 +306,17 @@ class Robot(pimm.ControlSystem):
             logging.info('Parking the arm at the home pose')
             robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = time.monotonic() + self._park_timeout_s
-            for _ in self._travel(robot, target):
-                if time.monotonic() >= deadline:
-                    logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
-                    return
+            timed_out = False
+
+            def before_deadline() -> bool:
+                nonlocal timed_out
+                timed_out = time.monotonic() >= deadline
+                return not timed_out
+
+            for _ in self._travel(robot, target, before_deadline):
                 time.sleep(0.005)
+            if timed_out:
+                logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
         except Exception:
             logging.exception('Parking failed, the arm stays where it stands')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -98,8 +98,6 @@ def _revolute_joint_names(urdf_xml):
 
 
 _MESH_DIR = Path(__file__).resolve().parent.parent.parent / 'assets/fr3_collision'
-_PARK_SLACK_RAD = 0.05
-_PARK_TIMEOUT_S = 10.0
 
 
 class Robot(pimm.ControlSystem):
@@ -114,6 +112,7 @@ class Robot(pimm.ControlSystem):
         collision_coeff: float = 2.0,
         manage_desk: bool = True,
         reboot_on_safety_error: bool = False,
+        park_timeout_s: float = 10.0,
     ) -> None:
         """
         :param ip: IP address of the robot.
@@ -129,6 +128,8 @@ class Robot(pimm.ControlSystem):
         :param reboot_on_safety_error: When the control box is in an unrecoverable ``SafetyError`` on start, reboot
             it, wait for it to come back, and try once more before giving up. Only applies when ``manage_desk`` is
             set.
+        :param park_timeout_s: How long the arm may travel back to ``home_joints`` when the run ends before the
+            driver gives up and stops control where it stands. It is spent inside the world's teardown budget.
         """
         self._ip = ip
         self._relative_dynamics_factor = relative_dynamics_factor
@@ -146,6 +147,7 @@ class Robot(pimm.ControlSystem):
         self._robot: pf.Robot | None = None
         self._desk_credentials = _read_desk_credentials() if manage_desk else None
         self._reboot_on_safety_error = reboot_on_safety_error
+        self._park_timeout_s = park_timeout_s
 
     @staticmethod
     def _build_robot_meta(robot) -> dict:
@@ -277,22 +279,28 @@ class Robot(pimm.ControlSystem):
                     return
 
     def _park(self, robot) -> None:
-        """Move the arm to the home pose, giving up after ``_PARK_TIMEOUT_S``.
+        """Move the arm to the home pose, giving up after ``park_timeout_s``.
 
-        Autonomous motion at shutdown: bounded, at the configured dynamics factor, to the configured
-        ``home_joints`` and nowhere else. Every failure reaches the log and no further, so the brake
-        engagement and control release that follow run whatever happens here.
+        Autonomous motion: bounded, at the configured dynamics factor, to the configured ``home_joints``
+        and nowhere else. Every failure reaches the log and no further.
         """
+        SLACK_RAD = 0.05
+        STILL_RAD_PER_S = 0.01
         target = np.asarray(self._home_joints, dtype=np.float64)
         # A reset lands anywhere inside home_joints_variation, so an arm within that spread is already parked.
-        tolerance = np.asarray(self._home_joints_variation, dtype=np.float64) + _PARK_SLACK_RAD
+        tolerance = np.asarray(self._home_joints_variation, dtype=np.float64) + SLACK_RAD
         try:
-            if np.all(np.abs(np.asarray(robot.state().q, dtype=np.float64) - target) <= tolerance):
+            state = robot.state()
+            at_home = np.all(np.abs(np.asarray(state.q, dtype=np.float64) - target) <= tolerance)
+            # An arm merely passing through the spread is still travelling somewhere else, and stopping there
+            # brakes it away from home.
+            still = np.all(np.abs(np.asarray(state.dq, dtype=np.float64)) <= STILL_RAD_PER_S)
+            if at_home and still:
                 return
             logging.info('Parking the arm at the home pose')
             robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             robot.set_target_joints(target)
-            deadline = time.monotonic() + _PARK_TIMEOUT_S
+            deadline = time.monotonic() + self._park_timeout_s
             while time.monotonic() < deadline:
                 goal = robot.goal()
                 if goal.status == pf.GoalStatus.REACHED:
@@ -301,7 +309,7 @@ class Robot(pimm.ControlSystem):
                     logging.error(f'Parking gave up, the arm stays where it stands: {goal.reason or goal.status}')
                     return
                 time.sleep(0.005)
-            logging.error(f'Parking timed out after {_PARK_TIMEOUT_S}s, the arm stays where it stands')
+            logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
         except Exception:
             logging.exception('Parking failed, the arm stays where it stands')
@@ -368,8 +376,11 @@ class Robot(pimm.ControlSystem):
                                 raise NotImplementedError(f'Unsupported command {cmd}')
 
                     yield rate_limiter.wait()
-            finally:
+
+                # Only a stop request earns the park. Answering a setup or control fault with a recovery and a
+                # fresh joint target would be autonomous motion in response to something going wrong.
                 self._park(robot)
+            finally:
                 # Halt the driver's control thread before _desk_session deactivates FCI, or it dies mid-control
                 # with "TCP connection got interrupted".
                 robot.stop()

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -28,9 +28,6 @@ def _check_error(is_error, was_error):
 DESK_USER_ENV = 'FRANKA_DESK_USER'
 DESK_PASSWORD_ENV = 'FRANKA_DESK_PASSWORD'
 
-# How long a caller waits between two reads of a joint goal in flight.
-_GOAL_POLL_INTERVAL_S = 0.005
-
 
 def _read_desk_credentials() -> tuple[str, str]:
     """Franka Desk login and password from the environment. Credentials stay out of the config so they never reach
@@ -229,14 +226,10 @@ class Robot(pimm.ControlSystem):
         """Command ``target`` and poll the goal until the arm arrives; raise if the goal stops advancing.
 
         Returns whether the arm arrived: ``False`` means ``should_stop`` ended the wait first. It is asked
-        HERE, before each poll, rather than in the loop body: the caller only regains control after a poll
-        has already happened, and a goal cancelled by the very event that ended the wait reports failure —
-        so a caller that gave up one poll too late would turn its own clean exit into a fault.
-
-        The yielded ``Sleep`` paces a caller that drives this with ``yield from``. A caller running its own
-        rate limiter drives it with a ``for`` loop instead and paces itself, which is why the command is
-        given per poll rather than taken as an argument.
+        before each poll, never after one, because a goal cancelled by the same event that ends the wait
+        reports failure — and reading it then would turn a clean exit into a fault.
         """
+        POLL_INTERVAL_S = 0.005
         robot.set_target_joints(target)
         while not should_stop():
             goal = robot.goal()
@@ -244,7 +237,7 @@ class Robot(pimm.ControlSystem):
                 return True
             if goal.status != pf.GoalStatus.IN_FLIGHT:
                 raise RuntimeError(f'homing failed: {goal.reason or goal.status}')
-            yield pimm.Sleep(_GOAL_POLL_INTERVAL_S)
+            yield pimm.Sleep(POLL_INTERVAL_S)
         return False
 
     def _reset(self, robot, robot_state: FrankaState, rate_limiter, should_stop) -> Iterator[pimm.Sleep]:

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -98,6 +98,8 @@ def _revolute_joint_names(urdf_xml):
 
 
 _MESH_DIR = Path(__file__).resolve().parent.parent.parent / 'assets/fr3_collision'
+_PARK_SLACK_RAD = 0.05
+_PARK_TIMEOUT_S = 10.0
 
 
 class Robot(pimm.ControlSystem):
@@ -116,7 +118,7 @@ class Robot(pimm.ControlSystem):
         """
         :param ip: IP address of the robot.
         :param relative_dynamics_factor: Relative dynamics factor in [0, 1]. Smaller values are more conservative.
-        :param home_joints: Joints of "reset" position.
+        :param home_joints: Joints of "reset" position, and the pose the arm is parked at when the run ends.
         :param home_joints_variation: Max random deviation per joint in radians. Set to [0]*7 to disable.
         :param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
             Default 2.0 (data collection). Use 6.0 for inference.
@@ -274,6 +276,36 @@ class Robot(pimm.ControlSystem):
                     yield desk
                     return
 
+    def _park(self, robot) -> None:
+        """Move the arm to the home pose, giving up after ``_PARK_TIMEOUT_S``.
+
+        Autonomous motion at shutdown: bounded, at the configured dynamics factor, to the configured
+        ``home_joints`` and nowhere else. Every failure reaches the log and no further, so the brake
+        engagement and control release that follow run whatever happens here.
+        """
+        target = np.asarray(self._home_joints, dtype=np.float64)
+        # A reset lands anywhere inside home_joints_variation, so an arm within that spread is already parked.
+        tolerance = np.asarray(self._home_joints_variation, dtype=np.float64) + _PARK_SLACK_RAD
+        try:
+            if np.all(np.abs(np.asarray(robot.state().q, dtype=np.float64) - target) <= tolerance):
+                return
+            logging.info('Parking the arm at the home pose')
+            robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
+            robot.set_target_joints(target)
+            deadline = time.monotonic() + _PARK_TIMEOUT_S
+            while time.monotonic() < deadline:
+                goal = robot.goal()
+                if goal.status == pf.GoalStatus.REACHED:
+                    return
+                if goal.status != pf.GoalStatus.IN_FLIGHT:
+                    logging.error(f'Parking gave up, the arm stays where it stands: {goal.reason or goal.status}')
+                    return
+                time.sleep(0.005)
+            logging.error(f'Parking timed out after {_PARK_TIMEOUT_S}s, the arm stays where it stands')
+        # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
+        except Exception:
+            logging.exception('Parking failed, the arm stays where it stands')
+
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         with self._desk_session():
             robot = self._ensure_robot()
@@ -337,6 +369,7 @@ class Robot(pimm.ControlSystem):
 
                     yield rate_limiter.wait()
             finally:
+                self._park(robot)
                 # Halt the driver's control thread before _desk_session deactivates FCI, or it dies mid-control
                 # with "TCP connection got interrupted".
                 robot.stop()

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -221,6 +221,22 @@ class Robot(pimm.ControlSystem):
         else:
             robot.set_load(0.0, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
 
+    @staticmethod
+    def _travel(robot, target) -> Iterator[None]:
+        """Command ``target`` and yield once per poll until the arm arrives; raise if the goal stops advancing.
+
+        The caller decides what a poll costs and when to give up — a running loop pays a rate-limited tick and
+        watches the stop signal, a teardown pays a short sleep and watches a deadline.
+        """
+        robot.set_target_joints(target)
+        while True:
+            goal = robot.goal()
+            if goal.status == pf.GoalStatus.REACHED:
+                return
+            if goal.status != pf.GoalStatus.IN_FLIGHT:
+                raise RuntimeError(f'homing failed: {goal.reason or goal.status}')
+            yield
+
     def _reset(self, robot, robot_state: FrankaState, rate_limiter, should_stop) -> Iterator[pimm.Sleep]:
         """Home the arm, yielding until it arrives. Drive with ``yield from``."""
         # The first emit must not ship an unfilled state.
@@ -234,17 +250,10 @@ class Robot(pimm.ControlSystem):
                 -np.asarray(self._home_joints_variation), np.asarray(self._home_joints_variation)
             )
             target = target + variation
-        robot.set_target_joints(target)
 
-        while True:
+        for _ in self._travel(robot, target):
             if should_stop.value:
                 return
-            goal = robot.goal()
-            if goal.status == pf.GoalStatus.REACHED:
-                break
-            if goal.status != pf.GoalStatus.IN_FLIGHT:
-                raise RuntimeError(f'homing failed: {goal.reason or goal.status}')
-
             st = robot.state()
             robot_state.encode(st)
             robot_state._start_reset()  # `encode` clears RESETTING; the arm has not arrived
@@ -286,7 +295,8 @@ class Robot(pimm.ControlSystem):
         """Move the arm to the home pose, giving up after ``park_timeout_s``.
 
         Autonomous motion: bounded, at the configured dynamics factor, to the configured ``home_joints``
-        and nowhere else. Every failure reaches the log and no further.
+        and nowhere else. Every failure — including a goal that stops advancing — reaches the log and no
+        further.
         """
         SLACK_RAD = 0.05
         STILL_RAD_PER_S = 0.01
@@ -303,17 +313,12 @@ class Robot(pimm.ControlSystem):
                 return
             logging.info('Parking the arm at the home pose')
             robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
-            robot.set_target_joints(target)
             deadline = time.monotonic() + self._park_timeout_s
-            while time.monotonic() < deadline:
-                goal = robot.goal()
-                if goal.status == pf.GoalStatus.REACHED:
-                    return
-                if goal.status != pf.GoalStatus.IN_FLIGHT:
-                    logging.error(f'Parking gave up, the arm stays where it stands: {goal.reason or goal.status}')
+            for _ in self._travel(robot, target):
+                if time.monotonic() >= deadline:
+                    logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
                     return
                 time.sleep(0.005)
-            logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
         except Exception:
             logging.exception('Parking failed, the arm stays where it stands')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -225,8 +225,7 @@ class Robot(pimm.ControlSystem):
     def _travel(robot, target) -> Iterator[None]:
         """Command ``target`` and yield once per poll until the arm arrives; raise if the goal stops advancing.
 
-        The caller decides what a poll costs and when to give up — a running loop pays a rate-limited tick and
-        watches the stop signal, a teardown pays a short sleep and watches a deadline.
+        Yielding is the only wait: what a poll costs, and when to give up waiting, are the caller's.
         """
         robot.set_target_joints(target)
         while True:

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -226,8 +226,8 @@ class Robot(pimm.ControlSystem):
         """Command ``target`` and poll the goal until the arm arrives; raise if the goal stops advancing.
 
         Returns whether the arm arrived: ``False`` means ``should_stop`` ended the wait first. It is asked
-        before each poll, never after one, because a goal cancelled by the same event that ends the wait
-        reports failure — and reading it then would turn a clean exit into a fault.
+        before each poll and never after one, so a caller that gives up never reads a goal it has already
+        given up on.
         """
         POLL_INTERVAL_S = 0.005
         robot.set_target_joints(target)

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 import xml.etree.ElementTree as ET
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +27,9 @@ def _check_error(is_error, was_error):
 
 DESK_USER_ENV = 'FRANKA_DESK_USER'
 DESK_PASSWORD_ENV = 'FRANKA_DESK_PASSWORD'
+
+# How long a caller waits between two reads of a joint goal in flight.
+_GOAL_POLL_INTERVAL_S = 0.005
 
 
 def _read_desk_credentials() -> tuple[str, str]:
@@ -222,22 +225,27 @@ class Robot(pimm.ControlSystem):
             robot.set_load(0.0, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
 
     @staticmethod
-    def _travel(robot, target, keep_waiting: Callable[[], bool]) -> Iterator[None]:
-        """Command ``target`` and yield once per poll until the arm arrives; raise if the goal stops advancing.
+    def _travel(robot, target, should_stop: Callable[[], bool]) -> Generator[pimm.Sleep, None, bool]:
+        """Command ``target`` and poll the goal until the arm arrives; raise if the goal stops advancing.
 
-        Yielding is the only wait, so what a poll costs is the caller's. When to give up is the caller's too,
-        but it is asked HERE, before each poll, rather than in the loop body: the caller only regains control
-        after a poll has already happened, and a goal cancelled by the very event that ended the wait reports
-        failure — so a caller that gave up one poll too late would turn its own clean exit into a fault.
+        Returns whether the arm arrived: ``False`` means ``should_stop`` ended the wait first. It is asked
+        HERE, before each poll, rather than in the loop body: the caller only regains control after a poll
+        has already happened, and a goal cancelled by the very event that ended the wait reports failure —
+        so a caller that gave up one poll too late would turn its own clean exit into a fault.
+
+        The yielded ``Sleep`` paces a caller that drives this with ``yield from``. A caller running its own
+        rate limiter drives it with a ``for`` loop instead and paces itself, which is why the command is
+        given per poll rather than taken as an argument.
         """
         robot.set_target_joints(target)
-        while keep_waiting():
+        while not should_stop():
             goal = robot.goal()
             if goal.status == pf.GoalStatus.REACHED:
-                return
+                return True
             if goal.status != pf.GoalStatus.IN_FLIGHT:
                 raise RuntimeError(f'homing failed: {goal.reason or goal.status}')
-            yield
+            yield pimm.Sleep(_GOAL_POLL_INTERVAL_S)
+        return False
 
     def _reset(self, robot, robot_state: FrankaState, rate_limiter, should_stop) -> Iterator[pimm.Sleep]:
         """Home the arm, yielding until it arrives. Drive with ``yield from``."""
@@ -253,7 +261,7 @@ class Robot(pimm.ControlSystem):
             )
             target = target + variation
 
-        for _ in self._travel(robot, target, lambda: not should_stop.value):
+        for _ in self._travel(robot, target, lambda: should_stop.value):
             st = robot.state()
             robot_state.encode(st)
             robot_state._start_reset()  # `encode` clears RESETTING; the arm has not arrived
@@ -293,10 +301,14 @@ class Robot(pimm.ControlSystem):
                     yield desk
                     return
 
-    def _park(self, robot) -> None:
-        """Move the arm to the home pose, giving up after ``park_timeout_s``.
+    def _park(self, robot) -> Iterator[pimm.Sleep]:
+        """Move the arm to the home pose, giving up after ``park_timeout_s``. Drive with ``yield from``.
 
-        Autonomous motion: bounded, at the configured dynamics factor, to the configured ``home_joints``
+        Runs after the control loop rather than in its ``finally``, so that only a stop request earns it.
+        Answering a setup or control fault with a recovery and a fresh joint target would be autonomous
+        motion in response to something going wrong.
+
+        The motion itself is bounded: at the configured dynamics factor, to the configured ``home_joints``
         and nowhere else. An arm already there arrives immediately, so arrival is the controller's to
         report rather than something to pre-check. Every failure — including a goal that stops advancing —
         reaches the log and no further.
@@ -306,16 +318,8 @@ class Robot(pimm.ControlSystem):
             logging.info('Parking the arm at the home pose')
             robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = time.monotonic() + self._park_timeout_s
-            timed_out = False
-
-            def before_deadline() -> bool:
-                nonlocal timed_out
-                timed_out = time.monotonic() >= deadline
-                return not timed_out
-
-            for _ in self._travel(robot, target, before_deadline):
-                time.sleep(0.005)
-            if timed_out:
+            arrived = yield from self._travel(robot, target, lambda: time.monotonic() >= deadline)
+            if not arrived:
                 logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
         except Exception:
@@ -384,9 +388,7 @@ class Robot(pimm.ControlSystem):
 
                     yield rate_limiter.wait()
 
-                # Only a stop request earns the park. Answering a setup or control fault with a recovery and a
-                # fresh joint target would be autonomous motion in response to something going wrong.
-                self._park(robot)
+                yield from self._park(robot)
             finally:
                 # Halt the driver's control thread before _desk_session deactivates FCI, or it dies mid-control
                 # with "TCP connection got interrupted".

--- a/positronic/drivers/roboarm/kinova/api.py
+++ b/positronic/drivers/roboarm/kinova/api.py
@@ -112,6 +112,7 @@ class KinovaAPI:
         if self.base.GetArmState().active_state == Base_pb2.ARMSTATE_IN_FAULT:
             self.base.ClearFaults()
             while self.base.GetArmState().active_state != Base_pb2.ARMSTATE_SERVOING_READY:
+                # blocking-sleep-ok: connect-time handshake, before any control loop exists to yield from
                 time.sleep(0.1)
         # Initialize control loop
         self.base.SetServoingMode(Base_pb2.ServoingModeInformation(servoing_mode=Base_pb2.LOW_LEVEL_SERVOING))

--- a/positronic/drivers/roboarm/tests/conftest.py
+++ b/positronic/drivers/roboarm/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Stand-in for the Franka vendor package.
+
+``positronic_franka`` builds against libfranka and ships only in the ``hardware`` extra, so the driver
+module cannot be imported from a default sync. Its Python-side logic needs no vendor behaviour, so a stub
+carrying the names the module binds at import is enough. Installed here, before any test module imports the
+driver, and only when the real package is absent.
+"""
+
+import importlib.util
+import sys
+import types
+from enum import Enum
+
+
+class GoalStatus(Enum):
+    REACHED = 'reached'
+    IN_FLIGHT = 'in_flight'
+    ABORTED = 'aborted'
+
+
+def _install_vendor_stub() -> None:
+    vendor = types.ModuleType('positronic_franka._franka')
+    vendor.__dict__.update(
+        GoalStatus=GoalStatus,
+        State=object,
+        Robot=object,
+        RealtimeConfig=types.SimpleNamespace(Ignore=object()),
+        InternalImpedance=lambda stiffness: ('internal_impedance', stiffness),
+    )
+
+    desk = types.ModuleType('positronic_franka.desk')
+    desk.__dict__.update(Desk=object, SafetyControllerError=type('SafetyControllerError', (Exception,), {}))
+
+    package = types.ModuleType('positronic_franka')
+    package.__dict__.update(_franka=vendor, desk=desk)
+
+    sys.modules.update({
+        'positronic_franka': package,
+        'positronic_franka._franka': vendor,
+        'positronic_franka.desk': desk,
+    })
+
+
+if importlib.util.find_spec('positronic_franka') is None:
+    _install_vendor_stub()

--- a/positronic/drivers/roboarm/tests/conftest.py
+++ b/positronic/drivers/roboarm/tests/conftest.py
@@ -18,8 +18,13 @@ class GoalStatus(Enum):
     ABORTED = 'aborted'
 
 
+PACKAGE = 'positronic_franka'
+VENDOR = f'{PACKAGE}._franka'
+DESK = f'{PACKAGE}.desk'
+
+
 def _install_vendor_stub() -> None:
-    vendor = types.ModuleType('positronic_franka._franka')
+    vendor = types.ModuleType(VENDOR)
     vendor.__dict__.update(
         GoalStatus=GoalStatus,
         State=object,
@@ -28,18 +33,14 @@ def _install_vendor_stub() -> None:
         InternalImpedance=lambda stiffness: ('internal_impedance', stiffness),
     )
 
-    desk = types.ModuleType('positronic_franka.desk')
+    desk = types.ModuleType(DESK)
     desk.__dict__.update(Desk=object, SafetyControllerError=type('SafetyControllerError', (Exception,), {}))
 
-    package = types.ModuleType('positronic_franka')
+    package = types.ModuleType(PACKAGE)
     package.__dict__.update(_franka=vendor, desk=desk)
 
-    sys.modules.update({
-        'positronic_franka': package,
-        'positronic_franka._franka': vendor,
-        'positronic_franka.desk': desk,
-    })
+    sys.modules.update({PACKAGE: package, VENDOR: vendor, DESK: desk})
 
 
-if importlib.util.find_spec('positronic_franka') is None:
+if importlib.util.find_spec(PACKAGE) is None:
     _install_vendor_stub()

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -125,8 +125,8 @@ class StopFlag(pimm.SignalReceiver[bool]):
 
 @pytest.fixture
 def desk(monkeypatch) -> FakeDesk:
-    monkeypatch.setenv('FRANKA_DESK_USER', 'user')
-    monkeypatch.setenv('FRANKA_DESK_PASSWORD', 'password')
+    monkeypatch.setenv(franka.DESK_USER_ENV, 'user')
+    monkeypatch.setenv(franka.DESK_PASSWORD_ENV, 'password')
     session = FakeDesk()
     monkeypatch.setattr(franka, 'Desk', lambda *credentials: session)
     return session

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -36,23 +36,30 @@ class FakeArm:
     set, is what every call but ``stop`` raises.
     """
 
-    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: object | None = None):
+    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: object | None = None, dq=None):
         self.q = np.asarray(q, dtype=np.float64)
+        self.dq = np.zeros(7) if dq is None else np.asarray(dq, dtype=np.float64)
         self.calls: list[str] = []
         self.targets: list[np.ndarray] = []
         self.raises: Exception | None = None
+        self.raises_once: Exception | None = None
         self._polls_to_reach = polls_to_reach
         self._polls = 0
         self._goal_status = goal_status
 
     def _record(self, call: str) -> None:
         self.calls.append(call)
+        if self.raises_once is not None:
+            once, self.raises_once = self.raises_once, None
+            raise once
         if self.raises is not None:
             raise self.raises
 
     def state(self) -> _ArmState:
         self._record('state')
-        return _ArmState(self.q.copy(), np.zeros(7), np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]), np.zeros(6), 0, '')
+        return _ArmState(
+            self.q.copy(), self.dq.copy(), np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]), np.zeros(6), 0, ''
+        )
 
     def goal(self) -> _Goal:
         self._record('goal')
@@ -149,6 +156,15 @@ def test_park_leaves_an_arm_within_the_homing_spread_alone():
     assert arm.targets == []
 
 
+def test_park_commands_home_for_an_arm_passing_through_the_spread():
+    variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
+    arm = FakeArm(HOME + np.asarray(variation), dq=[0.4] + [0.0] * 6)
+
+    _driver(arm, variation=variation, manage_desk=False)._park(arm)
+
+    np.testing.assert_allclose(arm.targets, [HOME])
+
+
 def test_park_gives_up_when_the_goal_stops_advancing():
     arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)
 
@@ -158,12 +174,11 @@ def test_park_gives_up_when_the_goal_stops_advancing():
     np.testing.assert_allclose(arm.q, JOGGED)
 
 
-def test_park_gives_up_when_the_arm_does_not_arrive_in_time(monkeypatch):
-    monkeypatch.setattr(franka, '_PARK_TIMEOUT_S', 0.05)
+def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
     arm = FakeArm(JOGGED, polls_to_reach=10**9)
 
     started = time.monotonic()
-    _driver(arm, manage_desk=False)._park(arm)
+    _driver(arm, manage_desk=False, park_timeout_s=0.05)._park(arm)
     elapsed = time.monotonic() - started
 
     assert 0.05 <= elapsed < 2.0
@@ -215,4 +230,22 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
         next(loop)
 
     assert arm.calls[mark:] == ['state', 'stop']  # the park was attempted and its failure went no further
+    assert desk.released
+
+
+def test_a_control_fault_stops_the_arm_without_parking_it(desk):
+    arm = FakeArm(HOME)
+    stop = StopFlag()
+    loop = _driver(arm).run(stop, SystemClock())
+
+    for _ in range(3):
+        next(loop)
+    arm.q = JOGGED
+    arm.raises_once = RuntimeError('libfranka: connection lost')  # the fault, not a dead arm — a park could move it
+    mark = len(arm.calls)
+    with pytest.raises(RuntimeError):
+        next(loop)
+
+    assert 'set_target_joints' not in arm.calls[mark:]  # a fault is not answered with autonomous motion
+    assert arm.calls[-1] == 'stop'
     assert desk.released

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -1,0 +1,218 @@
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import pimm
+from pimm.world import SystemClock
+from positronic.drivers.roboarm import franka
+
+HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
+JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+
+@dataclass
+class _Goal:
+    status: object
+    reason: str | None
+
+
+@dataclass
+class _ArmState:
+    q: np.ndarray
+    dq: np.ndarray
+    end_effector_pose: np.ndarray
+    ee_wrench: np.ndarray
+    error: int
+    error_message: str
+
+
+class FakeArm:
+    """In-memory ``pf.Robot``: a commanded joint target is reached after ``polls_to_reach`` reads of ``goal``.
+
+    ``goal_status`` pins the reported status, so a move that never lands can be scripted; ``raises``, once
+    set, is what every call but ``stop`` raises.
+    """
+
+    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: object | None = None):
+        self.q = np.asarray(q, dtype=np.float64)
+        self.calls: list[str] = []
+        self.targets: list[np.ndarray] = []
+        self.raises: Exception | None = None
+        self._polls_to_reach = polls_to_reach
+        self._polls = 0
+        self._goal_status = goal_status
+
+    def _record(self, call: str) -> None:
+        self.calls.append(call)
+        if self.raises is not None:
+            raise self.raises
+
+    def state(self) -> _ArmState:
+        self._record('state')
+        return _ArmState(self.q.copy(), np.zeros(7), np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]), np.zeros(6), 0, '')
+
+    def goal(self) -> _Goal:
+        self._record('goal')
+        self._polls += 1
+        if self._goal_status is not None:
+            return _Goal(self._goal_status, 'scripted')
+        if self._polls >= self._polls_to_reach:
+            self.q = self.targets[-1].copy()
+            return _Goal(franka.pf.GoalStatus.REACHED, None)
+        return _Goal(franka.pf.GoalStatus.IN_FLIGHT, None)
+
+    def set_target_joints(self, target) -> None:
+        self._record('set_target_joints')
+        self.targets.append(np.asarray(target, dtype=np.float64))
+        self._polls = 0
+
+    def recover_from_errors(self) -> None:
+        self._record('recover_from_errors')
+
+    def stop(self) -> None:
+        self.calls.append('stop')
+
+    def get_robot_model(self) -> str:
+        return (Path(franka.__file__).parent / 'fr3.urdf').read_text()
+
+    def set_collision_behavior(self, **thresholds) -> None:
+        self._record('set_collision_behavior')
+
+    def set_control_mode(self, mode) -> None:
+        self._record('set_control_mode')
+
+    def set_load(self, *load) -> None:
+        self._record('set_load')
+
+
+class FakeDesk:
+    """In-memory ``Desk``: records that the session opened the brakes and released control."""
+
+    def __init__(self):
+        self.prepared = False
+        self.released = False
+
+    def __enter__(self) -> 'FakeDesk':
+        return self
+
+    def __exit__(self, *exc_info) -> bool:
+        self.released = True
+        return False
+
+    def prepare(self) -> None:
+        self.prepared = True
+
+
+class StopFlag(pimm.SignalReceiver[bool]):
+    """``should_stop`` under the test's control."""
+
+    def __init__(self):
+        self.stopped = False
+
+    def read(self) -> pimm.Message[bool]:
+        return pimm.Message(self.stopped)
+
+
+@pytest.fixture
+def desk(monkeypatch) -> FakeDesk:
+    monkeypatch.setenv('FRANKA_DESK_USER', 'user')
+    monkeypatch.setenv('FRANKA_DESK_PASSWORD', 'password')
+    session = FakeDesk()
+    monkeypatch.setattr(franka, 'Desk', lambda *credentials: session)
+    return session
+
+
+def _driver(arm: FakeArm, *, variation: list[float] | None = None, **kwargs) -> franka.Robot:
+    robot = franka.Robot('192.0.2.1', home_joints=list(HOME), home_joints_variation=variation or [0.0] * 7, **kwargs)
+    robot._robot = arm  # _ensure_robot hands back an already-set handle, which is how the fake arm gets in
+    return robot
+
+
+def test_park_drives_the_arm_to_the_home_pose():
+    arm = FakeArm(JOGGED)
+
+    _driver(arm, manage_desk=False)._park(arm)
+
+    np.testing.assert_allclose(arm.targets, [HOME])
+    np.testing.assert_allclose(arm.q, HOME)
+
+
+def test_park_leaves_an_arm_within_the_homing_spread_alone():
+    variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
+    arm = FakeArm(HOME + np.asarray(variation))
+
+    _driver(arm, variation=variation, manage_desk=False)._park(arm)
+
+    assert arm.targets == []
+
+
+def test_park_gives_up_when_the_goal_stops_advancing():
+    arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)
+
+    _driver(arm, manage_desk=False)._park(arm)
+
+    assert arm.calls.count('goal') == 1
+    np.testing.assert_allclose(arm.q, JOGGED)
+
+
+def test_park_gives_up_when_the_arm_does_not_arrive_in_time(monkeypatch):
+    monkeypatch.setattr(franka, '_PARK_TIMEOUT_S', 0.05)
+    arm = FakeArm(JOGGED, polls_to_reach=10**9)
+
+    started = time.monotonic()
+    _driver(arm, manage_desk=False)._park(arm)
+    elapsed = time.monotonic() - started
+
+    assert 0.05 <= elapsed < 2.0
+    assert arm.calls.count('goal') > 1
+    np.testing.assert_allclose(arm.q, JOGGED)
+
+
+def test_park_swallows_a_robot_that_fails_mid_move():
+    arm = FakeArm(JOGGED)
+    arm.raises = RuntimeError('libfranka: connection lost')
+
+    _driver(arm, manage_desk=False)._park(arm)
+
+    np.testing.assert_allclose(arm.q, JOGGED)
+
+
+def test_teardown_parks_the_arm_before_stopping_control(desk):
+    arm = FakeArm(HOME)
+    stop = StopFlag()
+    loop = _driver(arm).run(stop, SystemClock())
+
+    for _ in range(3):
+        next(loop)
+    arm.q = JOGGED  # the operator jogs the arm, then finishes the run from there
+    mark = len(arm.calls)
+    stop.stopped = True
+    with pytest.raises(StopIteration):
+        next(loop)
+
+    teardown = arm.calls[mark:]
+    assert teardown.index('set_target_joints') < teardown.index('stop')
+    np.testing.assert_allclose(arm.targets[-1], HOME)
+    np.testing.assert_allclose(arm.q, HOME)
+    assert desk.prepared and desk.released
+
+
+def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
+    arm = FakeArm(HOME)
+    stop = StopFlag()
+    loop = _driver(arm).run(stop, SystemClock())
+
+    for _ in range(3):
+        next(loop)
+    arm.q = JOGGED
+    arm.raises = RuntimeError('libfranka: connection lost')
+    mark = len(arm.calls)
+    stop.stopped = True
+    with pytest.raises(StopIteration):
+        next(loop)
+
+    assert arm.calls[mark:] == ['state', 'stop']  # the park was attempted and its failure went no further
+    assert desk.released

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -1,5 +1,6 @@
 import time
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 import numpy as np
@@ -13,9 +14,22 @@ HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
 
+class Call(StrEnum):
+    """The vendor calls ``FakeArm`` records, named once for the fake and its assertions alike."""
+
+    STATE = 'state'
+    GOAL = 'goal'
+    SET_TARGET_JOINTS = 'set_target_joints'
+    RECOVER_FROM_ERRORS = 'recover_from_errors'
+    STOP = 'stop'
+    SET_COLLISION_BEHAVIOR = 'set_collision_behavior'
+    SET_CONTROL_MODE = 'set_control_mode'
+    SET_LOAD = 'set_load'
+
+
 @dataclass
 class _Goal:
-    status: object
+    status: franka.pf.GoalStatus
     reason: str | None
 
 
@@ -36,9 +50,9 @@ class FakeArm:
     set, is what every call but ``stop`` raises.
     """
 
-    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: object | None = None):
+    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: 'franka.pf.GoalStatus | None' = None):
         self.q = np.asarray(q, dtype=np.float64)
-        self.calls: list[str] = []
+        self.calls: list[Call] = []
         self.targets: list[np.ndarray] = []
         self.raises: Exception | None = None
         self.raises_once: Exception | None = None
@@ -46,7 +60,7 @@ class FakeArm:
         self._polls = 0
         self._goal_status = goal_status
 
-    def _record(self, call: str) -> None:
+    def _record(self, call: Call) -> None:
         self.calls.append(call)
         if self.raises_once is not None:
             once, self.raises_once = self.raises_once, None
@@ -55,11 +69,11 @@ class FakeArm:
             raise self.raises
 
     def state(self) -> _ArmState:
-        self._record('state')
+        self._record(Call.STATE)
         return _ArmState(self.q.copy(), np.zeros(7), np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]), np.zeros(6), 0, '')
 
     def goal(self) -> _Goal:
-        self._record('goal')
+        self._record(Call.GOAL)
         self._polls += 1
         if self._goal_status is not None:
             return _Goal(self._goal_status, 'scripted')
@@ -69,27 +83,27 @@ class FakeArm:
         return _Goal(franka.pf.GoalStatus.IN_FLIGHT, None)
 
     def set_target_joints(self, target) -> None:
-        self._record('set_target_joints')
+        self._record(Call.SET_TARGET_JOINTS)
         self.targets.append(np.asarray(target, dtype=np.float64))
         self._polls = 0
 
     def recover_from_errors(self) -> None:
-        self._record('recover_from_errors')
+        self._record(Call.RECOVER_FROM_ERRORS)
 
     def stop(self) -> None:
-        self.calls.append('stop')
+        self.calls.append(Call.STOP)
 
     def get_robot_model(self) -> str:
         return (Path(franka.__file__).parent / 'fr3.urdf').read_text()
 
     def set_collision_behavior(self, **thresholds) -> None:
-        self._record('set_collision_behavior')
+        self._record(Call.SET_COLLISION_BEHAVIOR)
 
     def set_control_mode(self, mode) -> None:
-        self._record('set_control_mode')
+        self._record(Call.SET_CONTROL_MODE)
 
     def set_load(self, *load) -> None:
-        self._record('set_load')
+        self._record(Call.SET_LOAD)
 
 
 class FakeDesk:
@@ -161,7 +175,7 @@ def test_park_gives_up_when_the_goal_stops_advancing():
 
     _driver(arm, manage_desk=False)._park(arm)
 
-    assert arm.calls.count('goal') == 1
+    assert arm.calls.count(Call.GOAL) == 1
     np.testing.assert_allclose(arm.q, JOGGED)
 
 
@@ -173,7 +187,7 @@ def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
     elapsed = time.monotonic() - started
 
     assert 0.05 <= elapsed < 2.0
-    assert arm.calls.count('goal') > 1
+    assert arm.calls.count(Call.GOAL) > 1
     np.testing.assert_allclose(arm.q, JOGGED)
 
 
@@ -200,7 +214,7 @@ def test_teardown_parks_the_arm_before_stopping_control(desk):
         next(loop)
 
     teardown = arm.calls[mark:]
-    assert teardown.index('set_target_joints') < teardown.index('stop')
+    assert teardown.index(Call.SET_TARGET_JOINTS) < teardown.index(Call.STOP)
     np.testing.assert_allclose(arm.targets[-1], HOME)
     np.testing.assert_allclose(arm.q, HOME)
     assert desk.prepared and desk.released
@@ -221,7 +235,7 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
         next(loop)
 
     # the park was attempted, and its failure went no further
-    assert arm.calls[mark:] == ['recover_from_errors', 'stop']
+    assert arm.calls[mark:] == [Call.RECOVER_FROM_ERRORS, Call.STOP]
     assert desk.released
 
 
@@ -238,6 +252,6 @@ def test_a_control_fault_stops_the_arm_without_parking_it(desk):
     with pytest.raises(RuntimeError):
         next(loop)
 
-    assert 'set_target_joints' not in arm.calls[mark:]  # a fault is not answered with autonomous motion
-    assert arm.calls[-1] == 'stop'
+    assert Call.SET_TARGET_JOINTS not in arm.calls[mark:]  # a fault is not answered with autonomous motion
+    assert arm.calls[-1] == Call.STOP
     assert desk.released

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -36,9 +36,8 @@ class FakeArm:
     set, is what every call but ``stop`` raises.
     """
 
-    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: object | None = None, dq=None):
+    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: object | None = None):
         self.q = np.asarray(q, dtype=np.float64)
-        self.dq = np.zeros(7) if dq is None else np.asarray(dq, dtype=np.float64)
         self.calls: list[str] = []
         self.targets: list[np.ndarray] = []
         self.raises: Exception | None = None
@@ -57,9 +56,7 @@ class FakeArm:
 
     def state(self) -> _ArmState:
         self._record('state')
-        return _ArmState(
-            self.q.copy(), self.dq.copy(), np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]), np.zeros(6), 0, ''
-        )
+        return _ArmState(self.q.copy(), np.zeros(7), np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]), np.zeros(6), 0, '')
 
     def goal(self) -> _Goal:
         self._record('goal')
@@ -147,22 +144,16 @@ def test_park_drives_the_arm_to_the_home_pose():
     np.testing.assert_allclose(arm.q, HOME)
 
 
-def test_park_leaves_an_arm_within_the_homing_spread_alone():
+def test_park_commands_the_exact_home_pose_from_inside_the_homing_spread():
     variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
     arm = FakeArm(HOME + np.asarray(variation))
 
     _driver(arm, variation=variation, manage_desk=False)._park(arm)
 
-    assert arm.targets == []
-
-
-def test_park_commands_home_for_an_arm_passing_through_the_spread():
-    variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
-    arm = FakeArm(HOME + np.asarray(variation), dq=[0.4] + [0.0] * 6)
-
-    _driver(arm, variation=variation, manage_desk=False)._park(arm)
-
+    # An arm inside the spread, or travelling through it, is not asked to be judged already home: the
+    # controller reports arrival, and a pose it already holds arrives at once.
     np.testing.assert_allclose(arm.targets, [HOME])
+    np.testing.assert_allclose(arm.q, HOME)
 
 
 def test_park_gives_up_when_the_goal_stops_advancing():
@@ -229,7 +220,8 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
     with pytest.raises(StopIteration):
         next(loop)
 
-    assert arm.calls[mark:] == ['state', 'stop']  # the park was attempted and its failure went no further
+    # the park was attempted, and its failure went no further
+    assert arm.calls[mark:] == ['recover_from_errors', 'stop']
     assert desk.released
 
 

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -58,7 +58,7 @@ class FakeArm:
         self.raises_once: Exception | None = None
         self._polls_to_reach = polls_to_reach
         self._polls = 0
-        self._goal_status = goal_status
+        self.goal_status = goal_status
 
     def _record(self, call: Call) -> None:
         self.calls.append(call)
@@ -75,8 +75,8 @@ class FakeArm:
     def goal(self) -> _Goal:
         self._record(Call.GOAL)
         self._polls += 1
-        if self._goal_status is not None:
-            return _Goal(self._goal_status, 'scripted')
+        if self.goal_status is not None:
+            return _Goal(self.goal_status, 'scripted')
         if self._polls >= self._polls_to_reach:
             self.q = self.targets[-1].copy()
             return _Goal(franka.pf.GoalStatus.REACHED, None)
@@ -255,3 +255,20 @@ def test_a_control_fault_stops_the_arm_without_parking_it(desk):
     assert Call.SET_TARGET_JOINTS not in arm.calls[mark:]  # a fault is not answered with autonomous motion
     assert arm.calls[-1] == Call.STOP
     assert desk.released
+
+
+def test_a_stop_during_the_reset_ends_the_run_without_a_fault(desk):
+    """The event that ends the world also cancels the in-flight goal, so a poll taken after the stop
+    reports failure. Reading it would turn a clean shutdown into a control fault — which skips the park."""
+    arm = FakeArm(JOGGED, polls_to_reach=10**9)  # the opening reset never lands on its own
+    stop = StopFlag()
+    loop = _driver(arm).run(stop, SystemClock())
+
+    next(loop)  # suspended inside the reset's travel
+    stop.stopped = True
+    arm.goal_status = franka.pf.GoalStatus.ABORTED
+
+    with pytest.raises(StopIteration):
+        next(loop)
+
+    assert arm.calls[-1] == Call.STOP

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -15,7 +15,7 @@ JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
 
 class Call(StrEnum):
-    """The vendor calls ``FakeArm`` records, named once for the fake and its assertions alike."""
+    """The vendor calls ``FakeArm`` records."""
 
     STATE = 'state'
     GOAL = 'goal'

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -149,10 +149,16 @@ def _driver(arm: FakeArm, *, variation: list[float] | None = None, **kwargs) -> 
     return robot
 
 
+def _drive(loop) -> None:
+    """Pump a driver loop to exhaustion, honouring each yielded Sleep — what the world does to it."""
+    for command in loop:
+        time.sleep(command.seconds)
+
+
 def test_park_drives_the_arm_to_the_home_pose():
     arm = FakeArm(JOGGED)
 
-    _driver(arm, manage_desk=False)._park(arm)
+    _drive(_driver(arm, manage_desk=False)._park(arm))
 
     np.testing.assert_allclose(arm.targets, [HOME])
     np.testing.assert_allclose(arm.q, HOME)
@@ -162,7 +168,7 @@ def test_park_commands_the_exact_home_pose_from_inside_the_homing_spread():
     variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
     arm = FakeArm(HOME + np.asarray(variation))
 
-    _driver(arm, variation=variation, manage_desk=False)._park(arm)
+    _drive(_driver(arm, variation=variation, manage_desk=False)._park(arm))
 
     # An arm inside the spread, or travelling through it, is not asked to be judged already home: the
     # controller reports arrival, and a pose it already holds arrives at once.
@@ -170,10 +176,19 @@ def test_park_commands_the_exact_home_pose_from_inside_the_homing_spread():
     np.testing.assert_allclose(arm.q, HOME)
 
 
+def test_the_park_waits_by_yielding_rather_than_blocking():
+    """A driver's waits are the world's to honour, teardown included: the park asks for them with Sleep."""
+    arm = FakeArm(JOGGED, polls_to_reach=3)
+
+    commands = list(_driver(arm, manage_desk=False)._park(arm))
+
+    assert commands and all(isinstance(command, pimm.Sleep) for command in commands)
+
+
 def test_park_gives_up_when_the_goal_stops_advancing():
     arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)
 
-    _driver(arm, manage_desk=False)._park(arm)
+    _drive(_driver(arm, manage_desk=False)._park(arm))
 
     assert arm.calls.count(Call.GOAL) == 1
     np.testing.assert_allclose(arm.q, JOGGED)
@@ -183,7 +198,7 @@ def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
     arm = FakeArm(JOGGED, polls_to_reach=10**9)
 
     started = time.monotonic()
-    _driver(arm, manage_desk=False, park_timeout_s=0.05)._park(arm)
+    _drive(_driver(arm, manage_desk=False, park_timeout_s=0.05)._park(arm))
     elapsed = time.monotonic() - started
 
     assert 0.05 <= elapsed < 2.0
@@ -195,7 +210,7 @@ def test_park_swallows_a_robot_that_fails_mid_move():
     arm = FakeArm(JOGGED)
     arm.raises = RuntimeError('libfranka: connection lost')
 
-    _driver(arm, manage_desk=False)._park(arm)
+    _drive(_driver(arm, manage_desk=False)._park(arm))
 
     np.testing.assert_allclose(arm.q, JOGGED)
 
@@ -210,8 +225,7 @@ def test_teardown_parks_the_arm_before_stopping_control(desk):
     arm.q = JOGGED  # the operator jogs the arm, then finishes the run from there
     mark = len(arm.calls)
     stop.stopped = True
-    with pytest.raises(StopIteration):
-        next(loop)
+    _drive(loop)
 
     teardown = arm.calls[mark:]
     assert teardown.index(Call.SET_TARGET_JOINTS) < teardown.index(Call.STOP)
@@ -231,8 +245,7 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
     arm.raises = RuntimeError('libfranka: connection lost')
     mark = len(arm.calls)
     stop.stopped = True
-    with pytest.raises(StopIteration):
-        next(loop)
+    _drive(loop)
 
     # the park was attempted, and its failure went no further
     assert arm.calls[mark:] == [Call.RECOVER_FROM_ERRORS, Call.STOP]
@@ -250,7 +263,7 @@ def test_a_control_fault_stops_the_arm_without_parking_it(desk):
     arm.raises_once = RuntimeError('libfranka: connection lost')  # the fault, not a dead arm — a park could move it
     mark = len(arm.calls)
     with pytest.raises(RuntimeError):
-        next(loop)
+        _drive(loop)
 
     assert Call.SET_TARGET_JOINTS not in arm.calls[mark:]  # a fault is not answered with autonomous motion
     assert arm.calls[-1] == Call.STOP
@@ -268,7 +281,6 @@ def test_a_stop_during_the_reset_ends_the_run_without_a_fault(desk):
     stop.stopped = True
     arm.goal_status = franka.pf.GoalStatus.ABORTED
 
-    with pytest.raises(StopIteration):
-        next(loop)
+    _drive(loop)
 
     assert arm.calls[-1] == Call.STOP

--- a/positronic/drivers/tests/test_no_blocking_sleep.py
+++ b/positronic/drivers/tests/test_no_blocking_sleep.py
@@ -1,0 +1,58 @@
+"""A driver waits by yielding, so no driver module blocks in the sleep of a system library."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+DRIVERS = Path(__file__).resolve().parent.parent
+WAIVER = '# blocking-sleep-ok:'
+BLOCKING = {('time', 'sleep')}
+
+
+def _main_guard_lines(tree: ast.Module) -> set[int]:
+    """Every line under an ``if __name__ == '__main__':`` block: there the module IS the runner."""
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = ast.unparse(node.test)
+        if '__main__' in test and '__name__' in test:
+            for body in node.body:
+                lines.update(range(body.lineno, (body.end_lineno or body.lineno) + 1))
+    return lines
+
+
+def _blocking_calls(path: Path) -> list[int]:
+    source = path.read_text()
+    tree = ast.parse(source)
+    exempt = _main_guard_lines(tree)
+    waived = {n for n, line in enumerate(source.splitlines(), 1) if WAIVER in line}
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if not isinstance(node.func.value, ast.Name):
+            continue
+        if (node.func.value.id, node.func.attr) not in BLOCKING:
+            continue
+        # A waiver reads on the call's own line or the line above it, where a comment naturally sits.
+        if node.lineno in exempt or waived & {node.lineno, node.lineno - 1}:
+            continue
+        found.append(node.lineno)
+    return found
+
+
+# A test that drives a control loop IS a runner, so it sleeps like one.
+MODULES = sorted(p for p in DRIVERS.rglob('*.py') if 'tests' not in p.parts)
+
+
+@pytest.mark.parametrize('path', MODULES, ids=lambda p: str(p.relative_to(DRIVERS)))
+def test_a_driver_does_not_block_in_a_system_sleep(path: Path):
+    """`yield pimm.Sleep(secs)` hands the wait to the runner, which advances the other control
+    systems meanwhile; `time.sleep` takes the wait and stalls them. Exempt: a module's own
+    `__main__` demo, which IS a runner, and a line carrying `# blocking-sleep-ok: <reason>`."""
+    assert _blocking_calls(path) == [], (
+        f'{path.relative_to(DRIVERS)} blocks in time.sleep at these lines; yield pimm.Sleep(secs) '
+        f'instead, or mark the line "{WAIVER} <reason>" if this code is the runner'
+    )


### PR DESCRIPTION
Homing is a harness behaviour: `Harness._home` emits `embodiment.home` on the robot command
channel, which the driver resolves to `_reset`. It fires before the first episode and at each
episode end. The world-end path never homes, so a run finished from an arbitrary pose — after an
operator jog, say — leaves the arm there and the brakes park it wherever it stands. At that
moment the command path is gone: the harness has returned, nothing emits, and `_reset` returns on
its first line because the stop signal is set.

`Robot._park` closes the gap in the driver, where the hardware knowledge is. It runs after the
control loop returns, before `robot.stop()`: one error recovery, a move to `home_joints`, and a
poll for arrival under `park_timeout_s` (10 s by default). Every failure — a stalled goal, the
cap, any exception — logs and returns, so `robot.stop()` and the Desk control release run
unconditionally.

Arrival is the controller's to report: a commanded goal reads REACHED, and a pose the arm already
holds reads it at once, so there is no separate at-home test to keep in step with the homing
spread. Homing and parking are otherwise the same motion and share it — `_travel` commands the
target and yields once per poll, raising if the goal stops advancing, while the caller decides
what a poll costs and when to give up. The running loop pays a rate-limited tick and watches the
stop signal; teardown pays a short sleep and watches a deadline. They differ only in what a
shutdown pose needs: the exact `home_joints` rather than home-plus-variation, failures swallowed
rather than raised.

**Only a stop request earns the park.** It sits after the loop rather than in the `finally`, so a
fault in setup, in `_reset` or in command handling stops and releases the arm where it stands:
answering a failure with a recovery and a fresh joint target would be autonomous motion in
response to something going wrong. A peer control system crashing sets the same stop signal, so
the arm parks then too — it is healthy, a human is attending, and home beats wherever a failing
camera driver left it.

**Pose source.** No new config: `Command.home` on the robot channel is `roboarm_command.Reset()`,
which the driver resolves to its own `home_joints`. The driver already owns that pose, so the park
reads it rather than introducing a `park_pose` to keep equal to it.

**Teardown budget.** `World.__exit__` joins background processes with one timeout, sized for brake
engagement ("tens of seconds") alone. The park adds up to `park_timeout_s` ahead of it, and the sum
can exceed 60 s — at which point SIGTERM lands mid-travel, which is what the park exists to
prevent. Raised to 90 s. The two numbers stay coordinated by the comment naming the relationship
rather than through the control-system interface.

Scope is Franka. The MuJoCo sim needs no park (no brakes, virtual clock) and YAM keeps its
zero-torque teardown.

**Tests.** Eight, where the driver had none. Five cover the park directly (drives a jogged arm
home; commands the exact home pose from inside the homing spread; gives up on a stalled goal;
honours the cap; swallows a robot that fails mid-move). Three drive the whole `run()` generator
against a fake arm, jogging it mid-run: the park precedes `robot.stop()` and lands on the exact
home pose; a park failure still reaches `robot.stop()` and the Desk release; a control fault
reaches both without commanding any motion. A sibling `conftest.py` stubs `positronic_franka` when
absent — it builds against libfranka and ships only in the `hardware` extra, so without it these
tests would skip rather than run.

**Pending:** rig verification — a finish from a jogged pose, and the real park-plus-brake wall time
against the 90 s join — on the next attended round.

Spec: Positronic-Robotics/internal#340. Decision record: Positronic-Robotics/internal#338 (D1/D3).

<!-- opened-by: posi-agent -->