### PR TITLE
Make `Rollout` the per-rollout unit and withhold its scene from the policy

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -7508,22 +7508,6 @@
         ],
         "./positronic/simulator/libero/env.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingImports",
                 "range": {
                     "startColumn": 5,

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -31,7 +31,7 @@ Score a suite, and browse every trial — video, robot state, per-trial success:
 # --policy.url is where the server is — <remote-server>:8000 if it runs on another machine
 uv run positronic eval run --eval=.sim.libero.object \
   --policy=.remote --policy.url=localhost:8000 \
-  --eval.trial_count=10 --output_dir=~/evals/libero
+  --eval.rollout_count=10 --output_dir=~/evals/libero
 
 uv run positronic-server --dataset.path=~/evals/libero \
   --ep_table_cfg=@positronic.cfg.server.eval_table

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -92,7 +92,7 @@ Use local when latency is critical (<50ms), robot has built-in GPU, or offline o
 
 Something has to say when an episode starts, finishes or is abandoned. `positronic-inference` ships two commands, one per answer (see [`positronic/inference.py`](../positronic/inference.py)):
 
-**Unattended (`sim`):** the harness self-drives the eval's trial plan — `--eval.trial_count=10` episodes back-to-back, each ending when the task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
+**Unattended (`sim`):** the harness self-drives the eval's trial plan — `--eval.rollout_count=10` episodes back-to-back, each ending when the task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
 
 **Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `r` to home the robot, `q` to quit. Headless — it renders nothing — and it takes `--task`, `--embodiment`, `--policy` and `--output_dir`. Manual evaluation and debugging on hardware.
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -92,7 +92,7 @@ Use local when latency is critical (<50ms), robot has built-in GPU, or offline o
 
 Something has to say when an episode starts, finishes or is abandoned. `positronic-inference` ships two commands, one per answer (see [`positronic/inference.py`](../positronic/inference.py)):
 
-**Unattended (`sim`):** the harness self-drives the eval's trial plan — `--eval.rollout_count=10` episodes back-to-back, each ending when the task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
+**Unattended (`sim`):** the harness self-drives the eval's rollout plan — `--eval.rollout_count=10` episodes back-to-back, each ending when the rollout's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
 
 **Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `r` to home the robot, `q` to quit. Headless — it renders nothing — and it takes `--task`, `--embodiment`, `--policy` and `--output_dir`. Manual evaluation and debugging on hardware.
 

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -24,7 +24,7 @@ def build_rollouts(
     rollout_count: int,
     scenes: list[dict[str, Any]] | None = None,
 ) -> list[Rollout]:
-    """The rollout plan a self-driving eval sweeps: one task per (scene, seed) pair.
+    """The rollout plan a self-driving eval sweeps: one rollout per (scene, seed) pair.
 
     Each ``scenes`` entry is a scene-spec base (e.g. ``{'eval.suite': ..., 'eval.task_id': ...}``) swept over
     the seed set; ``None`` sweeps the seed alone, for an eval with no scene axis. ``seed`` ``None`` draws an

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -5,7 +5,7 @@ from typing import Any
 import configuronic as cfn
 
 from positronic import keys
-from positronic.eval import Task
+from positronic.eval import Rollout
 
 
 @cfn.config()
@@ -17,18 +17,18 @@ def placeholder():
     )
 
 
-def build_tasks(
+def build_rollouts(
     instruction: str | Callable[[], str] | None,
     timeout: float,
     seed: int | None,
-    trial_count: int,
+    rollout_count: int,
     scenes: list[dict[str, Any]] | None = None,
-) -> list[Task]:
+) -> list[Rollout]:
     """The rollout plan a self-driving eval sweeps: one task per (scene, seed) pair.
 
     Each ``scenes`` entry is a scene-spec base (e.g. ``{'eval.suite': ..., 'eval.task_id': ...}``) swept over
     the seed set; ``None`` sweeps the seed alone, for an eval with no scene axis. ``seed`` ``None`` draws an
-    independent random seed per rollout; an int runs ``seed .. seed + trial_count - 1`` for every scene.
+    independent random seed per rollout; an int runs ``seed .. seed + rollout_count - 1`` for every scene.
     Every rollout carries the same ``instruction`` and ``timeout``.
     """
 
@@ -36,7 +36,7 @@ def build_tasks(
         return seed + i if seed is not None else random.randrange(2**31)
 
     return [
-        Task(instruction, timeout, {**scene, keys.EVAL_SEED: draw(i)})
+        Rollout(instruction, timeout, {**scene, keys.EVAL_SEED: draw(i)})
         for scene in (scenes if scenes is not None else [{}])
-        for i in range(trial_count)
+        for i in range(rollout_count)
     ]

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -1,6 +1,10 @@
 import random
+from collections.abc import Callable
+from typing import Any
 
 import configuronic as cfn
+
+from positronic.eval import Task
 
 
 @cfn.config()
@@ -12,19 +16,26 @@ def placeholder():
     )
 
 
-def build_trials(seed: int | None, trial_count: int, scenes: list[dict] | None = None) -> list[dict]:
-    """The per-trial RUN contexts a self-driving eval sweeps: one per (scene, seed) pair.
+def build_tasks(
+    instruction: str | Callable[[], str] | None,
+    timeout: float,
+    seed: int | None,
+    trial_count: int,
+    scenes: list[dict[str, Any]] | None = None,
+) -> list[Task]:
+    """The rollout plan a self-driving eval sweeps: one task per (scene, seed) pair.
 
-    Each ``scenes`` entry is a scene-spec context base (e.g. ``{'eval.suite': ..., 'eval.task_id': ...}``)
-    swept over the seed set; ``None`` sweeps the seed alone (an eval with no scene axis). ``seed`` ``None``
-    draws an independent random seed per trial; an int runs ``seed .. seed + trial_count - 1`` for every
-    scene. Each context also carries its flat ``eval.trial_index`` and the total ``eval.trial_count``.
+    Each ``scenes`` entry is a scene-spec base (e.g. ``{'eval.suite': ..., 'eval.task_id': ...}``) swept over
+    the seed set; ``None`` sweeps the seed alone, for an eval with no scene axis. ``seed`` ``None`` draws an
+    independent random seed per rollout; an int runs ``seed .. seed + trial_count - 1`` for every scene.
+    Every rollout carries the same ``instruction`` and ``timeout``.
     """
-    trials = []
-    for scene in scenes if scenes is not None else [{}]:
-        for s in range(trial_count):
-            trials.append({**scene, 'eval.seed': seed + s if seed is not None else random.randrange(2**31)})
-    for i, ctx in enumerate(trials):
-        ctx['eval.trial_index'] = i
-        ctx['eval.trial_count'] = len(trials)
-    return trials
+
+    def draw(i: int) -> int:
+        return seed + i if seed is not None else random.randrange(2**31)
+
+    return [
+        Task(instruction, timeout, {**scene, 'eval.seed': draw(i)})
+        for scene in (scenes if scenes is not None else [{}])
+        for i in range(trial_count)
+    ]

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import configuronic as cfn
 
+from positronic import keys
 from positronic.eval import Task
 
 
@@ -35,7 +36,7 @@ def build_tasks(
         return seed + i if seed is not None else random.randrange(2**31)
 
     return [
-        Task(instruction, timeout, {**scene, 'eval.seed': draw(i)})
+        Task(instruction, timeout, {**scene, keys.EVAL_SEED: draw(i)})
         for scene in (scenes if scenes is not None else [{}])
         for i in range(trial_count)
     ]

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -1,22 +1,21 @@
 import configuronic as cfn
 
 from positronic.cfg.embodiment import droid
-from positronic.cfg.eval import build_trials
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
 from positronic.eval import Eval, Task
 
 
 @cfn.config(embodiment=droid, timeout=180, trial_count=1)
 def _droid_pick_place(embodiment, instruction, timeout, trial_count):
-    """A real droid tote pick-and-place eval: the embodiment is the physical Franka, the task carries the instruction.
+    """A real droid tote pick-and-place eval: the embodiment is the physical Franka, each rollout the instruction.
 
-    Real has no scene to seed (``reset=None`` — reset is physical and human) and no privileged ground-truth source
-    to record (``privileged={}`` — the droid exposes none), so the outcome is the operator's annotation rather than
-    a computed criterion. ``timeout`` is the per-trial wall-clock budget the Harness applies on the unattended path;
-    ``trial_count`` is how many such trials it sweeps (real has no seed or task axis, so each is a bare timed trial).
+    Real has no scene to seed (no ``reset`` — staging is physical and human) and no privileged ground-truth source
+    to record (the droid exposes none), so the outcome is the operator's annotation rather than a computed
+    criterion. ``timeout`` is the per-rollout wall-clock budget the Harness applies on the unattended path;
+    ``trial_count`` is how many rollouts it sweeps — real has no seed or task axis, so each is a bare timed
+    rollout with an empty scene.
     """
-    task = Task(instruction=instruction, timeout=timeout)
-    return Eval(embodiment, task, build_trials(None, trial_count))
+    return [Eval(embodiment, [Task(instruction, timeout) for _ in range(trial_count)])]
 
 
 pick_place = _droid_pick_place.override(instruction=UNIFIED_TASK)

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -2,20 +2,20 @@ import configuronic as cfn
 
 from positronic.cfg.embodiment import droid
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
-from positronic.eval import Eval, Task
+from positronic.eval import Eval, Rollout
 
 
-@cfn.config(embodiment=droid, timeout=180, trial_count=1)
-def _droid_pick_place(embodiment, instruction, timeout, trial_count):
+@cfn.config(embodiment=droid, timeout=180, rollout_count=1)
+def _droid_pick_place(embodiment, instruction, timeout, rollout_count):
     """A real droid tote pick-and-place eval: the embodiment is the physical Franka, each rollout the instruction.
 
     Real has no scene to seed (no ``reset`` — staging is physical and human) and no privileged ground-truth source
     to record (the droid exposes none), so the outcome is the operator's annotation rather than a computed
     criterion. ``timeout`` is the per-rollout wall-clock budget the Harness applies on the unattended path;
-    ``trial_count`` is how many rollouts it sweeps — real has no seed or task axis, so each is a bare timed
+    ``rollout_count`` is how many rollouts it sweeps — real has no seed or task axis, so each is a bare timed
     rollout with an empty scene.
     """
-    return [Eval(embodiment, [Task(instruction, timeout) for _ in range(trial_count)])]
+    return [Eval(embodiment, [Rollout(instruction, timeout) for _ in range(rollout_count)])]
 
 
 pick_place = _droid_pick_place.override(instruction=UNIFIED_TASK)

--- a/positronic/cfg/eval/sim/__init__.py
+++ b/positronic/cfg/eval/sim/__init__.py
@@ -1,0 +1,14 @@
+import configuronic as cfn
+
+from positronic.cfg.eval.sim import libero, positronic, robolab
+
+
+@cfn.config(groups=[libero.all, robolab.benchmark, positronic.stack_cubes])
+def all(groups):
+    """Every sim benchmark in one command: each eval's World in turn, against one warm policy.
+
+    Each entry is itself a list of evals, so a group that grows a second embodiment joins this sweep without
+    touching it. Nothing runs concurrently — the evals rebuild the World one at a time, so only the env
+    server of the eval in flight is alive.
+    """
+    return [ev for group in groups for ev in group]

--- a/positronic/cfg/eval/sim/__init__.py
+++ b/positronic/cfg/eval/sim/__init__.py
@@ -8,7 +8,6 @@ def all(groups):
     """Every sim benchmark in one command, against one warm policy.
 
     Each entry is itself a list of evals, so a group that grows a second embodiment joins this sweep without
-    touching it. Listing backends together is only safe because ``eval run`` rebuilds the World one eval at a
-    time: two env servers never hold the GPU at once.
+    touching it. Adding a GPU-hungry backend here is safe only while evals run one at a time.
     """
     return [ev for group in groups for ev in group]

--- a/positronic/cfg/eval/sim/__init__.py
+++ b/positronic/cfg/eval/sim/__init__.py
@@ -5,10 +5,10 @@ from positronic.cfg.eval.sim import libero, positronic, robolab
 
 @cfn.config(groups=[libero.all, robolab.benchmark, positronic.stack_cubes])
 def all(groups):
-    """Every sim benchmark in one command: each eval's World in turn, against one warm policy.
+    """Every sim benchmark in one command, against one warm policy.
 
     Each entry is itself a list of evals, so a group that grows a second embodiment joins this sweep without
-    touching it. Nothing runs concurrently — the evals rebuild the World one at a time, so only the env
-    server of the eval in flight is alive.
+    touching it. Listing backends together is only safe because ``eval run`` rebuilds the World one eval at a
+    time: two env servers never hold the GPU at once.
     """
     return [ev for group in groups for ev in group]

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -4,6 +4,7 @@ from positronic import keys
 from positronic.cfg.eval import build_rollouts
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import Eval, Observation
+from positronic.simulator.env_server.protocol import META_INSTRUCTION
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.libero import adapter
 from positronic.simulator.libero.launcher import serve_libero
@@ -73,7 +74,7 @@ def _libero_eval(
     return [
         Eval(
             embodiment,
-            build_rollouts(lambda: proxy.meta['task'], timeout, seed, rollout_count, scenes),
+            build_rollouts(lambda: proxy.meta[META_INSTRUCTION], timeout, seed, rollout_count, scenes),
             reset=proxy.reset,
             privileged={'sim_state': Observation(proxy.privileged['sim_state'], None)},
             done=proxy.done,

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -1,9 +1,9 @@
 import configuronic as cfn
 
 from positronic import keys
-from positronic.cfg.eval import build_trials
+from positronic.cfg.eval import build_tasks
 from positronic.drivers.roboarm.models import bundled_panda_model
-from positronic.eval import Eval, Observation, Task
+from positronic.eval import Eval, Observation
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.libero.adapter import LiberoAdapter
 from positronic.simulator.libero.launcher import serve_libero
@@ -26,7 +26,7 @@ _SUITE_NUM_TASKS = {'libero_spatial': 10, 'libero_object': 10, 'libero_goal': 10
 def _libero_eval(
     suite, task_id, trial_count, timeout, camera_dict, camera_resolution, control_mode, seed, settle_steps
 ):
-    """A LIBERO eval: the embodiment proxies a remote LIBERO env, the task carries the scenario.
+    """A LIBERO eval: the embodiment proxies a remote LIBERO env, each rollout carries one scene of it.
 
     A LIBERO *suite* is a set of related manipulation tasks; ``task_id`` selects one within it — a fixed scene and
     language goal (see https://github.com/Lifelong-Robot-Learning/LIBERO). The suites bound below:
@@ -39,15 +39,15 @@ def _libero_eval(
 
     ``_libero_eval`` leaves ``suite`` unbound; each named config below is a ``.override`` binding it — to one
     suite, or to a list (``all``) swept in one run. An unbound ``task_id`` sweeps every task of each bound suite;
-    ``--eval.task_id`` pins one. The instruction is never pinned: the task reads its language live from the env,
-    which reports it (with ``suite`` and ``task_id``) in every reset's meta.
+    ``--eval.task_id`` pins one. The instruction is never pinned: each rollout reads its language live from the
+    env, which reports it (with ``suite`` and ``task_id``) in every reset's meta.
 
     positronic launches a single task-agnostic env server in its own 3.10 interpreter; the proxy drives it over
     the socket and the whole scene spec — suite, task_id, camera_resolution, control_mode, settle_steps — rides
-    each trial's reset token, so one embodiment serves any mix of suites and tasks. The per-trial seed selects a
-    saved init-state and re-randomizes the scene.
+    each rollout's reset token, so one embodiment serves any mix of suites and tasks. The per-rollout seed
+    selects a saved init-state and re-randomizes the scene.
     LIBERO's full physics state is the privileged ground truth (recorded, never fed to the policy), so
-    success is recomputable downstream; the live ``done`` flag also rides the trial's terminal.
+    success is recomputable downstream; the live ``done`` flag also rides the rollout's terminal.
     """
     proxy = RemoteEnvControlSystem(LiberoAdapter(camera_dict), serve_libero())
     # LIBERO drives the same Franka Panda as the native sim, so recordings carry the same model (URDF + meshes +
