### PR TITLE
Reduce a run whose `eval.pass` span never closed over its episodes

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -105,9 +105,9 @@ positronic eval timing-report <run_dir> [--gpu_policy_log <nvidia-smi dmon log>]
 Reduces the sidecars under `<run_dir>/telemetry/` into a pass report and writes `timing_summary.json` beside
 the input (`<run_dir>` may be an `s3://` URI). It reports:
 
-- the **wall split** — each phase's share of `W_pass` (reset / env.step / policy wait / record IO / overhead /
-  between-episodes), summing to 1; the policy-wait share also carries the sizing figure derived from it, how
-  many such evals one policy server could keep fed;
+- the **wall split** — each phase's share of the report's wall window (reset / env.step / policy wait / record
+  IO / overhead / between-episodes), summing to 1; the policy-wait share also carries the sizing figure derived
+  from it, how many such evals one policy server could keep fed;
 - the **env-step split** — physics / render / server-other (the env server's own decomposition), plus the wire
   and materialisation shares of the client step; absent for a native sim, which reports no server decomposition;
 - **inference latency** — call count and p50 / p95;
@@ -120,6 +120,13 @@ the input (`<run_dir>` may be an `s3://` URI). It reports:
   a GPU box, with the metrics unavailable — only a box holding no device at all carries no GPU line.
 
 Shares print as percentages; `timing_summary.json` keeps them as fractions.
+
+Every share, and the real-time factor, is a fraction of one wall window, and `window` names which: `W_pass`,
+the `eval.pass` span, whenever that span closed. A run killed or preempted mid-pass never writes it, so the
+reduce falls back to `W_episodes` — the wall from its first complete episode to its last, one window per run
+where a directory holds several. That window excludes whatever ran either side of those episodes, so a share
+of it is not a share of a pass; the report says which one it used in its own body as well as on the console.
+A directory holding neither a closed pass span nor an episode has nothing to reduce, and the reduce refuses.
 
 `--gpu_policy_log` folds in the policy endpoint (a different box) from an `nvidia-smi dmon -s um` log; it reads
 the `sm` / `fb` column positions from the log header and fails loudly if the `fb` (framebuffer) column is

--- a/positronic/cli/eval/tests/test_timing_report.py
+++ b/positronic/cli/eval/tests/test_timing_report.py
@@ -2,7 +2,14 @@ import json
 
 import pytest
 
-from positronic.cli.eval.timing_report import _build_report, _parse_dmon, _read_spans_dir, _read_stats_dir, _render
+from positronic.cli.eval.timing_report import (
+    WallWindow,
+    _build_report,
+    _parse_dmon,
+    _read_spans_dir,
+    _read_stats_dir,
+    _render,
+)
 from positronic.simulator.env_server.telemetry import ENV_PROCESS
 from positronic.telemetry import (
     ATTR_PROCESS_NAME,
@@ -107,7 +114,8 @@ def test_report_aggregates(tmp_path):
     report = _build_report(spans, _read_stats_dir(tmp_path / TELEMETRY_SUBDIR), policy_gpu=None)
 
     assert report.episodes == 2
-    assert report.wall_pass_s == pytest.approx(100.0)
+    assert report.window is WallWindow.W_PASS
+    assert report.wall_s == pytest.approx(100.0)
     assert report.real_time_factor == pytest.approx(0.40)  # 40 virtual-s / 100 wall-s
     assert report.infer_calls == 4
     assert report.infer_p50_ms == pytest.approx(2000.0)
@@ -216,7 +224,7 @@ def test_aborted_episode_wall_excluded_from_between_episodes(tmp_path):
     report = _build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)
 
     assert report.episodes == 1
-    assert report.wall_pass_s == pytest.approx(60.0)  # 100 s pass minus the 40 s aborted episode
+    assert report.wall_s == pytest.approx(60.0)  # 100 s pass minus the 40 s aborted episode
     split = report.wall_split
     # between_episodes is the completed episode's real inter-episode idle only (60 - 40), NOT (100 - 40)/100
     # with the aborted wall folded in.
@@ -288,8 +296,87 @@ def test_orphan_episode_from_killed_run_excluded(tmp_path):
     )
     report = _build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)
     assert report.episodes == 1
+    assert report.window is WallWindow.W_PASS
     assert report.real_time_factor == pytest.approx(0.20)  # 20 virtual-s / 100 wall-s; the orphan's 15 don't count
     assert report.wall_split.between_episodes == pytest.approx(0.60)
