### PR TITLE
Give every `production` endpoint its own credentials

### DIFF
--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -101,11 +101,11 @@ def production(
     """Routes each episode to one of several remote endpoints, each named for CLI overrides.
 
     An endpoint is a whole `remote` config rather than a URL, so what one server needs stays that
-    server's and reaches no other: `--policy.endpoints.groot.url=ws://desktop:8000` repoints one and
-    `--policy.endpoints.groot.headers='{"Authorization": "Bearer <token>"}'` credentials it. Adding one
-    names the config it is built from, `--policy.endpoints.groot=@positronic.cfg.policy.remote`, and
-    then its arguments. `weights` name the same endpoints and set their sampling odds; endpoints left
-    out of it weigh 1.0.
+    server's and reaches no other — `--policy.endpoints.groot.url=ws://desktop:8000` repoints one, and
+    `--policy.endpoints.groot=.nebius_remote` with its own `.url` moves that one alone behind a token
+    while the rest stay open. A name not already here is built from the config it is given,
+    `@positronic.cfg.policy.remote`. `weights` name the same endpoints and set their sampling odds;
+    endpoints left out of it weigh 1.0.
     """
     if not endpoints:
         raise ValueError(

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -91,30 +91,34 @@ def balanced(balance: int):
     return BalancedSampler(balance=balance)
 
 
-@cfn.config(endpoints={}, weights={}, recording_dir=None, sampler=None, group_fields=None)
+@cfn.config(endpoints={}, weights={}, sampler=None, group_fields=None)
 def production(
-    endpoints: dict[str, str],
+    endpoints: dict[str, RemotePolicy],
     weights: dict[str, float],
-    recording_dir: str | None,
     sampler: Sampler | None,
     group_fields: list[str] | None,
 ):
     """Routes each episode to one of several remote endpoints, each named for CLI overrides.
 
-    An endpoint is one URL, so `--policy.endpoints.groot=ws://desktop:8000` adds or repoints one without
-    restating the others. `weights` name the same endpoints and set their sampling odds; endpoints left
+    An endpoint is a whole `remote` config rather than a URL, so what one server needs stays that
+    server's and reaches no other: `--policy.endpoints.groot.url=ws://desktop:8000` repoints one and
+    `--policy.endpoints.groot.headers='{"Authorization": "Bearer <token>"}'` credentials it. Adding one
+    names the config it is built from, `--policy.endpoints.groot=@positronic.cfg.policy.remote`, and
+    then its arguments. `weights` name the same endpoints and set their sampling odds; endpoints left
     out of it weigh 1.0.
     """
     if not endpoints:
-        raise ValueError('At least one endpoint must be given, e.g. --policy.endpoints.groot=ws://desktop:8000')
+        raise ValueError(
+            'At least one endpoint must be given, e.g. --policy.endpoints.groot=@positronic.cfg.policy.remote '
+            '--policy.endpoints.groot.url=ws://desktop:8000'
+        )
     if unknown := weights.keys() - endpoints.keys():
         raise ValueError(f'weights name unknown endpoints: {sorted(unknown)}; known are {sorted(endpoints)}')
     # Every Sampler but the default uniform one picks by episode counts alone, so weights would be dropped.
     if weights and sampler is not None:
         raise ValueError(f'weights cannot be combined with {type(sampler).__name__}, which samples by count')
-    policies = [RemotePolicy(url, recording_dir=recording_dir) for url in endpoints.values()]
     w = [weights.get(name, 1.0) for name in endpoints] if weights else None
-    return SampledPolicy(*policies, weights=w, sampler=sampler, group_fields=group_fields)
+    return SampledPolicy(*endpoints.values(), weights=w, sampler=sampler, group_fields=group_fields)
 
 
 @cfn.config()
@@ -128,12 +132,12 @@ def phail_single(hostname, w_openpi=1.0, w_groot=1.0, w_act=1.0):
 
 phail_multiple = production.override(
     endpoints={
-        'smolvla': 'ws://notebook:8000',
-        'act': 'ws://notebook:8001',
-        'groot': 'ws://desktop:8000',
-        'openpi': 'ws://vm-openpi:8000',
+        'smolvla': remote.override(url='ws://notebook:8000'),
+        'act': remote.override(url='ws://notebook:8001'),
+        'groot': remote.override(url='ws://desktop:8000'),
+        'openpi': remote.override(url='ws://vm-openpi:8000'),
         # DreamZero's 5B wan2.2 needs an H100, so it cannot share the consumer boxes above.
-        'dreamzero': 'ws://vm-train2:8000',
+        'dreamzero': remote.override(url='ws://vm-train2:8000'),
     },
     sampler=balanced,
     group_fields=[keys.TASK, 'eval.object', 'eval.tote_placement', 'eval.external_camera'],

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -100,10 +100,9 @@ def production(
 ):
     """Routes each episode to one of several remote endpoints, each named for CLI overrides.
 
-    An endpoint is a whole `remote` config rather than a URL, so what one server needs stays that
-    server's and reaches no other — `--policy.endpoints.groot.url=ws://desktop:8000` repoints one, and
-    `--policy.endpoints.groot=.nebius_remote` with its own `.url` moves that one alone behind a token
-    while the rest stay open. A name not already here is built from the config it is given,
+    An endpoint is a whole `remote` config, so a credential set on one reaches no other:
+    `--policy.endpoints.groot=.nebius_remote` with its own `.url` moves that endpoint behind a token
+    and leaves the rest open. A name not already in `endpoints` needs the config it is built from,
     `@positronic.cfg.policy.remote`. `weights` name the same endpoints and set their sampling odds;
     endpoints left out of it weigh 1.0.
     """

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -1,0 +1,31 @@
+import pytest
+
+from positronic.cfg.policy import production, remote
+
+
+def test_a_credential_reaches_only_the_endpoint_it_was_set_on():
+    cfg = production.override(
+        endpoints={'open': remote.override(url='ws://desktop:8000'), 'gated': remote.override(url='wss://gpu:443')},
+        **{'endpoints.gated.headers': {'Authorization': 'Bearer t'}},
+    )
+    open_ep, gated_ep = cfg.instantiate()._policies
+    assert open_ep._endpoint._client.headers is None
+    assert gated_ep._endpoint._client.headers == {'Authorization': 'Bearer t'}
+
+
+def test_weights_follow_the_endpoint_names():
+    cfg = production.override(
+        endpoints={'a': remote.override(url='ws://a:8000'), 'b': remote.override(url='ws://b:8000')}, weights={'b': 3.0}
+    )
+    assert cfg.instantiate()._weights == [1.0, 3.0]
+
+
+def test_no_endpoints_is_an_error():
+    with pytest.raises(ValueError, match='At least one endpoint'):
+        production.instantiate()
+
+
+def test_weights_naming_an_unknown_endpoint_is_an_error():
+    cfg = production.override(endpoints={'a': remote.override(url='ws://a:8000')}, weights={'b': 3.0})
+    with pytest.raises(ValueError, match='unknown endpoints'):
+        cfg.instantiate()

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -8,7 +8,8 @@ def test_a_credential_reaches_only_the_endpoint_it_was_set_on(monkeypatch):
     monkeypatch.setenv(AUTH_TOKEN_ENV, 'tok')
     cfg = phail_multiple.override(**{'endpoints.groot': '.authed_remote', 'endpoints.groot.url': 'https://gpu.example'})
     built = {p._endpoint._client.session_url: p._endpoint._client.headers for p in cfg.instantiate()._policies}
-    assert built.pop('wss://gpu.example/api/v1/session') == {AUTH_HEADER: bearer('tok')}
+    gated = built.pop('wss://gpu.example/api/v1/session')
+    assert gated == {AUTH_HEADER: bearer('tok')}
     assert set(built.values()) == {None}
 
 

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -1,16 +1,15 @@
 import pytest
 
-from positronic.cfg.policy import production, remote
+from positronic.cfg.policy import phail_multiple, production, remote
+from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, bearer
 
 
-def test_a_credential_reaches_only_the_endpoint_it_was_set_on():
-    cfg = production.override(
-        endpoints={'open': remote.override(url='ws://desktop:8000'), 'gated': remote.override(url='wss://gpu:443')},
-        **{'endpoints.gated.headers': {'Authorization': 'Bearer t'}},
-    )
-    open_ep, gated_ep = cfg.instantiate()._policies
-    assert open_ep._endpoint._client.headers is None
-    assert gated_ep._endpoint._client.headers == {'Authorization': 'Bearer t'}
+def test_a_credential_reaches_only_the_endpoint_it_was_set_on(monkeypatch):
+    monkeypatch.setenv(AUTH_TOKEN_ENV, 'tok')
+    cfg = phail_multiple.override(**{'endpoints.groot': '.authed_remote', 'endpoints.groot.url': 'https://gpu.example'})
+    built = {p._endpoint._client.session_url: p._endpoint._client.headers for p in cfg.instantiate()._policies}
+    assert built.pop('wss://gpu.example/api/v1/session') == {AUTH_HEADER: bearer('tok')}
+    assert set(built.values()) == {None}
 
 
 def test_weights_follow_the_endpoint_names():


### PR DESCRIPTION
## Summary

`production` mapped a name to a URL and built every `RemotePolicy` without `headers`, so pointing one of its endpoints at a gated server got a 401 on the model list and a refused WebSocket handshake. Follow-up to the thread on #565, which deferred the fix because it needs a decision: one bearer header shared by the whole dict, or credentials per endpoint.

**Per endpoint.** Sharing is wrong here beyond being the wrong shape — the endpoints a run routes between need not share a token, and `phail_multiple` names four plaintext `ws://` boxes that would each receive a secret they have no use for.

So an endpoint is a whole `remote` config rather than a URL, and everything one server needs is set on that server alone:

```bash
uv run positronic-inference phail \
  --policy.endpoints.groot=.nebius_remote \
  --policy.endpoints.groot.url=https://<managed-url>
```

`groot` gets `Authorization: Bearer <token>`; the other four stay open. `.authed_remote` works the same way against an exported `AUTH_TOKEN`.

- `production` no longer builds connections — it routes. `endpoints` is `dict[str, RemotePolicy]`.
- `recording_dir` leaves `production` with that: it is a `RemotePolicy` argument, reached as `--policy.endpoints.<name>.recording_dir`. There is no longer one run-wide flag for a whole fleet — configuronic instantiates dict values unconditionally, so keeping it would have meant the unstated contract "every endpoint config accepts `recording_dir`". `--policy.recording_dir` on the single-endpoint `.remote` path is unaffected.
- Adding an endpoint now names its config: `--policy.endpoints.groot=@positronic.cfg.policy.remote` and then its arguments. Repointing an existing one is unchanged (`--policy.endpoints.groot.url=...`).

## Test plan

- `positronic/cfg/tests/test_policy.py` — new, covering `production`, which had no tests. The first case swaps one `phail_multiple` entry for `.authed_remote` and asserts that endpoint alone carries the bearer header while the other four stay open; it exercises the relative-import form the CLI takes.
- `uv run --locked pytest --no-cov` — 1116 passed, 9 skipped.
- `uv run positronic-inference phail --help` renders each endpoint as its config.