@@ -56,17 +56,9 @@ def _libero_eval(
     embodiment = remote_franka_embodiment(
         proxy, camera_dict, descriptor='remote.libero.franka', static_meta=bundled_panda_model()
     )
-    privileged = {'sim_state': Observation(proxy.privileged['sim_state'], None)}
-    task = Task(
-        instruction=lambda: proxy.meta['task'],
-        timeout=timeout,
-        privileged=privileged,
-        reset=proxy.reset,
-        done=proxy.done,
-    )
     # One scene per (suite, task) pair: an unbound ``task_id`` sweeps each suite, a pinned one runs that task
-    # in every bound suite. The scene spec rides each trial's reset token, so the single task-agnostic env
-    # server serves every trial.
+    # in every bound suite. The scene spec rides each rollout's reset token, so the single task-agnostic env
+    # server serves every rollout.
     scenes = [
         {
             'eval.suite': s,
@@ -78,7 +70,15 @@ def _libero_eval(
         for s in ([suite] if isinstance(suite, str) else suite)
         for t in ([task_id] if task_id is not None else range(_SUITE_NUM_TASKS[s]))
     ]
-    return Eval(embodiment, task, build_trials(seed, trial_count, scenes))
+    return [
+        Eval(
+            embodiment,
+            build_tasks(lambda: proxy.meta['task'], timeout, seed, trial_count, scenes),
+            reset=proxy.reset,
+            privileged={'sim_state': Observation(proxy.privileged['sim_state'], None)},
+            done=proxy.done,
+        )
+    ]
 
 
 # Each suite binds only its LIBERO ``suite``; an unbound ``task_id`` sweeps the whole suite, ``--eval.task_id``

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -5,7 +5,7 @@ from positronic.cfg.eval import build_tasks
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import Eval, Observation
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
-from positronic.simulator.libero.adapter import LiberoAdapter
+from positronic.simulator.libero import adapter
 from positronic.simulator.libero.launcher import serve_libero
 
 # Task count per LIBERO suite — the config expands an unbound ``task_id`` over ``range(num_tasks)``. positronic
@@ -49,7 +49,7 @@ def _libero_eval(
     LIBERO's full physics state is the privileged ground truth (recorded, never fed to the policy), so
     success is recomputable downstream; the live ``done`` flag also rides the rollout's terminal.
     """
-    proxy = RemoteEnvControlSystem(LiberoAdapter(camera_dict), serve_libero())
+    proxy = RemoteEnvControlSystem(adapter.LiberoAdapter(camera_dict), serve_libero())
     # LIBERO drives the same Franka Panda as the native sim, so recordings carry the same model (URDF + meshes +
     # joint names + control frame) for the 3D viewer and offline IK, supplied here since the 3.10 server can't
     # import positronic to emit it via ``robot_meta``.
@@ -61,11 +61,11 @@ def _libero_eval(
     # server serves every rollout.
     scenes = [
         {
-            'eval.suite': s,
-            'eval.task_id': t,
-            'eval.camera_resolution': camera_resolution,
-            'eval.control_mode': control_mode,
-            'eval.settle_steps': settle_steps,
+            adapter.SUITE: s,
+            adapter.TASK_ID: t,
+            adapter.CAMERA_RESOLUTION: camera_resolution,
+            adapter.CONTROL_MODE: control_mode,
+            adapter.SETTLE_STEPS: settle_steps,
         }
         for s in ([suite] if isinstance(suite, str) else suite)
         for t in ([task_id] if task_id is not None else range(_SUITE_NUM_TASKS[s]))

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -1,7 +1,7 @@
 import configuronic as cfn
 
 from positronic import keys
-from positronic.cfg.eval import build_tasks
+from positronic.cfg.eval import build_rollouts
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import Eval, Observation
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
@@ -20,11 +20,11 @@ _SUITE_NUM_TASKS = {'libero_spatial': 10, 'libero_object': 10, 'libero_goal': 10
     timeout=20.0,
     seed=None,
     task_id=None,
-    trial_count=1,
+    rollout_count=1,
     settle_steps=10,
 )
 def _libero_eval(
-    suite, task_id, trial_count, timeout, camera_dict, camera_resolution, control_mode, seed, settle_steps
+    suite, task_id, rollout_count, timeout, camera_dict, camera_resolution, control_mode, seed, settle_steps
 ):
     """A LIBERO eval: the embodiment proxies a remote LIBERO env, each rollout carries one scene of it.
 
@@ -73,7 +73,7 @@ def _libero_eval(
     return [
         Eval(
             embodiment,
-            build_tasks(lambda: proxy.meta['task'], timeout, seed, trial_count, scenes),
+            build_rollouts(lambda: proxy.meta['task'], timeout, seed, rollout_count, scenes),
             reset=proxy.reset,
             privileged={'sim_state': Observation(proxy.privileged['sim_state'], None)},
             done=proxy.done,

--- a/positronic/cfg/eval/sim/positronic.py
+++ b/positronic/cfg/eval/sim/positronic.py
@@ -3,8 +3,8 @@ import configuronic as cfn
 import positronic.cfg.simulator
 from positronic import keys
 from positronic.cfg.embodiment import mujoco_franka
-from positronic.cfg.eval import build_trials
-from positronic.eval import Eval, Observation, Task
+from positronic.cfg.eval import build_tasks
+from positronic.eval import Eval, Observation
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.utils import package_assets_path
 
@@ -25,24 +25,24 @@ from positronic.utils import package_assets_path
 def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, instruction, timeout, seed, trial_count):
     """A Mujoco Franka sim eval: the eval holds the sim, the embodiment is pure robot.
 
-    The task carries the instruction, the per-trial ``timeout``, the privileged sim-state
-    ground truth (built from the eval's sim, recorded but never fed to the policy), and the
-    sim's seeded scene reset. The scene (``loaders``) is embodiment-specific and wired here,
-    not a generic Task field; the loaders carry no seeds of their own — the per-trial seed
-    handed to ``sim.reset`` drives the whole scene draw. ``trial_count`` seeds (from ``seed``)
-    make the trial sweep; this eval has no task axis, so each is a fresh scene draw.
+    Every rollout carries the instruction and the ``timeout``; the eval carries the privileged sim-state
+    ground truth (built from its sim, recorded but never fed to the policy) and the sim's seeded scene
+    reset. The scene shape (``loaders``) is embodiment-specific and wired here, not a per-rollout field;
+    the loaders carry no seeds of their own — the seed in each rollout's scene, handed to ``sim.reset``,
+    drives the whole scene draw. ``trial_count`` seeds (from ``seed``) make the sweep; this eval has no
+    task axis, so each rollout is a fresh scene draw.
     """
     sim = MujocoSim(mujoco_model_path, loaders, camera_fps=camera_fps)
     embodiment = mujoco_franka(sim, camera_dict)
-    # Full sim state is the privileged ground truth; scoring is computed downstream.
-    privileged = {'sim_state': Observation(sim.sim_state, None)}
-    task = Task(
-        instruction=instruction,
-        timeout=timeout,
-        privileged=privileged,
-        reset=lambda ctx: sim.reset(ctx.get('eval.seed')),
-    )
-    return Eval(embodiment, task, build_trials(seed, trial_count))
+    return [
+        Eval(
+            embodiment,
+            build_tasks(instruction, timeout, seed, trial_count),
+            reset=lambda scene: sim.reset(scene.get('eval.seed')),
+            # Full sim state is the privileged ground truth; scoring is computed downstream.
+            privileged={'sim_state': Observation(sim.sim_state, None)},
+        )
+    ]
 
 
 stack_cubes = _mujoco_franka_eval.override(instruction='Pick up the green cube and place it on the red cube.')

--- a/positronic/cfg/eval/sim/positronic.py
+++ b/positronic/cfg/eval/sim/positronic.py
@@ -3,7 +3,7 @@ import configuronic as cfn
 import positronic.cfg.simulator
 from positronic import keys
 from positronic.cfg.embodiment import mujoco_franka
-from positronic.cfg.eval import build_tasks
+from positronic.cfg.eval import build_rollouts
 from positronic.eval import Eval, Observation
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.utils import package_assets_path
@@ -20,16 +20,16 @@ from positronic.utils import package_assets_path
     },
     timeout=15,
     seed=None,
-    trial_count=1,
+    rollout_count=1,
 )
-def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, instruction, timeout, seed, trial_count):
+def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, instruction, timeout, seed, rollout_count):
     """A Mujoco Franka sim eval: the eval holds the sim, the embodiment is pure robot.
 
     Every rollout carries the instruction and the ``timeout``; the eval carries the privileged sim-state
     ground truth (built from its sim, recorded but never fed to the policy) and the sim's seeded scene
     reset. The scene shape (``loaders``) is embodiment-specific and wired here, not a per-rollout field;
     the loaders carry no seeds of their own — the seed in each rollout's scene, handed to ``sim.reset``,
-    drives the whole scene draw. ``trial_count`` seeds (from ``seed``) make the sweep; this eval has no
+    drives the whole scene draw. ``rollout_count`` seeds (from ``seed``) make the sweep; this eval has no
     task axis, so each rollout is a fresh scene draw.
     """
     sim = MujocoSim(mujoco_model_path, loaders, camera_fps=camera_fps)
@@ -37,7 +37,7 @@ def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, ins
     return [
         Eval(
             embodiment,
-            build_tasks(instruction, timeout, seed, trial_count),
+            build_rollouts(instruction, timeout, seed, rollout_count),
             reset=lambda scene: sim.reset(scene[keys.EVAL_SEED]),
             # Full sim state is the privileged ground truth; scoring is computed downstream.
             privileged={'sim_state': Observation(sim.sim_state, None)},

--- a/positronic/cfg/eval/sim/positronic.py
+++ b/positronic/cfg/eval/sim/positronic.py
@@ -38,7 +38,7 @@ def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, ins
         Eval(
             embodiment,
             build_tasks(instruction, timeout, seed, trial_count),
-            reset=lambda scene: sim.reset(scene.get('eval.seed')),
+            reset=lambda scene: sim.reset(scene[keys.EVAL_SEED]),
             # Full sim state is the privileged ground truth; scoring is computed downstream.
             privileged={'sim_state': Observation(sim.sim_state, None)},
         )

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -2,6 +2,7 @@ import configuronic as cfn
 
 from positronic import keys
 from positronic.eval import Eval, Observation, Rollout
+from positronic.simulator.env_server.protocol import META_INSTRUCTION
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.robolab import adapter
 from positronic.simulator.robolab.launcher import serve_robolab
@@ -184,7 +185,11 @@ def _robolab_eval(task, instruction_type, rollout_count, timeout, camera_dict):
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
     rollouts = [
-        Rollout(lambda: proxy.meta['task'], timeout, {adapter.TASK: name, adapter.INSTRUCTION_TYPE: instruction_type})
+        Rollout(
+            lambda: proxy.meta[META_INSTRUCTION],
+            timeout,
+            {adapter.TASK: name, adapter.INSTRUCTION_TYPE: instruction_type},
+        )
         for name in names
         for _ in range(rollout_count)
     ]

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -1,7 +1,7 @@
 import configuronic as cfn
 
 from positronic import keys
-from positronic.eval import Eval, Observation, Task
+from positronic.eval import Eval, Observation, Rollout
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.robolab import adapter
 from positronic.simulator.robolab.launcher import serve_robolab
@@ -150,10 +150,10 @@ def _resolve_tasks(task) -> list[str]:
 @cfn.config(
     camera_dict={keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera', keys.WRIST_IMAGE: 'wrist_cam'},
     instruction_type='default',
-    trial_count=1,
+    rollout_count=1,
     timeout=None,
 )
-def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
+def _robolab_eval(task, instruction_type, rollout_count, timeout, camera_dict):
     """A RoboLab eval: the embodiment proxies a remote RoboLab env, each rollout carries one task of it.
 
     RoboLab (https://github.com/NVLabs/RoboLab) is NVIDIA's Isaac Lab benchmark: 120 tabletop manipulation
@@ -183,15 +183,15 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     # The DROID rig's model (Franka arm + Robotiq 2F-85) rides the env's ``robot_meta`` — the launcher
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
-    tasks = [
-        Task(lambda: proxy.meta['task'], timeout, {adapter.TASK: name, adapter.INSTRUCTION_TYPE: instruction_type})
+    rollouts = [
+        Rollout(lambda: proxy.meta['task'], timeout, {adapter.TASK: name, adapter.INSTRUCTION_TYPE: instruction_type})
         for name in names
-        for _ in range(trial_count)
+        for _ in range(rollout_count)
     ]
     return [
         Eval(
             embodiment,
-            tasks,
+            rollouts,
             reset=proxy.reset,
             privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
             done=proxy.done,

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -3,7 +3,7 @@ import configuronic as cfn
 from positronic import keys
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
-from positronic.simulator.robolab.adapter import RobolabAdapter
+from positronic.simulator.robolab import adapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 # The 120 benchmark tasks: name -> (categories, episode_length_s). positronic cannot import robolab (it lives in
@@ -179,12 +179,12 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
         # The env truncates itself at each task's episode_length_s; the harness deadline is a backstop above
         # the longest selected task.
         timeout = max(_TASKS[name][1] for name in names) + 10.0
-    proxy = RemoteEnvControlSystem(RobolabAdapter(camera_dict), serve_robolab())
+    proxy = RemoteEnvControlSystem(adapter.RobolabAdapter(camera_dict), serve_robolab())
     # The DROID rig's model (Franka arm + Robotiq 2F-85) rides the env's ``robot_meta`` — the launcher
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
     tasks = [
-        Task(lambda: proxy.meta['task'], timeout, {'eval.task': name, 'eval.instruction_type': instruction_type})
+        Task(lambda: proxy.meta['task'], timeout, {adapter.TASK: name, adapter.INSTRUCTION_TYPE: instruction_type})
         for name in names
         for _ in range(trial_count)
     ]

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -154,7 +154,7 @@ def _resolve_tasks(task) -> list[str]:
     timeout=None,
 )
 def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
-    """A RoboLab eval: the embodiment proxies a remote RoboLab env, the task carries the scenario.
+    """A RoboLab eval: the embodiment proxies a remote RoboLab env, each rollout carries one task of it.
 
     RoboLab (https://github.com/NVLabs/RoboLab) is NVIDIA's Isaac Lab benchmark: 120 tabletop manipulation
     tasks on the DROID rig (Franka arm + Robotiq 2F-85), each with a fixed scene, a language instruction in
@@ -165,12 +165,12 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
 
     ``_robolab_eval`` leaves ``task`` unbound; each named config below is a ``.override`` binding it — to a
     single task name, a category, or ``all``. A list of names also works. The instruction is never pinned:
-    the task reads its language live from the env, which reports the resolved instruction in every reset's
-    meta.
+    each rollout reads its language live from the env, which reports the resolved instruction in every
+    reset's meta.
 
     positronic launches a single task-agnostic env server in RoboLab's own Isaac Lab interpreter; the proxy
-    drives it over the socket and the task name + instruction type ride each trial's reset token. There is no
-    per-trial seed: RoboLab's eval path exposes no seed hook, so trial contexts carry none. The env's live
+    drives it over the socket and the task name + instruction type ride each rollout's reset token. There is
+    no per-rollout seed: RoboLab's eval path exposes no seed hook, so the scenes carry none. The env's live
     subtask progress ``[status, completed, total, score]`` is the privileged ground truth (recorded, never
     fed to the policy).
     """
@@ -183,23 +183,20 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     # The DROID rig's model (Franka arm + Robotiq 2F-85) rides the env's ``robot_meta`` — the launcher
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
-    # RoboLab exposes no seed hook, so trial contexts carry no ``eval.seed``.
-    trials = [
-        {'eval.task': name, 'eval.instruction_type': instruction_type} for name in names for _ in range(trial_count)
+    tasks = [
+        Task(lambda: proxy.meta['task'], timeout, {'eval.task': name, 'eval.instruction_type': instruction_type})
+        for name in names
+        for _ in range(trial_count)
     ]
-    for i, ctx in enumerate(trials):
-        ctx.update({'eval.trial_index': i, 'eval.trial_count': len(trials)})
-    return Eval(
-        embodiment,
-        Task(
-            instruction=lambda: proxy.meta['task'],
-            timeout=timeout,
-            privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
+    return [
+        Eval(
+            embodiment,
+            tasks,
             reset=proxy.reset,
+            privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
             done=proxy.done,
-        ),
-        trials,
-    )
+        )
+    ]
 
 
 # The full 120-task benchmark in one run.

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -46,10 +46,10 @@ def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
 def _run_world(policy, ev: Eval, output_dir: Path | None, inference_latency: bool | float):
     """Wire one eval's embodiment under a fresh Harness + World and run it to completion.
 
-    The harness self-drives ``ev.tasks``; the shared ``policy``'s lifetime stays with ``main``.
+    The harness self-drives ``ev.rollouts``; the shared ``policy``'s lifetime stays with ``main``.
     """
     embodiment = ev.embodiment
-    harness = Harness(policy, embodiment, tasks=ev.tasks, reset=ev.reset, inference_latency=inference_latency)
+    harness = Harness(policy, embodiment, rollouts=ev.rollouts, reset=ev.reset, inference_latency=inference_latency)
 
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -3,7 +3,6 @@ import os
 import uuid
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager, nullcontext
-from dataclasses import replace
 from pathlib import Path
 
 import configuronic as cfn
@@ -17,7 +16,7 @@ from positronic.cfg.eval import placeholder
 from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
-from positronic.eval import Embodiment, Eval, Task
+from positronic.eval import Embodiment, Eval
 from positronic.policy.harness import Harness
 from positronic.simulator.env_server.telemetry import ATTR_RUN_ID, ENV_RUN_ID, ENV_TELEMETRY_DIR
 
@@ -44,20 +43,19 @@ def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
     return local_dir
 
 
-def _run_world(policy, embodiment: Embodiment, task: Task | None, trials: list[dict] | None, output_dir: Path | None):
-    """Wire one embodiment under a fresh Harness + World and run it to completion.
+def _run_world(policy, ev: Eval, output_dir: Path | None, inference_latency: bool | float):
+    """Wire one eval's embodiment under a fresh Harness + World and run it to completion.
 
-    The harness self-drives ``trials``; the shared ``policy``'s lifetime stays with ``main``.
+    The harness self-drives ``ev.tasks``; the shared ``policy``'s lifetime stays with ``main``.
     """
-    harness = Harness(policy, embodiment, task=task, trials=trials)
+    embodiment = ev.embodiment
+    harness = Harness(policy, embodiment, tasks=ev.tasks, reset=ev.reset, inference_latency=inference_latency)
 
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
     with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
-        privileged = task.privileged if task is not None else {}
-        done = task.done if task is not None else None
         ds_agent = wire.wire_embodiment(
-            world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
+            world, harness, embodiment, dataset_writer, time_mode, privileged=ev.privileged, done=ev.done
         )
         if ds_agent is not None:
             world.connect(harness.ds_command, ds_agent.command)
@@ -149,8 +147,15 @@ def timed_pass(output_dir: str | Path | None, timing: bool, policy):
                 os.environ[name] = value
 
 
-def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, timing: bool = False):
-    """Run an unattended sweep: the harness self-drives each eval's trial plan, rebuilding the World per eval.
+def main(
+    policy,
+    *,
+    evals: list[Eval],
+    output_dir: str | Path | None = None,
+    timing: bool = False,
+    inference_latency: bool | float = False,
+):
+    """Run an unattended sweep: the harness self-drives each eval's rollout plan, rebuilding the World per eval.
 
     ``main`` owns the policy lifetime: it warms the policy once up front and closes it once after the last
     World, so a multi-eval sweep reuses one live policy across the rebuilds.
@@ -173,7 +178,7 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     try:
         with timed_pass(output_dir, timing, policy):
             for ev in evals:
-                _run_world(policy, ev.embodiment, ev.task, ev.trials, output_dir)
+                _run_world(policy, ev, output_dir, inference_latency)
     finally:
         policy.close()
 
@@ -191,7 +196,7 @@ def _refuse(inapplicable: dict[str, object], where: str) -> None:
 
 @cfn.config(eval=placeholder, policy=policy_cfg.unset)
 def run(
-    eval: Eval | str,
+    eval: list[Eval] | str,
     policy,
     output_dir=None,
     inference_latency=False,
@@ -201,7 +206,10 @@ def run(
     transaction_key: str | None = None,
     platform_url: str | None = None,
 ) -> SubmissionCreateResponse | None:
-    """Run a selected eval (embodiment + task + its trial sweep) through the shared inference harness.
+    """Run a selected eval through the shared inference harness.
+
+    An eval config produces one ``Eval`` per embodiment, so a selection spanning several sims — every
+    embodiment's rollouts against one warm policy — arrives here as a list and runs sequentially.
 
     Here by default: ``--eval`` is an eval config and ``--policy`` the policy that drives it.
     ``--policy-image`` instead sends the run to the platform, which pulls that image and runs the
@@ -219,12 +227,9 @@ def run(
         if policy is None:
             raise SystemExit('--policy is required to run here; --policy-image runs it on the platform instead')
         _refuse({'--alias': alias, '--transaction-key': transaction_key, '--platform-url': platform_url}, 'local')
-        if not isinstance(eval, Eval):
+        if not isinstance(eval, list):
             raise SystemExit(f'--eval={eval!r} is a name, not a config: pass --policy-image to run it on the platform')
-        # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob
-        # (sim inference-cost simulation). Overlay it onto every trial context, then self-drive the eval.
-        eval = replace(eval, trials=[{**trial, 'inference_latency': inference_latency} for trial in eval.trials])
-        main(policy=policy, evals=[eval], output_dir=output_dir, timing=timing)
+        main(policy=policy, evals=eval, output_dir=output_dir, timing=timing, inference_latency=inference_latency)
         return None
 
     if policy is not None:

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -7,11 +7,11 @@ import pytest
 
 from positronic import telemetry, telemetry_keys
 from positronic.cli.eval.run import _pass_span, main, timed_pass
-from positronic.eval import Embodiment, Eval, Task
+from positronic.eval import Embodiment, Eval
 
 
 def _eval(simulated: bool) -> Eval:
-    return Eval(embodiment=cast(Embodiment, SimpleNamespace(simulated=simulated)), task=cast(Task, SimpleNamespace()))
+    return Eval(embodiment=cast(Embodiment, SimpleNamespace(simulated=simulated)))
 
 
 def test_timed_sweep_rejects_real_embodiment(tmp_path):
@@ -37,8 +37,7 @@ def test_an_exhausted_trial_plan_ends_the_sweep():
     embodiment = Embodiment(
         descriptor='stub', observations={}, commands={}, static_meta={}, meta_source=None, simulated=True
     )
-    task = Task(instruction='stub', timeout=0.05)
-    main(policy=_IdlePolicy(), evals=[Eval(embodiment=embodiment, task=task, trials=[])])
+    main(policy=_IdlePolicy(), evals=[Eval(embodiment=embodiment, tasks=[])])
 
 
 def test_timed_sweep_needs_an_output_dir():

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -37,7 +37,7 @@ def test_an_exhausted_trial_plan_ends_the_sweep():
     embodiment = Embodiment(
         descriptor='stub', observations={}, commands={}, static_meta={}, meta_source=None, simulated=True
     )
-    main(policy=_IdlePolicy(), evals=[Eval(embodiment=embodiment, tasks=[])])
+    main(policy=_IdlePolicy(), evals=[Eval(embodiment=embodiment, rollouts=[])])
 
 
 def test_timed_sweep_needs_an_output_dir():

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -67,7 +67,7 @@ class Embodiment:
         return {name: cmd.home for name, cmd in self.commands.items()}
 
 
-class Task:
+class Rollout:
     """One rollout: the goal the policy is told, the budget it runs under, and the scene it runs in.
 
     ``instruction`` is the language goal the policy conditions on, resolved live on every read: an embodiment
@@ -101,11 +101,11 @@ class Eval:
     """One embodiment, the rollouts to run on it, and the scene wiring they share.
 
     An eval config returns a list of these — one per embodiment — so a benchmark spanning several sims is a
-    single selection. ``tasks`` is the rollout plan the self-driving Harness works through; ``None`` leaves
+    single selection. ``rollouts`` is the plan the self-driving Harness works through; ``None`` leaves
     the lifecycle to an operator's directives.
 
     For a sim eval the config holds the shared ``MujocoSim`` the embodiment and the wiring below are both
-    built from, so the embodiment stays pure robot. ``reset`` stages a task's scene from its ``scene``
+    built from, so the embodiment stays pure robot. ``reset`` stages a rollout's scene from its ``scene``
     payload; ``None`` on a real embodiment, where a human stages it. ``privileged`` maps a record key to the
     ground-truth source to capture (the sim's full ``save_state``, a real scale) — recorded but never fed to
     the policy. ``done`` is the terminating signal: a source delivering a dict payload when a rollout ends,
@@ -113,7 +113,7 @@ class Eval:
     """
 
     embodiment: Embodiment
-    tasks: list[Task] | None = None
+    rollouts: list[Rollout] | None = None
     reset: Callable[[dict[str, Any]], None] | None = None
     privileged: dict[str, Observation] = field(default_factory=dict)
     done: pimm.SignalEmitter | None = None

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -68,54 +68,52 @@ class Embodiment:
 
 
 class Task:
-    """The scenario layered on an embodiment: the policy-facing instruction plus
-    the privileged ground-truth signals to record.
+    """One rollout: the goal the policy is told, the budget it runs under, and the scene it runs in.
 
     ``instruction`` is the language goal the policy conditions on, resolved live on every read: an embodiment
-    that only learns its task on reset (a remote env reporting it in meta) passes a source callable, while a
-    fixed scenario passes a plain string (wrapped as a constant). ``timeout`` is the per-trial time budget in
-    seconds (sim-time for simulated embodiments, wall-clock for real). ``privileged`` maps a record key to the
-    ground-truth source to capture (the sim's full ``save_state``, a real scale) — recorded but never fed to
-    the policy.
+    that only learns its goal on reset (a remote env reporting it in meta) passes a source callable, a fixed
+    scenario a plain string, and a rollout whose operator named no goal passes ``None``. ``timeout`` is the
+    budget in seconds (sim-time for a simulated embodiment, wall-clock for a real one); ``None`` leaves the
+    rollout unbounded, so only a directive ends it.
 
-    ``reset`` re-randomizes the scene for a new trial from the per-trial run context, reading the keys it
-    needs (e.g. ``eval.seed``, and ``eval.task_id`` for a multi-task suite); ``None`` on real embodiments,
-    where reset is physical/human.
-
-    ``done`` is the optional terminating signal: a source that delivers a dict payload when the
-    trial ends. The Harness reads it to stop the trial early and records the payload into the
-    episode's static data.
+    ``scene`` is what the eval's ``reset`` reads to stage this rollout — a seed, a benchmark suite and task
+    id, whatever the reset actuator needs. It is recorded with the episode and never fed to the policy, so a
+    policy cannot condition on the ground truth its rollout is scored against.
     """
 
     def __init__(
         self,
-        instruction: str | Callable[[], str],
-        timeout: float,
-        privileged: dict[str, Observation] | None = None,
-        reset: Callable[[dict[str, Any]], None] | None = None,
-        done: pimm.SignalEmitter | None = None,
+        instruction: str | Callable[[], str] | None = None,
+        timeout: float | None = None,
+        scene: dict[str, Any] | None = None,
     ):
-        self._instruction = (lambda: instruction) if isinstance(instruction, str) else instruction
+        self._instruction = instruction if callable(instruction) else (lambda: instruction)
         self.timeout = timeout
-        self.privileged = privileged or {}
-        self.reset = reset
-        self.done = done
+        self.scene = scene or {}
 
     @property
-    def instruction(self) -> str:
+    def instruction(self) -> str | None:
         return self._instruction()
 
 
 @dataclass
 class Eval:
-    """An eval = embodiment + task + the trial sweep, produced by a single config.
+    """One embodiment, the rollouts to run on it, and the scene wiring they share.
 
-    For a sim eval that config holds the shared ``MujocoSim`` both are built from, so the
-    embodiment stays pure robot while the task carries the scene's privileged signals. ``trials`` is the
-    sequence of RUN contexts the self-driving Harness runs — one per (task variant, seed) the config sweeps;
-    empty for an attended/real eval, whose episodes begin on a directive rather than on a trial plan.
+    An eval config returns a list of these — one per embodiment — so a benchmark spanning several sims is a
+    single selection. ``tasks`` is the rollout plan the self-driving Harness works through; ``None`` leaves
+    the lifecycle to an operator's directives.
+
+    For a sim eval the config holds the shared ``MujocoSim`` the embodiment and the wiring below are both
+    built from, so the embodiment stays pure robot. ``reset`` stages a task's scene from its ``scene``
+    payload; ``None`` on a real embodiment, where a human stages it. ``privileged`` maps a record key to the
+    ground-truth source to capture (the sim's full ``save_state``, a real scale) — recorded but never fed to
+    the policy. ``done`` is the terminating signal: a source delivering a dict payload when a rollout ends,
+    which the Harness reads to stop early and records into the episode's static data.
     """
 
     embodiment: Embodiment
-    task: Task
-    trials: list[dict[str, Any]] = field(default_factory=list)
+    tasks: list[Task] | None = None
+    reset: Callable[[dict[str, Any]], None] | None = None
+    privileged: dict[str, Observation] = field(default_factory=dict)
+    done: pimm.SignalEmitter | None = None

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -77,8 +77,8 @@ class Rollout:
     rollout unbounded, so only a directive ends it.
 
     ``scene`` is what the eval's ``reset`` reads to stage this rollout — a seed, a benchmark suite and task
-    id, whatever the reset actuator needs. It is recorded with the episode and never fed to the policy, so a
-    policy cannot condition on the ground truth its rollout is scored against.
+    id, whatever the reset actuator needs — and is recorded with the episode. Which of it a policy may see
+    is the Harness's to state, since the Harness is what assembles the observations.
     """
 
     def __init__(

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -88,3 +88,16 @@ SERVER_META = f'{POLICY_META}.{SERVER}'
 # leaves it absent on failure — a reader defaults it rather than assuming a False.
 EVAL_SUCCESS = 'eval.success'
 EVAL_TERMINATED = 'eval.terminated'
+
+# The scene draw a rollout is staged from. Every seeded reset actuator reads it — the native sim, the LIBERO
+# env server — and a reader that misses it draws its own scene instead of the one the plan asked for.
+EVAL_SEED = 'eval.seed'
+
+# The rest of what the harness stamps into every episode it records: which eval produced it, the rollout's
+# budget and its place in the trial plan, and the sim inference-cost simulation the run was driven under.
+EVAL_UNIVERSE = 'eval.universe'
+EVAL_EMBODIMENT = 'eval.embodiment'
+EVAL_TIMEOUT = 'eval.timeout'
+EVAL_TRIAL_INDEX = 'eval.trial_index'
+EVAL_TRIAL_COUNT = 'eval.trial_count'
+INFERENCE_LATENCY = 'inference_latency'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -89,8 +89,7 @@ SERVER_META = f'{POLICY_META}.{SERVER}'
 EVAL_SUCCESS = 'eval.success'
 EVAL_TERMINATED = 'eval.terminated'
 
-# The scene draw a rollout is staged from. Every seeded reset actuator reads it — the native sim, the LIBERO
-# env server — and a reader that misses it draws its own scene instead of the one the plan asked for.
+# The draw a rollout's scene is staged from: same seed, same scene.
 EVAL_SEED = 'eval.seed'
 
 # The rest of what the harness stamps into every episode it records: which eval produced it, the rollout's

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -93,10 +93,10 @@ EVAL_TERMINATED = 'eval.terminated'
 EVAL_SEED = 'eval.seed'
 
 # The rest of what the harness stamps into every episode it records: which eval produced it, the rollout's
-# budget and its place in the trial plan, and the sim inference-cost simulation the run was driven under.
+# budget and its place in the plan, and the sim inference-cost simulation the run was driven under.
 EVAL_UNIVERSE = 'eval.universe'
 EVAL_EMBODIMENT = 'eval.embodiment'
 EVAL_TIMEOUT = 'eval.timeout'
-EVAL_TRIAL_INDEX = 'eval.trial_index'
-EVAL_TRIAL_COUNT = 'eval.trial_count'
+EVAL_ROLLOUT_INDEX = 'eval.rollout_index'
+EVAL_ROLLOUT_COUNT = 'eval.rollout_count'
 INFERENCE_LATENCY = 'inference_latency'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -92,11 +92,13 @@ EVAL_TERMINATED = 'eval.terminated'
 # The draw a rollout's scene is staged from: same seed, same scene.
 EVAL_SEED = 'eval.seed'
 
-# The rest of what the harness stamps into every episode it records: which eval produced it, the rollout's
-# budget and its place in the plan, and the sim inference-cost simulation the run was driven under.
+# Which eval produced an episode, and how its rollout was bounded. ``EVAL_TIMEOUT`` is absent on an
+# unbounded rollout, and the plan position on one no plan authored.
 EVAL_UNIVERSE = 'eval.universe'
 EVAL_EMBODIMENT = 'eval.embodiment'
 EVAL_TIMEOUT = 'eval.timeout'
 EVAL_ROLLOUT_INDEX = 'eval.rollout_index'
 EVAL_ROLLOUT_COUNT = 'eval.rollout_count'
+
+# The simulated inference cost the episode was recorded under.
 INFERENCE_LATENCY = 'inference_latency'

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -148,10 +148,11 @@ class Harness(pimm.ControlSystem):
     calls the session, demuxes the action dicts into per-channel trajectories, and emits.
 
     Every episode runs one ``Rollout``. A ``rollouts`` plan makes the harness self-driving: it starts the
-    next one whenever idle and returns once the plan is exhausted, so the unattended path needs no driver. Without a
-    plan a RUN directive carries the rollout instead, and the two are the same episode to everything
-    downstream. Only the rollout's ``instruction`` crosses to the policy — its scene goes to ``reset`` and into
-    the recording, so a policy cannot condition on the ground truth it is scored against.
+    next one whenever idle and returns once the plan is exhausted, so the unattended path needs no driver.
+    Without a plan a RUN directive carries the rollout instead, and the two are the same episode to
+    everything downstream. Only the rollout's ``instruction`` reaches an observation — its scene goes to
+    ``reset``, to the recording, and to ``new_session``, where a sampling policy groups by it, so no model
+    is shown the ground truth its rollout is scored against.
 
     A rollout's ``timeout`` bounds it, self-driven or operator-driven, so an attended episode given a
     budget still terminates at the deadline if the operator never sends FINISH. A bounded rollout also ends
@@ -176,14 +177,14 @@ class Harness(pimm.ControlSystem):
     ):
         self._embodiment = embodiment
         # The unattended rollout plan; when None, directives are the only lifecycle source.
-        self._plan = iter(rollouts) if rollouts is not None else None
+        self._plan = enumerate(rollouts) if rollouts is not None else None
         self._rollout_count = len(rollouts) if rollouts is not None else None
-        self._rollout_index = -1
         self._reset = reset
         self.policy: Policy = policy
         self.context: dict[str, Any] = {}
-        # What crosses to the policy, assembled per episode: the instruction and nothing else about the
-        # rollout. The rest — scene, seed, plan position — is recorded but withheld.
+        # The rollout's model-facing half, assembled per episode: the instruction and nothing else. The
+        # scene, seed and plan position are recorded and reach ``new_session``, which a sampling policy
+        # groups episodes by, but they never enter an observation and so never reach a model.
         self._policy_inputs: dict[str, Any] = {}
         self._static_meta = static_meta or {}
         self._policy_session: Session | None = None
@@ -296,14 +297,11 @@ class Harness(pimm.ControlSystem):
         # period) to the closing episode — the cooperative scheduler cannot give the recorder a turn alone.
         self._telemetry.end(virtual_now)
 
-    def _plan_position(self) -> dict[str, Any]:
-        """Where the live episode sits in the rollout plan; empty for a directive-driven one, which has none."""
-        if self._rollout_count is None:
-            return {}
-        return {keys.EVAL_ROLLOUT_INDEX: self._rollout_index, keys.EVAL_ROLLOUT_COUNT: self._rollout_count}
-
-    def _begin_episode(self, rollout: Rollout, clock: pimm.Clock) -> None:
+    def _begin_episode(self, rollout: Rollout, clock: pimm.Clock, position: dict[str, Any]) -> None:
         """Open a fresh episode: stage the scene, fix the episode context and session, open the recording.
+
+        ``position`` is where this rollout sits in the plan, and is empty for one a directive carried, which
+        sits in no plan.
 
         ``reset`` only arms the producer, which publishes the first observation on a later round. The
         recorder drains its channels the turn it opens, so the pre-reset frame and the inter-episode home
@@ -313,7 +311,7 @@ class Harness(pimm.ControlSystem):
         self._awaiting_obs = set(self._embodiment.observations)
         self._rollout_started = False
         self._timeout = rollout.timeout
-        context: dict[str, Any] = {**rollout.scene, **self._plan_position()}
+        context: dict[str, Any] = {**rollout.scene, **position}
         if rollout.timeout is not None:
             context[keys.EVAL_TIMEOUT] = rollout.timeout
         # Before the reset, so the reset and the rollout's other phase spans parent to the episode span.
@@ -369,7 +367,7 @@ class Harness(pimm.ControlSystem):
         match directive.type:
             case DirectiveType.RUN:
                 if not self._running:  # a RUN mid-trial is ignored — the operator finishes before starting anew
-                    self._begin_episode(self._directive_rollout(directive.payload or {}), clock)
+                    self._begin_episode(self._directive_rollout(directive.payload or {}), clock, {})
             case DirectiveType.FINISH:
                 if self._running:  # a FINISH while idle is ignored — nothing to finalize
                     yield from self._end_episode(clock, directive.payload)
@@ -470,7 +468,7 @@ class Harness(pimm.ControlSystem):
         _assert_anchored(actions, clock.now())
         self._emit_commands(actions)
 
-    def _trial_terminal(self, clock: pimm.Clock) -> dict[str, Any] | None:
+    def _rollout_terminal(self, clock: pimm.Clock) -> dict[str, Any] | None:
         """The terminal static payload if a self-driven trial has ended this round, else ``None``.
 
         The deadline is hard: a truthy ``done`` delivered within budget records ``eval.terminated`` True plus
@@ -518,13 +516,14 @@ class Harness(pimm.ControlSystem):
                 if manual_msg.updated and manual_msg.data is not None:
                     self._emit_now(manual_msg.data, clock)
                 elif self._plan is not None:
-                    rollout = next(self._plan, None)
-                    if rollout is None:  # plan exhausted — let the recorder commit the final episode, then exit
+                    entry = next(self._plan, None)
+                    if entry is None:  # plan exhausted — let the recorder commit the final episode, then exit
                         yield pimm.Sleep(0.5)
                         break
-                    self._rollout_index += 1
-                    self._begin_episode(rollout, clock)
-            elif self._deadline is not None and (terminal := self._trial_terminal(clock)) is not None:
+                    index, rollout = entry
+                    position = {keys.EVAL_ROLLOUT_INDEX: index, keys.EVAL_ROLLOUT_COUNT: self._rollout_count}
+                    self._begin_episode(rollout, clock, position)
+            elif self._deadline is not None and (terminal := self._rollout_terminal(clock)) is not None:
                 yield from self._end_episode(clock, terminal)
             else:
                 try:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -61,20 +61,8 @@ class Directive:
         return cls(DirectiveType.ABORT)
 
 
-# ``Directive.RUN`` names the rollout's budget with this key and its instruction with ``keys.TASK``; every
-# other payload key describes the scene the operator staged.
+# The rollout's budget in a ``Directive.RUN`` payload; its instruction rides ``keys.TASK``.
 RUN_TIMEOUT = 'timeout'
-
-
-def _directive_rollout(payload: dict[str, Any]) -> Rollout:
-    """A RUN payload read as one rollout.
-
-    An operator names the goal and, where the rollout is to end on its own, a budget; the rest of what they
-    report describes the scene they staged, so it is recorded and withheld from the policy like any other
-    scene. Without a budget the episode is unbounded and ends on FINISH or ABORT.
-    """
-    scene = {k: v for k, v in payload.items() if k not in (keys.TASK, RUN_TIMEOUT)}
-    return Rollout(instruction=payload.get(keys.TASK), timeout=payload.get(RUN_TIMEOUT), scene=scene)
 
 
 class _EpisodeTelemetry:
@@ -366,12 +354,22 @@ class Harness(pimm.ControlSystem):
         self._home(clock)
         self._running = False
 
+    @staticmethod
+    def _directive_rollout(payload: dict[str, Any]) -> Rollout:
+        """A RUN payload read as one rollout.
+
+        An operator names the goal and, where the rollout is to end on its own, a budget; every other key
+        describes the scene they staged, and is recorded and withheld from the policy like any other scene.
+        """
+        scene = {k: v for k, v in payload.items() if k not in (keys.TASK, RUN_TIMEOUT)}
+        return Rollout(instruction=payload.get(keys.TASK), timeout=payload.get(RUN_TIMEOUT), scene=scene)
+
     def _handle_directive(self, directive: Directive, clock: pimm.Clock) -> Generator[pimm.Command, None, None]:
         """Dispatch a directive to the episode lifecycle; updates ``_running``."""
         match directive.type:
             case DirectiveType.RUN:
                 if not self._running:  # a RUN mid-trial is ignored — the operator finishes before starting anew
-                    self._begin_episode(_directive_rollout(directive.payload or {}), clock)
+                    self._begin_episode(self._directive_rollout(directive.payload or {}), clock)
             case DirectiveType.FINISH:
                 if self._running:  # a FINISH while idle is ignored — nothing to finalize
                     yield from self._end_episode(clock, directive.payload)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -357,7 +357,7 @@ class Harness(pimm.ControlSystem):
         """A RUN payload read as one rollout.
 
         An operator names the goal and, where the rollout is to end on its own, a budget; every other key
-        describes the scene they staged, and is recorded and withheld from the policy like any other scene.
+        describes the scene they staged, and is recorded like any other scene.
         """
         scene = {k: v for k, v in payload.items() if k not in (keys.TASK, RUN_TIMEOUT)}
         return Rollout(instruction=payload.get(keys.TASK), timeout=payload.get(RUN_TIMEOUT), scene=scene)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -469,12 +469,12 @@ class Harness(pimm.ControlSystem):
         self._emit_commands(actions)
 
     def _rollout_terminal(self, clock: pimm.Clock) -> dict[str, Any] | None:
-        """The terminal static payload if a self-driven trial has ended this round, else ``None``.
+        """The terminal static payload if a self-driven rollout has ended this round, else ``None``.
 
         The deadline is hard: a truthy ``done`` delivered within budget records ``eval.terminated`` True plus
         its payload, the budget passing records False, and a terminal past the deadline is a timeout rather
         than a late success. Only a freshly delivered ``done`` counts — the receiver latches its last value,
-        so a prior trial's terminal would otherwise re-fire; gating on delivery clears it without asking the
+        so a prior rollout's terminal would otherwise re-fire; gating on delivery clears it without asking the
         producer to republish. Reached only for a rollout with a deadline.
         """
         done_msg = self.done.read()

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,5 +1,5 @@
 import time
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -59,6 +59,22 @@ class Directive:
     def ABORT(cls) -> 'Directive':
         """Discard the live recording and home the devices."""
         return cls(DirectiveType.ABORT)
+
+
+# ``Directive.RUN`` names the rollout's budget with this key and its instruction with ``keys.TASK``; every
+# other payload key describes the scene the operator staged.
+RUN_TIMEOUT = 'timeout'
+
+
+def _directive_task(payload: dict[str, Any]) -> Task:
+    """A RUN payload read as one rollout.
+
+    An operator names the goal and, where the rollout is to end on its own, a budget; the rest of what they
+    report describes the scene they staged, so it is recorded and withheld from the policy like any other
+    scene. Without a budget the episode is unbounded and ends on FINISH or ABORT.
+    """
+    scene = {k: v for k, v in payload.items() if k not in (keys.TASK, RUN_TIMEOUT)}
+    return Task(instruction=payload.get(keys.TASK), timeout=payload.get(RUN_TIMEOUT), scene=scene)
 
 
 class _EpisodeTelemetry:
@@ -141,15 +157,19 @@ class Harness(pimm.ControlSystem):
 
     Handles directives (RUN/FINISH/ABORT) and dataset recording. Inference intelligence — scheduling,
     error recovery, blending, absolute time stamping — lives in the policy/session layer; the harness
-    calls the session, demuxes the action dicts into per-channel trajectories, and emits. The RUN context
-    is handed whole to the task's scene reset, which reads the per-trial keys it needs (e.g. ``eval.seed``).
+    calls the session, demuxes the action dicts into per-channel trajectories, and emits.
 
-    A ``trials`` plan (a sequence of RUN contexts) makes the harness self-driving: it starts the next trial
-    whenever idle and returns once the plan is exhausted, so the unattended path needs no driver. A task's
-    ``timeout`` bounds every trial, self-driven or operator-driven, so an attended episode still terminates
-    at the deadline if the operator never sends FINISH. A bounded trial also ends early on a truthy
-    privileged ``done``, recording ``eval.terminated`` True and the delivered payload in its static data; a
-    timeout records False. A task-less session has neither deadline nor budget and ends only on directives.
+    Every episode runs one ``Task``. A ``tasks`` plan makes the harness self-driving: it starts the next task
+    whenever idle and returns once the plan is exhausted, so the unattended path needs no driver. Without a
+    plan a RUN directive carries the rollout instead, and the two are the same episode to everything
+    downstream. Only the task's ``instruction`` crosses to the policy — its scene goes to ``reset`` and into
+    the recording, so a policy cannot condition on the ground truth it is scored against.
+
+    A task's ``timeout`` bounds the rollout, self-driven or operator-driven, so an attended episode given a
+    budget still terminates at the deadline if the operator never sends FINISH. A bounded rollout also ends
+    early on a truthy privileged ``done``, recording ``eval.terminated`` True and the delivered payload in
+    its static data; a timeout records False. A task without a budget has no deadline, so ``done`` does not
+    terminate it and only directives end it. ``inference_latency`` applies to every episode of the run.
 
     The ``Embodiment`` supplies the observation serializers (which own the canonical key names), the command
     channels and the home action. The policy owns its wrapper stack; the harness runs what it is given,
@@ -161,26 +181,33 @@ class Harness(pimm.ControlSystem):
         policy: Policy,
         embodiment: Embodiment,
         *,
-        task: Task | None = None,
-        trials: Iterable[dict[str, Any]] | None = None,
+        tasks: list[Task] | None = None,
+        reset: Callable[[dict[str, Any]], None] | None = None,
         static_meta: dict[str, Any] | None = None,
+        inference_latency: bool | float = False,
     ):
-        assert trials is None or task is not None, 'A trial plan needs a task: its timeout bounds each trial'
         self._embodiment = embodiment
-        self._task = task
-        # Each entry is a RUN context; when None, directives are the only lifecycle source.
-        self._trials = iter(trials) if trials is not None else None
+        # The unattended rollout plan; when None, directives are the only lifecycle source.
+        self._plan = iter(tasks) if tasks is not None else None
+        self._trial_count = len(tasks) if tasks is not None else None
+        self._trial_index = -1
+        self._reset = reset
         self.policy: Policy = policy
         self.context: dict[str, Any] = {}
+        # What crosses to the policy, assembled per episode: the instruction and nothing else about the
+        # rollout. The rest — scene, seed, plan position — is recorded but withheld.
+        self._policy_inputs: dict[str, Any] = {}
         self._static_meta = static_meta or {}
         self._policy_session: Session | None = None
         # True between RUN and FINISH/ABORT: the trial is live — stepping and recording happen together.
         self._running = False
-        # Sim-only, delivered on the RUN context: ``True`` advances the sim clock by the measured wall cost
-        # of the inference call, a float by a fixed deterministic amount (the reproducible golden). The chunk
-        # is anchored before the sleep, so ``_step`` post-shifts it.
-        self._inference_latency: bool | float = False
-        # ``task.timeout``, set per episode; a task-less session has no deadline and ends on directives.
+        # Sim-only: ``True`` advances the sim clock by the measured wall cost of the inference call, a float
+        # by a fixed deterministic amount (the reproducible golden). The chunk is anchored before the sleep,
+        # so ``_step`` post-shifts it.
+        self._inference_latency: bool | float = inference_latency
+        # The live task's ``timeout`` and the deadline it arms; both ``None`` for an unbounded episode, which
+        # ends on directives.
+        self._timeout: float | None = None
         self._deadline: float | None = None
         # Whether this episode's first observation has landed. Until it does the deadline stands where the
         # reset put it, which bounds an episode whose first observation never arrives.
@@ -210,20 +237,19 @@ class Harness(pimm.ControlSystem):
         """What is known about the rig before the episode runs, live values winning."""
         return self._embodiment.static_meta | self._static_meta | self.robot_meta_in.value
 
-    def _build_episode_meta(self, context: dict[str, Any]) -> dict[str, Any]:
+    def _build_episode_meta(self) -> dict[str, Any]:
         meta = self._statics()
-        if self._task is not None:
-            # TODO: also stamp the eval's catalog name and its resolved config — both need configuronic
-            # introspection that does not exist yet.
-            meta['eval.universe'] = 'sim' if self._embodiment.simulated else 'real'
-            meta['eval.embodiment'] = self._embodiment.descriptor
-            meta['eval.timeout'] = self._task.timeout
+        # TODO: also stamp the eval's catalog name and its resolved config — both need configuronic
+        # introspection that does not exist yet.
+        meta[keys.EVAL_UNIVERSE] = 'sim' if self._embodiment.simulated else 'real'
+        meta[keys.EVAL_EMBODIMENT] = self._embodiment.descriptor
+        meta[keys.INFERENCE_LATENCY] = self._inference_latency
         # ``policy.meta`` is the static baseline; the session overlays per-episode specifics (e.g. the
         # sampled sub-policy) and wins on conflict.
         session_meta = self.policy.meta | (self._policy_session.meta if self._policy_session else {})
         for k, v in flatten_dict(session_meta).items():
             meta[f'{keys.POLICY_META}.{k}'] = v
-        meta.update(context)
+        meta.update(self.context)
         return meta
 
     def _emit_now(self, action: dict[str, Any], clock: pimm.Clock) -> None:
@@ -272,7 +298,7 @@ class Harness(pimm.ControlSystem):
         """Commit the live episode: cancel the in-flight chunk, stop the recorder — stamping the
         episode's full static meta (plus any terminal payload) — then close its span."""
         self._cancel_trajectories()
-        self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(self.context), **(payload or {})}))
+        self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})}))
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
         # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
         # last-value-wins would drop one) and before the home command, so homing stays out of the recording.
