### PR TITLE
Expand `~` in the filesystem paths a CLI entry point opens

### DIFF
--- a/positronic/cli/eval/tests/test_timing_report.py
+++ b/positronic/cli/eval/tests/test_timing_report.py
@@ -1,5 +1,6 @@
 import json
 
+import pos3
 import pytest
 
 from positronic.cli.eval.timing_report import (
@@ -9,6 +10,7 @@ from positronic.cli.eval.timing_report import (
     _read_spans_dir,
     _read_stats_dir,
     _render,
+    timing_report,
 )
 from positronic.simulator.env_server.telemetry import ENV_PROCESS
 from positronic.telemetry import (
@@ -744,3 +746,43 @@ def test_parse_dmon_fails_loudly_without_fb(tmp_path):
     log.write_text('# gpu    sm\n#  Idx     %\n    0    50\n')
     with pytest.raises(ValueError, match='fb'):
         _parse_dmon(log)
+
+
+def test_a_tilde_run_dir_and_dmon_log_resolve_against_home(tmp_path, monkeypatch):
+    """The documented eval quickstart writes to a `~`-relative directory, so the reduce reads one back."""
+    (tmp_path / 'run').mkdir()
+    _fixture(tmp_path / 'run' / TELEMETRY_SUBDIR)
+    (tmp_path / 'dmon.log').write_text('# gpu    sm    fb\n#  Idx     %    MB\n    0    50  1024\n')
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    timing_report(run_dir='~/run', gpu_policy_log='~/dmon.log')
+
+    summary = json.loads((tmp_path / 'run' / 'timing_summary.json').read_text())
+    assert summary['episodes'] == 2
+    assert summary['gpu']['policy']['peak_vram_gb'] == pytest.approx(1.0)
+
+
+def test_a_remote_run_dir_reaches_pos3_verbatim(tmp_path, monkeypatch):
+    """Expansion is the local branch's alone: an `s3://` URI is the remote store's to parse, `~` and all."""
+    _fixture(tmp_path / TELEMETRY_SUBDIR)
+    downloaded, uploaded = [], []
+    monkeypatch.setattr(pos3, 'download', lambda uri: downloaded.append(uri) or tmp_path)
+    monkeypatch.setattr(pos3, 'upload', lambda key, path, delete=True: uploaded.append(key))
+
+    timing_report(run_dir='s3://bucket/~run')
+
+    assert downloaded == ['s3://bucket/~run']
+    assert uploaded == ['s3://bucket/~run.timing_summary.json']
+
+
+def test_a_run_dir_holding_no_telemetry_directory_names_it(tmp_path):
+    with pytest.raises(ValueError, match='no telemetry directory') as excinfo:
+        timing_report(run_dir=str(tmp_path))
+    assert str(tmp_path / TELEMETRY_SUBDIR) in str(excinfo.value)
+
+
+def test_a_telemetry_directory_holding_no_spans_is_not_reported_as_untimed(tmp_path):
+    """The sidecar directory exists, so the run was timed — what is missing is its flushed spans."""
+    (tmp_path / TELEMETRY_SUBDIR).mkdir()
+    with pytest.raises(ValueError, match='carries no spans'):
+        timing_report(run_dir=str(tmp_path))

--- a/positronic/cli/eval/timing_report.py
+++ b/positronic/cli/eval/timing_report.py
@@ -620,13 +620,17 @@ def timing_report(run_dir: str, gpu_policy_log: str | None):
     for an ``s3://`` input to the sibling key ``<run_dir>.timing_summary.json`` (pos3 forbids uploading inside
     the downloaded prefix) — and prints the report.
     """
-    root = Path(pos3.download(run_dir)) if '://' in run_dir else Path(run_dir)
+    root = Path(pos3.download(run_dir)) if '://' in run_dir else Path(run_dir).expanduser()
     telemetry_dir = root / TELEMETRY_SUBDIR
-    spans = _read_spans_dir(telemetry_dir) if telemetry_dir.is_dir() else []
+    if not telemetry_dir.is_dir():
+        raise ValueError(
+            f'no telemetry directory at {telemetry_dir}: not a run directory, or recorded without --timing'
+        )
+    spans = _read_spans_dir(telemetry_dir)
     if not spans:
-        raise ValueError(f'no telemetry under {telemetry_dir} (recorded without --timing?)')
+        raise ValueError(f'{telemetry_dir} carries no spans (a run killed before its sidecars were flushed?)')
 
-    policy_gpu = _parse_dmon(Path(gpu_policy_log)) if gpu_policy_log is not None else None
+    policy_gpu = _parse_dmon(Path(gpu_policy_log).expanduser()) if gpu_policy_log is not None else None
     report = _build_report(spans, _read_stats_dir(telemetry_dir), policy_gpu)
     summary_path = root / 'timing_summary.json'
     summary_path.write_text(json.dumps(asdict(report), indent=2))

--- a/positronic/drivers/roboarm/generate_mujoco.py
+++ b/positronic/drivers/roboarm/generate_mujoco.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from pathlib import Path
 
 import configuronic as cfn
 import mujoco as mj
@@ -151,7 +152,8 @@ def main(
     kv: float,
     actuator_type: str,
 ):
-    with open(urdf_path, 'w') as f:
+    urdf, target = Path(urdf_path).expanduser(), Path(target_path).expanduser()
+    with open(urdf, 'w') as f:
         xml = create_arm(
             link_lengths=link_lengths,
             motors=motors,
@@ -161,9 +163,9 @@ def main(
         )
         f.write(xml)
 
-    spec = convert_urdf_to_mujoco(urdf_path, wall_mounted=wall_mounted, kp=kp, kv=kv, actuator_type=actuator_type)
+    spec = convert_urdf_to_mujoco(str(urdf), wall_mounted=wall_mounted, kp=kp, kv=kv, actuator_type=actuator_type)
     spec.compile()
-    with open(target_path, 'w') as f:
+    with open(target, 'w') as f:
         f.write(spec.to_xml())
 
 

--- a/positronic/drivers/roboarm/kinematics_debug.py
+++ b/positronic/drivers/roboarm/kinematics_debug.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import configuronic as cfn
 import mujoco
 import numpy as np
@@ -38,7 +40,7 @@ trajectory = [[i * 5000.0, random_6dof_on_sphere()] for i in range(100)]
 
 def debug_kinematics(urdf_path: str, mujoco_model_path: str, rerun: str, trajectory: list[list[float]]):
     rr.init('debug_kinematics')
-    rr.save(rerun)
+    rr.save(str(Path(rerun).expanduser()))
 
     taus = []
 

--- a/positronic/drivers/roboarm/kinova/base.py
+++ b/positronic/drivers/roboarm/kinova/base.py
@@ -9,6 +9,7 @@
 # sublicensed, and/or sold without explicit permission from the copyright holder.
 
 import math
+from pathlib import Path
 
 import mujoco
 import numpy as np
@@ -40,7 +41,7 @@ class KinematicsSolver:
     """Solves forward and inverse kinematics for the Kinova arm."""
 
     def __init__(self, path: str = 'positronic/drivers/roboarm/kinova/gen3.xml', ee_offset=0.0, site_name='pinch_site'):
-        self.model = mujoco.MjModel.from_xml_path(path)
+        self.model = mujoco.MjModel.from_xml_path(str(Path(path).expanduser()))
         self.data = mujoco.MjData(self.model)
         self.model.body_gravcomp[:] = 1.0
 
@@ -259,7 +260,7 @@ class JointCompliantController:
         self.target_qpos = None
 
         # Initialize pinocchio model and data
-        self.model = pin.buildModelFromUrdf(path)
+        self.model = pin.buildModelFromUrdf(str(Path(path).expanduser()))
         self.joint_nq = [joint.nq for joint in self.model.joints]
         self.data = self.model.createData()
         self._q_pin = np.zeros(self.model.nq)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -560,7 +560,7 @@ def main(
     dataset: Dataset,
     ep_table_cfg: TableConfig | None,
     max_resolution: int,
-    cache_dir: str = os.path.expanduser('~/.cache/positronic/server/'),
+    cache_dir: str = '~/.cache/positronic/server/',
     host: str = '0.0.0.0',
     port: int = 8400,
     debug: bool = False,
@@ -618,6 +618,7 @@ def main(
     deb_level = logging.DEBUG if debug else logging.INFO
     logging.basicConfig(level=deb_level, format='%(asctime)s - %(levelname)s - %(message)s')
 
+    cache_dir = os.path.expanduser(cache_dir)
     app_state['root'] = root
     app_state['cache_dir'] = cache_dir
     app_state['loading_state'] = True

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -118,7 +118,7 @@ class MujocoSim(pimm.ControlSystem):
         grip_fps: float | None = None,
         sim_state_fps: float | None = None,
     ):
-        self.mujoco_model_path = mujoco_model_path
+        self.mujoco_model_path = str(Path(mujoco_model_path).expanduser())
         self.loaders = loaders
         self.warmup_steps = 1000
         self.fps_counter = pimm.utils.RateCounter('MujocoSim')

--- a/positronic/vendors/gr00t/train.py
+++ b/positronic/vendors/gr00t/train.py
@@ -35,7 +35,7 @@ def main(
 ):
     exp_name = str(exp_name)
     groot_root = Path(__file__).parents[4] / 'gr00t'
-    python_bin = str(Path(groot_venv_path) / 'bin' / 'python')
+    python_bin = str(Path(groot_venv_path).expanduser() / 'bin' / 'python')
     modality_config_path = MODALITY_CONFIGS.get(modality_config, modality_config)
 
     with pos3.mirror():

--- a/utilities/plot_eval.py
+++ b/utilities/plot_eval.py
@@ -6,6 +6,7 @@ Usage:
 """
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 import configuronic as cfn
@@ -27,6 +28,7 @@ def main(dataset: Dataset, output: str):  # noqa: C901
         dataset: The dataset to evaluate. Defaults to stacking_episodes config.
         output: Path to the output HTML file.
     """
+    output_path = Path(output).expanduser()
     print(f'Loading dataset with {len(dataset)} episodes...')
 
     data_by_ckpt = defaultdict(list)
@@ -170,9 +172,9 @@ def main(dataset: Dataset, output: str):  # noqa: C901
         showlegend=False,  # Hiding legend to avoid clutter, titles are enough
     )
 
-    print(f'Saving plots to {output}...')
-    fig.write_html(output)
-    print(f'Done. Open {output} in your browser to view results.')
+    print(f'Saving plots to {output_path}...')
+    fig.write_html(output_path)
+    print(f'Done. Open {output_path} in your browser to view results.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`positronic eval timing-report --run_dir=~/evals/timing` failed as though the run carried no telemetry.
The `~` reached `Path` unexpanded, so the reduce looked under a literal `~/evals/timing/telemetry` — and
the error it raised named the one cause that could not be it, sending the reader to check how the run was
recorded rather than the path they typed. A `~`-relative directory is what `docs/evaluation.md` tells a
reader to write, and `eval run --output_dir` accepts one because `pos3.sync` expands it.

`timing_report` now expands both of its local paths, and its failure splits by cause: no telemetry
directory at all (not a run directory, or recorded without `--timing`), against a directory carrying no
spans (a run killed before its sidecars flushed). The rest of the class comes with it — the plot output,
the arm generator's URDF and target, the kinematics debug recording, the server's RRD cache (whose default
expanded itself while a caller's `~` did not), the GR00T venv, and the MuJoCo model and Kinova URDF.

The expansion goes where the path is opened, which is what `pos3` and `LocalDataset` already do and why a
`~` output directory works for `eval run` today. For the MuJoCo model and the Kinova URDF that point is
the class that loads them, so one line covers every CLI feeding them rather than each CLI repeating it.
The `s3://` branch is left alone deliberately: the URI is the remote store's to parse. A shared
`local_path()` helper was the alternative and buys nothing — `Path(x).expanduser()` is the idiom already
in `local_dataset` and the vendors. The durable closure is `configuronic` coercing a `Path`-annotated
parameter, which would also let these signatures say `Path` instead of `str`; that is a change in that
repo, not this one.

The sweep read every `cfn.cli` entry point's path-shaped parameters, from an AST walk over the repo,
through to whatever opens them. Two groups are deliberately untouched. Anything reaching `pos3.sync` /
`download` / `upload` or `LocalDataset*` is expanded there already: `eval run --output_dir`, every vendor
train and convert output, `probe`, `inference stats`, `fake_dataset_generator`, `convert_ds`,
`validate_server`, `migrate_remote`, `release_phail`. And a model id a third-party loader resolves
(`lerobot train --base_model`, `lerobot_0_3_3`'s `act --checkpoint_path`) is an id that may also be a
path, not a path this repo opens.

Verified with `uv run --locked pytest --no-cov` (1107 passed) and `pre-commit run` over the changed files.
Four tests in `positronic/cli/eval/tests/test_timing_report.py`, each confirmed to fail before the
change: a `~` run dir and dmon log resolve against `HOME`; an `s3://` run dir reaches `pos3` verbatim,
which is the boundary an over-broad expansion would break; and each of the two failures names its own
cause.

Fixes #615.

<!-- opened-by: posi-agent -->