### PR TITLE
Keep an aborted episode on disk, unfinished

### DIFF
--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -165,7 +165,7 @@ class EpisodeWriter:
     def __exit__(self, exc_type, exc, tb) -> None:
         ...
 
-    # Abort the episode; underlying writers are aborted and the `Episode` directory is removed
+    # Abort the episode: it stays on disk, unfinished, and never joins the dataset
     def abort(self) -> None:
         pass
 
@@ -269,7 +269,7 @@ Episodes are recorded via an `EpisodeWriter` implementations. You add time-varyi
 Name collisions are disallowed: attempting to `append` to a name that already exists as a static item raises an error, and vice versa.
 
 Use as a context manager: exiting the `with` block finalizes all underlying `Signal` writers and persists metadata.
-Aborting: `abort()` stops recording, asks each underlying `Signal` writer to abort, and removes the `Episode` directory. After abort, all writer operations (`append`, `set_static`) raise.
+Aborting: `abort()` stops recording and finalizes each underlying `Signal` writer, leaving the episode on disk with its `.unfinished` marker and no `meta.json`. It never joins the dataset — `LocalDataset` skips it and `DiskEpisode` refuses to open it — and its bytes stay for inspection of whatever the run was doing when it stopped. After abort, all writer operations (`append`, `set_static`) raise.
 
 ### System Metadata (meta)
 

--- a/positronic/dataset/episode.py
+++ b/positronic/dataset/episode.py
@@ -173,7 +173,11 @@ class EpisodeWriter(AbstractContextManager, ABC, Generic[T]):
 
     @abstractmethod
     def abort(self) -> None:
-        """Abort the write and discard any partially written data."""
+        """Stop writing without committing. The episode does not join the dataset.
+
+        What happens to what was already written is the implementation's: `DiskEpisodeWriter`
+        keeps it on disk, unfinished, for inspection.
+        """
         pass
 
     @property

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import platform
-import shutil
 import sys
 import time
 import uuid
@@ -259,16 +258,24 @@ class DiskEpisodeWriter(EpisodeWriter):
             self._on_close(self)
 
     def abort(self) -> None:
-        """Abort writing: close resources and remove episode directory."""
+        """Stop writing without committing: the episode stays on disk, unfinished.
+
+        It keeps its `.unfinished` marker and gets no `meta.json`, which is what every reader here
+        already keys off — `LocalDataset` skips it and `DiskEpisode` refuses to open it. So it is
+        out of the dataset while its bytes remain for whoever wants to see what a run was doing
+        when it stopped.
+
+        The signal writers are FINALIZED rather than aborted: their own abort unlinks what they
+        wrote, which is the thing being kept.
+        """
         if self._aborted:
             return
         if self._finished:
             raise RuntimeError('Cannot abort a finished writer')
 
         for w in list(self._writers.values()):
-            w.abort()
+            w.__exit__(None, None, None)
 
-        shutil.rmtree(self._path, ignore_errors=True)
         self._aborted = True
 
     @property

--- a/positronic/dataset/tests/test_episode.py
+++ b/positronic/dataset/tests/test_episode.py
@@ -6,7 +6,13 @@ import pyarrow.parquet as pq
 import pytest
 
 from positronic.dataset import Episode
-from positronic.dataset.local_dataset import UNFINISHED_MARKER, DiskEpisode, DiskEpisodeWriter
+from positronic.dataset.local_dataset import (
+    UNFINISHED_MARKER,
+    DiskEpisode,
+    DiskEpisodeWriter,
+    LocalDataset,
+    LocalDatasetWriter,
+)
 from positronic.dataset.tests.test_video import assert_frames_equal, create_frame
 from positronic.dataset.transforms.episode import Derive, FromValue, Get, Group, Identity
 
@@ -208,22 +214,37 @@ def test_episode_static_rejects_none(tmp_path):
             w.set_static('maybe', None)
 
 
-def test_episode_writer_abort_cleans_up_and_blocks_further_use(tmp_path):
+def test_episode_writer_abort_keeps_the_episode_unfinished_and_blocks_further_use(tmp_path):
     ep_dir = tmp_path / 'ep_abort'
     with DiskEpisodeWriter(ep_dir) as w:
-        # Append some data to create resources
         w.append('a', 1, 1000)
         w.set_static('k', 1)
-        assert ep_dir.exists()
 
-        # Abort should remove the directory and prevent further actions
         w.abort()
-        assert not ep_dir.exists()
 
+        assert ep_dir.exists()
+        assert (ep_dir / UNFINISHED_MARKER).exists()
+        assert not (ep_dir / 'meta.json').exists()
         with pytest.raises(RuntimeError):
             w.append('a', 2, 2000)
         with pytest.raises(RuntimeError):
             w.set_static('z', 2)
+
+    with pytest.raises(ValueError, match='unfinished'):
+        DiskEpisode(ep_dir)
+
+
+def test_an_aborted_episode_is_not_in_the_dataset(tmp_path):
+    """What keeps it out is the marker, not its absence: the bytes stay for inspection."""
+    ds = LocalDatasetWriter(tmp_path)
+    with ds.new_episode() as good:
+        good.append('a', 1, 1000)
+    aborted = ds.new_episode()
+    aborted.append('a', 2, 2000)
+    aborted.abort()
+    aborted.__exit__(None, None, None)
+
+    assert len(LocalDataset(tmp_path)) == 1
 
 
 def test_episode_writer_context_aborts_on_exception(tmp_path):
@@ -232,7 +253,9 @@ def test_episode_writer_context_aborts_on_exception(tmp_path):
         with DiskEpisodeWriter(ep_dir) as w:
             w.append('a', 1, 1000)
             raise RuntimeError('boom')
-    assert not ep_dir.exists()
+
+    assert (ep_dir / UNFINISHED_MARKER).exists()
+    assert not (ep_dir / 'meta.json').exists()
 
 
 def test_episode_writer_set_static_twice_raises(tmp_path):


### PR DESCRIPTION
## What

`DiskEpisodeWriter.abort()` no longer deletes the episode directory. It finalizes the signal writers and leaves what was recorded where it is, unfinished.

## Why

The episode a run was making when it stopped — crashed, ended with the episode still open, abandoned by the operator — was the one recording nobody could look at: `abort()` was `shutil.rmtree`, and `DsWriterAgent`'s teardown calls it on whatever is open. That is the case where the bytes are worth most, and they were the only ones deleted.

## How it stays out of the dataset

Nothing new. `_aborted` already makes `__exit__` return before the metadata block, so the episode gets no `meta.json` and keeps the `.unfinished` marker the writer put there at the start — which is exactly what the readers key on today: `LocalDataset` skips a directory holding it, `DiskEpisode` refuses to open one. Out of the dataset, still on disk.

The one adjacent change: the signal writers are finalized (`__exit__`) rather than aborted, because a signal writer's own `abort()` unlinks what it wrote — the thing being kept.

## What this costs

The directories accumulate and nothing sweeps them, so a run's output directory is not tidy after a crash. They also upload with the rest of the run, which is accepted: every reader that opens the dataset there ignores them, so what reaches a prefix is an extra directory nobody opens.

## Verification

`uv run pytest positronic/dataset positronic/policy positronic/server positronic/tests` — 510 passed, 4 skipped.

Two tests changed to the new contract (an aborted writer keeps its directory, marker and no `meta.json`; a context that raises leaves the same), and one added: an aborted episode is absent from `LocalDataset` while its directory is present.

<!-- opened-by: posi-agent -->