@@ -282,31 +308,40 @@ class Harness(pimm.ControlSystem):
         # period) to the closing episode — the cooperative scheduler cannot give the recorder a turn alone.
         self._telemetry.end(virtual_now)
 
-    def _begin_episode(self, context: dict[str, Any], clock: pimm.Clock) -> None:
-        """Open a fresh episode: reset the scene, fix the task context and session, and open the recording.
+    def _plan_position(self) -> dict[str, Any]:
+        """Where the live episode sits in the rollout plan; empty for a directive-driven one, which has none."""
+        if self._trial_count is None:
+            return {}
+        return {keys.EVAL_TRIAL_INDEX: self._trial_index, keys.EVAL_TRIAL_COUNT: self._trial_count}
 
-        A resettable task's ``reset`` only arms the producer, which publishes the first observation on a later
-        round. The recorder drains its channels the turn it opens, so the pre-reset frame and the
-        inter-episode home command drop out and its first sample is the post-reset scene. The deadline is
-        armed here and moved to that first observation once it lands, so an episode that never gets one is
-        still bounded.
+    def _begin_episode(self, task: Task, clock: pimm.Clock) -> None:
+        """Open a fresh episode: stage the scene, fix the episode context and session, open the recording.
+
+        ``reset`` only arms the producer, which publishes the first observation on a later round. The
+        recorder drains its channels the turn it opens, so the pre-reset frame and the inter-episode home
+        command drop out and its first sample is the post-reset scene. The deadline is armed here and moved
+        to that first observation once it lands, so an episode that never gets one is still bounded.
         """
-        self.context = context
-        self._inference_latency = self.context.get('inference_latency', False)
         self._awaiting_obs = set(self._embodiment.observations)
         self._rollout_started = False
+        self._timeout = task.timeout
+        context: dict[str, Any] = {**task.scene, **self._plan_position()}
+        if task.timeout is not None:
+            context[keys.EVAL_TIMEOUT] = task.timeout
         # Before the reset, so the reset and the rollout's other phase spans parent to the episode span.
         self._telemetry.begin(context)
-        # Reset before opening the session: a resettable task only learns its instruction on reset (a remote
-        # env reports it then), so the session context — and the sampling it drives — must read it here.
-        if self._task is not None and self._task.reset is not None:
+        # Reset before opening the session: an embodiment that only learns its goal on reset (a remote env
+        # reports it then) resolves its instruction here, so the session context — and the sampling it
+        # drives — reads the instruction once it is known.
+        if self._reset is not None:
             with telemetry.span(telemetry_keys.SPAN_RESET):
-                self._task.reset(self.context)
-        if self._task is not None:
-            self.context = {**self.context, keys.TASK: self._task.instruction}
+                self._reset(task.scene)
+        instruction = task.instruction
+        self._policy_inputs = {keys.TASK: instruction} if instruction is not None else {}
+        self.context = context | self._policy_inputs
         self._policy_session = self.policy.new_session(self.context, clock.now)
         self._running = True
-        self._deadline = clock.now() + self._task.timeout if self._task is not None else None
+        self._deadline = clock.now() + task.timeout if task.timeout is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
     def _end_episode(
@@ -336,7 +371,7 @@ class Harness(pimm.ControlSystem):
         match directive.type:
             case DirectiveType.RUN:
                 if not self._running:  # a RUN mid-trial is ignored — the operator finishes before starting anew
-                    self._begin_episode(directive.payload or {}, clock)
+                    self._begin_episode(_directive_task(directive.payload or {}), clock)
             case DirectiveType.FINISH:
                 if self._running:  # a FINISH while idle is ignored — nothing to finalize
                     yield from self._end_episode(clock, directive.payload)
@@ -374,8 +409,8 @@ class Harness(pimm.ControlSystem):
             return None
         inputs[keys.WALL_TIME_NS] = time.time_ns()
         inputs[keys.OBS_TIME_NS] = clock.now_ns()
-        inputs.update(self.context)
-        inputs['descriptor'] = self._descriptor  # last, so a context key can't shadow it
+        inputs.update(self._policy_inputs)
+        inputs['descriptor'] = self._descriptor
         return inputs
 
     def _emit_commands(self, actions: list[dict[str, Any]]) -> None:
@@ -411,8 +446,8 @@ class Harness(pimm.ControlSystem):
             # duration.
             self._rollout_started = True
             self._telemetry.start_rollout(clock.now())
-            if self._task is not None:
-                self._deadline = clock.now() + self._task.timeout
+            if self._timeout is not None:
+                self._deadline = clock.now() + self._timeout
 
         # Advance the sim clock by the inference cost so rollouts feel the model's latency, but only on
         # cycles where inference ran — sleeping on blocked cycles would slow directive handling. The chunk
@@ -484,12 +519,13 @@ class Harness(pimm.ControlSystem):
             elif not self._running:
                 if manual_msg.updated and manual_msg.data is not None:
                     self._emit_now(manual_msg.data, clock)
-                elif self._trials is not None:
-                    trial = next(self._trials, None)
-                    if trial is None:  # plan exhausted — let the recorder commit the final episode, then exit
+                elif self._plan is not None:
+                    task = next(self._plan, None)
+                    if task is None:  # plan exhausted — let the recorder commit the final episode, then exit
                         yield pimm.Sleep(0.5)
                         break
-                    self._begin_episode(trial, clock)
+                    self._trial_index += 1
+                    self._begin_episode(task, clock)
             elif self._deadline is not None and (terminal := self._trial_terminal(clock)) is not None:
                 yield from self._end_episode(clock, terminal)
             else:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -11,7 +11,7 @@ from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.drivers.roboarm.ik import assert_default_frame
-from positronic.eval import Embodiment, Task
+from positronic.eval import Embodiment, Rollout
 from positronic.policy.base import Policy, Session
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.utils import flatten_dict, frozen_view
@@ -66,7 +66,7 @@ class Directive:
 RUN_TIMEOUT = 'timeout'
 
 
-def _directive_task(payload: dict[str, Any]) -> Task:
+def _directive_rollout(payload: dict[str, Any]) -> Rollout:
     """A RUN payload read as one rollout.
 
     An operator names the goal and, where the rollout is to end on its own, a budget; the rest of what they
