### PR TITLE
Serve a Nebius endpoint on its private IP, and read its address from the endpoint

### DIFF
--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -204,7 +204,9 @@ flow to your account directly via the API key — they aren't synced to S3.
 `serve.sh` creates a [Nebius Serverless Endpoint](https://docs.nebius.com/serverless/endpoints/manage)
 running `python -m positronic.vendors.<vendor>.server` on H100, with a public static IP on
 port 8000. Endpoints don't have managed DNS yet, so the IP is the contact address — it's stable
-across endpoint stop/start, but new endpoints get new IPs. Supported vendors:
+across endpoint stop/start, but new endpoints get new IPs. A consumer inside the cloud on the
+same subnet needs no public IP: `NEBIUS_PUBLIC=0` serves the endpoint on its private address
+instead, which also leaves the project's public-IP quota alone. Supported vendors:
 `lerobot_0_3_3`, `lerobot`, `openpi`, `gr00t`.
 
 Take a vendor and a unique endpoint name as the first two arguments; remaining arguments forward
@@ -239,8 +241,8 @@ bash workflows/nebius/serve.sh gr00t groot-server ee_rot6d_rel \
   --pipeline.source.checkpoints_dir=s3://<your-bucket>/checkpoints/groot/<exp_name>/
 ```
 
-`serve.sh` blocks until the public IP is allocated (typically <1 min), then prints a banner with
-the URL, endpoint ID, and the commands to follow logs and tear down. The container takes another
+`serve.sh` blocks until the endpoint reports its address (typically <1 min), then prints a banner
+with the URL, endpoint ID, and the commands to follow logs and tear down. The container takes another
 ~10–15 min to finish `uv sync` and load the model into GPU memory; once `INFO Started server
 process` appears in `nebius ai endpoint logs`, sanity-check with:
 
@@ -259,7 +261,7 @@ uv run positronic-inference sim \
   --output_dir=.data/inference/<run-name>/
 ```
 
-When you're done, `stop.sh` deletes the endpoint and releases the public IP:
+When you're done, `stop.sh` deletes the endpoint and releases its address:
 
 ```bash
 bash workflows/nebius/stop.sh my-act-demo
@@ -329,6 +331,7 @@ override them** with their own project + subnet IDs:
 |---|---|---|
 | `NEBIUS_PARENT_ID` | `project-e00f38wexevrr52b8j` | Nebius project to create the job/endpoint in |
 | `NEBIUS_SUBNET_ID` | `vpcsubnet-e00pk1j1x6hjmr4m92` | VPC subnet for the compute instance |
+| `NEBIUS_PUBLIC` | `1` | *(`serve.sh` only)* Whether the endpoint gets a public IP. `NEBIUS_PUBLIC=0` creates it without one and reports its private `host:port`, for a consumer inside the cloud on the same subnet. A `--public` create with no public-IP quota left does not fail — it waits for an allocation that never arrives and the endpoint stays in `PROVISIONING`. |
 | `WANDB_SECRET` | `positronic-serverless-wandb-api-key` | MysteryBox secret name for the WandB key. Set empty (`WANDB_SECRET=`) to skip wandb entirely. |
 | `NEBIUS_CACHE_FS` | `computefilesystem-e00f6jyfr5wkawyrab` | Shared filesystem **ID** (not name — `--volume` rejects names) mounted RW at `/cache` for the `uv`/HF/openpi caches (`UV_CACHE_DIR`, `HF_HOME`, `OPENPI_DATA_HOME`). Not used by pos3. The default is Positronic-internal; external users must override with their own filesystem ID. |
 | `NEBIUS_IMAGE_REPO` | `positro/robolab` | *(`eval.sh` only)* Image repository the RoboLab eval job pulls, without the tag. Defaults to the Docker Hub `positro/robolab`; set it to an in-region Nebius Container Registry path (`cr.<region>.nebius.cloud/<registry-id>/robolab`) to skip the cross-cloud Docker Hub pull. `<registry-id>` is the Container Registry ID **without** the `registry-` prefix (from `nebius registry list`) — NOT the project ID. Combined with `NEBIUS_IMAGE_TAG` as `${NEBIUS_IMAGE_REPO}:${NEBIUS_IMAGE_TAG}`. |

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -87,6 +87,13 @@ esac
 
 SERVER_ARGS="run --python 3.13 ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
 
+# A public IP is only needed by a consumer outside the cloud. The project's public-IP quota is small and
+# permanently occupied by the long-lived instances, and a --public create against a full quota waits for an
+# allocation that never comes — the endpoint sits in PROVISIONING with no error. An in-cloud consumer on the
+# same subnet reaches the endpoint on its private IP, so set NEBIUS_PUBLIC=0 there.
+PUBLIC_FLAG=(--public)
+[ "${NEBIUS_PUBLIC:-1}" = "0" ] && PUBLIC_FLAG=()
+
 echo "Creating $VENDOR endpoint '$NAME'..."
 nebius ai endpoint create \
   --parent-id "$PARENT_ID" \
@@ -107,7 +114,7 @@ nebius ai endpoint create \
   --env-secret AWS_SECRET_ACCESS_KEY=positronic-serverless-aws-secret-access-key \
   --env AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud:443 \
   --env AWS_DEFAULT_REGION=eu-north1 \
-  --public >/dev/null
+  "${PUBLIC_FLAG[@]}" >/dev/null
 
 ID=$(nebius ai endpoint list --parent-id "$PARENT_ID" --format json \
   | jq -r --arg n "$NAME" '.items[]? | select(.metadata.name==$n) | .metadata.id')
@@ -118,18 +125,29 @@ if [ -z "$ID" ]; then
 fi
 
 echo "Endpoint ID: $ID"
-echo "Waiting for public IP (typically <1 min)..."
 
 IP=""
-for i in $(seq 1 30); do
-  IP=$(nebius ai endpoint get "$ID" --format json 2>/dev/null \
-    | jq -r '.status.public_endpoints[0]? // empty')
-  if [ -n "$IP" ]; then break; fi
-  sleep 10
-done
+if [ "${NEBIUS_PUBLIC:-1}" = "0" ]; then
+  echo "Waiting for private IP (typically <1 min)..."
+  for i in $(seq 1 30); do
+    IP=$(nebius vpc allocation list --parent-id "$PARENT_ID" --format json 2>/dev/null \
+      | jq -r --arg n "${ID}-private" '.items[]? | select(.metadata.name==$n)
+               | .status.details.allocated_cidr? // empty' | cut -d/ -f1)
+    if [ -n "$IP" ]; then break; fi
+    sleep 10
+  done
+else
+  echo "Waiting for public IP (typically <1 min)..."
+  for i in $(seq 1 30); do
+    IP=$(nebius ai endpoint get "$ID" --format json 2>/dev/null \
+      | jq -r '.status.public_endpoints[0]? // empty')
+    if [ -n "$IP" ]; then break; fi
+    sleep 10
+  done
+fi
 
 if [ -z "$IP" ]; then
-  echo "Public IP not allocated within 5 min. Check: nebius ai endpoint get $ID" >&2
+  echo "IP not allocated within 5 min. Check: nebius ai endpoint get $ID" >&2
   exit 1
 fi
 

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -23,10 +23,9 @@ IMAGE_TAG="${NEBIUS_IMAGE_TAG:-latest}"
 # Nebius GPU preset. Default is one H100; multi-GPU presets must match the server's GPU count
 # (DreamZero's --num_gpus runs torchrun --nproc_per_node, so an 8-GPU server needs an 8-GPU preset).
 PRESET="${NEBIUS_PRESET:-1gpu-16vcpu-200gb}"
-# A public IP is only needed by a consumer outside the cloud. The project's public-IP quota is small and
-# permanently occupied by the long-lived instances, and a --public create against a full quota waits for an
-# allocation that never comes — the endpoint sits in PROVISIONING with no error. An in-cloud consumer on the
-# same subnet reaches the endpoint on its private IP, so set NEBIUS_PUBLIC=0 there.
+# A public IP is only needed by a consumer outside the cloud; one on the same subnet reaches the endpoint on
+# its private IP. A --public create with no public-IP quota left does not fail — it waits for an allocation
+# that never arrives and the endpoint stays in PROVISIONING, so set NEBIUS_PUBLIC=0 for an in-cloud consumer.
 PUBLIC="${NEBIUS_PUBLIC:-1}"
 
 if [ $# -lt 2 ]; then

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -126,10 +126,14 @@ fi
 
 echo "Endpoint ID: $ID"
 
+# The two fields carry different shapes: a private address is bare `host:port`, a public one is a full
+# tunnel URL with its own scheme. Prefixing a scheme unconditionally corrupts the public form.
 if [ "${NEBIUS_PUBLIC:-1}" = "0" ]; then
   FIELD=private_endpoints
+  SCHEME=http://
 else
   FIELD=public_endpoints
+  SCHEME=
 fi
 
 echo "Waiting for the $FIELD address (typically <1 min)..."
@@ -146,12 +150,7 @@ if [ -z "$ADDRESS" ]; then
   exit 1
 fi
 
-# The two fields carry different shapes: a private address is bare `host:port`, a public one is a
-# full tunnel URL with its own scheme. Prefixing a scheme unconditionally corrupts the public form.
-case "$ADDRESS" in
-  http://*|https://*) URL="$ADDRESS" ;;
-  *)                  URL="http://$ADDRESS" ;;
-esac
+URL="$SCHEME$ADDRESS"
 
 cat <<BANNER
 

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Submit a Nebius Serverless Endpoint running a vendor inference server.
 #
-# After creation, polls until a public IP is allocated and prints connection
+# After creation, polls until the endpoint reports an address and prints connection
 # details. The container itself takes ~10-15 min more to finish uv sync and
-# load the model into GPU memory after the IP appears.
+# load the model into GPU memory after the address appears.
 #
 # Hardcoded: GPU platform, MysteryBox secret names, S3 endpoint URL,
 # container port. Vendor selects image + uv extra. Override-able via env:
-# NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID.
+# NEBIUS_PARENT_ID, NEBIUS_SUBNET_ID, NEBIUS_PUBLIC.
 
 set -euo pipefail
 
@@ -126,35 +126,37 @@ fi
 
 echo "Endpoint ID: $ID"
 
-IP=""
 if [ "${NEBIUS_PUBLIC:-1}" = "0" ]; then
-  echo "Waiting for private IP (typically <1 min)..."
-  for i in $(seq 1 30); do
-    IP=$(nebius vpc allocation list --parent-id "$PARENT_ID" --format json 2>/dev/null \
-      | jq -r --arg n "${ID}-private" '.items[]? | select(.metadata.name==$n)
-               | .status.details.allocated_cidr? // empty' | cut -d/ -f1)
-    if [ -n "$IP" ]; then break; fi
-    sleep 10
-  done
+  FIELD=private_endpoints
 else
-  echo "Waiting for public IP (typically <1 min)..."
-  for i in $(seq 1 30); do
-    IP=$(nebius ai endpoint get "$ID" --format json 2>/dev/null \
-      | jq -r '.status.public_endpoints[0]? // empty')
-    if [ -n "$IP" ]; then break; fi
-    sleep 10
-  done
+  FIELD=public_endpoints
 fi
 
-if [ -z "$IP" ]; then
-  echo "IP not allocated within 5 min. Check: nebius ai endpoint get $ID" >&2
+echo "Waiting for the $FIELD address (typically <1 min)..."
+ADDRESS=""
+for i in $(seq 1 30); do
+  ADDRESS=$(nebius ai endpoint get "$ID" --format json 2>/dev/null \
+    | jq -r --arg f "$FIELD" '.status[$f][0]? // empty')
+  if [ -n "$ADDRESS" ]; then break; fi
+  sleep 10
+done
+
+if [ -z "$ADDRESS" ]; then
+  echo "No $FIELD address within 5 min. Check: nebius ai endpoint get $ID" >&2
   exit 1
 fi
+
+# The two fields carry different shapes: a private address is bare `host:port`, a public one is a
+# full tunnel URL with its own scheme. Prefixing a scheme unconditionally corrupts the public form.
+case "$ADDRESS" in
+  http://*|https://*) URL="$ADDRESS" ;;
+  *)                  URL="http://$ADDRESS" ;;
+esac
 
 cat <<BANNER
 
 ==============================================================
-  Endpoint URL:  http://$IP
+  Endpoint URL:  $URL
   Endpoint ID:   $ID
   Endpoint name: $NAME
   Vendor:        $VENDOR
@@ -167,9 +169,9 @@ The container is still warming up (image pull + uv sync + checkpoint load,
 
 Once the model is loaded, sanity-check with:
 
-  curl http://$IP/api/v1/models
+  curl $URL/api/v1/models
 
-To release the endpoint and its public IP:
+To release the endpoint and its address:
 
   bash workflows/nebius/stop.sh $NAME
 

--- a/workflows/nebius/serve.sh
+++ b/workflows/nebius/serve.sh
@@ -23,6 +23,11 @@ IMAGE_TAG="${NEBIUS_IMAGE_TAG:-latest}"
 # Nebius GPU preset. Default is one H100; multi-GPU presets must match the server's GPU count
 # (DreamZero's --num_gpus runs torchrun --nproc_per_node, so an 8-GPU server needs an 8-GPU preset).
 PRESET="${NEBIUS_PRESET:-1gpu-16vcpu-200gb}"
+# A public IP is only needed by a consumer outside the cloud. The project's public-IP quota is small and
+# permanently occupied by the long-lived instances, and a --public create against a full quota waits for an
+# allocation that never comes — the endpoint sits in PROVISIONING with no error. An in-cloud consumer on the
+# same subnet reaches the endpoint on its private IP, so set NEBIUS_PUBLIC=0 there.
+PUBLIC="${NEBIUS_PUBLIC:-1}"
 
 if [ $# -lt 2 ]; then
   cat >&2 <<'EOF'
@@ -87,12 +92,8 @@ esac
 
 SERVER_ARGS="run --python 3.13 ${EXTRA}python -m positronic.vendors.${VENDOR}.server $*"
 
-# A public IP is only needed by a consumer outside the cloud. The project's public-IP quota is small and
-# permanently occupied by the long-lived instances, and a --public create against a full quota waits for an
-# allocation that never comes — the endpoint sits in PROVISIONING with no error. An in-cloud consumer on the
-# same subnet reaches the endpoint on its private IP, so set NEBIUS_PUBLIC=0 there.
 PUBLIC_FLAG=(--public)
-[ "${NEBIUS_PUBLIC:-1}" = "0" ] && PUBLIC_FLAG=()
+[ "$PUBLIC" = "0" ] && PUBLIC_FLAG=()
 
 echo "Creating $VENDOR endpoint '$NAME'..."
 nebius ai endpoint create \
@@ -128,7 +129,7 @@ echo "Endpoint ID: $ID"
 
 # The two fields carry different shapes: a private address is bare `host:port`, a public one is a full
 # tunnel URL with its own scheme. Prefixing a scheme unconditionally corrupts the public form.
-if [ "${NEBIUS_PUBLIC:-1}" = "0" ]; then
+if [ "$PUBLIC" = "0" ]; then
   FIELD=private_endpoints
   SCHEME=http://
 else


### PR DESCRIPTION
## What

`workflows/nebius/serve.sh` gains `NEBIUS_PUBLIC=0`: the create omits `--public`, and the address wait reads `.status.private_endpoints[0]` instead of `.status.public_endpoints[0]`. Both are fields on the endpoint itself, so one poll serves either mode; the URL scheme follows the mode rather than the string, because a private address is a bare `host:port` while a public one is a full tunnel URL that already carries `https://`. `workflows/nebius/README.md` documents the knob.

## Why

A `--public` create against a spent public-IP quota does not fail — it waits for an allocation that never arrives, so the endpoint sits in `PROVISIONING` with no error reported anywhere, and the script's own wait exits 1 on an endpoint that will never get an address. That blocks serving two policies at once for a sim box that is inside the cloud on the same subnet and needs no public IP at all.

Raising the quota is the other way to unblock it, and it is worth doing separately — but it is a request to Nebius with its own cost, and it would not change the fact that an in-cloud consumer is asking for an address it cannot use. The knob defaults to `1`, so every existing caller keeps the public endpoint it has today.

The banner previously built `http://` + the public value, which already carried its own scheme. Deriving the scheme from `NEBIUS_PUBLIC` alongside the field name keeps the two shapes decided in one place.

## Verification

The private path was exercised on this project: the create succeeds without `--public` and the wait resolves the endpoint's private `host:port` within the first poll. `bash -n` clean. The commits after the first two are simplifications and documentation with no behaviour change — one source of truth for the mode, the scheme read off it, the comment cut to the constraint — and are syntax-checked only.

## Refs

No ticket; an infra fix taken from serving two policies to an in-cloud sim box.

<!-- opened-by: posi-agent -->