### PR TITLE
Enforce the vendor boundary: nothing outside vendors imports a vendor, and no vendor imports another

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1156,14 +1156,6 @@
         ],
         "./positronic/cfg/policy.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 26,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,6 +96,13 @@ a policy object plugged into *its* loop, the integration still separates that fr
 layer and serves it behind the env wire. Handing a Positronic policy to a foreign loop forfeits
 both invariants — the run produces no dataset, and execution is scheduled by code we don't control.
 
+Two import boundaries follow for `positronic/vendors/`, where the shims live, and a structural test
+(`positronic/tests/test_vendor_boundary.py`) enforces both. Nothing outside `positronic/vendors/`
+imports from it: core defines the contract and a vendor adapts to it, so an import the other way
+inverts the dependency and drags the vendor's optional extra into code that must work without it.
+And no vendor imports another: each shim answers to its own upstream, on its own pinned deps and
+often its own interpreter — a helper two of them need belongs in core.
+
 ## Derived decisions
 
 What the goals and principles force. Each is stated with what forces it —

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Run trained policies through the [inference script](positronic/inference.py):
 
 ```bash
 uv run --locked positronic-inference sim \
-    --policy=@positronic.cfg.policy.act_absolute \
+    --policy=@positronic.vendors.lerobot_0_3_3.policy.act_absolute \
     --policy.base.checkpoints_dir=~/checkpoints/lerobot/<run_id> \
     --eval.timeout=60 \
     --show_gui=True \

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -81,7 +81,7 @@ Load model directly on robot/simulator machine. Only ACT is supported locally (G
 
 ```bash
 uv run positronic-inference sim \