@@ -74,7 +74,7 @@ def _directive_task(payload: dict[str, Any]) -> Task:
     scene. Without a budget the episode is unbounded and ends on FINISH or ABORT.
     """
     scene = {k: v for k, v in payload.items() if k not in (keys.TASK, RUN_TIMEOUT)}
-    return Task(instruction=payload.get(keys.TASK), timeout=payload.get(RUN_TIMEOUT), scene=scene)
+    return Rollout(instruction=payload.get(keys.TASK), timeout=payload.get(RUN_TIMEOUT), scene=scene)
 
 
 class _EpisodeTelemetry:
@@ -137,7 +137,7 @@ class _EpisodeTelemetry:
         telemetry.force_flush()
 
     def _close(self, virtual_now: float) -> None:
-        # A rollout whose first observation never landed — a reset that raised, or a task already done before
+        # A rollout whose first observation never landed — a reset that raised, or a rollout already done before
         # it arrived — has zero virtual duration.
         virtual_s = max(virtual_now - self._virtual_start, 0.0) if self._virtual_start is not None else 0.0
         assert self._span is not None
@@ -159,16 +159,16 @@ class Harness(pimm.ControlSystem):
     error recovery, blending, absolute time stamping — lives in the policy/session layer; the harness
     calls the session, demuxes the action dicts into per-channel trajectories, and emits.
 
-    Every episode runs one ``Task``. A ``tasks`` plan makes the harness self-driving: it starts the next task
-    whenever idle and returns once the plan is exhausted, so the unattended path needs no driver. Without a
+    Every episode runs one ``Rollout``. A ``rollouts`` plan makes the harness self-driving: it starts the
+    next one whenever idle and returns once the plan is exhausted, so the unattended path needs no driver. Without a
     plan a RUN directive carries the rollout instead, and the two are the same episode to everything
-    downstream. Only the task's ``instruction`` crosses to the policy — its scene goes to ``reset`` and into
+    downstream. Only the rollout's ``instruction`` crosses to the policy — its scene goes to ``reset`` and into
     the recording, so a policy cannot condition on the ground truth it is scored against.
 
-    A task's ``timeout`` bounds the rollout, self-driven or operator-driven, so an attended episode given a
+    A rollout's ``timeout`` bounds it, self-driven or operator-driven, so an attended episode given a
     budget still terminates at the deadline if the operator never sends FINISH. A bounded rollout also ends
     early on a truthy privileged ``done``, recording ``eval.terminated`` True and the delivered payload in
-    its static data; a timeout records False. A task without a budget has no deadline, so ``done`` does not
+    its static data; a timeout records False. A rollout without a budget has no deadline, so ``done`` does not
     terminate it and only directives end it. ``inference_latency`` applies to every episode of the run.
 
     The ``Embodiment`` supplies the observation serializers (which own the canonical key names), the command
@@ -181,16 +181,16 @@ class Harness(pimm.ControlSystem):
         policy: Policy,
         embodiment: Embodiment,
         *,
-        tasks: list[Task] | None = None,
+        rollouts: list[Rollout] | None = None,
         reset: Callable[[dict[str, Any]], None] | None = None,
         static_meta: dict[str, Any] | None = None,
         inference_latency: bool | float = False,
     ):
         self._embodiment = embodiment
         # The unattended rollout plan; when None, directives are the only lifecycle source.
-        self._plan = iter(tasks) if tasks is not None else None
-        self._trial_count = len(tasks) if tasks is not None else None
-        self._trial_index = -1
+        self._plan = iter(rollouts) if rollouts is not None else None
+        self._rollout_count = len(rollouts) if rollouts is not None else None
+        self._rollout_index = -1
         self._reset = reset
         self.policy: Policy = policy
         self.context: dict[str, Any] = {}
@@ -205,7 +205,7 @@ class Harness(pimm.ControlSystem):
         # by a fixed deterministic amount (the reproducible golden). The chunk is anchored before the sleep,
         # so ``_step`` post-shifts it.
         self._inference_latency: bool | float = inference_latency
-        # The live task's ``timeout`` and the deadline it arms; both ``None`` for an unbounded episode, which
+        # The live rollout's ``timeout`` and the deadline it arms; both ``None`` for an unbounded episode, which
         # ends on directives.
         self._timeout: float | None = None
         self._deadline: float | None = None
@@ -310,11 +310,11 @@ class Harness(pimm.ControlSystem):
 
     def _plan_position(self) -> dict[str, Any]:
         """Where the live episode sits in the rollout plan; empty for a directive-driven one, which has none."""
-        if self._trial_count is None:
+        if self._rollout_count is None:
             return {}
-        return {keys.EVAL_TRIAL_INDEX: self._trial_index, keys.EVAL_TRIAL_COUNT: self._trial_count}
+        return {keys.EVAL_ROLLOUT_INDEX: self._rollout_index, keys.EVAL_ROLLOUT_COUNT: self._rollout_count}
 
-    def _begin_episode(self, task: Task, clock: pimm.Clock) -> None:
+    def _begin_episode(self, rollout: Rollout, clock: pimm.Clock) -> None:
         """Open a fresh episode: stage the scene, fix the episode context and session, open the recording.
 
         ``reset`` only arms the producer, which publishes the first observation on a later round. The