+
+
+def test_run_whose_pass_span_never_closed_reduces_over_its_episodes(tmp_path):
+    """A killed or preempted run writes no ``eval.pass`` span, but its finished episodes are complete recorded
+    data. They reduce against the wall they span — 10 s to 100 s here — which the report names W_episodes
+    because it excludes whatever ran either side of them and is therefore not a pass window."""
+    telemetry_dir = tmp_path / TELEMETRY_SUBDIR
+    telemetry_dir.mkdir()
+    _write_lines(
+        telemetry_dir / f'{HARNESS_PROCESS}{SPANS_SUFFIX}',
+        [
+            _span(SPAN_EPISODE, 10, 50, 'ep0', 'unwritten-pass', {ATTR_EPISODE_VIRTUAL_S: 20.0}),
+            _span(SPAN_RESET, 10, 15, 'reset0', 'ep0'),
+            _span(SPAN_EPISODE, 60, 100, 'ep1', 'unwritten-pass', {ATTR_EPISODE_VIRTUAL_S: 20.0}),
+        ],
+    )
+
+    report = _build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)
+
+    assert report.episodes == 2
+    assert report.window is WallWindow.W_EPISODES
+    assert report.wall_s == pytest.approx(90.0)
+    assert report.real_time_factor == pytest.approx(40 / 90)
+    assert report.wall_split.reset == pytest.approx(5 / 90)
+    # The 10 s between the two episodes is inside the window and attributes; the 10 s before the first is not.
+    assert report.wall_split.between_episodes == pytest.approx(10 / 90)
+
+
+def test_two_killed_runs_in_one_directory_get_a_window_each(tmp_path):
+    """Grouping episodes by the pass span they name keeps two killed runs appended to one directory apart. The
+    idle wall between them belongs to neither run, exactly as the gap between two pass spans does — one window
+    spanning both would report 1040 s of wall for 80 s of work."""
+    telemetry_dir = tmp_path / TELEMETRY_SUBDIR
+    telemetry_dir.mkdir()
+    _write_lines(
+        telemetry_dir / f'{HARNESS_PROCESS}{SPANS_SUFFIX}',
+        [
+            _span(SPAN_EPISODE, 0, 40, 'ep0', 'unwritten-pass-a', {ATTR_EPISODE_VIRTUAL_S: 20.0}),
+            _span(SPAN_EPISODE, 1000, 1040, 'ep1', 'unwritten-pass-b', {ATTR_EPISODE_VIRTUAL_S: 20.0}),
+        ],
+    )
+
+    report = _build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)
+
+    assert report.episodes == 2
+    assert report.wall_s == pytest.approx(80.0)
+    assert report.wall_split.between_episodes == pytest.approx(0.0)
+
+
+def test_telemetry_with_neither_a_pass_nor_an_episode_names_what_is_missing(tmp_path):
+    """Spans that carry no closed pass and no episode leave nothing to reduce. The refusal must say so: a run
+    killed before its first episode finished did record telemetry, so blaming a missing ``--timing`` sends the
+    reader after a flag they set."""
+    telemetry_dir = tmp_path / TELEMETRY_SUBDIR
+    telemetry_dir.mkdir()
+    _write_lines(telemetry_dir / f'{HARNESS_PROCESS}{SPANS_SUFFIX}', [_span(SPAN_RESET, 0, 5, 'reset0')])
+
+    with pytest.raises(ValueError, match=f'no closed `{SPAN_EVAL_PASS}` span and no `{SPAN_EPISODE}` span') as exc:
+        _build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)
+    assert '--timing' not in str(exc.value)
+
+
+def test_render_names_the_episode_window_it_reduced_over(tmp_path):
+    """The console warning is lost once the report is pasted elsewhere, so the rendered body itself must say
+    the shares are of the episode window rather than of a pass."""
+    telemetry_dir = tmp_path / TELEMETRY_SUBDIR
+    telemetry_dir.mkdir()
+    _write_lines(
+        telemetry_dir / f'{HARNESS_PROCESS}{SPANS_SUFFIX}',
+        [_span(SPAN_EPISODE, 0, 90, 'ep0', 'unwritten-pass', {ATTR_EPISODE_VIRTUAL_S: 20.0})],
+    )
+
+    rendered = _render(_build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)).splitlines()
+
+    assert f'no {SPAN_EVAL_PASS} span closed' in rendered[0]
+    assert 'W_episodes (wall):   90.0 s (0.03 h)' in rendered
+    assert 'wall split (share of W_episodes):' in rendered
+    assert not any('W_pass' in line for line in rendered)
 
 
 def test_multi_gpu_peak_vram_sums_devices_per_sample(tmp_path):