-  --policy=@positronic.cfg.policy.act_absolute \
+  --policy=@positronic.vendors.lerobot_0_3_3.policy.act_absolute \
   --policy.base.checkpoints_dir=~/checkpoints/lerobot/experiment_v1/ \
   --policy.base.checkpoint=10000
 ```

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -490,8 +490,8 @@ def calculate_units(episode: Episode) -> int:  # noqa: C901
     if episode[keys.TASK] in FIXED_ITEM_COUNTS:
         return FIXED_ITEM_COUNTS[episode[keys.TASK]]
 
-    if 'target_grip' in episode.signals:
-        grip_sig = episode.signals['target_grip']
+    if keys.TARGET_GRIP in episode.signals:
+        grip_sig = episode.signals[keys.TARGET_GRIP]
     elif keys.GRIP in episode.signals:
         grip_sig = episode.signals[keys.GRIP]
     else:

--- a/positronic/cfg/codecs.py
+++ b/positronic/cfg/codecs.py
@@ -86,7 +86,7 @@ def compose(
     return result
 
 
-@cfn.config(rotation_rep=None, tgt_ee_pose_key=keys.TARGET_EE_POSE, tgt_grip_key='target_grip')
+@cfn.config(rotation_rep=None, tgt_ee_pose_key=keys.TARGET_EE_POSE, tgt_grip_key=keys.TARGET_GRIP)
 def absolute_pos_action(rotation_rep: str | None, tgt_ee_pose_key: str, tgt_grip_key: str):
     """Absolute position action codec for ACT/OpenPI."""
     from positronic.policy.action import AbsolutePositionAction
@@ -116,7 +116,7 @@ traj_ee_action = absolute_pos_action.override(tgt_ee_pose_key=keys.EE_POSE, tgt_
 @cfn.config(
     solver='dls_limits',
     tgt_ee_pose_key=keys.TARGET_EE_POSE,
-    tgt_grip_key='target_grip',
+    tgt_grip_key=keys.TARGET_GRIP,
     current_q_key=keys.JOINTS,
     num_joints=7,
 )

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -124,7 +124,7 @@ old_to_new = Group(
         keys.EE_POSE: Concat('robot_position_translation', 'robot_position_quaternion'),
         keys.TASK: FromValue('Pick up the green cube and place it on the red cube.'),
         keys.GRIP: _flip_grip(keys.GRIP),
-        'target_grip': _flip_grip('target_grip'),
+        keys.TARGET_GRIP: _flip_grip(keys.TARGET_GRIP),
     }),
     Rename(**{
         keys.JOINTS: 'robot_joints',
@@ -146,7 +146,7 @@ sim_pnp = transform.override(
             Derive(
                 task=FromValue('Pick up objects from the red tote and place them in the green tote.'),
                 grip=_flip_grip(keys.GRIP),
-                target_grip=_flip_grip('target_grip'),
+                target_grip=_flip_grip(keys.TARGET_GRIP),
             ),
             Rename(**{keys.EXTERIOR_IMAGE: 'image.back_view'}),
             Identity(),

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -31,7 +31,7 @@ def droid(robot_arm, gripper, cameras):
     }
     commands = {
         keys.ROBOT_COMMAND: Command(robot_arm.commands, roboarm_command.Reset(), Serializers.robot_command),
-        'target_grip': Command(gripper.target_grip, 0.0, None),
+        keys.TARGET_GRIP: Command(gripper.target_grip, 0.0, None),
     }
     return Embodiment(
         descriptor='',
@@ -54,7 +54,7 @@ def yam(robot_arm, cameras):
     }
     commands = {
         keys.ROBOT_COMMAND: Command(robot_arm.commands, roboarm_command.Reset(), Serializers.robot_command),
-        'target_grip': Command(robot_arm.target_grip, 0.0, None),
+        keys.TARGET_GRIP: Command(robot_arm.target_grip, 0.0, None),
     }
     return Embodiment(
         descriptor='yam',
@@ -142,7 +142,7 @@ def mujoco_franka(sim, camera_dict):
     home = roboarm_command.JointPosition(np.array(sim.initial_ctrl[:7]))
     commands = {
         keys.ROBOT_COMMAND: Command(sim.commands, home, Serializers.robot_command),
-        'target_grip': Command(sim.target_grip, 0.0, None),
+        keys.TARGET_GRIP: Command(sim.target_grip, 0.0, None),
     }
     return Embodiment(
         descriptor='mujoco.franka',

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -1,16 +1,12 @@
 import os
 
 import configuronic as cfn
-import pos3
 
 from positronic import keys
-from positronic.cfg import codecs
 from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, bearer
-from positronic.policy import Codec, Policy, RemotePolicy, SampledPolicy
-from positronic.policy.sampler import Sampler
-from positronic.policy.spec import PolicySource, inline
-from positronic.policy.wrappers import ChunkedSchedule
-from positronic.utils import get_latest_checkpoint, nebius
+from positronic.policy import RemotePolicy, SampledPolicy
+from positronic.policy.sampler import BalancedSampler, Sampler
+from positronic.utils import nebius
 
 
 @cfn.config()
@@ -21,43 +17,10 @@ def placeholder():
     )
 
 
-@cfn.config(checkpoint=None)
-def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None = None, device=None):
-    from lerobot.policies.act.modeling_act import ACTPolicy
-
-    from positronic.vendors.lerobot_0_3_3.backbone import register_all
-    from positronic.vendors.lerobot_0_3_3.policy import LerobotPolicy
-
-    register_all()
-
-    checkpoints_dir = checkpoints_dir.rstrip('/') + '/checkpoints/'
-    if checkpoint is None:
-        checkpoint = get_latest_checkpoint(checkpoints_dir)
-    else:
-        checkpoint = str(checkpoint).strip('/')
-
-    fully_specified_checkpoint_dir = checkpoints_dir.rstrip('/') + '/' + checkpoint + '/pretrained_model/'
-    policy = ACTPolicy.from_pretrained(pos3.download(fully_specified_checkpoint_dir), strict=True)
-    if n_action_steps is not None:
-        policy.config.n_action_steps = n_action_steps
-
-    return LerobotPolicy(
-        policy, device, extra_meta={keys.TYPE: 'act', keys.CHECKPOINT_PATH: fully_specified_checkpoint_dir}
-    )
-
-
-@cfn.config(
-    base=act, codec=codecs.compose.override(obs=codecs.eepose_obs, action=codecs.absolute_pos_action, horizon=1.0)
-)
-def act_absolute(base: Policy, codec: Codec):
-    """ACT with the absolute-position codec, composed in-process."""
-    return inline(ChunkedSchedule() | codec | PolicySource(base))
-
-
 @cfn.config(weights=None)
 def sample(origins: list[cfn.Config], weights: list[float] | None):
     """One could use the following CLI:
-    --policy=.sample --policy.origins='[".act"]' --policy.origins.0.checkpoint_path=<yada-yada>
+    --policy=.sample --policy.origins='[".remote"]' --policy.origins.0.url=<yada-yada>
     """
     return SampledPolicy(*origins, weights=weights)
 
@@ -86,8 +49,6 @@ nebius_remote = cfn.Config(RemotePolicy, headers=nebius_bearer_headers)
 
 @cfn.config(balance=2)
 def balanced(balance: int):
-    from positronic.policy.sampler import BalancedSampler
-
     return BalancedSampler(balance=balance)
 
 

--- a/positronic/gui/web.py
+++ b/positronic/gui/web.py
@@ -281,7 +281,7 @@ class WebEvalUI(pimm.ControlSystem):
 
         @app.post('/grip')
         async def grip(body: _GripBody):
-            self.manual_command.emit({'target_grip': body.value}, clock.now_ns())
+            self.manual_command.emit({keys.TARGET_GRIP: body.value}, clock.now_ns())
 
         # The legacy asyncio `websockets` backend drains the transport from its reader and keepalive
         # coroutines concurrently with our send loop, tripping an assertion that kills the feed. The

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -14,6 +14,9 @@ ROBOT_COMMAND = 'robot_command'
 TARGET_EE_POSE = f'{ROBOT_COMMAND}.pose'
 TARGET_JOINTS = f'{ROBOT_COMMAND}.joints'
 
+# The gripper's command channel: a scalar target beside the arm's ``ROBOT_COMMAND``.
+TARGET_GRIP = 'target_grip'
+
 
 def is_robot_command(name: str) -> bool:
     """Whether ``name`` is in the robot-command family: ``robot_command``, or an arm's ``robot_command.{side}``.
@@ -30,6 +33,14 @@ GRIP = 'grip'
 TASK = 'task'
 WRIST_IMAGE = 'image.wrist'
 EXTERIOR_IMAGE = 'image.exterior'
+
+# The harness stamps each observation with the control clock's time (``OBS_TIME_NS``) and the wall
+# clock's (``WALL_TIME_NS``); recording timelines and action scheduling read time back off them.
+# ``ACTION_TIMESTAMP`` is where a decoded action carries its schedule slot, in seconds from the
+# observation it answers.
+OBS_TIME_NS = 'obs_time_ns'
+WALL_TIME_NS = 'wall_time_ns'
+ACTION_TIMESTAMP = 'timestamp'
 
 # The robot model, carried in episode statics for the transforms that solve against it (``IKJointsAction``).
 # ``CONTROL_FRAME`` names the frame in ``URDF`` that the embodiment reports ``EE_POSE`` in; every embodiment

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -218,7 +218,7 @@ class TestActionHorizonWrapping:
         wrapped = ActionHorizon(0.5).wrap(endpoint)
 
         session = wrapped.new_session()
-        actions = session({'obs_time_ns': 0})
+        actions = session({keys.OBS_TIME_NS: 0})
         assert actions is not None
         assert len(actions) == 3  # 2 within-horizon actions + horizon sentinel
         assert actions[0]['timestamp'] == 0.0
@@ -257,7 +257,7 @@ def test_records_infer_span_without_scheduling_wrapper(tmp_path):
     endpoint, _ = _mock_endpoint(infer_return=[{'a': 1, 'timestamp': 0.0}])
     session = endpoint.new_session()
     with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-infer-span'):
-        assert session({'obs_time_ns': 0}) is not None
+        assert session({keys.OBS_TIME_NS: 0}) is not None
     spans = list(telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS)))
     assert [s.name for s in spans] == [telemetry_keys.SPAN_POLICY_INFER]
 
@@ -276,7 +276,7 @@ def test_infer_span_excludes_client_side_image_preparation(tmp_path):
 
     with patch('positronic.policy.remote.encode_jpeg', side_effect=_stamp_encode):
         with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-infer-prep'):
-            session({'cam': _make_image(48, 64), 'obs_time_ns': 0})
+            session({'cam': _make_image(48, 64), keys.OBS_TIME_NS: 0})
 
     (span,) = telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS))
     assert span.name == telemetry_keys.SPAN_POLICY_INFER
@@ -292,7 +292,7 @@ def test_records_infer_span_when_inference_raises(tmp_path):
     session = endpoint.new_session()
     with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-infer-raise'):
         with pytest.raises(TimeoutError):
-            session({'obs_time_ns': 0})
+            session({keys.OBS_TIME_NS: 0})
     spans = list(telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS)))
     assert [s.name for s in spans] == [telemetry_keys.SPAN_POLICY_INFER]
 
@@ -327,7 +327,7 @@ def test_declared_stack_built_at_session_open():
     clock = [1.0]
     policy, mock_ws = _mock_remote_policy(CHUNKED_STACK, infer_return=[{'a': 1, 'timestamp': 0.0}])
     session = policy.new_session(now=lambda: clock[0])
-    actions = session({'obs_time_ns': 0})
+    actions = session({keys.OBS_TIME_NS: 0})
     assert actions == [{'a': 1, 'timestamp': 1.0}]
 
 
@@ -422,7 +422,7 @@ class TestServedCommandDecode:
         wire_action = [{keys.ROBOT_COMMAND: self._wire_command(), 'timestamp': 0.0}]
         policy, _ = _mock_remote_policy(CHUNKED_STACK, infer_return=wire_action)
 
-        actions = policy.new_session(now=lambda: 0.0)({'obs_time_ns': 0})
+        actions = policy.new_session(now=lambda: 0.0)({keys.OBS_TIME_NS: 0})
 
         assert actions is not None, 'the chunk was swallowed before any command reached a driver'
         assert isinstance(actions[0][keys.ROBOT_COMMAND], command.CartesianPosition)
@@ -433,7 +433,7 @@ class TestServedCommandDecode:
         served = make_mock_policy([{keys.ROBOT_COMMAND: self._wire_command(), 'timestamp': 0.0}], {'model_name': 'm'})
         host, port, _ = start_server(ChunkedSchedule() | remote | PolicySource(served))
 
-        actions = RemotePolicy(f'{host}:{port}').new_session(now=lambda: 0.0)({'obs_time_ns': 0})
+        actions = RemotePolicy(f'{host}:{port}').new_session(now=lambda: 0.0)({keys.OBS_TIME_NS: 0})
 
         assert actions is not None, 'the chunk was swallowed before any command reached a driver'
         decoded = actions[0][keys.ROBOT_COMMAND]

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -251,8 +251,8 @@ def test_in_process_equals_remote_for_same_pipeline(start_server):
 
     local_session = inline(pipeline()).new_session(now=lambda: clock[0])
 
-    remote_actions = remote_session({'obs_time_ns': 0})
-    local_actions = local_session({'obs_time_ns': 0})
+    remote_actions = remote_session({keys.OBS_TIME_NS: 0})
+    local_actions = local_session({keys.OBS_TIME_NS: 0})
     assert remote_actions == local_actions
     # Three scripted actions plus the chunk-closing validity sentinel ActionTimestamp appends.
     assert local_actions == [
@@ -264,8 +264,8 @@ def test_in_process_equals_remote_for_same_pipeline(start_server):
 
     # Both gate identically while the chunk plays out.
     clock[0] = 100.15
-    assert remote_session({'obs_time_ns': 0}) is None
-    assert local_session({'obs_time_ns': 0}) is None
+    assert remote_session({keys.OBS_TIME_NS: 0}) is None
+    assert local_session({keys.OBS_TIME_NS: 0}) is None
 
     remote_session.close()
 

--- a/positronic/policy/action.py
+++ b/positronic/policy/action.py
@@ -41,7 +41,7 @@ class AbsolutePositionAction(Codec):
         action_vector = data['action']
         target_pose = geom.Transform3D.from_vector(action_vector[:-1], self.rot_rep)
         target_grip = action_vector[-1].item()
-        return {keys.ROBOT_COMMAND: command.CartesianPosition(pose=target_pose), 'target_grip': target_grip}
+        return {keys.ROBOT_COMMAND: command.CartesianPosition(pose=target_pose), keys.TARGET_GRIP: target_grip}
 
     def _encode_episode(self, episode: Episode) -> Signal[np.ndarray]:
         pose = episode[self.tgt_ee_pose_key]
@@ -81,7 +81,7 @@ class AbsoluteJointsAction(Codec):
 
         joint_positions = action_vector[: self.num_joints]
         target_grip = action_vector[-1].item()
-        return {keys.ROBOT_COMMAND: command.JointPosition(positions=joint_positions), 'target_grip': target_grip}
+        return {keys.ROBOT_COMMAND: command.JointPosition(positions=joint_positions), keys.TARGET_GRIP: target_grip}
 
     def _encode_episode(self, episode: Episode) -> Signal[np.ndarray]:
         return transforms.concat(episode[self.tgt_joints_key], episode[self.tgt_grip_key], dtype=np.float32)
@@ -142,7 +142,7 @@ class RelativePositionAction(Codec):
         rotation_rep: RotRep | str = RotRep.QUAT,
         robot_pose_key: str = keys.EE_POSE,
         target_pose_key: str = keys.TARGET_EE_POSE,
-        target_grip_key: str = 'target_grip',
+        target_grip_key: str = keys.TARGET_GRIP,
     ):
         self.rot_rep = RotRep(rotation_rep)
         self.robot_pose_key = robot_pose_key
@@ -168,7 +168,7 @@ class RelativePositionAction(Codec):
 
         target_pose = geom.Transform3D(translation=tr_add, rotation=rot_mul)
         target_grip = action_vector[self.rot_rep.size + 3].item()
-        return {keys.ROBOT_COMMAND: command.CartesianPosition(pose=target_pose), 'target_grip': target_grip}
+        return {keys.ROBOT_COMMAND: command.CartesianPosition(pose=target_pose), keys.TARGET_GRIP: target_grip}
 
     def _encode_episode(self, episode: Episode) -> Signal[np.ndarray]:
         robot_pose = episode[self.robot_pose_key]
@@ -238,7 +238,7 @@ class JointDeltaAction(Codec):
         action_vector = action_vector.clip(-1.0, 1.0)
         velocities = action_vector[: self.num_joints] * self.MAX_JOINT_DELTA
         grip = 1.0 if action_vector[self.num_joints].item() > 0.5 else 0.0
-        return {keys.ROBOT_COMMAND: command.JointDelta(velocities=velocities), 'target_grip': grip}
+        return {keys.ROBOT_COMMAND: command.JointDelta(velocities=velocities), keys.TARGET_GRIP: grip}
 
     def to_spec(self):
         return {'name': 'joint_delta_action', 'args': {'num_joints': self.num_joints}}

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -236,7 +236,7 @@ def is_action(entry: dict) -> bool:
     (see ``ActionTimestamp``). Consumers that classify or plot per-command fields skip the
     sentinel through this predicate rather than hard-coding its shape.
     """
-    return bool(entry.keys() - {'timestamp'})
+    return bool(entry.keys() - {obs_keys.ACTION_TIMESTAMP})
 
 
 class ActionTimestamp(Codec):
@@ -267,11 +267,11 @@ class ActionTimestamp(Codec):
         # Build fresh entries rather than stamping in place: a session may hand back a cached template
         # list, and appending the sentinel to it would regrow the chunk on every re-inference.
         if isinstance(data, list):
-            stamped = [{**d, 'timestamp': i * self._dt} for i, d in enumerate(data)]
+            stamped = [{**d, obs_keys.ACTION_TIMESTAMP: i * self._dt} for i, d in enumerate(data)]
             if stamped:
-                stamped.append({'timestamp': len(stamped) * self._dt})
+                stamped.append({obs_keys.ACTION_TIMESTAMP: len(stamped) * self._dt})
             return stamped
-        return {**data, 'timestamp': 0}
+        return {**data, obs_keys.ACTION_TIMESTAMP: 0}
 
     @property
     def training_encoder(self) -> EpisodeTransform:
@@ -311,9 +311,9 @@ class ActionHorizon(Codec):
         if isinstance(data, list):
             # Treat untimestamped actions as t=0 so they always pass the horizon
             # (servers may apply horizon truncation before stamping).
-            kept = [d for d in data if d.get('timestamp', 0.0) < self._horizon_sec]
+            kept = [d for d in data if d.get(obs_keys.ACTION_TIMESTAMP, 0.0) < self._horizon_sec]
             if len(kept) < len(data):
-                kept.append({'timestamp': self._horizon_sec})
+                kept.append({obs_keys.ACTION_TIMESTAMP: self._horizon_sec})
             return kept
         return data
 
@@ -388,7 +388,7 @@ class BinarizeGripInference(Codec):
         timing | BinarizeGripInference() | obs & action
     """
 
-    def __init__(self, threshold: float = 0.5, key: str = 'target_grip'):
+    def __init__(self, threshold: float = 0.5, key: str = obs_keys.TARGET_GRIP):
         self._threshold = threshold
         self._key = key
 
@@ -431,8 +431,8 @@ class FlipGrip(Codec):
         return Identity()
 
     def _decode_single(self, data: dict, context: dict | None) -> dict:
-        if 'target_grip' in data:
-            data['target_grip'] = 1.0 - data['target_grip']
+        if obs_keys.TARGET_GRIP in data:
+            data[obs_keys.TARGET_GRIP] = 1.0 - data[obs_keys.TARGET_GRIP]
         return data
 
     def to_spec(self):

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -24,7 +24,7 @@ MAX_ACTION_SKEW_SEC = 60.0
 
 def _assert_anchored(actions: list[dict[str, Any]], now: float) -> None:
     """Reject a chunk whose timestamps are not times on the harness clock."""
-    skew = max((abs(action['timestamp'] - now) for action in actions), default=0.0)
+    skew = max((abs(action[keys.ACTION_TIMESTAMP] - now) for action in actions), default=0.0)
     if skew > MAX_ACTION_SKEW_SEC:
         raise ValueError(
             f'Action scheduled {skew:.0f}s from now, over the {MAX_ACTION_SKEW_SEC:.0f}s bound: the rig-side '
@@ -378,8 +378,8 @@ class Harness(pimm.ControlSystem):
                     inputs[full_name] = v
         if self._awaiting_obs:
             return None
-        inputs['wall_time_ns'] = time.time_ns()
-        inputs['obs_time_ns'] = clock.now_ns()
+        inputs[keys.WALL_TIME_NS] = time.time_ns()
+        inputs[keys.OBS_TIME_NS] = clock.now_ns()
         inputs.update(self.context)
         inputs['descriptor'] = self._descriptor  # last, so a context key can't shadow it
         return inputs
@@ -394,7 +394,7 @@ class Harness(pimm.ControlSystem):
         for name, emitter in self.commands.items():
             # Wrappers do action-timing math in float seconds; every pimm channel client expects ns. This is
             # the single explicit seconds->ns seam.
-            traj = [(int(a['timestamp'] * 1e9), a[name]) for a in actions if name in a]
+            traj = [(int(a[keys.ACTION_TIMESTAMP] * 1e9), a[name]) for a in actions if name in a]
             emitter.emit(traj)
 
     def _inference_delay(self, wall_start: float) -> float:
@@ -430,7 +430,7 @@ class Harness(pimm.ControlSystem):
         delay = self._inference_delay(wall_start)
         if delay > 0.0:
             yield pimm.Sleep(delay)
-            actions = [{**a, 'timestamp': a['timestamp'] + delay} for a in actions]
+            actions = [{**a, keys.ACTION_TIMESTAMP: a[keys.ACTION_TIMESTAMP] + delay} for a in actions]
             self._bump_schedule_end(delay)
 
         # The latency sleep (or a slow inference call on a real clock) may have crossed the deadline. Drop

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -60,7 +60,7 @@ from positronic.policy.base import DelegatingSession, PolicyWrapper, Session
 from positronic.policy.codec import is_action
 from positronic.utils.rerun_compat import log_numeric_series, set_timeline_sequence, set_timeline_time
 
-DEFAULT_TIMELINES = {'wall_time': 'wall_time_ns', 'obs_time': 'obs_time_ns'}
+DEFAULT_TIMELINES = {'wall_time': obs_keys.WALL_TIME_NS, 'obs_time': obs_keys.OBS_TIME_NS}
 
 # Process-wide episode counter so files stay unique even across concurrent
 # ``Recorder`` instances (e.g. one per websocket session on a server).
@@ -165,8 +165,8 @@ def _command_field_arrays(key: str, commands: list, horizons: np.ndarray) -> lis
 
 def _horizon(actions: list[dict]) -> np.ndarray:
     """Relative chunk time (seconds) used as the curve x-axis, falling back to action index."""
-    if actions and all('timestamp' in a for a in actions):
-        ts = _stack_numeric([a['timestamp'] for a in actions])
+    if actions and all(obs_keys.ACTION_TIMESTAMP in a for a in actions):
+        ts = _stack_numeric([a[obs_keys.ACTION_TIMESTAMP] for a in actions])
         if ts is not None and ts.ndim == 1:
             return ts.astype(np.float64)
     return np.arange(len(actions), dtype=np.float64)
@@ -388,7 +388,11 @@ class _RecordingTapSession(DelegatingSession):
         horizon = _horizon(actions)
         tv = self._rec._timeline_values
         base_ns = int(tv.get('obs_time', tv.get('wall_time', next(iter(tv.values()), 0))))
-        grip = _stack_numeric([a['target_grip'] for a in actions]) if all('target_grip' in a for a in actions) else None
+        grip = (
+            _stack_numeric([a[obs_keys.TARGET_GRIP] for a in actions])
+            if all(obs_keys.TARGET_GRIP in a for a in actions)
+            else None
+        )
         actual_pos = obs.get(obs_keys.EE_POSE) if isinstance(obs, Mapping) else None
         actual_grip = obs.get(obs_keys.GRIP) if isinstance(obs, Mapping) else None
         # Under TemporalStack these arrive as (T, 7) / (T,) stacks; the overlay draws the current pose,
@@ -401,7 +405,7 @@ class _RecordingTapSession(DelegatingSession):
         keys: list[str] = []
         for action in actions:
             for key in action:
-                if key not in keys and key != 'timestamp':
+                if key not in keys and key != obs_keys.ACTION_TIMESTAMP:
                     keys.append(key)
         for key in keys:
             idx = [i for i, a in enumerate(actions) if key in a]

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -334,7 +334,7 @@ def test_harness_emits_cartesian_move(world):
     assert obs['descriptor'] == ''  # no descriptor passed -> empty string reaches the policy
     # Recording == canonical policy I/O: the policy sees the same ``robot_state`` serializer
     # the dataset records. wall/obs timestamps carry volatile values, so lock the stable key set.
-    assert set(obs) - {'wall_time_ns', 'obs_time_ns'} == {
+    assert set(obs) - {keys.WALL_TIME_NS, keys.OBS_TIME_NS} == {
         CAM,
         keys.JOINTS,
         keys.JOINT_VEL,

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -19,7 +19,6 @@ from positronic.policy.codec import (
     FlipGrip,
 )
 from positronic.policy.observation import ObservationCodec
-from positronic.vendors.gr00t.codecs import ee_quat, joints_traj
 
 
 def test_observation_encode_images_and_state_shapes():
@@ -588,39 +587,3 @@ def test_operator_precedence():
     assert result['encoded_by_a'] is True
     assert result['encoded_by_b'] is True
     assert result['encoded_by_c'] is True
-
-
-def test_groot_ee_codec_decodes_modality_keyed_actions():
-    """GR00T ee_quat codec decodes modality-keyed model output into robot commands.
-
-    GR00T models return ``{'ee_pose': ..., 'grip': ...}`` per action step,
-    not a flat ``action`` vector. The codec chain must convert this format.
-    """
-    codec = ee_quat()
-
-    # Simulate GR00T model output: list of modality-keyed dicts (one per action step)
-    ee_pose = np.concatenate([Rotation.identity.as_quat, [0.1, 0.2, 0.3]]).astype(np.float32)
-    model_output = [{'ee_pose': ee_pose, 'grip': np.float32(0.5)} for _ in range(3)]
-
-    decoded = codec.decode(model_output, context=_T0_OBS)
-    assert len(decoded) == 4  # 3 actions + timestamp sentinel
-    for d in decoded[:-1]:
-        assert obs_keys.ROBOT_COMMAND in d
-        assert 'target_grip' in d
-        assert 'timestamp' in d
-    assert decoded[-1] == {'timestamp': pytest.approx(3 / 15.0)}  # timestamp sentinel
-
-
-def test_groot_joints_codec_decodes_modality_keyed_actions():
-    """GR00T joints_traj codec decodes joint_position-keyed model output."""
-    codec = joints_traj()
-
-    joint_pos = np.array([0.1, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7], dtype=np.float32)
-    model_output = [{'joint_position': joint_pos, 'grip': np.float32(0.8)} for _ in range(3)]
-
-    decoded = codec.decode(model_output, context=_T0_OBS)
-    assert len(decoded) == 4  # 3 actions + timestamp sentinel
-    for d in decoded[:-1]:
-        assert obs_keys.ROBOT_COMMAND in d
-        assert 'target_grip' in d
-    assert decoded[-1] == {'timestamp': pytest.approx(3 / 15.0)}  # timestamp sentinel

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -191,7 +191,7 @@ class _MetaPolicy(Policy):
         return {'base_key': 'base_value'}
 
 
-_T0_OBS = {'obs_time_ns': 0}
+_T0_OBS = {obs_keys.OBS_TIME_NS: 0}
 
 
 def test_action_horizon_sec_truncates_chunk():

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -95,7 +95,7 @@ def test_tap_delegates_inner_call(tmp_path):
     actions = [{'v': 1, 'timestamp': 0.0}, {'v': 2, 'timestamp': 0.1}]
     policy = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy(actions))
     session = policy.new_session()
-    result = session({'x': 1.0, 'wall_time_ns': 1_000_000})
+    result = session({'x': 1.0, keys.WALL_TIME_NS: 1_000_000})
     assert result == actions
 
 
@@ -109,7 +109,7 @@ def test_obs_log_filtering_uses_pure_tap_names(tmp_path):
     rec = Recorder(tmp_path)
     session = rec.tap('cam').wrap(_TrackingPolicy([{'v': 1.0, 'timestamp': 0.0}])).new_session()
     session({
-        'wall_time_ns': 1_000_000,
+        keys.WALL_TIME_NS: 1_000_000,
         keys.TASK: 'pick up the cube',
         'camera': np.zeros((4, 4, 3), dtype=np.uint8),
         'joint_pos': np.array([1.0, 2.0], dtype=np.float32),
@@ -136,7 +136,7 @@ def test_logs_command_chunk_without_mutating(tmp_path):
         {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), 'target_grip': 0.6, 'timestamp': 0.1},
     ]
     session = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy(actions)).new_session()
-    result = session({'x': 1.0, 'wall_time_ns': 1})
+    result = session({'x': 1.0, keys.WALL_TIME_NS: 1})
     assert result[0][keys.ROBOT_COMMAND] is actions[0][keys.ROBOT_COMMAND]  # unchanged on return
 
 
@@ -174,7 +174,7 @@ def test_two_taps_log_both_seams(tmp_path):
     actions = [{'v': 1.0, 'timestamp': 0.0}]
     policy = (rec.tap('raw') | rec.tap('server')).wrap(_TrackingPolicy(actions))
     session = policy.new_session()
-    session({'camera': np.zeros((4, 4, 3), dtype=np.uint8), 'wall_time_ns': 1})
+    session({'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.WALL_TIME_NS: 1})
 
     assert 'raw/camera' in rec._image_paths
     assert 'server/camera' in rec._image_paths
@@ -187,7 +187,7 @@ def test_timeline_values_captured_once_and_carried(tmp_path):
     policy = (rec.tap('raw') | rec.tap('server')).wrap(inner)
     session = policy.new_session()
 
-    session({'wall_time_ns': 111, 'obs_time_ns': 222, 'x': 1.0})
+    session({keys.WALL_TIME_NS: 111, keys.OBS_TIME_NS: 222, 'x': 1.0})
 
     # Both taps entered before the inner session ran, and both share the values
     # captured once from the raw obs at the outermost tap.
@@ -203,7 +203,7 @@ def test_partial_timelines_only_set_present_keys(tmp_path):
     inner = _CapturingPolicy(rec, [{'v': 1.0, 'timestamp': 0.0}])
     session = rec.tap('raw').wrap(inner).new_session()
 
-    session({'wall_time_ns': 555, 'x': 1.0})  # no obs_time_ns
+    session({keys.WALL_TIME_NS: 555, 'x': 1.0})  # no obs_time_ns
     assert inner.last_session.seen_timeline_values == {'wall_time': 555}
 
 

--- a/positronic/policy/tests/test_wrappers.py
+++ b/positronic/policy/tests/test_wrappers.py
@@ -64,7 +64,7 @@ class _ConstPolicy(Policy):
 
 
 def _obs(now_sec=0.0):
-    return {'obs_time_ns': int(now_sec * 1e9)}
+    return {keys.OBS_TIME_NS: int(now_sec * 1e9)}
 
 
 class TestChunkedSchedule:
@@ -125,7 +125,7 @@ class TestPipelineComposition:
         assert isinstance(pipeline, PolicyWrapper)
         policy = pipeline.wrap(_ConstPolicy([{'v': 1, 'timestamp': 0.0}]))
         session = policy.new_session(now=clock.now)
-        result = session({'obs_time_ns': int(1e9), 'v': np.array([5.0])})
+        result = session({keys.OBS_TIME_NS: int(1e9), 'v': np.array([5.0])})
         assert result is not None
         assert result[0]['v'] == 1
 
@@ -230,7 +230,7 @@ class _CapturePolicy(Policy):
 
 
 def _stack_obs(now_sec, value):
-    return {'obs_time_ns': int(now_sec * 1e9), 'v': np.array([value])}
+    return {keys.OBS_TIME_NS: int(now_sec * 1e9), 'v': np.array([value])}
 
 
 class TestTemporalStack:

--- a/positronic/policy/wrappers.py
+++ b/positronic/policy/wrappers.py
@@ -11,12 +11,13 @@ from collections import deque
 
 import numpy as np
 
+from positronic import keys
 from positronic.policy.base import DelegatingSession, Now, PolicyWrapper, Session
 
 
 def _obs_time(obs) -> float:
     """Observation timestamp in seconds, from the harness's nanosecond stamp."""
-    return obs['obs_time_ns'] / 1e9
+    return obs[keys.OBS_TIME_NS] / 1e9
 
 
 class ChunkedSchedule(PolicyWrapper):
@@ -55,8 +56,8 @@ class ChunkedSchedule(PolicyWrapper):
                 # Anchor to post-inference time so execution starts when inference *finished*.
                 # Copy dicts so we don't mutate caller-owned data (sessions may reuse templates).
                 now = self._now()
-                result = [{**r, 'timestamp': now + r.get('timestamp', 0.0)} for r in result]
-                self._trajectory_end = result[-1]['timestamp'] if result else None
+                result = [{**r, keys.ACTION_TIMESTAMP: now + r.get(keys.ACTION_TIMESTAMP, 0.0)} for r in result]
+                self._trajectory_end = result[-1][keys.ACTION_TIMESTAMP] if result else None
             return result
 
         def cancel(self):

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -46,8 +46,8 @@ def _build_wire_obs(sample: dict, task: str | None, now_ns: int, recorded_ts: in
     obs.update({k: v for k, v in sample.items() if k.startswith('image.')})
     if task:
         obs[keys.TASK] = task
-    obs['wall_time_ns'] = now_ns  # rerun wall_time timeline
-    obs['obs_time_ns'] = recorded_ts  # rerun obs_time + action_time anchor
+    obs[keys.WALL_TIME_NS] = now_ns  # rerun wall_time timeline
+    obs[keys.OBS_TIME_NS] = recorded_ts  # rerun obs_time + action_time anchor
     return obs
 
 
@@ -91,11 +91,11 @@ def _log_commands(actions: list[dict], wall_ns: int, inf_ns: int) -> None:
         rows = [list(d) for d in deltas]
     else:
         return
-    horizon = np.array([float(a.get('timestamp', i)) for i, a in enumerate(actions)])
+    horizon = np.array([float(a.get(keys.ACTION_TIMESTAMP, i)) for i, a in enumerate(actions)])
     horizon -= horizon[0]
-    if all('target_grip' in a for a in actions):
-        labels.append('target_grip')
-        rows = [row + [a['target_grip']] for row, a in zip(rows, actions, strict=True)]
+    if all(keys.TARGET_GRIP in a for a in actions):
+        labels.append(keys.TARGET_GRIP)
+        rows = [row + [a[keys.TARGET_GRIP]] for row, a in zip(rows, actions, strict=True)]
     data = np.array(rows, float)
 
     rr.log('commands', rr.SeriesLines(names=labels), static=True)

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -43,7 +43,7 @@ class Replay(DsPlayerAgent):
         self.robot_meta_in = pimm.FakeReceiver(self)
         self.frames = pimm.ReceiverDict(self, fake=True)
         self.outputs['robot_commands'] = _TrajectoryEmitter(self)
-        self.outputs['target_grip'] = _TrajectoryEmitter(self)
+        self.outputs[keys.TARGET_GRIP] = _TrajectoryEmitter(self)
 
     @property
     def robot_commands(self) -> pimm.ControlSystemEmitter:
@@ -51,7 +51,7 @@ class Replay(DsPlayerAgent):
 
     @property
     def target_grip(self) -> pimm.ControlSystemEmitter:
-        return self.outputs['target_grip']
+        return self.outputs[keys.TARGET_GRIP]
 
 
 class RestoreCommand(Derive):

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -155,6 +155,6 @@ class WireCommandAdapter(EnvAdapter):
                 cmd = None
             case roboarm_command.CartesianDelta() | roboarm_command.JointDelta():
                 self._held.pop(keys.ROBOT_COMMAND)
-        if 'target_grip' in self._held:
-            self._grip = float(self._held['target_grip'])
+        if keys.TARGET_GRIP in self._held:
+            self._grip = float(self._held[keys.TARGET_GRIP])
         return {'command': _wire_command(_in_env_control_frame(cmd, self.env_control_frame)), 'grip': self._grip}

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -160,7 +160,7 @@ def remote_franka_embodiment(
         keys.ROBOT_COMMAND: Command(
             proxy.commands[keys.ROBOT_COMMAND], roboarm_command.Reset(), Serializers.robot_command
         ),
-        'target_grip': Command(proxy.commands['target_grip'], 0.0, None),
+        keys.TARGET_GRIP: Command(proxy.commands[keys.TARGET_GRIP], 0.0, None),
     }
     return Embodiment(
         descriptor=descriptor,

--- a/positronic/tests/test_keys.py
+++ b/positronic/tests/test_keys.py
@@ -15,6 +15,8 @@ _GUARDED = {
     keys.EXTERIOR_IMAGE,
     keys.EVAL_SUCCESS,
     keys.EVAL_TERMINATED,
+    keys.OBS_TIME_NS,
+    keys.WALL_TIME_NS,
 }
 # keys.GRIP and keys.TASK are deliberately not guarded: their values are bare tokens the wire reuses
 # across unrelated namespaces (action-command grip, vendor state-vectors, scene/reset tokens), so a

--- a/positronic/tests/test_vendor_boundary.py
+++ b/positronic/tests/test_vendor_boundary.py
@@ -58,11 +58,10 @@ def test_nothing_outside_vendors_imports_a_vendor():
     offenders = []
     for root in _CORE_ROOTS:
         for path in sorted(root.rglob('*.py')):
-            if path.is_relative_to(_VENDORS_ROOT):
-                continue
-            offenders += [
-                f'{path.relative_to(_REPO_ROOT)}:{lineno}: imports {name}' for name, lineno in _vendor_imports(path)
-            ]
+            if not path.is_relative_to(_VENDORS_ROOT):
+                offenders += [
+                    f'{path.relative_to(_REPO_ROOT)}:{lineno}: imports {name}' for name, lineno in _vendor_imports(path)
+                ]
     assert not offenders, (
         'Only code under `positronic/vendors/` may import from it '
         '(see "Foreign components plug in through shims" in ARCHITECTURE.md):\n' + '\n'.join(offenders)
@@ -76,10 +75,9 @@ def test_no_vendor_imports_another_vendor():
         # Files at the vendors root belong to no vendor, so for them every vendor is foreign.
         vendor = rel.parts[0] if len(rel.parts) > 1 else None
         for name, lineno in _vendor_imports(path):
+            # A bare `positronic.vendors` import names the shared parent, which no vendor owns — allowed.
             suffix = name.removeprefix(_VENDORS_PACKAGE + '.')
-            if suffix == name:  # the bare `positronic.vendors` — the shared parent, owned by no vendor
-                continue
-            if suffix.split('.')[0] != vendor:
+            if suffix != name and suffix.split('.')[0] != vendor:
                 offenders.append(f'{path.relative_to(_REPO_ROOT)}:{lineno}: imports {name}')
     assert not offenders, (
         'A vendor may not import another vendor — a helper both need belongs in core '

--- a/positronic/tests/test_vendor_boundary.py
+++ b/positronic/tests/test_vendor_boundary.py
@@ -1,0 +1,87 @@
+import ast
+from pathlib import Path
+
+# `positronic/vendors/<x>/` holds the shim for one third-party stack, and two import boundaries
+# follow (see "Foreign components plug in through shims" in ARCHITECTURE.md). Nothing outside
+# `positronic/vendors/` imports from it: core defines the contract and a vendor adapts to it, so an
+# import the other way inverts the dependency and drags the vendor's optional extra into code that
+# must work without it. And no vendor imports another: each shim answers to its own upstream, on its
+# own pinned deps and often its own interpreter — a helper two of them need belongs in core.
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _PACKAGE_ROOT.parent
+_VENDORS_ROOT = _PACKAGE_ROOT / 'vendors'
+_VENDORS_PACKAGE = 'positronic.vendors'
+# First-party trees held to the boundary. The vendors tree itself is walked separately, against the
+# cross-vendor rule.
+_CORE_ROOTS = (_PACKAGE_ROOT, _REPO_ROOT / 'pimm', _REPO_ROOT / 'utilities')
+
+
+def _package_parts(path: Path) -> tuple[str, ...]:
+    # Dropping the last component covers both cases: a module's package is its directory, and an
+    # `__init__.py`'s package is the directory itself (relative imports resolve against it).
+    return path.relative_to(_REPO_ROOT).with_suffix('').parts[:-1]
+
+
+def _imports(path: Path):
+    """Yields every imported module name in `path` as (absolute dotted name, line number).
+
+    A `from` import yields one name per alias, joined onto the base module, so a submodule imported
+    as `from positronic import vendors` resolves to `positronic.vendors`. Relative imports are
+    resolved against the file's package.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name, node.lineno
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                assert node.module is not None  # an absolute `from` import always names a module
+                base = node.module.split('.')
+            else:
+                package = _package_parts(path)
+                base = list(package[: len(package) - (node.level - 1)])
+                if node.module:
+                    base += node.module.split('.')
+            for alias in node.names:
+                yield '.'.join([*base, alias.name]), node.lineno
+
+
+def _vendor_imports(path: Path):
+    for name, lineno in _imports(path):
+        if name == _VENDORS_PACKAGE or name.startswith(_VENDORS_PACKAGE + '.'):
+            yield name, lineno
+
+
+def test_nothing_outside_vendors_imports_a_vendor():
+    offenders = []
+    for root in _CORE_ROOTS:
+        for path in sorted(root.rglob('*.py')):
+            if path.is_relative_to(_VENDORS_ROOT):
+                continue
+            offenders += [
+                f'{path.relative_to(_REPO_ROOT)}:{lineno}: imports {name}' for name, lineno in _vendor_imports(path)
+            ]
+    assert not offenders, (
+        'Only code under `positronic/vendors/` may import from it '
+        '(see "Foreign components plug in through shims" in ARCHITECTURE.md):\n' + '\n'.join(offenders)
+    )
+
+
+def test_no_vendor_imports_another_vendor():
+    offenders = []
+    for path in sorted(_VENDORS_ROOT.rglob('*.py')):
+        rel = path.relative_to(_VENDORS_ROOT)
+        # Files at the vendors root belong to no vendor, so for them every vendor is foreign.
+        vendor = rel.parts[0] if len(rel.parts) > 1 else None
+        for name, lineno in _vendor_imports(path):
+            suffix = name.removeprefix(_VENDORS_PACKAGE + '.')
+            if suffix == name:  # the bare `positronic.vendors` — the shared parent, owned by no vendor
+                continue
+            if suffix.split('.')[0] != vendor:
+                offenders.append(f'{path.relative_to(_REPO_ROOT)}:{lineno}: imports {name}')
+    assert not offenders, (
+        'A vendor may not import another vendor — a helper both need belongs in core '
+        '(see "Foreign components plug in through shims" in ARCHITECTURE.md):\n' + '\n'.join(offenders)
+    )

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -182,7 +182,7 @@ class DreamZeroActionCodec(Codec):
         action = data['action']
         joints = action[: self._num_joints]
         grip = action[self._num_joints].item()
-        return {keys.ROBOT_COMMAND: command.JointPosition(positions=joints), 'target_grip': grip}
+        return {keys.ROBOT_COMMAND: command.JointPosition(positions=joints), keys.TARGET_GRIP: grip}
 
     @property
     def training_encoder(self):
@@ -223,7 +223,7 @@ def dreamzero_action(tgt_joints_key: str, tgt_grip_key: str, num_joints: int):
 # Composed codec: DreamZero observation + action + timing. compose defaults to the full chunk
 # (horizon=None), so all 24 actions DreamZero returns execute and the re-query aligns with the
 # frame-stack window.
-_action = dreamzero_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key='target_grip')
+_action = dreamzero_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key=keys.TARGET_GRIP)
 joints = codecs.compose.override(obs=dreamzero_obs, action=_action, fps=15.0)
 
 # The pretrained DROID model (wan2.1) asserts exactly 320x180 frames; the wan2.2 fine-tunes resize the
@@ -234,7 +234,7 @@ _traj_action = dreamzero_action.override(tgt_joints_key=keys.JOINTS, tgt_grip_ke
 joints_traj = codecs.compose.override(obs=dreamzero_obs, action=_traj_action, fps=15.0)
 
 # IK variants: reconstruct joint targets from recorded EE targets via IK
-_ik_action = codecs.ik_joints_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key='target_grip')
+_ik_action = codecs.ik_joints_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key=keys.TARGET_GRIP)
 
 
 @cfn.config(solver='dls_limits')
@@ -242,7 +242,7 @@ def _ik_dreamzero_action(solver: str):
     """IK signal derivation composed with DreamZero action codec."""
     solver_map = {'lm': LMIKSolver, 'dls': DLSIKSolver, 'dls_limits': DLSIKSolverWithLimits}
     ik = IKJointsAction(solver_cls=solver_map[solver])
-    return ik | DreamZeroActionCodec(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key='target_grip')
+    return ik | DreamZeroActionCodec(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key=keys.TARGET_GRIP)
 
 
 joints_ik = codecs.compose.override(obs=dreamzero_obs, action=_ik_dreamzero_action, fps=15.0)

--- a/positronic/vendors/gr00t/codecs.py
+++ b/positronic/vendors/gr00t/codecs.py
@@ -19,6 +19,13 @@ from positronic.policy.codec import Codec, lerobot_image, lerobot_state
 
 RotRep = geom.Rotation.Representation
 
+# GR00T's modality vocabulary: the state/action fields its data config declares and its model emits.
+# ``GRIP`` shares a value with ``keys.GRIP`` by vocabulary, not by contract — renaming the positronic
+# wire key must not rename the modality.
+EE_POSE = 'ee_pose'
+JOINT_POSITION = 'joint_position'
+GRIP = 'grip'
+
 
 class GrootObservationCodec(Codec):
     """GR00T N1.6 observation encoder.
@@ -46,28 +53,28 @@ class GrootObservationCodec(Codec):
         self._num_joints = num_joints
 
         self._derive_transforms: dict[str, Any] = {
-            'grip': self._derive_grip,
+            GRIP: self._derive_grip,
             'wrist_image': partial(self._derive_image, wrist_camera),
             'exterior_image_1': partial(self._derive_image, exterior_camera),
             'task': Get(keys.TASK, ''),
         }
 
-        state_meta: dict[str, Any] = {'grip': {'start': 0, 'end': 1, 'original_key': 'grip'}}
+        state_meta: dict[str, Any] = {GRIP: {'start': 0, 'end': 1, 'original_key': GRIP}}
         lerobot_features: dict[str, Any] = {
-            'grip': lerobot_state(1),
+            GRIP: lerobot_state(1),
             'wrist_image': lerobot_image(*image_size),
             'exterior_image_1': lerobot_image(*image_size),
         }
 
         if include_ee_pose:
             obs_ee_dim = rotation_rep.size + 3 if rotation_rep else 7
-            state_meta['ee_pose'] = {'start': 0, 'end': obs_ee_dim, 'original_key': 'ee_pose'}
-            lerobot_features['ee_pose'] = lerobot_state(obs_ee_dim)
-            self._derive_transforms['ee_pose'] = self._derive_ee_pose
+            state_meta[EE_POSE] = {'start': 0, 'end': obs_ee_dim, 'original_key': EE_POSE}
+            lerobot_features[EE_POSE] = lerobot_state(obs_ee_dim)
+            self._derive_transforms[EE_POSE] = self._derive_ee_pose
         if include_joints:
-            state_meta['joint_position'] = {'start': 0, 'end': num_joints, 'original_key': 'joint_position'}
-            lerobot_features['joint_position'] = lerobot_state(num_joints)
-            self._derive_transforms['joint_position'] = self._derive_joints
+            state_meta[JOINT_POSITION] = {'start': 0, 'end': num_joints, 'original_key': JOINT_POSITION}
+            lerobot_features[JOINT_POSITION] = lerobot_state(num_joints)
+            self._derive_transforms[JOINT_POSITION] = self._derive_joints
 
         self._training_meta = {
             'gr00t_modality': {
@@ -117,12 +124,12 @@ class GrootObservationCodec(Codec):
     def dummy_encoded(self, data=None) -> dict[str, Any]:
         """Return a zero-filled encoded observation in GR00T's nested format."""
         w, h = self._image_size
-        state: dict[str, Any] = {'grip': np.zeros((1, 1, 1), dtype=np.float32)}
+        state: dict[str, Any] = {GRIP: np.zeros((1, 1, 1), dtype=np.float32)}
         if self._include_ee_pose:
             ee_dim = self._rotation_rep.size + 3 if self._rotation_rep else 7
-            state['ee_pose'] = np.zeros((1, 1, ee_dim), dtype=np.float32)
+            state[EE_POSE] = np.zeros((1, 1, ee_dim), dtype=np.float32)
         if self._include_joints:
-            state['joint_position'] = np.zeros((1, 1, self._num_joints), dtype=np.float32)
+            state[JOINT_POSITION] = np.zeros((1, 1, self._num_joints), dtype=np.float32)
         return {
             'video': {
                 'wrist_image': np.zeros((1, 1, h, w, 3), dtype=np.uint8),
@@ -137,14 +144,14 @@ class GrootObservationCodec(Codec):
 
     def encode(self, inputs: dict[str, Any]) -> dict[str, Any]:
         grip = np.asarray(inputs[keys.GRIP], dtype=np.float32).reshape(-1)
-        state_dict: dict[str, Any] = {'grip': grip[np.newaxis, np.newaxis, ...]}
+        state_dict: dict[str, Any] = {GRIP: grip[np.newaxis, np.newaxis, ...]}
 
         if self._include_ee_pose:
             ee_pose = self._encode_ee_pose(inputs)
-            state_dict['ee_pose'] = ee_pose[np.newaxis, np.newaxis, ...]
+            state_dict[EE_POSE] = ee_pose[np.newaxis, np.newaxis, ...]
         if self._include_joints:
             joints = np.asarray(inputs[keys.JOINTS], dtype=np.float32).reshape(-1)
-            state_dict['joint_position'] = joints[np.newaxis, np.newaxis, ...]
+            state_dict[JOINT_POSITION] = joints[np.newaxis, np.newaxis, ...]
 
         return {
             'video': {
@@ -181,7 +188,7 @@ class _GrootActionModality(Codec):
 
     def _decode_single(self, data: dict, context: dict | None) -> dict:
         action_part = np.asarray(data[self._action_key], dtype=np.float32).reshape(-1)
-        grip_part = np.asarray(data['grip'], dtype=np.float32).reshape(-1)
+        grip_part = np.asarray(data[GRIP], dtype=np.float32).reshape(-1)
         return {'action': np.concatenate([action_part, grip_part])}
 
     @property
@@ -198,7 +205,7 @@ def groot_obs(rotation_rep: str | None, include_joints: bool, include_ee_pose: b
     )
 
 
-@cfn.config(action_key='ee_pose', action_dim=7)
+@cfn.config(action_key=EE_POSE, action_dim=7)
 def groot_action(base, action_key: str, action_dim: int):
     """Wrap an action codec with GR00T modality metadata and decode adapter.
 
@@ -207,7 +214,7 @@ def groot_action(base, action_key: str, action_dim: int):
     into a flat ``action`` vector that ``base`` can decode.
     """
     return base | _GrootActionModality(
-        {action_key: {'start': 0, 'end': action_dim}, 'grip': {'start': action_dim, 'end': action_dim + 1}},
+        {action_key: {'start': 0, 'end': action_dim}, GRIP: {'start': action_dim, 'end': action_dim + 1}},
         action_key=action_key,
     )
 
@@ -233,7 +240,7 @@ joints_traj = codecs.compose.override(
     obs=groot_obs.override(include_joints=True, include_ee_pose=False),
     action=groot_action.override(
         base=codecs.absolute_joints_action.override(tgt_joints_key=keys.JOINTS, tgt_grip_key=keys.GRIP),
-        action_key='joint_position',
+        action_key=JOINT_POSITION,
     ),
     binarize_grip=(keys.GRIP,),
 )
@@ -241,6 +248,6 @@ joints_traj = codecs.compose.override(
 # IK variants: GR00T obs (with joints) + IK joint-space action via groot_action wrapper
 ee_joints_ik = codecs.compose.override(
     obs=groot_obs.override(include_joints=True),
-    action=groot_action.override(base=codecs.ik_joints_action, action_key='joint_position'),
+    action=groot_action.override(base=codecs.ik_joints_action, action_key=JOINT_POSITION),
 )
 ee_joints_ik_sim = ee_joints_ik.override(**{'action.base.solver': 'lm'})

--- a/positronic/vendors/gr00t/tests/test_codecs.py
+++ b/positronic/vendors/gr00t/tests/test_codecs.py
@@ -3,37 +3,37 @@ import pytest
 
 from positronic import keys
 from positronic.geom import Rotation
-from positronic.vendors.gr00t.codecs import ee_quat, joints_traj
+from positronic.vendors.gr00t.codecs import EE_POSE, GRIP, JOINT_POSITION, ee_quat, joints_traj
 
-_T0_OBS = {'obs_time_ns': 0}
+_T0_OBS = {keys.OBS_TIME_NS: 0}
 
 
 def test_ee_quat_decodes_modality_keyed_actions():
-    """GR00T models return ``{'ee_pose': ..., 'grip': ...}`` per action step, not a flat ``action``
-    vector; the codec chain must convert this format into robot commands."""
+    """GR00T models return modality-keyed dicts per action step, not a flat ``action`` vector;
+    the codec chain must convert this format into robot commands."""
     codec = ee_quat()
 
     ee_pose = np.concatenate([Rotation.identity.as_quat, [0.1, 0.2, 0.3]]).astype(np.float32)
-    model_output = [{'ee_pose': ee_pose, 'grip': np.float32(0.5)} for _ in range(3)]
+    model_output = [{EE_POSE: ee_pose, GRIP: np.float32(0.5)} for _ in range(3)]
 
     decoded = codec.decode(model_output, context=_T0_OBS)
     assert len(decoded) == 4  # 3 actions + timestamp sentinel
     for d in decoded[:-1]:
         assert keys.ROBOT_COMMAND in d
-        assert 'target_grip' in d
-        assert 'timestamp' in d
-    assert decoded[-1] == {'timestamp': pytest.approx(3 / 15.0)}  # timestamp sentinel
+        assert keys.TARGET_GRIP in d
+        assert keys.ACTION_TIMESTAMP in d
+    assert decoded[-1] == {keys.ACTION_TIMESTAMP: pytest.approx(3 / 15.0)}  # timestamp sentinel
 
 
 def test_joints_traj_decodes_modality_keyed_actions():
     codec = joints_traj()
 
     joint_pos = np.array([0.1, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7], dtype=np.float32)
-    model_output = [{'joint_position': joint_pos, 'grip': np.float32(0.8)} for _ in range(3)]
+    model_output = [{JOINT_POSITION: joint_pos, GRIP: np.float32(0.8)} for _ in range(3)]
 
     decoded = codec.decode(model_output, context=_T0_OBS)
     assert len(decoded) == 4  # 3 actions + timestamp sentinel
     for d in decoded[:-1]:
         assert keys.ROBOT_COMMAND in d
-        assert 'target_grip' in d
-    assert decoded[-1] == {'timestamp': pytest.approx(3 / 15.0)}  # timestamp sentinel
+        assert keys.TARGET_GRIP in d
+    assert decoded[-1] == {keys.ACTION_TIMESTAMP: pytest.approx(3 / 15.0)}  # timestamp sentinel

--- a/positronic/vendors/gr00t/tests/test_codecs.py
+++ b/positronic/vendors/gr00t/tests/test_codecs.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from positronic import keys
+from positronic.geom import Rotation
+from positronic.vendors.gr00t.codecs import ee_quat, joints_traj
+
+_T0_OBS = {'obs_time_ns': 0}
+
+
+def test_ee_quat_decodes_modality_keyed_actions():
+    """GR00T models return ``{'ee_pose': ..., 'grip': ...}`` per action step, not a flat ``action``
+    vector; the codec chain must convert this format into robot commands."""
+    codec = ee_quat()
+
+    ee_pose = np.concatenate([Rotation.identity.as_quat, [0.1, 0.2, 0.3]]).astype(np.float32)
+    model_output = [{'ee_pose': ee_pose, 'grip': np.float32(0.5)} for _ in range(3)]
+
+    decoded = codec.decode(model_output, context=_T0_OBS)
+    assert len(decoded) == 4  # 3 actions + timestamp sentinel
+    for d in decoded[:-1]:
+        assert keys.ROBOT_COMMAND in d
+        assert 'target_grip' in d
+        assert 'timestamp' in d
+    assert decoded[-1] == {'timestamp': pytest.approx(3 / 15.0)}  # timestamp sentinel
+
+
+def test_joints_traj_decodes_modality_keyed_actions():
+    codec = joints_traj()
+
+    joint_pos = np.array([0.1, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7], dtype=np.float32)
+    model_output = [{'joint_position': joint_pos, 'grip': np.float32(0.8)} for _ in range(3)]
+
+    decoded = codec.decode(model_output, context=_T0_OBS)
+    assert len(decoded) == 4  # 3 actions + timestamp sentinel
+    for d in decoded[:-1]:
+        assert keys.ROBOT_COMMAND in d
+        assert 'target_grip' in d
+    assert decoded[-1] == {'timestamp': pytest.approx(3 / 15.0)}  # timestamp sentinel

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -1,10 +1,20 @@
 from typing import Any
 
+import configuronic as cfn
 import numpy as np
+import pos3
 import torch
+from lerobot.constants import CHECKPOINTS_DIR, PRETRAINED_MODEL_DIR
+from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.pretrained import PreTrainedPolicy
 
-from positronic.policy import Policy, Session
+from positronic import keys
+from positronic.cfg import codecs
+from positronic.policy import Codec, Policy, Session
+from positronic.policy.spec import PolicySource, inline
+from positronic.policy.wrappers import ChunkedSchedule
+from positronic.utils import get_latest_checkpoint
+from positronic.vendors.lerobot_0_3_3.backbone import register_all
 
 
 def _detect_device() -> str:
@@ -74,3 +84,31 @@ class LerobotPolicy(Policy):
             self._policy = None
             if self._device.startswith('cuda'):
                 torch.cuda.empty_cache()
+
+
+@cfn.config(checkpoint=None)
+def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None = None, device=None):
+    register_all()
+
+    checkpoints_dir = checkpoints_dir.rstrip('/') + f'/{CHECKPOINTS_DIR}/'
+    if checkpoint is None:
+        checkpoint = get_latest_checkpoint(checkpoints_dir)
+    else:
+        checkpoint = str(checkpoint).strip('/')
+
+    fully_specified_checkpoint_dir = checkpoints_dir.rstrip('/') + '/' + checkpoint + f'/{PRETRAINED_MODEL_DIR}/'
+    policy = ACTPolicy.from_pretrained(pos3.download(fully_specified_checkpoint_dir), strict=True)
+    if n_action_steps is not None:
+        policy.config.n_action_steps = n_action_steps
+
+    return LerobotPolicy(
+        policy, device, extra_meta={keys.TYPE: 'act', keys.CHECKPOINT_PATH: fully_specified_checkpoint_dir}
+    )
+
+
+@cfn.config(
+    base=act, codec=codecs.compose.override(obs=codecs.eepose_obs, action=codecs.absolute_pos_action, horizon=1.0)
+)
+def act_absolute(base: Policy, codec: Codec):
+    """ACT with the absolute-position codec, composed in-process."""
+    return inline(ChunkedSchedule() | codec | PolicySource(base))

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -13,7 +13,7 @@ from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
 from positronic.policy.spec import PolicySource, inline
 from positronic.policy.wrappers import ChunkedSchedule
-from positronic.utils import get_latest_checkpoint
+from positronic.utils.checkpoints import resolve_checkpoint
 from positronic.vendors.lerobot_0_3_3.backbone import register_all
 
 
@@ -87,23 +87,17 @@ class LerobotPolicy(Policy):
 
 
 @cfn.config(checkpoint=None)
-def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None = None, device=None):
+def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None = None, device: str | None = None):
     register_all()
 
-    checkpoints_dir = checkpoints_dir.rstrip('/') + f'/{CHECKPOINTS_DIR}/'
-    if checkpoint is None:
-        checkpoint = get_latest_checkpoint(checkpoints_dir)
-    else:
-        checkpoint = str(checkpoint).strip('/')
-
-    fully_specified_checkpoint_dir = checkpoints_dir.rstrip('/') + '/' + checkpoint + f'/{PRETRAINED_MODEL_DIR}/'
-    policy = ACTPolicy.from_pretrained(pos3.download(fully_specified_checkpoint_dir), strict=True)
+    checkpoints_dir = checkpoints_dir.rstrip('/') + f'/{CHECKPOINTS_DIR}'
+    checkpoint = resolve_checkpoint(checkpoints_dir, checkpoint, None)
+    checkpoint_dir = f'{checkpoints_dir}/{checkpoint}/{PRETRAINED_MODEL_DIR}/'
+    policy = ACTPolicy.from_pretrained(pos3.download(checkpoint_dir), strict=True)
     if n_action_steps is not None:
         policy.config.n_action_steps = n_action_steps
 
-    return LerobotPolicy(
-        policy, device, extra_meta={keys.TYPE: 'act', keys.CHECKPOINT_PATH: fully_specified_checkpoint_dir}
-    )
+    return LerobotPolicy(policy, device, extra_meta={keys.TYPE: 'act', keys.CHECKPOINT_PATH: checkpoint_dir})
 
 
 @cfn.config(

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import configuronic as cfn
 import pos3
+from lerobot.constants import CHECKPOINTS_DIR, PRETRAINED_MODEL_DIR
 from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.pretrained import PreTrainedPolicy
 
@@ -48,7 +49,7 @@ class LerobotSource(ModelSource):
         model_type: str = 'act',
     ):
         self._policy_factory = policy_factory
-        self._checkpoints_dir = str(checkpoints_dir).rstrip('/') + '/checkpoints'
+        self._checkpoints_dir = str(checkpoints_dir).rstrip('/') + f'/{CHECKPOINTS_DIR}'
         self._checkpoint = checkpoint
         self._device = device or _detect_device()
         self._model_type = model_type
@@ -61,7 +62,7 @@ class LerobotSource(ModelSource):
         return resolve_checkpoint(self._checkpoints_dir, self._checkpoint, model_id)
 
     def load(self, model_id: str, on_progress: Callable[[str], None] | None = None) -> Policy:
-        checkpoint_path = f'{self._checkpoints_dir}/{model_id}/pretrained_model'
+        checkpoint_path = f'{self._checkpoints_dir}/{model_id}/{PRETRAINED_MODEL_DIR}'
         logger.info(f'Loading checkpoint from {checkpoint_path}')
         local = run_with_progress(
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress

--- a/positronic/vendors/lerobot_0_3_3/train.py
+++ b/positronic/vendors/lerobot_0_3_3/train.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import configuronic as cfn
 import pos3
 from lerobot.configs.train import TrainPipelineConfig
-from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
+from lerobot.constants import ACTION, CHECKPOINTS_DIR, OBS_IMAGE, OBS_STATE, PRETRAINED_MODEL_DIR
 from lerobot.envs.configs import EnvConfig, FeatureType, PolicyFeature
 from lerobot.scripts import train as lerobot_train
 
@@ -154,13 +154,13 @@ def train(
     _update_config(cfg, **cfg_kwargs)
 
     if cfg.resume:
-        checkpoints_dir = Path(cfg.output_dir) / 'checkpoints'
+        checkpoints_dir = Path(cfg.output_dir) / CHECKPOINTS_DIR
         if checkpoints_dir.exists():
             # Find the latest checkpoint directory (highest integer value)
             checkpoint_dirs = [d for d in checkpoints_dir.iterdir() if d.is_dir() and d.name.isdigit()]
             if checkpoint_dirs:
                 latest_checkpoint = max(checkpoint_dirs, key=lambda d: int(d.name))
-                config_path = latest_checkpoint / 'pretrained_model' / 'train_config.json'
+                config_path = latest_checkpoint / PRETRAINED_MODEL_DIR / 'train_config.json'
                 logging.info(f'Resuming run. Automatically setting config_path to {config_path}')
                 # Hack: lerobot requires config_path to be in sys.argv for validation
                 sys.argv.append(f'--config_path={config_path}')

--- a/positronic/vendors/lerobot_0_3_3/train.py
+++ b/positronic/vendors/lerobot_0_3_3/train.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import configuronic as cfn
 import pos3
-from lerobot.configs.train import TrainPipelineConfig
+from lerobot.configs.train import TRAIN_CONFIG_NAME, TrainPipelineConfig
 from lerobot.constants import ACTION, CHECKPOINTS_DIR, OBS_IMAGE, OBS_STATE, PRETRAINED_MODEL_DIR
 from lerobot.envs.configs import EnvConfig, FeatureType, PolicyFeature
 from lerobot.scripts import train as lerobot_train
@@ -120,7 +120,7 @@ def train(
         codec = getattr(module, parts[-1])
         logging.info(f'Resolved codec from string: {codec}')
 
-    base_config = str(Path(__file__).resolve().parent.joinpath('train_config.json'))
+    base_config = str(Path(__file__).resolve().parent.joinpath(TRAIN_CONFIG_NAME))
     assert Path(base_config).is_file(), f'Base config file {base_config} does not exist.'
     exp_name = str(exp_name)
     cfg = TrainPipelineConfig.from_pretrained(base_config)
@@ -160,7 +160,7 @@ def train(
             checkpoint_dirs = [d for d in checkpoints_dir.iterdir() if d.is_dir() and d.name.isdigit()]
             if checkpoint_dirs:
                 latest_checkpoint = max(checkpoint_dirs, key=lambda d: int(d.name))
-                config_path = latest_checkpoint / PRETRAINED_MODEL_DIR / 'train_config.json'
+                config_path = latest_checkpoint / PRETRAINED_MODEL_DIR / TRAIN_CONFIG_NAME
                 logging.info(f'Resuming run. Automatically setting config_path to {config_path}')
                 # Hack: lerobot requires config_path to be in sys.argv for validation
                 sys.argv.append(f'--config_path={config_path}')

--- a/positronic/vendors/molmoact2/codecs.py
+++ b/positronic/vendors/molmoact2/codecs.py
@@ -65,7 +65,7 @@ molmoact2_obs = cfn.Config(MolmoAct2ObservationCodec)
 # AbsoluteJointsAction; serving reads the 8-vector directly.
 # Its gripper follows the DROID convention (0=open, 1=closed), matching positronic's Robotiq/DH
 # drivers, so the grip passes through unchanged on both state-in and target_grip-out.
-_action = codecs.absolute_joints_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key='target_grip')
+_action = codecs.absolute_joints_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key=keys.TARGET_GRIP)
 
 # franka_droid runs at 15 Hz; the model emits a 15-step horizon and compose executes all steps by default.
 droid = codecs.compose.override(obs=molmoact2_obs, action=_action, fps=15.0)

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -203,7 +203,7 @@ class PoseDeltaAction(Codec):
         physical = action[:6] * self.OUTPUT_MAX
         delta = geom.Transform3D(translation=physical[:3], rotation=geom.Rotation.from_rotvec(physical[3:6]))
         grip = (float(action[6]) + 1.0) / 2.0
-        return {keys.ROBOT_COMMAND: command.CartesianDelta(delta=delta), 'target_grip': grip}
+        return {keys.ROBOT_COMMAND: command.CartesianDelta(delta=delta), keys.TARGET_GRIP: grip}
 
 
 # Constants pi05_libero's training distribution requires that the env's wire observation does not carry

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -49,7 +49,7 @@ def wire(  # noqa: C901
             ds_agent.add_signal(keys.ROBOT_COMMAND, TrajectoryOverrideSerializer(Serializers.robot_command))
             ds_agent.add_signal('robot_state', Serializers.robot_state)
         if gripper is not None:
-            ds_agent.add_signal('target_grip', TrajectoryOverrideSerializer(None))
+            ds_agent.add_signal(keys.TARGET_GRIP, TrajectoryOverrideSerializer(None))
             ds_agent.add_signal(keys.GRIP)
 
         for signal_name, emitter in cameras.items():
@@ -58,7 +58,7 @@ def wire(  # noqa: C901
             world.connect(harness.robot_commands, ds_agent.inputs[keys.ROBOT_COMMAND])
             world.connect(robot_arm.state, ds_agent.inputs['robot_state'])
         if gripper is not None:
-            world.connect(harness.target_grip, ds_agent.inputs['target_grip'])
+            world.connect(harness.target_grip, ds_agent.inputs[keys.TARGET_GRIP])
             world.connect(gripper.grip, ds_agent.inputs[keys.GRIP])
 
     if gui is not None:

--- a/utilities/convert_ds.py
+++ b/utilities/convert_ds.py
@@ -57,7 +57,9 @@ def update_v0_1_0(path: str):
                 keys.WRIST_IMAGE: 'image.handcam_left',
                 keys.EXTERIOR_IMAGE: 'image.back_view',
             }),
-            Identity(select=['grip', 'target_grip', 'mjSTATE_FULLPHYSICS', 'mjSTATE_INTEGRATION', 'mjSTATE_WARMSTART']),
+            Identity(
+                select=[keys.GRIP, keys.TARGET_GRIP, 'mjSTATE_FULLPHYSICS', 'mjSTATE_INTEGRATION', 'mjSTATE_WARMSTART']
+            ),
         ),
     )
 

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -44,7 +44,7 @@ GROOT_META = {
         'action': {
             'target_robot_position_translation': {'start': 0, 'end': 3},
             'target_robot_position_quaternion': {'start': 3, 'end': 7, 'rotation_type': 'quaternion'},
-            'target_grip': {'start': 7, 'end': 8},
+            keys.TARGET_GRIP: {'start': 7, 'end': 8},
         }
     },
 }


### PR DESCRIPTION
## Summary
- New structural guard `positronic/tests/test_vendor_boundary.py`: walks `positronic/`, `pimm/`, and `utilities/` with `ast`, resolves relative imports, and fails naming file:line on any import of a vendor from outside `positronic/vendors/` or from another vendor.
- Fixes the two boundary violations: the `act`/`act_absolute` configs move from `positronic/cfg/policy.py` to `positronic/vendors/lerobot_0_3_3/policy.py` (nothing in code referenced them — only docs by absolute path, now updated), and the gr00t codec tests move from `positronic/policy/tests/test_policy_io.py` to `positronic/vendors/gr00t/tests/test_codecs.py`.
- ARCHITECTURE.md states both boundaries as a consequence of "Foreign components plug in through shims".
- The moved config's checkpoint-layout literals are replaced with lerobot's own `CHECKPOINTS_DIR`/`PRETRAINED_MODEL_DIR` constants (also in the vendor's server and train), and its checkpoint resolution reuses `resolve_checkpoint`, aligning local loading with the serving path.

Closes #608

## Test plan
- `uv run --locked pytest --no-cov` — 1086 passed, 8 skipped (includes both guard tests).
- Guard proven to fire: planted core→vendor imports (absolute and `from positronic import vendors`) and cross-vendor imports (absolute and relative) each fail with the offending file and line.
- `uv run --locked --extra lerobot_0_3_3 pytest positronic/vendors/lerobot_0_3_3 --no-cov` — vendor modules import cleanly with lerobot installed, 4 passed.
- basedpyright — 0 errors; the baseline shrank by the one stale `cfg/policy.py` entry.