@@ -324,10 +324,10 @@ class Harness(pimm.ControlSystem):
         """
         self._awaiting_obs = set(self._embodiment.observations)
         self._rollout_started = False
-        self._timeout = task.timeout
-        context: dict[str, Any] = {**task.scene, **self._plan_position()}
-        if task.timeout is not None:
-            context[keys.EVAL_TIMEOUT] = task.timeout
+        self._timeout = rollout.timeout
+        context: dict[str, Any] = {**rollout.scene, **self._plan_position()}
+        if rollout.timeout is not None:
+            context[keys.EVAL_TIMEOUT] = rollout.timeout
         # Before the reset, so the reset and the rollout's other phase spans parent to the episode span.
         self._telemetry.begin(context)
         # Reset before opening the session: an embodiment that only learns its goal on reset (a remote env
@@ -335,13 +335,13 @@ class Harness(pimm.ControlSystem):
         # drives — reads the instruction once it is known.
         if self._reset is not None:
             with telemetry.span(telemetry_keys.SPAN_RESET):
-                self._reset(task.scene)
-        instruction = task.instruction
+                self._reset(rollout.scene)
+        instruction = rollout.instruction
         self._policy_inputs = {keys.TASK: instruction} if instruction is not None else {}
         self.context = context | self._policy_inputs
         self._policy_session = self.policy.new_session(self.context, clock.now)
         self._running = True
-        self._deadline = clock.now() + task.timeout if task.timeout is not None else None
+        self._deadline = clock.now() + rollout.timeout if rollout.timeout is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
     def _end_episode(
@@ -371,7 +371,7 @@ class Harness(pimm.ControlSystem):
         match directive.type:
             case DirectiveType.RUN:
                 if not self._running:  # a RUN mid-trial is ignored — the operator finishes before starting anew
-                    self._begin_episode(_directive_task(directive.payload or {}), clock)
+                    self._begin_episode(_directive_rollout(directive.payload or {}), clock)
             case DirectiveType.FINISH:
                 if self._running:  # a FINISH while idle is ignored — nothing to finalize
                     yield from self._end_episode(clock, directive.payload)
@@ -479,7 +479,7 @@ class Harness(pimm.ControlSystem):
         its payload, the budget passing records False, and a terminal past the deadline is a timeout rather
         than a late success. Only a freshly delivered ``done`` counts — the receiver latches its last value,
         so a prior trial's terminal would otherwise re-fire; gating on delivery clears it without asking the
-        producer to republish. Reached only for a task with a deadline.
+        producer to republish. Reached only for a rollout with a deadline.
         """
         done_msg = self.done.read()
         if done_msg.updated and done_msg.data and done_msg.ts <= self._deadline * 1e9:
@@ -520,12 +520,12 @@ class Harness(pimm.ControlSystem):
                 if manual_msg.updated and manual_msg.data is not None:
                     self._emit_now(manual_msg.data, clock)
                 elif self._plan is not None:
-                    task = next(self._plan, None)
-                    if task is None:  # plan exhausted — let the recorder commit the final episode, then exit
+                    rollout = next(self._plan, None)
+                    if rollout is None:  # plan exhausted — let the recorder commit the final episode, then exit
                         yield pimm.Sleep(0.5)
                         break
-                    self._trial_index += 1
-                    self._begin_episode(task, clock)
+                    self._rollout_index += 1
+                    self._begin_episode(rollout, clock)
             elif self._deadline is not None and (terminal := self._trial_terminal(clock)) is not None:
                 yield from self._end_episode(clock, terminal)
             else:

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -203,7 +203,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
             static_meta=dict(ROBOT_STATIC_META),
             meta_source=robot.robot_meta,
         )
-        harness = Harness(ChunkedSchedule().wrap(policy), embodiment)
+        harness = Harness(ChunkedSchedule().wrap(policy), embodiment, inference_latency=INFERENCE_LATENCY_S)
         ds_agent = wire.wire_embodiment(world, harness, embodiment, ds_writer, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
         directive_em = world.pair(harness.directive)
@@ -211,7 +211,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
         # Robot/gripper emit state every tick, so the script only drives the
         # episode lifecycle and the one-shot error injection.
         script = [
-            (partial(directive_em.emit, Directive.RUN(task='golden', inference_latency=INFERENCE_LATENCY_S)), 0.0),
+            (partial(directive_em.emit, Directive.RUN(task='golden')), 0.0),
             (None, 1.5),  # several reactive inference + chunk/horizon cycles
             (robot.inject_error, 0.0),  # one-shot error: that frame is dropped, then inference resumes
             (None, 0.5),

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -25,7 +25,7 @@ from positronic.drivers.roboarm.command import (
     to_wire,
 )
 from positronic.drivers.roboarm.models import DEFAULT_FRAME, EE_LINK, bundled_franka_model
-from positronic.eval import Command, Embodiment, Observation, Task
+from positronic.eval import Command, Embodiment, Observation, Rollout
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import Policy, Session
@@ -601,7 +601,7 @@ def test_finish_emits_ds_stop_with_data_and_homes(world):
 def test_trial_timeout_self_terminates(world):
     """A self-driven trial ends at ``task.timeout``: terminated=False, robot homed."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), tasks=[Task('test', 0.05)])
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('test', 0.05)])
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -633,7 +633,7 @@ def test_trial_budget_starts_at_the_first_usable_observation(world):
     embodiment.observations[CAM] = Observation(
         pimm.NoOpEmitter(), lambda frames: next(usable, Serializers.camera_images(frames))
     )
-    harness = Harness(policy, embodiment, tasks=[Task('test', 0.05)])
+    harness = Harness(policy, embodiment, rollouts=[Rollout('test', 0.05)])
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.2, 0.0, -0.1], [0.7, 0.1, -0.2])
     payload = partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
@@ -673,7 +673,7 @@ def test_attended_task_run_respects_timeout(world):
 @pytest.mark.timeout(3.0)
 def test_attended_task_run_respects_done(world):
     """The privileged ``done`` ends an attended run too: a fresh terminal within budget terminates the
-    episode even though no FINISH arrives. ``done`` is honored whenever a task supplies it, attended or
+    episode even though no FINISH arrives. ``done`` is honored whenever a rollout supplies it, attended or
     self-driven."""
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment())
@@ -698,7 +698,7 @@ def test_trial_stop_signal_terminates(world):
     """Delivering the privileged ``done`` ends a trial early: terminated=True, payload recorded, homed."""
     policy = StubPolicy()
     # Timeout far in the future so the stop-signal, not the clock, ends the trial.
-    harness = Harness(policy, make_embodiment(), tasks=[Task('test', 100.0)])
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('test', 100.0)])
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
@@ -724,7 +724,7 @@ def test_stale_done_does_not_terminate_next_trial(world):
     latched value is ignored — no producer ``reset`` clears it here (``reset`` is ``None``, as on a real
     embodiment). A falsy payload never terminates; trial 1 runs until its own fresh terminal lands."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), tasks=[Task('t', 100.0), Task('t', 100.0)])
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('t', 100.0), Rollout('t', 100.0)])
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
@@ -797,7 +797,7 @@ def test_policy_first_obs_is_frame0(world):
         simulated=True,
     )
     policy = StubPolicy()
-    harness = Harness(policy, embodiment, tasks=[Task('t', 100.0)], reset=device.reset)
+    harness = Harness(policy, embodiment, rollouts=[Rollout('t', 100.0)], reset=device.reset)
     wire.wire_embodiment(world, harness, embodiment, None)
 
     scheduler = world.start([harness, device])
@@ -810,7 +810,7 @@ def test_policy_first_obs_is_frame0(world):
 
 @pytest.mark.timeout(3.0)
 def test_task_done_terminates_through_wire_embodiment(world):
-    """A Task's ``done`` source reaches ``harness.done`` through ``wire_embodiment`` and ends the
+    """An eval's ``done`` source reaches ``harness.done`` through ``wire_embodiment`` and ends the
     trial, recording its payload — the production wiring path, not a direct port pairing."""
 
     class _Device(pimm.ControlSystem):
@@ -838,7 +838,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
     )
     # Termination is independent of the policy wrappers; the minimal embodiment has no
     # ``robot_state``, so run the stub policy bare.
-    harness = Harness(StubPolicy(), embodiment, tasks=[Task('t', 100.0)])
+    harness = Harness(StubPolicy(), embodiment, rollouts=[Rollout('t', 100.0)])
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     wire.wire_embodiment(world, harness, embodiment, None, done=device.done)
@@ -857,7 +857,7 @@ def test_done_after_deadline_is_a_timeout(world):
     """The deadline is hard: a ``done`` delivered past it (here during the latency sleep) records as a
     timeout — ``eval.terminated`` False, payload dropped — not a late stop-signal success."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), tasks=[Task('t', 0.05)], inference_latency=0.2)
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('t', 0.05)], inference_latency=0.2)
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
@@ -884,13 +884,13 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
     eval-identity block land in episode meta."""
     policy = StubPolicy()
     seeds = []
-    tasks = [Task('stack', 0.05, {keys.EVAL_SEED: 7 + i}) for i in range(2)]
+    rollouts = [Rollout('stack', 0.05, {keys.EVAL_SEED: 7 + i}) for i in range(2)]
 
     def reset(scene):
         seeds.append(scene[keys.EVAL_SEED])
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
-    harness = Harness(policy, make_embodiment(), tasks=tasks, reset=reset)
+    harness = Harness(policy, make_embodiment(), rollouts=rollouts, reset=reset)
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -909,16 +909,16 @@ def test_trial_plan_self_drives(world):
     """With a trial plan the harness runs unattended: no driver, one episode per entry, each stamped with
     its place in the plan."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05) for _ in range(2)])
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('stack', 0.05) for _ in range(2)])
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
     drive_scheduler(scheduler, steps=400)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert [s.static_data['eval.trial_index'] for s in stops] == [0, 1]
+    assert [s.static_data['eval.rollout_index'] for s in stops] == [0, 1]
     assert all(s.static_data[keys.TASK] == 'stack' for s in stops)
-    assert all(s.static_data['eval.trial_count'] == 2 for s in stops)
+    assert all(s.static_data['eval.rollout_count'] == 2 for s in stops)
     assert len(stops) == 2
     assert all(s.static_data[keys.EVAL_TERMINATED] is False for s in stops)
     assert policy.reset_calls == 2
@@ -930,7 +930,7 @@ def test_scene_is_recorded_but_withheld_from_the_policy(world):
     is scored against, so it reaches the reset and the recording but never the observation dict."""
     policy = StubPolicy()
     scene = {keys.EVAL_SEED: 7, 'eval.task_id': 3}
-    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05, scene)])
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('stack', 0.05, scene)])
     p = _pair_all(world, harness)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -955,7 +955,7 @@ def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
     """A chunk whose latency sleep crosses the deadline is dropped, never emitted."""
     policy = StubPolicy()
     # The 0.2s latency sleep crosses the 0.05s deadline before the chunk is emitted.
-    harness = Harness(policy, make_embodiment(), tasks=[Task('test', 0.05)], inference_latency=0.2)
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('test', 0.05)], inference_latency=0.2)
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     ds_recorder = RecordingEmitter()
@@ -1056,8 +1056,8 @@ def test_task_instruction_reaches_session_context_after_reset(world):
     def reset(_scene):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