--- a/positronic/cli/eval/tests/test_timing_report.py
+++ b/positronic/cli/eval/tests/test_timing_report.py
@@ -374,9 +374,9 @@ def test_render_names_the_episode_window_it_reduced_over(tmp_path):
     rendered = _render(_build_report(_read_spans_dir(telemetry_dir), [], policy_gpu=None)).splitlines()
 
     assert f'no {SPAN_EVAL_PASS} span closed' in rendered[0]
-    assert 'W_episodes (wall):   90.0 s (0.03 h)' in rendered
-    assert 'wall split (share of W_episodes):' in rendered
-    assert not any('W_pass' in line for line in rendered)
+    assert f'{WallWindow.W_EPISODES} (wall):   90.0 s (0.03 h)' in rendered
+    assert f'wall split (share of {WallWindow.W_EPISODES}):' in rendered
+    assert not any(WallWindow.W_PASS in line for line in rendered)
 
 
 def test_multi_gpu_peak_vram_sums_devices_per_sample(tmp_path):

--- a/positronic/cli/eval/timing_report.py
+++ b/positronic/cli/eval/timing_report.py
@@ -14,6 +14,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass, fields
+from enum import StrEnum
 from pathlib import Path
 
 import configuronic as cfn
@@ -98,15 +99,29 @@ class GpuReport:
     policy: GpuSummary | None
 
 
+class WallWindow(StrEnum):
+    """The wall window every share in a report is a fraction of, named by the symbol the report prints.
+
+    ``W_PASS`` is the ``eval.pass`` span, which covers the whole pass including the setup and teardown either
+    side of its episodes. ``W_EPISODES`` is the fallback for a run whose pass span never closed: the wall from
+    its first episode's start to its last one's end. That window is narrower — whatever ran before the first
+    episode or after the last is outside it — so a share of it is not a share of a pass, and the two carry
+    different names for that reason.
+    """
+
+    W_PASS = 'W_pass'
+    W_EPISODES = 'W_episodes'
+
+
 @dataclass
 class WallSplit:
-    """Each phase's share of pass wall time.
+    """Each phase's share of the report's wall window.
 
     ``overhead`` is the within-episode wall unattributed to a measured phase (including the recorder's
     parquet/video close flush, which runs after record IO); ``between_episodes`` is the inter-episode wall
-    (session teardown, homing, world rebuild) inside the pass span between one episode's finish and the next's
-    start. The measured phases plus these two cover the pass span minus any aborted-episode wall, which is
-    excluded from W_pass entirely.
+    (session teardown, homing, world rebuild) inside the window between one episode's finish and the next's
+    start. The measured phases plus these two cover the window minus any aborted-episode wall, which is
+    excluded from it entirely.
     """
 
     reset: float
@@ -135,10 +150,16 @@ class EnvStepSplit:
 
 @dataclass
 class PassReport:
-    """Pass-level wall-clock roll-up reduced from the recorded telemetry spans and stats."""
+    """Pass-level wall-clock roll-up reduced from the recorded telemetry spans and stats.
+
+    ``window`` names which wall ``wall_s`` measures and which every share in ``wall_split``, and the real-time
+    factor, are fractions of. It rides with the numbers because a run killed mid-pass reduces against the
+    narrower episode window, and a figure normalised by that one is not comparable with a pass figure.
+    """
 
     episodes: int
-    wall_pass_s: float
+    window: WallWindow
+    wall_s: float
     real_time_factor: float
     infer_calls: int
     infer_p50_ms: float
@@ -167,12 +188,12 @@ def _read_stats_dir(telemetry_dir: Path) -> list[dict]:
     return samples
 
 
-def _gpu_summary_from_stats(stats: list[dict], pass_windows: list[tuple[int, int]]) -> GpuSummary | None:
-    """The sim box's GPU summary from the machine-load stream. Only samples taken inside a completed pass's
-    wall window count — a reused directory carries an earlier (possibly killed) run's samples, the stats twin
+def _gpu_summary_from_stats(stats: list[dict], windows: list[tuple[int, int]]) -> GpuSummary | None:
+    """The sim box's GPU summary from the machine-load stream. Only samples taken inside one of the report's
+    wall windows count — a reused directory carries an earlier (possibly killed) run's samples, the stats twin
     of the orphan-episode exclusion. ``None`` when no counted sample held a device at all (a CPU sim box); a
     box whose devices all refused their queries is a summary with nothing measured, not a CPU box."""
