### PR TITLE
Pass auth headers to every endpoint a sampled run reaches

### DIFF
--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -52,10 +52,11 @@ def balanced(balance: int):
     return BalancedSampler(balance=balance)
 
 
-@cfn.config(endpoints={}, weights={}, recording_dir=None, sampler=None, group_fields=None)
+@cfn.config(endpoints={}, weights={}, headers=None, recording_dir=None, sampler=None, group_fields=None)
 def production(
     endpoints: dict[str, str],
     weights: dict[str, float],
+    headers: dict[str, str] | None,
     recording_dir: str | None,
     sampler: Sampler | None,
     group_fields: list[str] | None,
@@ -65,6 +66,10 @@ def production(
     An endpoint is one URL, so `--policy.endpoints.groot=ws://desktop:8000` adds or repoints one without
     restating the others. `weights` name the same endpoints and set their sampling odds; endpoints left
     out of it weigh 1.0.
+
+    `headers` go to every endpoint, which is what a set of endpoints behind one authenticating proxy
+    needs: a sampled run reaches each of them with the same credential. Endpoints wanting different
+    credentials are separate policies, sampled through `sample`.
     """
     if not endpoints:
         raise ValueError('At least one endpoint must be given, e.g. --policy.endpoints.groot=ws://desktop:8000')
@@ -73,7 +78,7 @@ def production(
     # Every Sampler but the default uniform one picks by episode counts alone, so weights would be dropped.
     if weights and sampler is not None:
         raise ValueError(f'weights cannot be combined with {type(sampler).__name__}, which samples by count')
-    policies = [RemotePolicy(url, recording_dir=recording_dir) for url in endpoints.values()]
+    policies = [RemotePolicy(url, headers=headers, recording_dir=recording_dir) for url in endpoints.values()]
     w = [weights.get(name, 1.0) for name in endpoints] if weights else None
     return SampledPolicy(*policies, weights=w, sampler=sampler, group_fields=group_fields)
 

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -1,0 +1,38 @@
+import positronic.cfg.policy as cfg_policy
+
+
+class _SpyRemotePolicy:
+    """Captures what `production` hands each endpoint, without opening a connection."""
+
+    def __init__(self, url: str, *, headers=None, recording_dir=None, **kwargs):
+        self.url = url
+        self.headers = headers
+        self.recording_dir = recording_dir
+
+
+def _endpoints_of(monkeypatch, preset, **overrides) -> list[_SpyRemotePolicy]:
+    built: list[_SpyRemotePolicy] = []
+
+    def spy(url, **kwargs):
+        policy = _SpyRemotePolicy(url, **kwargs)
+        built.append(policy)
+        return policy
+
+    monkeypatch.setattr(cfg_policy, 'RemotePolicy', spy)
+    monkeypatch.setattr(cfg_policy, 'SampledPolicy', lambda *policies, **kwargs: policies)
+    preset.override(**overrides).instantiate()
+    return built
+
+
+def test_headers_reach_every_sampled_endpoint(monkeypatch):
+    headers = {'X-Proxy-Id': 'id', 'X-Proxy-Secret': 'secret'}
+    built = _endpoints_of(
+        monkeypatch, cfg_policy.production, endpoints={'a': 'ws://a:8000', 'b': 'ws://b:8000'}, headers=headers
+    )
+    assert [p.url for p in built] == ['ws://a:8000', 'ws://b:8000']
+    assert [p.headers for p in built] == [headers, headers]
+
+
+def test_no_headers_by_default(monkeypatch):
+    built = _endpoints_of(monkeypatch, cfg_policy.production, endpoints={'a': 'ws://a:8000'})
+    assert [p.headers for p in built] == [None]


### PR DESCRIPTION
`production` takes `headers` and hands them to every `RemotePolicy` it builds, so a set of endpoints behind one authenticating proxy can be sampled in a single run. Two tests pin it: the headers reach every endpoint, and the default still reaches none.

Until now the multi-endpoint preset was the one path that dropped them. `RemotePolicy` has always taken `headers` as a keyword-only argument, and `authed_remote` / `nebius_remote` pass it, but `production` built `RemotePolicy(url, recording_dir=recording_dir)` — so a run against endpoints that need a credential had no way to present one. It failed in whichever direction the caller chose: unauthenticated, a 401 per episode and nothing recorded; or, when the caller passed the credential, it did not configure at all —

```
configuronic.config.ConfigError: Error instantiating "policy":
production() got an unexpected keyword argument 'headers'
```

That is the shape every rig round of the wooden-spoon task uses: several checkpoints behind one balanced sampler, one key/secret pair in front of all of them, the operator scoring episodes without knowing which endpoint she is watching. `phail_multiple` is `production.override(...)`, so it inherited the gap, and nothing else covered the case — the single-endpoint path passes no headers either, and `authed_remote` carries a bearer token rather than a header pair.

One set of headers goes to all endpoints because that is what one proxy in front of several endpoints means: the credential is the same for each. Endpoints wanting different credentials stay separate policies composed through `sample`, where per-policy configuration already belongs. The docstring says so, so the boundary does not have to be inferred. Existing callers are untouched — the argument defaults to none.

The second test is the one worth keeping honest about: it fails if the change ever starts sending headers a caller did not ask for, which is the opposite error and the easier one to ship.

Verification: both tests pass. The same patch applied to a rig's checkout took a two-endpoint blind batch from refusing at config time to launching and authenticating — the proxy accepts the pair and no longer 401s.

Refs: Positronic-Robotics/internal#411

<!-- opened-by: posi-agent -->