-    tasks = [Task(lambda: scene['task'], 0.05)]
-    harness = Harness(policy, make_embodiment(), tasks=tasks, reset=reset)
+    rollouts = [Rollout(lambda: scene['task'], 0.05)]
+    harness = Harness(policy, make_embodiment(), rollouts=rollouts, reset=reset)
     _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -1445,7 +1445,7 @@ def test_stop_mid_episode_keeps_episode_open_for_recorder_flush(tmp_path):
     shutdown-flush ``record.io`` span parents to the episode, not the pass. Driven straight through the
     generator protocol: the yield after the queued STOP is the recorder's flush slot."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 10.0)], reset=lambda scene: None)
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('stack', 10.0)], reset=lambda scene: None)
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     stop = SimpleNamespace(value=False)
@@ -1488,7 +1488,7 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
     ``policy.infer`` span is recorded at the remote inference boundary, so the terminal is a ``RemoteStubPolicy``
     (a real ``RemoteSession`` over a fake inference session)."""
     policy = ChunkedSchedule().wrap(RemoteStubPolicy())
-    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05)], reset=lambda scene: None)
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('stack', 0.05)], reset=lambda scene: None)
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A latched observation set makes every step's inference fire (the harness reads the latest value).
@@ -1507,7 +1507,7 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
 
     assert len(by_name[telemetry_keys.SPAN_EVAL_PASS]) == 1
     assert len(by_name[telemetry_keys.SPAN_EPISODE]) == 1
-    assert by_name[telemetry_keys.SPAN_RESET]  # the task's scene reset was timed
+    assert by_name[telemetry_keys.SPAN_RESET]  # the scene reset was timed
     assert by_name[telemetry_keys.SPAN_POLICY_INFER]  # at least one real inference round-trip
 
     pass_span = by_name[telemetry_keys.SPAN_EVAL_PASS][0]
@@ -1558,7 +1558,7 @@ def test_failed_pass_seals_open_episode_span(tmp_path):
         raise RuntimeError('reset boom')
 
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 10.0)], reset=boom)
+    harness = Harness(policy, make_embodiment(), rollouts=[Rollout('stack', 10.0)], reset=boom)
     harness.ds_command._bind(RecordingEmitter())
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -599,7 +599,7 @@ def test_finish_emits_ds_stop_with_data_and_homes(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_timeout_self_terminates(world):
-    """A self-driven trial ends at ``task.timeout``: terminated=False, robot homed."""
+    """A self-driven rollout ends at ``rollout.timeout``: terminated=False, robot homed."""
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment(), rollouts=[Rollout('test', 0.05)])
     p = _pair_all(world, harness)
@@ -1069,8 +1069,8 @@ def test_run_calls_policy_reset_with_context(world):
 
 @pytest.mark.timeout(3.0)
 def test_task_instruction_reaches_session_context_after_reset(world):
-    """A task eval resets the scene before opening the session, so an instruction resolvable only on reset
-    (as a remote env reports its task) still reaches ``new_session`` — task-grouped sampling/counting needs it."""
+    """An eval with a scene reset stages it before opening the session, so an instruction resolvable only on
+    reset (as a remote env reports its task) still reaches ``new_session`` — the sampler groups by it."""
     policy = StubPolicy()
     scene = {}
 
@@ -1568,7 +1568,7 @@ def test_aborted_episode_span_marked_aborted(world, tmp_path):
 
 @pytest.mark.timeout(3.0)
 def test_failed_pass_seals_open_episode_span(tmp_path):
-    """A ``task.reset`` raising after the episode span was opened must seal that span before the
+    """An eval's ``reset`` raising after the episode span was opened must seal that span before the
     provider flushes on exit. Ending it is what exports it at all: an unended span never leaves the batch
     processor, so its finished ``reset`` child orphans (unknown parent) and the report loses that phase and
     charges the episode's whole wall to ``between_episodes``. Sealed and marked ``episode.partial`` — with its

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -884,10 +884,10 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
     eval-identity block land in episode meta."""
     policy = StubPolicy()
     seeds = []
-    tasks = [Task('stack', 0.05, {'eval.seed': 7 + i}) for i in range(2)]
+    tasks = [Task('stack', 0.05, {keys.EVAL_SEED: 7 + i}) for i in range(2)]
 
     def reset(scene):
-        seeds.append(scene.get('eval.seed'))
+        seeds.append(scene[keys.EVAL_SEED])
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
     harness = Harness(policy, make_embodiment(), tasks=tasks, reset=reset)
@@ -929,7 +929,7 @@ def test_scene_is_recorded_but_withheld_from_the_policy(world):
     """Of the rollout, only the instruction crosses to the policy. The scene is the ground truth the rollout
     is scored against, so it reaches the reset and the recording but never the observation dict."""
     policy = StubPolicy()
-    scene = {'eval.seed': 7, 'eval.task_id': 3}
+    scene = {keys.EVAL_SEED: 7, 'eval.task_id': 3}
     harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05, scene)])
     p = _pair_all(world, harness)
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -653,7 +653,7 @@ def test_trial_budget_starts_at_the_first_usable_observation(world):
 
 @pytest.mark.timeout(3.0)
 def test_attended_task_run_respects_timeout(world):
-    """A budget on the RUN directive bounds an attended run too: RUN arrives but no FINISH, yet the trial
+    """A budget on the RUN directive bounds an attended run too: RUN arrives but no FINISH, yet the rollout
     still self-terminates at the deadline. The deadline is armed for whichever rollout the episode runs, not
     only for one the plan authored."""
     policy = StubPolicy()
@@ -906,7 +906,7 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_plan_self_drives(world):
-    """With a trial plan the harness runs unattended: no driver, one episode per entry, each stamped with
+    """With a rollout plan the harness runs unattended: no driver, one episode per entry, each stamped with
     its place in the plan."""
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment(), rollouts=[Rollout('stack', 0.05) for _ in range(2)])

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -925,6 +925,27 @@ def test_trial_plan_self_drives(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_a_directive_episode_carries_no_plan_position(world):
+    """A RUN directive sits in no plan, so its episode is stamped with no place in one — even on a harness
+    that also holds a plan, whose next index it must not borrow."""
+    harness = Harness(StubPolicy(), make_embodiment(), rollouts=[Rollout('stack', 0.05)])
+    p = _pair_all(world, harness)
+    # Ahead of the harness in the round, so its RUN lands before the plan claims the first idle round.
+    run = partial(p['directive_em'].emit, Directive.RUN(task='attended', timeout=0.05))
+    driver = ManualDriver([(run, 0.0), (None, 0.5)])
+
+    scheduler = world.start([driver, harness])
+    drive_scheduler(scheduler, steps=1200)
+
+    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert stops[0].static_data[keys.TASK] == 'attended'
+    assert keys.EVAL_ROLLOUT_INDEX not in stops[0].static_data
+    assert keys.EVAL_ROLLOUT_COUNT not in stops[0].static_data
+    # The plan is untouched by the directive episode, so its own rollout still runs as entry 0.
+    assert [s.static_data.get(keys.EVAL_ROLLOUT_INDEX) for s in stops] == [None, 0]
+
+
+@pytest.mark.timeout(3.0)
 def test_scene_is_recorded_but_withheld_from_the_policy(world):
     """Of the rollout, only the instruction crosses to the policy. The scene is the ground truth the rollout
     is scored against, so it reaches the reset and the recording but never the observation dict."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -898,10 +898,10 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
 
     assert seeds == [7, 8]
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert [s.static_data['eval.seed'] for s in stops] == [7, 8]
-    assert all(s.static_data['eval.universe'] == 'real' for s in stops)
-    assert all(s.static_data['eval.embodiment'] == '' for s in stops)
-    assert all(s.static_data['eval.timeout'] == 0.05 for s in stops)
+    assert [s.static_data[keys.EVAL_SEED] for s in stops] == [7, 8]
+    assert all(s.static_data[keys.EVAL_UNIVERSE] == 'real' for s in stops)
+    assert all(s.static_data[keys.EVAL_EMBODIMENT] == '' for s in stops)
+    assert all(s.static_data[keys.EVAL_TIMEOUT] == 0.05 for s in stops)
 
 
 @pytest.mark.timeout(3.0)
@@ -916,9 +916,9 @@ def test_trial_plan_self_drives(world):
     drive_scheduler(scheduler, steps=400)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert [s.static_data['eval.rollout_index'] for s in stops] == [0, 1]
+    assert [s.static_data[keys.EVAL_ROLLOUT_INDEX] for s in stops] == [0, 1]
     assert all(s.static_data[keys.TASK] == 'stack' for s in stops)
-    assert all(s.static_data['eval.rollout_count'] == 2 for s in stops)
+    assert all(s.static_data[keys.EVAL_ROLLOUT_COUNT] == 2 for s in stops)
     assert len(stops) == 2
     assert all(s.static_data[keys.EVAL_TERMINATED] is False for s in stops)
     assert policy.reset_calls == 2
@@ -946,7 +946,7 @@ def test_scene_is_recorded_but_withheld_from_the_policy(world):
     assert all(scene.keys().isdisjoint(obs) for obs in policy.observations)
 
     (stop,) = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert stop.static_data['eval.seed'] == 7
+    assert stop.static_data[keys.EVAL_SEED] == 7
     assert stop.static_data['eval.task_id'] == 3
 
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -601,7 +601,7 @@ def test_finish_emits_ds_stop_with_data_and_homes(world):
 def test_trial_timeout_self_terminates(world):
     """A self-driven trial ends at ``task.timeout``: terminated=False, robot homed."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=0.05), trials=[{}])
+    harness = Harness(policy, make_embodiment(), tasks=[Task('test', 0.05)])
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -633,7 +633,7 @@ def test_trial_budget_starts_at_the_first_usable_observation(world):
     embodiment.observations[CAM] = Observation(
         pimm.NoOpEmitter(), lambda frames: next(usable, Serializers.camera_images(frames))
     )
-    harness = Harness(policy, embodiment, task=Task(instruction='test', timeout=0.05), trials=[{}])
+    harness = Harness(policy, embodiment, tasks=[Task('test', 0.05)])
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.2, 0.0, -0.1], [0.7, 0.1, -0.2])
     payload = partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
@@ -653,15 +653,15 @@ def test_trial_budget_starts_at_the_first_usable_observation(world):
 
 @pytest.mark.timeout(3.0)
 def test_attended_task_run_respects_timeout(world):
-    """A task's ``timeout`` bounds an attended (directive-driven) run too: RUN arrives but no FINISH, yet
-    the trial still self-terminates at the deadline. The deadline is armed whenever a task is supplied, not
-    only on the self-driven ``trials`` path."""
+    """A budget on the RUN directive bounds an attended run too: RUN arrives but no FINISH, yet the trial
+    still self-terminates at the deadline. The deadline is armed for whichever rollout the episode runs, not
+    only for one the plan authored."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=0.05))
+    harness = Harness(policy, make_embodiment())
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
-    p['directive_em'].emit(Directive.RUN(task='test'))
+    p['directive_em'].emit(Directive.RUN(task='test', timeout=0.05))
     drive_scheduler(scheduler, steps=200)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
@@ -676,12 +676,12 @@ def test_attended_task_run_respects_done(world):
     episode even though no FINISH arrives. ``done`` is honored whenever a task supplies it, attended or
     self-driven."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=100.0))
+    harness = Harness(policy, make_embodiment())
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
     scheduler = world.start([harness])
-    p['directive_em'].emit(Directive.RUN(task='test'))
+    p['directive_em'].emit(Directive.RUN(task='test', timeout=100.0))
     drive_scheduler(scheduler, steps=5)
     assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
 
@@ -698,7 +698,7 @@ def test_trial_stop_signal_terminates(world):
     """Delivering the privileged ``done`` ends a trial early: terminated=True, payload recorded, homed."""
     policy = StubPolicy()
     # Timeout far in the future so the stop-signal, not the clock, ends the trial.
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='test', timeout=100.0), trials=[{}])
+    harness = Harness(policy, make_embodiment(), tasks=[Task('test', 100.0)])
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
@@ -724,7 +724,7 @@ def test_stale_done_does_not_terminate_next_trial(world):
     latched value is ignored — no producer ``reset`` clears it here (``reset`` is ``None``, as on a real
     embodiment). A falsy payload never terminates; trial 1 runs until its own fresh terminal lands."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='t', timeout=100.0), trials=[{}, {}])
+    harness = Harness(policy, make_embodiment(), tasks=[Task('t', 100.0), Task('t', 100.0)])
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
@@ -796,9 +796,8 @@ def test_policy_first_obs_is_frame0(world):
         control_systems=(device,),
         simulated=True,
     )
-    task = Task(instruction='t', timeout=100.0, reset=device.reset)
     policy = StubPolicy()
-    harness = Harness(policy, embodiment, task=task, trials=[{}])
+    harness = Harness(policy, embodiment, tasks=[Task('t', 100.0)], reset=device.reset)
     wire.wire_embodiment(world, harness, embodiment, None)
 
     scheduler = world.start([harness, device])
@@ -837,13 +836,12 @@ def test_task_done_terminates_through_wire_embodiment(world):
         static_meta={},
         meta_source=None,
     )
-    task = Task(instruction='t', timeout=100.0, done=device.done)
     # Termination is independent of the policy wrappers; the minimal embodiment has no
     # ``robot_state``, so run the stub policy bare.
-    harness = Harness(StubPolicy(), embodiment, task=task, trials=[{}])
+    harness = Harness(StubPolicy(), embodiment, tasks=[Task('t', 100.0)])
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
-    wire.wire_embodiment(world, harness, embodiment, None, done=task.done)
+    wire.wire_embodiment(world, harness, embodiment, None, done=device.done)
 
     scheduler = world.start([harness, device])
     drive_scheduler(scheduler, steps=60)
@@ -859,9 +857,7 @@ def test_done_after_deadline_is_a_timeout(world):
     """The deadline is hard: a ``done`` delivered past it (here during the latency sleep) records as a
     timeout — ``eval.terminated`` False, payload dropped — not a late stop-signal success."""
     policy = StubPolicy()
-    harness = Harness(
-        policy, make_embodiment(), task=Task(instruction='t', timeout=0.05), trials=[{'inference_latency': 0.2}]
-    )
+    harness = Harness(policy, make_embodiment(), tasks=[Task('t', 0.05)], inference_latency=0.2)
     p = _pair_all(world, harness)
     done_em = world.pair(harness.done)
 
@@ -884,18 +880,17 @@ def test_done_after_deadline_is_a_timeout(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
-    """Each RUN hands its ``eval.seed`` to the task's scene reset; the seed and the
+    """Each rollout hands its ``eval.seed`` to the scene reset; the seed and the
     eval-identity block land in episode meta."""
     policy = StubPolicy()
     seeds = []
-    trials = [{'eval.seed': 7 + i} for i in range(2)]
+    tasks = [Task('stack', 0.05, {'eval.seed': 7 + i}) for i in range(2)]
 
-    def reset(context):
-        seeds.append(context.get('eval.seed'))
+    def reset(scene):
+        seeds.append(scene.get('eval.seed'))
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
-    task = Task(instruction='stack', timeout=0.05, reset=reset)
-    harness = Harness(policy, make_embodiment(), task=task, trials=trials)
+    harness = Harness(policy, make_embodiment(), tasks=tasks, reset=reset)
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -911,10 +906,10 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_plan_self_drives(world):
-    """With a trial plan the harness runs unattended: no driver, one episode per entry."""
+    """With a trial plan the harness runs unattended: no driver, one episode per entry, each stamped with
+    its place in the plan."""
     policy = StubPolicy()
-    trials = [{'eval.trial_index': i} for i in range(2)]
-    harness = Harness(policy, make_embodiment(), task=Task(instruction='stack', timeout=0.05), trials=trials)
+    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05) for _ in range(2)])
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -923,9 +918,36 @@ def test_trial_plan_self_drives(world):
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert [s.static_data['eval.trial_index'] for s in stops] == [0, 1]
     assert all(s.static_data[keys.TASK] == 'stack' for s in stops)
+    assert all(s.static_data['eval.trial_count'] == 2 for s in stops)
     assert len(stops) == 2
     assert all(s.static_data[keys.EVAL_TERMINATED] is False for s in stops)
     assert policy.reset_calls == 2
+
+
+@pytest.mark.timeout(3.0)
+def test_scene_is_recorded_but_withheld_from_the_policy(world):
+    """Of the rollout, only the instruction crosses to the policy. The scene is the ground truth the rollout
+    is scored against, so it reaches the reset and the recording but never the observation dict."""
+    policy = StubPolicy()
+    scene = {'eval.seed': 7, 'eval.task_id': 3}
+    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05, scene)])
+    p = _pair_all(world, harness)
+
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    driver = ManualDriver([
+        (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.0),
+        (None, 0.1),
+    ])
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=200)
+
+    assert policy.observations, 'policy was never called'
+    assert all(obs[keys.TASK] == 'stack' for obs in policy.observations)
+    assert all(scene.keys().isdisjoint(obs) for obs in policy.observations)
+
+    (stop,) = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
+    assert stop.static_data['eval.seed'] == 7
+    assert stop.static_data['eval.task_id'] == 3
 
 
 @pytest.mark.timeout(3.0)
@@ -933,9 +955,7 @@ def test_timeout_crossed_during_latency_sleep_drops_chunk(world):
     """A chunk whose latency sleep crosses the deadline is dropped, never emitted."""
     policy = StubPolicy()
     # The 0.2s latency sleep crosses the 0.05s deadline before the chunk is emitted.
-    harness = Harness(
-        policy, make_embodiment(), task=Task(instruction='test', timeout=0.05), trials=[{'inference_latency': 0.2}]
-    )
+    harness = Harness(policy, make_embodiment(), tasks=[Task('test', 0.05)], inference_latency=0.2)
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     ds_recorder = RecordingEmitter()
@@ -1033,11 +1053,11 @@ def test_task_instruction_reaches_session_context_after_reset(world):
     policy = StubPolicy()
     scene = {}
 