-    in_window = [s for s in stats if any(start <= int(s[STAT_T_NS]) <= end for start, end in pass_windows)]
+    in_window = [s for s in stats if any(start <= int(s[STAT_T_NS]) <= end for start, end in windows)]
     # The recorded count is the box's NVML handle count, so it stands whether or not any device answered:
     # reading it across every sample, including the empty ones, separates an unreadable GPU box from a CPU one.
     box_devices = max((int(s[STAT_GPU_COUNT]) for s in in_window), default=0)
@@ -423,27 +444,60 @@ def _env_step_split(spans: list[SpanRec], episodes: list[SpanRec], env_step_sum:
     )
 
 
+def _episode_windows(episodes: list[SpanRec]) -> dict[str | None, tuple[int, int]]:
+    """One wall window per run whose ``eval.pass`` span never closed, keyed by the pass span the episodes name
+    as their parent — from that run's first episode start to its last episode end.
+
+    Grouping by parent is what keeps two killed runs appended to one directory apart: each contributes its own
+    window, so the dead wall between them falls outside both, exactly as the gap between two pass spans does.
+    Aborted episodes count towards the window, because they are subtracted from it by the same rule that
+    subtracts them from a pass span's wall.
+    """
+    by_parent: dict[str | None, list[SpanRec]] = defaultdict(list)
+    for episode in episodes:
+        by_parent[episode.parent_id].append(episode)
+    return {
+        parent: (min(e.start_ns for e in group), max(e.end_ns for e in group)) for parent, group in by_parent.items()
+    }
+
+
 def _build_report(spans: list[SpanRec], stats: list[dict], policy_gpu: GpuSummary | None) -> PassReport:
     children: dict[str, list[SpanRec]] = defaultdict(list)
     for span in spans:
         if span.parent_id is not None:
             children[span.parent_id].append(span)
 
-    # W_pass is the pass span's wall (summed if several passes appended to one dir), so inter-episode teardown
-    # counts in the denominator; the wall gap between two separate passes falls outside every pass span. An
-    # aborted episode's wall is subtracted out: the episode is dropped as invalid data (its virtual time, phases
-    # and infers never reduce), so its wall must also leave every W_pass-normalised figure rather than land in
-    # ``between_episodes`` and deflate the policy-wait / real-time factors.
+    # The denominator is the pass span's wall (summed if several passes appended to one dir), so inter-episode
+    # teardown counts in it; the wall gap between two separate passes falls outside every pass span. A run
+    # killed or preempted mid-pass never writes that span, so it falls back to the wall its complete episodes
+    # span — narrower, and named W_episodes rather than W_pass because a share of it is not a share of a pass.
+    all_episodes = [s for s in spans if s.name == SPAN_EPISODE]
     passes = [p for p in spans if p.name == SPAN_EVAL_PASS]
