### PR TITLE
Run `check-rules` once after the polish pass in `address-review`

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: address-review
 description: Respond to GitHub PR review comments in one pass — fetch, triage (agree or disagree), fix the valid ones, commit, push, reply to all, and resolve only the threads you fixed (declines, defers, and discussion questions stay open for the human). Use when a PR has reviewer or bot (e.g. Codex) comments to address.
-allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(awk:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*), Edit, Write
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git remote:*), Bash(awk:*), Bash(gh api:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh run:*), Bash(uv run:*), Bash(bash .claude/skills/address-review/watch.sh:*), Edit, Write, Skill(check-rules), Task
 ---
 
 # Address Review Comments
@@ -128,6 +128,14 @@ comments checks from the `polish` skill (Steps 2 and 4 there) over it — explic
 including the structural-twins check. Fix what emerges before committing; fold those
 changes into the same commit and mention them in the relevant replies.
 
+**Then run `check-rules`, once.** After the polish pass above has settled, run the
+`check-rules` skill a single time over this pass's changes; skip it when the pass changed
+no code (a decline/defer/discuss-only round has nothing to check). One run, at this point:
+run it earlier and the polish fixes land behind it unchecked; run it every iteration and
+each round pays its one-agent-per-rule fan-out. Fix the violations it reports and fold the
+fixes into the same commit — without re-running it on them. A finding you judge wrong is a
+note in the Step 6 report, not a new waiver.
+
 ## Step 4: Verify, commit, push
 
 Re-run the Step 1 fetch right before committing and triage anything new. A comment that lands
@@ -222,6 +230,7 @@ and the human resolves when satisfied.
 
 Summarize:
 - a table of comment → verdict → fix (with commit SHA),
+- what `check-rules` found and you fixed (by rule id), plus any finding you judged wrong,
 - what was pushed,
 - which threads you resolved (fixes only) vs left open (declines / defers / discussion),
 - any follow-ups the user should track.

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -232,7 +232,9 @@ and the human resolves when satisfied.
 
 Summarize:
 - a table of comment → verdict → fix (with commit SHA),
-- what `check-rules` found and you fixed (by rule id), plus any finding you judged wrong,
+- what `check-rules` found and you fixed (by rule id), the waivers it honoured (with their
+  reasons — a rule silenced by a waiver must not read as one that passed), and any finding
+  you judged wrong,
 - what was pushed,
 - which threads you resolved (fixes only) vs left open (declines / defers / discussion),
 - any follow-ups the user should track.

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -133,8 +133,10 @@ changes into the same commit and mention them in the relevant replies.
 no code (a decline/defer/discuss-only round has nothing to check). One run, at this point:
 run it earlier and the polish fixes land behind it unchecked; run it every iteration and
 each round pays its one-agent-per-rule fan-out. Fix the violations it reports and fold the
-fixes into the same commit — without re-running it on them. A finding you judge wrong is a
-note in the Step 6 report, not a new waiver.
+fixes into the same commit — without re-running it on them. Those fixes, like any late
+arrivals folded in at Step 4, land behind the check: the single run bounds the pass's cost,
+and the reviewer's re-review of the pushed commit backstops what slips through. A finding
+you judge wrong is a note in the Step 6 report, not a new waiver.
 
 ## Step 4: Verify, commit, push
 


### PR DESCRIPTION
## Summary
- `address-review` Step 3 now runs the `check-rules` skill exactly once per pass, after the polish-style whole-file checks settle: not earlier (polish fixes would land unchecked behind it), not per iteration (each run pays the one-agent-per-rule fan-out), and not re-run on its own fixes. A pass that changed no code skips it.
- Violations it reports are fixed and folded into the pass's commit; a finding judged wrong becomes a note in the Step 6 report, not a new waiver. The Step 6 summary lists rule fixes by id.
- Frontmatter `allowed-tools` gains `Skill(check-rules)` and `Task`, so the per-rule agent fan-out doesn't stall the unattended watcher loop on a permission prompt — same rationale as the existing `watch.sh` allow rule.

## Test plan
Skill text only, no code changed. Exercised the next time `/address-review` runs a pass with code fixes.