-    def reset(_context):
+    def reset(_scene):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
-    task = Task(instruction=lambda: scene['task'], timeout=0.05, reset=reset)
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{}])
+    tasks = [Task(lambda: scene['task'], 0.05)]
+    harness = Harness(policy, make_embodiment(), tasks=tasks, reset=reset)
     _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -1425,8 +1445,7 @@ def test_stop_mid_episode_keeps_episode_open_for_recorder_flush(tmp_path):
     shutdown-flush ``record.io`` span parents to the episode, not the pass. Driven straight through the
     generator protocol: the yield after the queued STOP is the recorder's flush slot."""
     policy = StubPolicy()
-    task = Task(instruction='stack', timeout=10.0, reset=lambda context: None)  # never ends within the drive
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}])
+    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 10.0)], reset=lambda scene: None)
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     stop = SimpleNamespace(value=False)
@@ -1469,8 +1488,7 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
     ``policy.infer`` span is recorded at the remote inference boundary, so the terminal is a ``RemoteStubPolicy``
     (a real ``RemoteSession`` over a fake inference session)."""
     policy = ChunkedSchedule().wrap(RemoteStubPolicy())
-    task = Task(instruction='stack', timeout=0.05, reset=lambda context: None)
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}])
+    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 0.05)], reset=lambda scene: None)
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A latched observation set makes every step's inference fire (the harness reads the latest value).
@@ -1540,8 +1558,7 @@ def test_failed_pass_seals_open_episode_span(tmp_path):
         raise RuntimeError('reset boom')
 
     policy = StubPolicy()
-    task = Task(instruction='stack', timeout=10.0, reset=boom)
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}])
+    harness = Harness(policy, make_embodiment(), tasks=[Task('stack', 10.0)], reset=boom)
     harness.ds_command._bind(RecordingEmitter())
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()

--- a/positronic/simulator/env_server/protocol.py
+++ b/positronic/simulator/env_server/protocol.py
@@ -14,6 +14,10 @@ import functools
 import msgpack
 import numpy as np
 
+# The meta field an env reports its language goal in. The two sides run in different interpreters — the
+# server cannot import positronic — so this is the one name they can both spell from the same place.
+META_INSTRUCTION = 'task'
+
 
 def _pack(obj):
     if isinstance(obj, np.ndarray):

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -192,10 +192,10 @@ def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str]
     # The server is already up (the test fixture owns it), so the proxy just receives its address.
     proxy = RemoteEnvControlSystem(StackCubesAdapter(camera_dict), nullcontext((host, port)))
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.mujoco.franka')
-    task = Rollout('Pick up the green cube and place it on the red cube.', timeout, {keys.EVAL_SEED: 100})
+    rollout = Rollout('Pick up the green cube and place it on the red cube.', timeout, {keys.EVAL_SEED: 100})
     return Eval(
         embodiment,
-        [task],
+        [rollout],
         reset=proxy.reset,
         privileged={'sim_state': Observation(proxy.privileged['sim_state'], None)},
         done=proxy.done,

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -165,7 +165,7 @@ class StackCubesAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the env's model camera name
 
     def _reset_token(self, context: dict[str, Any]) -> Any:
-        return context.get('eval.seed')
+        return context[keys.EVAL_SEED]
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         state = MujocoFrankaState()
@@ -192,7 +192,7 @@ def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str]
     # The server is already up (the test fixture owns it), so the proxy just receives its address.
     proxy = RemoteEnvControlSystem(StackCubesAdapter(camera_dict), nullcontext((host, port)))
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.mujoco.franka')
-    task = Task('Pick up the green cube and place it on the red cube.', timeout, {'eval.seed': 100})
+    task = Task('Pick up the green cube and place it on the red cube.', timeout, {keys.EVAL_SEED: 100})
     return Eval(
         embodiment,
         [task],

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -187,17 +187,16 @@ class StackCubesAdapter(WireCommandAdapter):
         return None  # native stack_cubes scores downstream — it reports no live terminal
 
 
-def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str]) -> Eval:
-    """Build the remote ``stack_cubes`` eval (embodiment + task) wired to a running env server."""
+def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str], timeout: float) -> Eval:
+    """Build the remote ``stack_cubes`` eval — one seeded rollout — wired to a running env server."""
     # The server is already up (the test fixture owns it), so the proxy just receives its address.
     proxy = RemoteEnvControlSystem(StackCubesAdapter(camera_dict), nullcontext((host, port)))
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.mujoco.franka')
-    privileged = {'sim_state': Observation(proxy.privileged['sim_state'], None)}
-    task = Task(
-        instruction='Pick up the green cube and place it on the red cube.',
-        timeout=15.0,
-        privileged=privileged,
+    task = Task('Pick up the green cube and place it on the red cube.', timeout, {'eval.seed': 100})
+    return Eval(
+        embodiment,
+        [task],
         reset=proxy.reset,
+        privileged={'sim_state': Observation(proxy.privileged['sim_state'], None)},
         done=proxy.done,
     )
-    return Eval(embodiment, task)

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -19,7 +19,7 @@ import positronic.cfg.simulator
 from pimm.world import LocalQueueEmitter, LocalQueueReceiver, VirtualClock
 from positronic import geom, keys
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.eval import Eval, Observation, Task
+from positronic.eval import Eval, Observation, Rollout
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.env_server.server import EnvProtocol
@@ -192,7 +192,7 @@ def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str]
     # The server is already up (the test fixture owns it), so the proxy just receives its address.
     proxy = RemoteEnvControlSystem(StackCubesAdapter(camera_dict), nullcontext((host, port)))
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.mujoco.franka')
-    task = Task('Pick up the green cube and place it on the red cube.', timeout, {keys.EVAL_SEED: 100})
+    task = Rollout('Pick up the green cube and place it on the red cube.', timeout, {keys.EVAL_SEED: 100})
     return Eval(
         embodiment,
         [task],

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -1,5 +1,4 @@
 from contextlib import nullcontext
-from dataclasses import replace
 
 import numpy as np
 import pos3
@@ -253,7 +252,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
     cached value holds across the steps that follow."""
     with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
-        task = Task(instruction=lambda: proxy.meta['task'], timeout=1.0, reset=proxy.reset)
+        task = Task(lambda: proxy.meta['task'], 1.0)
         scheduler = world.start([proxy])
 
         proxy.reset({'eval.seed': 0})
@@ -269,14 +268,9 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     camera key."""
     host, port = env_server
     with pos3.mirror():
-        ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
-        ev.task.timeout = 0.1
+        ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS, timeout=0.1)
         policy = StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0)
-        main(
-            policy=ChunkedSchedule().wrap(policy),
-            evals=[replace(ev, trials=[{'eval.trial_index': 0, 'eval.seed': 100}])],
-            output_dir=str(tmp_path),
-        )
+        main(policy=ChunkedSchedule().wrap(policy), evals=[ev], output_dir=str(tmp_path))
 
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
@@ -299,8 +293,8 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
 def test_every_sim_eval_publishes_the_shared_camera_keys(eval_cfg):
     """A codec names the camera it wants, so a sim spelling its cameras its own way can be scored only by a codec
     written for it. Every sim publishes the shared pair, whatever the benchmark calls those cameras."""
-    observations = eval_cfg.instantiate().embodiment.observations
-    assert {keys.EXTERIOR_IMAGE, keys.WRIST_IMAGE} <= set(observations)
+    (ev,) = eval_cfg.instantiate()
+    assert {keys.EXTERIOR_IMAGE, keys.WRIST_IMAGE} <= set(ev.embodiment.observations)
 
 
 class _JointposChunks(Policy):
@@ -343,13 +337,8 @@ def test_full_chunk_executes_between_replans(env_server, tmp_path):
     raw = _JointposChunks(roboarm_command.JointPosition(np.zeros(7)), chunk_len)
     policy = (ChunkedSchedule() | ActionTimestamp(fps=1.0 / control_dt)).wrap(raw)
     with pos3.mirror():
-        ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
-        ev.task.timeout = 20 * control_dt
-        main(
-            policy=policy,
-            evals=[replace(ev, trials=[{'eval.trial_index': 0, 'eval.seed': 100}])],
-            output_dir=str(tmp_path),
-        )
+        ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS, timeout=20 * control_dt)
+        main(policy=policy, evals=[ev], output_dir=str(tmp_path))
 
     grip = LocalDataset(tmp_path)[0].signals['target_grip']
     executed = [(float(v), int(ts)) for v, ts in (grip[i] for i in range(len(grip)))]

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -20,6 +20,7 @@ from positronic.policy.tests.test_harness import StubPolicy
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.simulator.env_server.adapter import EnvAdapter, _in_env_control_frame, _wire_command
 from positronic.simulator.env_server.client import EnvConnection
+from positronic.simulator.env_server.protocol import META_INSTRUCTION
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
 from positronic.simulator.env_server.server import EnvProtocol
 from positronic.simulator.env_server.tests.conftest import serve_env
@@ -189,7 +190,7 @@ class _CountdownEnv(EnvProtocol):
 
     def reset(self, token):
         self._steps = 0
-        meta = {'task': 'countdown'}  # scene meta the env reports only at reset; ``step`` omits it
+        meta = {META_INSTRUCTION: 'countdown'}  # scene meta the env reports only at reset; ``step`` omits it
         return {
             'obs': {'q': np.full(7, self._steps, dtype=np.float64)},
             'meta': meta,
@@ -252,7 +253,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
     cached value holds across the steps that follow."""
     with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
-        rollout = Rollout(lambda: proxy.meta['task'], 1.0)
+        rollout = Rollout(lambda: proxy.meta[META_INSTRUCTION], 1.0)
         scheduler = world.start([proxy])
 
         proxy.reset({keys.EVAL_SEED: 0})
@@ -263,7 +264,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
 
 @pytest.mark.timeout(60.0)
 def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
-    """The real ``stack_cubes`` wrapper, end to end: no terminal, so the trial runs to the rollout timeout
+    """The real ``stack_cubes`` wrapper, end to end: no terminal, so the rollout runs to its timeout
     (``eval.terminated`` False, ``eval.success`` absent) and records the canonical signals under the shared
     camera key."""
     host, port = env_server

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -278,8 +278,8 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     assert isinstance(episode, Episode)
     assert episode.static[keys.EVAL_TERMINATED] is False
     assert keys.EVAL_SUCCESS not in episode.static
-    assert episode.static['eval.universe'] == 'sim'
-    assert episode.static['eval.embodiment'] == 'remote.mujoco.franka'
+    assert episode.static[keys.EVAL_UNIVERSE] == 'sim'
+    assert episode.static[keys.EVAL_EMBODIMENT] == 'remote.mujoco.franka'
     assert episode.static['scene_xml'].startswith('<mujoco')
     signals = episode.signals
     assert keys.EXTERIOR_IMAGE in signals

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -208,7 +208,7 @@ class _CountdownEnv(EnvProtocol):
 
 class _CountdownAdapter(EnvAdapter):
     def reset_token(self, context):
-        return context.get('eval.seed')
+        return context[keys.EVAL_SEED]
 
     def action(self, commands, now_ns):
         return {}
@@ -236,7 +236,7 @@ def test_proxy_publishes_frame0_then_free_runs():
         scheduler = world.start([proxy])
         drive_scheduler(scheduler, steps=2)  # inactive: the proxy paces time without an env
 
-        proxy.reset({'eval.seed': 0})  # arm frame-0; the run loop publishes it on its next turn
+        proxy.reset({keys.EVAL_SEED: 0})  # arm frame-0; the run loop publishes it on its next turn
         drive_scheduler(scheduler, steps=1)
         np.testing.assert_array_equal(obs_rx.read().data, np.zeros(7))
         assert done_rx.read().data == {}
@@ -255,7 +255,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
         task = Task(lambda: proxy.meta['task'], 1.0)
         scheduler = world.start([proxy])
 
-        proxy.reset({'eval.seed': 0})
+        proxy.reset({keys.EVAL_SEED: 0})
         assert task.instruction == 'countdown'  # resolved live off the cached reset meta
         drive_scheduler(scheduler, steps=4)  # the env steps, each ``step`` omitting meta ...
         assert task.instruction == 'countdown'  # ... yet the reset-scoped cache holds

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -252,13 +252,13 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
     cached value holds across the steps that follow."""
     with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
-        task = Rollout(lambda: proxy.meta['task'], 1.0)
+        rollout = Rollout(lambda: proxy.meta['task'], 1.0)
         scheduler = world.start([proxy])
 
         proxy.reset({keys.EVAL_SEED: 0})
-        assert task.instruction == 'countdown'  # resolved live off the cached reset meta
+        assert rollout.instruction == 'countdown'  # resolved live off the cached reset meta
         drive_scheduler(scheduler, steps=4)  # the env steps, each ``step`` omitting meta ...
-        assert task.instruction == 'countdown'  # ... yet the reset-scoped cache holds
+        assert rollout.instruction == 'countdown'  # ... yet the reset-scoped cache holds
 
 
 @pytest.mark.timeout(60.0)

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -13,7 +13,7 @@ from positronic.cli.eval.run import main
 from positronic.dataset import Episode
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.eval import Task
+from positronic.eval import Rollout
 from positronic.policy import Policy, Session
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.tests.test_harness import StubPolicy
@@ -247,12 +247,12 @@ def test_proxy_publishes_frame0_then_free_runs():
 
 @pytest.mark.timeout(60.0)
 def test_proxy_caches_reset_meta_as_live_instruction_source():
-    """The env reports scene meta only at ``reset`` (``step`` omits it); the proxy caches it so a ``Task``
+    """The env reports scene meta only at ``reset`` (``step`` omits it); the proxy caches it so a ``Rollout``
     reads its language live off ``proxy.meta`` — the callable-instruction path LIBERO relies on — and the
     cached value holds across the steps that follow."""
     with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
-        task = Task(lambda: proxy.meta['task'], 1.0)
+        task = Rollout(lambda: proxy.meta['task'], 1.0)
         scheduler = world.start([proxy])
 
         proxy.reset({keys.EVAL_SEED: 0})
@@ -263,7 +263,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
 
 @pytest.mark.timeout(60.0)
 def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
-    """The real ``stack_cubes`` wrapper, end to end: no terminal, so the trial runs to the task timeout
+    """The real ``stack_cubes`` wrapper, end to end: no terminal, so the trial runs to the rollout timeout
     (``eval.terminated`` False, ``eval.success`` absent) and records the canonical signals under the shared
     camera key."""
     host, port = env_server

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -15,6 +15,14 @@ from positronic import geom, keys
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
 
+# The scene-spec keys a LIBERO rollout's scene must carry, alongside ``keys.EVAL_SEED``. The eval config
+# writes them and ``_reset_token`` reads them back into the server's reset token.
+SUITE = 'eval.suite'
+TASK_ID = 'eval.task_id'
+CAMERA_RESOLUTION = 'eval.camera_resolution'
+CONTROL_MODE = 'eval.control_mode'
+SETTLE_STEPS = 'eval.settle_steps'
+
 
 class LiberoAdapter(WireCommandAdapter):
     def __init__(self, camera_dict: dict[str, str]):
@@ -28,12 +36,12 @@ class LiberoAdapter(WireCommandAdapter):
         # the hold-arm/open-gripper wait the server runs after a seeded reset so dropped objects settle before
         # the first observation (openpi's num_steps_wait dummy-action wait).
         return {
-            'suite': context['eval.suite'],
-            'task_id': context['eval.task_id'],
-            'camera_resolution': context['eval.camera_resolution'],
-            'control_mode': context['eval.control_mode'],
-            'seed': context.get('eval.seed'),
-            'settle_steps': context['eval.settle_steps'],
+            'suite': context[SUITE],
+            'task_id': context[TASK_ID],
+            'camera_resolution': context[CAMERA_RESOLUTION],
+            'control_mode': context[CONTROL_MODE],
+            'seed': context[keys.EVAL_SEED],
+            'settle_steps': context[SETTLE_STEPS],
         }
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -15,8 +15,9 @@ from positronic import geom, keys
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
 
-# The scene-spec keys a LIBERO rollout's scene must carry, alongside ``keys.EVAL_SEED``. The eval config
-# writes them and ``_reset_token`` reads them back into the server's reset token.
+# The LIBERO scene a rollout runs in, alongside ``keys.EVAL_SEED``: which task of which suite, rendered at
+# what resolution, driven in what control mode, and how long the arm holds after the reset so dropped
+# objects settle.
 SUITE = 'eval.suite'
 TASK_ID = 'eval.task_id'
 CAMERA_RESOLUTION = 'eval.camera_resolution'

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -48,6 +48,7 @@ from typing import Any
 
 import mujoco
 import numpy as np
+from protocol import META_INSTRUCTION
 from robosuite.utils.transform_utils import get_pose_error, make_pose, mat2quat, quat2axisangle
 from server import EnvProtocol, EnvServer
 
@@ -131,7 +132,7 @@ class LiberoEnv(EnvProtocol):
             camera_heights=camera_resolution,
             camera_widths=camera_resolution,
         )
-        self._meta = {'suite': suite_name, 'task_id': task_id, 'task': task.language}
+        self._meta = {'suite': suite_name, 'task_id': task_id, META_INSTRUCTION: task.language}
         self._control_dt = 1.0 / self._env.env.control_freq
         robot = self._env.env.robots[0]
         self._qpos_idx = np.asarray(robot._ref_joint_pos_indexes)

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -16,8 +16,7 @@ from positronic.drivers.roboarm.models import DROID_EE_FRAME
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
 
-# The scene-spec keys a RoboLab rollout's scene must carry. The eval config writes them and ``_reset_token``
-# reads them back into the server's reset token.
+# The RoboLab scene a rollout runs in: which of the benchmark's tasks, and which of its three phrasings.
 TASK = 'eval.task'
 INSTRUCTION_TYPE = 'eval.instruction_type'
 

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -16,6 +16,11 @@ from positronic.drivers.roboarm.models import DROID_EE_FRAME
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
 