-    pass_ids = {p.span_id for p in passes}
-    aborted_wall = float(
-        sum(
-            _dur_s(s)
-            for s in spans
-            if s.name == SPAN_EPISODE and s.attrs.get(ATTR_EPISODE_ABORTED, False) and s.parent_id in pass_ids
+    if passes:
+        window = WallWindow.W_PASS
+        windows = {p.span_id: (p.start_ns, p.end_ns) for p in passes}
+    else:
+        window = WallWindow.W_EPISODES
+        windows = _episode_windows(all_episodes)
+        if windows:
+            logger.warning(
+                'no %s span closed (a killed or preempted run?); reducing over the wall its complete episodes '
+                'span, so every share is of %s rather than of a pass window',
+                SPAN_EVAL_PASS,
+                window.value,
+            )
+    if not windows:
+        raise ValueError(
+            f'the recorded telemetry holds {len(spans)} span(s) but no closed `{SPAN_EVAL_PASS}` span and no '
+            f'`{SPAN_EPISODE}` span, so there is nothing to reduce (killed before its first episode finished?)'
         )
+    # An aborted episode's wall is subtracted out: the episode is dropped as invalid data (its virtual time,
+    # phases and infers never reduce), so its wall must also leave every normalised figure rather than land in
+    # ``between_episodes`` and deflate the policy-wait / real-time factors.
+    aborted_wall = float(
+        sum(_dur_s(s) for s in all_episodes if s.attrs.get(ATTR_EPISODE_ABORTED, False) and s.parent_id in windows)
     )
-    wall_pass = float(sum(_dur_s(p) for p in passes)) - aborted_wall
+    wall = float(sum(end - start for start, end in windows.values())) / 1e9 - aborted_wall
     # A failed pass still reduces — its partial window, episodes and samples are real recorded data — but
     # never silently: the mix is named so a skewed-looking split has its explanation on the console.
     failed = sum(bool(p.attrs.get(ATTR_PASS_FAILED, False)) for p in passes)
@@ -451,10 +505,9 @@ def _build_report(spans: list[SpanRec], stats: list[dict], policy_gpu: GpuSummar
         logger.warning(
             '%d of %d pass(es) failed mid-run; their partial windows are included in the report', failed, len(passes)
         )
-    # Only episodes under a completed pass reduce: a killed run flushes its episodes but never writes its
-    # ``eval.pass`` span, and such orphans would inflate every pass-normalized figure when the directory is
-    # reused for a later run.
-    episodes = [s for s in spans if s.name == SPAN_EPISODE and not s.attrs.get(ATTR_EPISODE_ABORTED, False)]
+    # Only episodes belonging to a window reduce: where one pass completed, a killed earlier run's episodes are
+    # in the same reused directory but under no window of their own, and would inflate every normalised figure.
+    episodes = [s for s in all_episodes if not s.attrs.get(ATTR_EPISODE_ABORTED, False)]
     # A partial episode (its rollout failed mid-run) is kept, not dropped: its finished phases are real wall
     # and must attribute rather than fall into ``between_episodes``. Named, like ``pass.failed``, so the split
     # is read with its incomplete window in view.
@@ -463,10 +516,10 @@ def _build_report(spans: list[SpanRec], stats: list[dict], policy_gpu: GpuSummar
         logger.warning(
             '%d episode(s) did not run to completion (a failed pass?); their finished phases are included', partial
         )
-    orphans = sum(e.parent_id not in pass_ids for e in episodes)
+    orphans = sum(e.parent_id not in windows for e in episodes)
     if orphans:
         logger.warning('%d episode(s) belong to no completed pass (a killed run?); excluded from the report', orphans)
-        episodes = [e for e in episodes if e.parent_id in pass_ids]
+        episodes = [e for e in episodes if e.parent_id in windows]
     timings = [_episode_timing(e, children) for e in episodes]
 
     episode_wall_sum = float(sum(t.wall_s for t in timings))
@@ -475,7 +528,7 @@ def _build_report(spans: list[SpanRec], stats: list[dict], policy_gpu: GpuSummar
     all_infer_ms = np.array([ms for t in timings for ms in t.infer_ms], dtype=float)
 
     def phase_fraction(total: float) -> float:
-        return (total / wall_pass) if wall_pass else 0.0
+        return (total / wall) if wall else 0.0
 
     wall_split = WallSplit(
         reset=phase_fraction(sum(t.reset_s for t in timings)),
@@ -483,18 +536,19 @@ def _build_report(spans: list[SpanRec], stats: list[dict], policy_gpu: GpuSummar
         policy_wait=phase_fraction(sum(t.policy_wait_s for t in timings)),
         record_io=phase_fraction(sum(t.record_io_s for t in timings)),
         overhead=phase_fraction(sum(t.overhead_s for t in timings)),
-        between_episodes=phase_fraction(wall_pass - episode_wall_sum),
+        between_episodes=phase_fraction(wall - episode_wall_sum),
     )
     return PassReport(
         episodes=len(episodes),
-        wall_pass_s=wall_pass,
-        real_time_factor=(sum(t.virtual_s for t in timings) / wall_pass) if wall_pass else 0.0,
+        window=window,
+        wall_s=wall,
+        real_time_factor=(sum(t.virtual_s for t in timings) / wall) if wall else 0.0,
         infer_calls=int(all_infer_ms.size),
         infer_p50_ms=float(np.percentile(all_infer_ms, 50)) if all_infer_ms.size else 0.0,
         infer_p95_ms=float(np.percentile(all_infer_ms, 95)) if all_infer_ms.size else 0.0,
         wall_split=wall_split,
         env_step_split=_env_step_split(spans, episodes, env_step_sum, materialize_sum),
-        gpu=GpuReport(sim=_gpu_summary_from_stats(stats, [(p.start_ns, p.end_ns) for p in passes]), policy=policy_gpu),
+        gpu=GpuReport(sim=_gpu_summary_from_stats(stats, list(windows.values())), policy=policy_gpu),
     )
 
 
@@ -508,13 +562,22 @@ def _share_row(name: str, fraction: float) -> str:
 
 
 def _render(report: PassReport) -> str:
-    lines = [
+    window = report.window.value
+    lines = []
+    # The console warning is lost the moment this text is pasted anywhere, and the numbers under a narrower
+    # window read exactly like pass numbers, so the report says which window it reduced over in its own body.
+    if report.window is WallWindow.W_EPISODES:
+        lines.append(
+            f'no {SPAN_EVAL_PASS} span closed (a killed or preempted run?): {window} is the wall from the first '
+            f'complete episode to the last, and every share below is of that, not of a pass'
+        )
+    lines += [
         f'episodes:            {report.episodes}',
-        f'W_pass (wall):       {report.wall_pass_s:.1f} s ({report.wall_pass_s / 3600:.2f} h)',
+        f'{window + " (wall):":<21}{report.wall_s:.1f} s ({report.wall_s / 3600:.2f} h)',
         f'real-time factor:    {report.real_time_factor * 100:>6.1f}% (sim-s per wall-s)',
         f'infer calls:         {report.infer_calls}',
         f'infer p50 / p95:     {report.infer_p50_ms:.1f} / {report.infer_p95_ms:.1f} ms',
-        'wall split (share of W_pass):',
+        f'wall split (share of {window}):',
     ]
     for f in fields(WallSplit):
         share = getattr(report.wall_split, f.name)
@@ -560,7 +623,7 @@ def timing_report(run_dir: str, gpu_policy_log: str | None):
     root = Path(pos3.download(run_dir)) if '://' in run_dir else Path(run_dir)
     telemetry_dir = root / TELEMETRY_SUBDIR
     spans = _read_spans_dir(telemetry_dir) if telemetry_dir.is_dir() else []
-    if not any(s.name == SPAN_EVAL_PASS for s in spans):
+    if not spans:
         raise ValueError(f'no telemetry under {telemetry_dir} (recorded without --timing?)')
 
     policy_gpu = _parse_dmon(Path(gpu_policy_log)) if gpu_policy_log is not None else None


### PR DESCRIPTION
## What

`positronic eval timing-report` now reduces a run that was killed or preempted mid-pass. Where no `eval.pass` span closed, the wall window falls back to the span of the run's complete episodes, grouped by the pass span they name as their parent, so two killed runs appended to one directory keep a window each and the dead wall between them counts for neither.

Every share, and the real-time factor, is a fraction of one window, and a new `window` field names which — `W_pass` or `W_episodes`. `PassReport.wall_pass_s` becomes `wall_s` for the same reason: the field no longer always measures a pass.

## Why

`timing_report` gated on a closed `eval.pass` span, which is only written when a pass finishes. A killed run therefore reduced to nothing however many complete episode spans were on disk — and the orphan filter dropped those episodes a second time, since every one of them names a parent span that was never written. A preempted box is exactly the case whose timings someone wants to read.

The alternative shape is to reduce the same numbers and simply omit the pass-derived ones — drop `W_pass` and the wall split, keep the inference latencies. Rejected: that is most of the value gone for the case this fixes. So the figures are recomputed against the fallback window instead, and the window rides with them rather than being implied. `W_episodes` is narrower by construction — it excludes whatever ran either side of the episodes — so a share of it is not a share of a pass, and nothing here silently relabels one as the other. The report says which window it used in its own rendered body as well as on the console, because the console warning is lost the moment the text is pasted anywhere.

`no telemetry under <dir> (recorded without --timing?)` now fires only when there is genuinely no telemetry. Spans carrying neither a closed pass nor an episode name what is missing, rather than sending a reader after a flag they did set.

## Verification

`pytest positronic/cli/eval/tests/test_timing_report.py` — 27 pass, including four new cases: the fallback window and its shares, two killed runs in one directory getting a window each, the refusal that names what is missing, and the rendered body naming `W_episodes` with no `W_pass` anywhere in it. `ruff check`/`format` clean.

## Refs

Closes internal#353.

<!-- opened-by: posi-agent -->