+# The scene-spec keys a RoboLab rollout's scene must carry. The eval config writes them and ``_reset_token``
+# reads them back into the server's reset token.
+TASK = 'eval.task'
+INSTRUCTION_TYPE = 'eval.instruction_type'
+
 
 class RobolabAdapter(WireCommandAdapter):
     def __init__(self, camera_dict: dict[str, str]):
@@ -25,7 +30,7 @@ class RobolabAdapter(WireCommandAdapter):
 
     def _reset_token(self, context: dict[str, Any]) -> Any:
         # No seed rides the token: RoboLab's eval path has no seed hook, so a recorded seed would only mislead.
-        return {'task': context['eval.task'], 'instruction_type': context['eval.instruction_type']}
+        return {'task': context[TASK], 'instruction_type': context[INSTRUCTION_TYPE]}
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         # The env reports the eef pose in the control frame IK drives; ``eef_quat`` is scalar-first (wxyz),

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -30,7 +30,7 @@ import cv2  # noqa: F401 -- robolab requires cv2 imported before isaaclab
 import numpy as np
 import torch
 from isaaclab.app import AppLauncher
-from protocol import decode
+from protocol import META_INSTRUCTION, decode
 from server import EnvProtocol, EnvServer
 
 
@@ -173,7 +173,7 @@ class RobolabEnv(EnvProtocol):
         # ``instruction`` is the resolved language goal (``create_env`` picks the variant); the rest is the
         # task identity the episode records.
         self._meta = {
-            'task': self._env_cfg.instruction,
+            META_INSTRUCTION: self._env_cfg.instruction,
             'env_name': env_name,
             'task_name': self._env_cfg._task_name,
             'attributes': list(self._env_cfg._task_attributes),

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -86,11 +86,11 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
 
     episode = ds[0]
     assert episode.static[keys.EVAL_TERMINATED] is False
-    assert episode.static['eval.rollout_index'] == 0
-    assert episode.static['eval.seed'] == 100
-    assert episode.static['eval.universe'] == 'sim'
-    assert episode.static['eval.embodiment'] == 'mujoco.franka'
-    assert episode.static['eval.timeout'] == 0.4
+    assert episode.static[keys.EVAL_ROLLOUT_INDEX] == 0
+    assert episode.static[keys.EVAL_SEED] == 100
+    assert episode.static[keys.EVAL_UNIVERSE] == 'sim'
+    assert episode.static[keys.EVAL_EMBODIMENT] == 'mujoco.franka'
+    assert episode.static[keys.EVAL_TIMEOUT] == 0.4
     # The post-loader scene description rides robot_meta into static: with eval.seed it makes
     # the episode self-contained for downstream scoring and faithful replay.
     assert episode.static['scene_xml'].startswith('<mujoco')
@@ -296,7 +296,7 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     episode = ds[0]
     assert episode.static[keys.EVAL_TERMINATED] is True
     assert episode.static[keys.EVAL_SUCCESS] is True  # the delivered ``done`` payload lands in static data
-    assert episode.static['eval.embodiment'] == 'test.countdown'
+    assert episode.static[keys.EVAL_EMBODIMENT] == 'test.countdown'
     # The terminal frame (the step where ``done`` fired) is recorded, not dropped by STOP closing the writer.
     values = [v for v, _ in episode.signals['value']]
     assert values[-1][0] == 4.0

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -1,6 +1,5 @@
 import os
 import xml.etree.ElementTree as ET
-from dataclasses import replace
 
 import mujoco as mj
 import numpy as np
@@ -69,19 +68,17 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     camera_dict = {keys.WRIST_IMAGE: 'handcam_left_ph'}
 
     with pos3.mirror():
-        ev = stack_cubes(
+        evals = stack_cubes(
             mujoco_model_path='positronic/assets/mujoco/franka_table.xml',
             loaders=positronic.cfg.simulator.stack_cubes_loaders(),
             camera_fps=10,
             camera_dict=camera_dict,
             instruction='integration-test',
             timeout=0.4,
+            seed=100,
+            trial_count=2,
         )
-        main(
-            policy=ChunkedSchedule().wrap(policy),
-            evals=[replace(ev, trials=[{'eval.trial_index': i, 'eval.seed': 100 + i} for i in range(2)])],
-            output_dir=str(tmp_path),
-        )
+        main(policy=ChunkedSchedule().wrap(policy), evals=evals, output_dir=str(tmp_path))
 
     ds = LocalDataset(tmp_path)
     # Two trials: the harness runs the plan itself, self-terminating each trial at the task's timeout.
@@ -192,7 +189,7 @@ class _CountdownProducer(pimm.ControlSystem):
                     self._active = False
 
 
-def _countdown_eval(producer: _CountdownProducer, timeout: float) -> Eval:
+def _countdown_eval(producer: _CountdownProducer, timeout: float, trial_count: int = 1) -> Eval:
     embodiment = Embodiment(
         descriptor='test.countdown',
         observations={'value': Observation(producer.observations['value'], None)},
@@ -206,8 +203,8 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float) -> Eval:
         control_systems=(producer,),
         simulated=True,
     )
-    task = Task(instruction='count', timeout=timeout, privileged={}, reset=producer.reset, done=producer.done)
-    return Eval(embodiment, task)
+    tasks = [Task('count', timeout, {'eval.seed': i}) for i in range(trial_count)]
+    return Eval(embodiment, tasks, reset=producer.reset, done=producer.done)
 
 
 @pytest.mark.timeout(30.0)
@@ -217,11 +214,11 @@ def test_countdown_records_frame0_every_trial(tmp_path):
     drops the pre-reset frame and the producer publishes frame-0 in sequence. The small ``control_dt`` wakes
     the producer quickly between trials, so a stray step would overwrite frame-0 if it weren't published in
     the producer's own turn."""
-    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35)
+    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35, trial_count=2)
     with pos3.mirror():
         main(
             policy=StubPolicy(command=ev.embodiment.commands[keys.ROBOT_COMMAND].home, target_grip=0.0),
-            evals=[replace(ev, trials=[{'eval.trial_index': i, 'eval.seed': i} for i in range(2)])],
+            evals=[ev],
             # the degenerate obs is not Franka-shaped, so run the policy unwrapped
             output_dir=str(tmp_path),
         )
@@ -239,13 +236,13 @@ def test_timing_writes_telemetry_sidecars(tmp_path):
     span taxonomy nests (episode under pass; reset, policy.infer and the recorder's record.io under episode),
     and the machine-load stats stream records at least one sample. record.io parenting proves the episode span
     stays in flight while the recorder commits STOP."""
-    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.2)
+    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.2, trial_count=2)
     with pos3.mirror():
         main(
             policy=ChunkedSchedule().wrap(
                 RemoteStubPolicy(command=ev.embodiment.commands['robot_command'].home, target_grip=0.0)
             ),
-            evals=[replace(ev, trials=[{'eval.trial_index': i} for i in range(2)])],
+            evals=[ev],
             output_dir=str(tmp_path),
             timing=True,
         )
@@ -290,7 +287,7 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     with pos3.mirror():
         main(
             policy=StubPolicy(command=ev.embodiment.commands[keys.ROBOT_COMMAND].home, target_grip=0.0),
-            evals=[replace(ev, trials=[{'eval.trial_index': 0, 'eval.seed': 100}])],
+            evals=[ev],
             output_dir=str(tmp_path),
         )
 

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -16,7 +16,7 @@ from positronic.dataset.local_dataset import LocalDataset
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.models import bundled_panda_model
-from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Task
+from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Rollout
 from positronic.policy.tests.test_harness import RemoteStubPolicy, StubPolicy
 from positronic.policy.wrappers import ChunkedSchedule
 from positronic.simulator.env_server import telemetry as env_telemetry
@@ -76,17 +76,17 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
             instruction='integration-test',
             timeout=0.4,
             seed=100,
-            trial_count=2,
+            rollout_count=2,
         )
         main(policy=ChunkedSchedule().wrap(policy), evals=evals, output_dir=str(tmp_path))
 
     ds = LocalDataset(tmp_path)
-    # Two trials: the harness runs the plan itself, self-terminating each trial at the task's timeout.
+    # Two trials: the harness runs the plan itself, self-terminating each trial at the rollout's timeout.
     assert len(ds) == 2
 
     episode = ds[0]
     assert episode.static[keys.EVAL_TERMINATED] is False
-    assert episode.static['eval.trial_index'] == 0
+    assert episode.static['eval.rollout_index'] == 0
     assert episode.static['eval.seed'] == 100
     assert episode.static['eval.universe'] == 'sim'
     assert episode.static['eval.embodiment'] == 'mujoco.franka'
@@ -139,7 +139,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     last_obs = policy.observations[-1]
     assert isinstance(last_obs[keys.WRIST_IMAGE], np.ndarray)
     assert keys.EE_POSE in last_obs
-    # The task's instruction is injected by the harness.
+    # The rollout instruction is injected by the harness.
     assert last_obs[keys.TASK] == 'integration-test'
     assert last_obs['descriptor'] == 'mujoco.franka'
 
@@ -189,7 +189,7 @@ class _CountdownProducer(pimm.ControlSystem):
                     self._active = False
 
 
-def _countdown_eval(producer: _CountdownProducer, timeout: float, trial_count: int = 1) -> Eval:
+def _countdown_eval(producer: _CountdownProducer, timeout: float, rollout_count: int = 1) -> Eval:
     embodiment = Embodiment(
         descriptor='test.countdown',
         observations={'value': Observation(producer.observations['value'], None)},
@@ -203,8 +203,8 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float, trial_count: i
         control_systems=(producer,),
         simulated=True,
     )
-    tasks = [Task('count', timeout, {keys.EVAL_SEED: i}) for i in range(trial_count)]
-    return Eval(embodiment, tasks, reset=producer.reset, done=producer.done)
+    rollouts = [Rollout('count', timeout, {keys.EVAL_SEED: i}) for i in range(rollout_count)]
+    return Eval(embodiment, rollouts, reset=producer.reset, done=producer.done)
 
 
 @pytest.mark.timeout(30.0)
@@ -214,7 +214,7 @@ def test_countdown_records_frame0_every_trial(tmp_path):
     drops the pre-reset frame and the producer publishes frame-0 in sequence. The small ``control_dt`` wakes
     the producer quickly between trials, so a stray step would overwrite frame-0 if it weren't published in
     the producer's own turn."""
-    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35, trial_count=2)
+    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35, rollout_count=2)
     with pos3.mirror():
         main(
             policy=StubPolicy(command=ev.embodiment.commands[keys.ROBOT_COMMAND].home, target_grip=0.0),
@@ -236,7 +236,7 @@ def test_timing_writes_telemetry_sidecars(tmp_path):
     span taxonomy nests (episode under pass; reset, policy.infer and the recorder's record.io under episode),
     and the machine-load stats stream records at least one sample. record.io parenting proves the episode span
     stays in flight while the recorder commits STOP."""
-    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.2, trial_count=2)
+    ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.2, rollout_count=2)
     with pos3.mirror():
         main(
             policy=ChunkedSchedule().wrap(

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -81,7 +81,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
         main(policy=ChunkedSchedule().wrap(policy), evals=evals, output_dir=str(tmp_path))
 
     ds = LocalDataset(tmp_path)
-    # Two trials: the harness runs the plan itself, self-terminating each trial at the rollout's timeout.
+    # Two rollouts: the harness runs the plan itself, self-terminating each at its own timeout.
     assert len(ds) == 2
 
     episode = ds[0]

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -203,7 +203,7 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float, trial_count: i
         control_systems=(producer,),
         simulated=True,
     )
-    tasks = [Task('count', timeout, {'eval.seed': i}) for i in range(trial_count)]
+    tasks = [Task('count', timeout, {keys.EVAL_SEED: i}) for i in range(trial_count)]
     return Eval(embodiment, tasks, reset=producer.reset, done=producer.done)
 
 

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -45,7 +45,7 @@ CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports
 # Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
 uv run --locked positronic-inference sim \
   --policy=.remote --policy.url=<h100-host>:8000 \
-  --eval.trial_count=2
+  --eval.rollout_count=2
 ```
 
 The server owns the whole policy pipeline: it runs the codec (raw observations in, decoded joint
@@ -149,7 +149,7 @@ Sanity-check once warm: `curl http://<h100-host>:8000/api/v1/models` → `{"mode
 ```bash
 uv run --locked positronic-inference sim \
   --policy=.remote --policy.url=<h100-host>:8000 \
-  --eval.trial_count=<N> --output_dir=<dir-or-s3-path>
+  --eval.rollout_count=<N> --output_dir=<dir-or-s3-path>
 ```
 
 Sim runs locally on your machine; only inference is remote. Each episode records 3 camera views +
@@ -195,7 +195,7 @@ launch). With `positronic-inference`, pass them through the remote policy:
 # padding the window with the current frame repeated.
 uv run --locked positronic-inference sim \
   --policy=.remote --policy.url='<h100-host>:8000?local.pad_start=false' \
-  --eval.trial_count=2
+  --eval.rollout_count=2
 ```
 
 `local` is the rig-side video-context stack, `codec` the server-side codec (e.g. `{"codec.fps": 10}`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,13 +276,17 @@ exclude = [
 # still pulls their diagnostics. `ignore` suppresses those transitive vendor errors too.
 ignore = ["positronic/vendors"]
 
-# ``robolab/env.py`` runs in RoboLab's isolated interpreter with the env-server modules (``server``,
-# ``protocol``, ``telemetry``) copied flat onto PYTHONPATH, so it imports them top-level. Put ``env_server``
-# on the search path for that directory so those flat imports resolve for the type checker exactly as they
-# do at runtime; the project root stays on the path so the other robolab files' ``positronic.*`` imports
-# (an editable install the checker resolves by search path) keep resolving.
+# ``robolab/env.py`` and ``libero/env.py`` run in their benchmark's isolated interpreter with the env-server
+# modules (``server``, ``protocol``, ``telemetry``) copied flat onto PYTHONPATH, so they import them
+# top-level. Put ``env_server`` on the search path for those directories so the flat imports resolve for the
+# type checker exactly as they do at runtime; the project root stays on the path so the other files'
+# ``positronic.*`` imports (an editable install the checker resolves by search path) keep resolving.
 [[tool.basedpyright.executionEnvironments]]
 root = "positronic/simulator/robolab"
+extraPaths = [".", "positronic/simulator/env_server"]
+
+[[tool.basedpyright.executionEnvironments]]
+root = "positronic/simulator/libero"
 extraPaths = [".", "positronic/simulator/env_server"]
 
 [tool.setuptools.packages.find]

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -417,7 +417,7 @@ bash workflows/nebius/serve.sh openpi pi05-jointpos droid_jointpos
 
 bash workflows/nebius/eval.sh \
   --eval=@positronic.cfg.eval.sim.robolab.banana_in_bowl \
-  --eval.trial_count=10 \
+  --eval.rollout_count=10 \
   --policy=@positronic.cfg.policy.authed_remote \
   --policy.url=https://<endpoint-managed-url> \
   --output_dir=s3://<your-bucket>/evals/robolab_banana/

--- a/workflows/nebius/eval.sh
+++ b/workflows/nebius/eval.sh
@@ -50,7 +50,7 @@ Forwards all arguments to `positronic eval run`. Serve the policy first
 
   bash workflows/nebius/eval.sh \
     --eval=@positronic.cfg.eval.sim.robolab.banana_in_bowl \
-    --eval.trial_count=10 \
+    --eval.rollout_count=10 \
     --policy=@positronic.cfg.policy.authed_remote \
     --policy.url=https://<endpoint-managed-url> \
     --output_dir=s3://<your-bucket>/evals/robolab_banana/


### PR DESCRIPTION
## Summary

Steps 14's core from #464: the per-rollout unit becomes a typed `Rollout`, and the policy boundary becomes structural.

- **An eval config returns `list[Eval]`, one per embodiment.** `--eval=.sim.all` is a single selection covering LIBERO's 40 tasks, RoboLab's 120 and the native sim, against one warm policy. The Worlds still rebuild one at a time, so only the env server of the eval in flight is ever alive.
- **`Rollout` is the unit**: instruction, timeout, and the `scene` payload its eval's `reset` stages from. The RUN-context dicts are gone. The wiring that was task-invariant — `reset`, `privileged`, `done` — moves onto `Eval`.
- **A RUN directive is read as one such rollout**, so an attended episode and a planned one are the same thing to everything downstream. `Directive.RUN(**kwargs)` is unchanged for its emitters; `timeout` joins `task` as a field of the rollout rather than the scene.
- **Only the instruction crosses to the policy.** `eval.seed`, `eval.task_id` and the rest of the scene are recorded in episode statics but never enter the observation dict. The old `inputs.update(self.context)` shipped them and relied on every codec to ignore them — blindness by convention, now by structure.
- **Scene keys gained owners.** `eval.seed` was spelled in three modules and read with `.get`, so a typo on either side drew an unseeded scene in silence; it is `keys.EVAL_SEED` and both readers subscript. The backend-specific keys live on the adapter that unpacks them.

`Rollout` replaces `Task`, whose name collided with the benchmark task `eval.task_id` names; the count and position follow it, so `--eval.trial_count` is now `--eval.rollout_count` and the recorded statics are `eval.rollout_index` / `eval.rollout_count`.

Index and count are derived from the plan instead of stamped into each context, and `inference_latency` becomes a run-level `Harness` argument rather than riding every trial. The droid eval stops recording a random `eval.seed` for a scene that has none.

Recorded episode statics are unchanged apart from that droid seed.

## Test plan

- `uv run --locked pytest --no-cov` — 1108 passed, 9 skipped
- `ruff check`, `ruff format`, `basedpyright` all clean
- `test_scene_is_recorded_but_withheld_from_the_policy` is the new guard for the boundary; verified it fails when `_policy_inputs` is swapped back for `self.context`
- `test_golden_pipeline` passes unchanged, so moving `inference_latency` off the RUN context did not shift any timing
- `.sim.all` instantiates to 3 evals / 161 rollouts; `.sim.libero.spatial --eval.seed=3 --eval.trial_count=2` gives 20 tasks with the expected scenes
