### PR TITLE
Retry a 403 upgrade refusal a few times before surfacing it

### DIFF
--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -114,7 +114,7 @@ class _ConnectRetries:
     """The retry policy over one ``new_session``'s connect attempts.
 
     403 is both a cold backend and a refused credential, so it gets a few attempts rather than the whole
-    ``connect_deadline``, and that count belongs to one connect rather than to a client that opens many.
+    ``connect_deadline``.
     """
 
     MAX_FORBIDDEN_ATTEMPTS = 3

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -113,6 +113,27 @@ def _session_path(path: str, url: str) -> str:
     return path
 
 
+class _ConnectRetries:
+    """The retry policy over one ``new_session``'s connect attempts.
+
+    A 403 gets ``MAX_FORBIDDEN_ATTEMPTS`` of them, so the count belongs to one connect rather than to a
+    client that goes on to open further sessions.
+    """
+
+    def __init__(self) -> None:
+        self._forbidden_attempts = 0
+
+    def should_retry(self, e: Exception) -> bool:
+        """Whether the backend that refused this attempt may still answer a later one."""
+        if not isinstance(e, InvalidStatus):
+            return True
+        status = e.response.status_code
+        if status == HTTPStatus.FORBIDDEN:
+            self._forbidden_attempts += 1
+            return self._forbidden_attempts < MAX_FORBIDDEN_ATTEMPTS
+        return status >= HTTPStatus.INTERNAL_SERVER_ERROR or status == HTTPStatus.TOO_MANY_REQUESTS
+
+
 class InferenceClient:
     """The wire connection to one inference server, addressed by one URL.
 
@@ -162,24 +183,11 @@ class InferenceClient:
         self.connect_deadline = connect_deadline
         self.infer_timeout = infer_timeout
 
-    @staticmethod
-    def _may_still_come_up(status: int | None, forbidden_attempts: int) -> bool:
-        """Whether a refused connect leaves the backend a chance of answering a later attempt.
-
-        ``status`` is a non-101 upgrade response's status, ``None`` where the connect failed before one
-        arrived; ``forbidden_attempts`` includes the attempt being judged.
-        """
-        if status is None:
-            return True
-        if status == HTTPStatus.FORBIDDEN:
-            return forbidden_attempts < MAX_FORBIDDEN_ATTEMPTS
-        return status >= HTTPStatus.INTERNAL_SERVER_ERROR or status == HTTPStatus.TOO_MANY_REQUESTS
-
     def new_session(self) -> InferenceSession:
         """Creates a new inference session on the model the URL names."""
         deadline = time.monotonic() + self.connect_deadline
         backoff = 1.0
-        forbidden_attempts = 0
+        retries = _ConnectRetries()
         while True:
             ws = None
             try:
@@ -205,10 +213,7 @@ class InferenceClient:
             except (TimeoutError, ssl.SSLError, ConnectionClosed, InvalidHandshake) as e:
                 if ws is not None:
                     ws.close()
-                status = e.response.status_code if isinstance(e, InvalidStatus) else None
-                if status == HTTPStatus.FORBIDDEN:
-                    forbidden_attempts += 1
-                if not self._may_still_come_up(status, forbidden_attempts):
+                if not retries.should_retry(e):
                     raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.session_url})') from e

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -19,9 +19,6 @@ logger = logging.getLogger(__name__)
 # per use.
 DEFAULT_INFER_TIMEOUT = 180.0
 
-# 403 is both a cold backend and a refused credential, so it gets a few attempts, not the whole ``connect_deadline``.
-MAX_FORBIDDEN_ATTEMPTS = 3
-
 
 class InferenceSession:
     def __init__(self, websocket: Connection, infer_timeout: float = DEFAULT_INFER_TIMEOUT):
@@ -116,9 +113,11 @@ def _session_path(path: str, url: str) -> str:
 class _ConnectRetries:
     """The retry policy over one ``new_session``'s connect attempts.
 
-    A 403 gets ``MAX_FORBIDDEN_ATTEMPTS`` of them, so the count belongs to one connect rather than to a
-    client that goes on to open further sessions.
+    403 is both a cold backend and a refused credential, so it gets a few attempts rather than the whole
+    ``connect_deadline``, and that count belongs to one connect rather than to a client that opens many.
     """
+
+    MAX_FORBIDDEN_ATTEMPTS = 3
 
     def __init__(self) -> None:
         self._forbidden_attempts = 0
@@ -130,7 +129,7 @@ class _ConnectRetries:
         status = e.response.status_code
         if status == HTTPStatus.FORBIDDEN:
             self._forbidden_attempts += 1
-            return self._forbidden_attempts < MAX_FORBIDDEN_ATTEMPTS
+            return self._forbidden_attempts < self.MAX_FORBIDDEN_ATTEMPTS
         return status >= HTTPStatus.INTERNAL_SERVER_ERROR or status == HTTPStatus.TOO_MANY_REQUESTS
 
 

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 # per use.
 DEFAULT_INFER_TIMEOUT = 180.0
 
-# A cold backend behind Modal's proxy refuses the upgrade with 403 and accepts the next attempt. A server
-# refusing the credential answers 403 too — ``PolicyServer`` does — so a 403 buys this many attempts rather
-# than the whole ``connect_deadline``.
+# 403 is both a cold backend and a refused credential, so it gets a few attempts, not the whole ``connect_deadline``.
 MAX_FORBIDDEN_ATTEMPTS = 3
 
 

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -2,6 +2,7 @@ import logging
 import ssl
 import time
 import urllib.parse
+from enum import Enum
 from http import HTTPStatus
 from typing import Any
 
@@ -110,6 +111,11 @@ def _session_path(path: str, url: str) -> str:
     return path
 
 
+class _ConnectOutcome(Enum):
+    RETRY = 'retry'
+    SURFACE = 'surface'
+
+
 class _ConnectRetries:
     """The retry policy over one ``new_session``'s connect attempts.
 
@@ -122,15 +128,17 @@ class _ConnectRetries:
     def __init__(self) -> None:
         self._forbidden_attempts = 0
 
-    def should_retry(self, e: Exception) -> bool:
-        """Whether the backend that refused this attempt may still answer a later one."""
+    def take(self, e: Exception) -> _ConnectOutcome:
+        """Spend a refused connect against the budget."""
         if not isinstance(e, InvalidStatus):
-            return True
+            return _ConnectOutcome.RETRY
         status = e.response.status_code
         if status == HTTPStatus.FORBIDDEN:
             self._forbidden_attempts += 1
-            return self._forbidden_attempts < self.MAX_FORBIDDEN_ATTEMPTS
-        return status >= HTTPStatus.INTERNAL_SERVER_ERROR or status == HTTPStatus.TOO_MANY_REQUESTS
+            again = self._forbidden_attempts < self.MAX_FORBIDDEN_ATTEMPTS
+        else:
+            again = status >= HTTPStatus.INTERNAL_SERVER_ERROR or status == HTTPStatus.TOO_MANY_REQUESTS
+        return _ConnectOutcome.RETRY if again else _ConnectOutcome.SURFACE
 
 
 class InferenceClient:
@@ -212,7 +220,7 @@ class InferenceClient:
             except (TimeoutError, ssl.SSLError, ConnectionClosed, InvalidHandshake) as e:
                 if ws is not None:
                     ws.close()
-                if not retries.should_retry(e):
+                if retries.take(e) is _ConnectOutcome.SURFACE:
                     raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.session_url})') from e

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -114,19 +114,6 @@ def _session_path(path: str, url: str) -> str:
     return path
 
 
-def _may_still_come_up(status: int | None, forbidden: int) -> bool:
-    """Whether a refused connect leaves the backend a chance of answering a later attempt.
-
-    ``status`` is a non-101 upgrade response's status, ``None`` where the connect failed before one arrived;
-    ``forbidden`` counts the 403s seen so far, this one included.
-    """
-    if status is None:
-        return True
-    if status == 403:
-        return forbidden < MAX_FORBIDDEN_ATTEMPTS
-    return status >= 500 or status == 429
-
-
 class InferenceClient:
     """The wire connection to one inference server, addressed by one URL.
 
@@ -176,6 +163,19 @@ class InferenceClient:
         self.connect_deadline = connect_deadline
         self.infer_timeout = infer_timeout
 
+    @staticmethod
+    def _may_still_come_up(status: int | None, forbidden: int) -> bool:
+        """Whether a refused connect leaves the backend a chance of answering a later attempt.
+
+        ``status`` is a non-101 upgrade response's status, ``None`` where the connect failed before one
+        arrived; ``forbidden`` counts the 403s seen so far, this one included.
+        """
+        if status is None:
+            return True
+        if status == 403:
+            return forbidden < MAX_FORBIDDEN_ATTEMPTS
+        return status >= 500 or status == 429
+
     def new_session(self) -> InferenceSession:
         """Creates a new inference session on the model the URL names."""
         deadline = time.monotonic() + self.connect_deadline
@@ -209,7 +209,7 @@ class InferenceClient:
                 status = e.response.status_code if isinstance(e, InvalidStatus) else None
                 if status == 403:
                     forbidden += 1
-                if not _may_still_come_up(status, forbidden):
+                if not self._may_still_come_up(status, forbidden):
                     raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.session_url})') from e

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -2,6 +2,7 @@ import logging
 import ssl
 import time
 import urllib.parse
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -164,23 +165,23 @@ class InferenceClient:
         self.infer_timeout = infer_timeout
 
     @staticmethod
-    def _may_still_come_up(status: int | None, forbidden: int) -> bool:
+    def _may_still_come_up(status: int | None, forbidden_attempts: int) -> bool:
         """Whether a refused connect leaves the backend a chance of answering a later attempt.
 
         ``status`` is a non-101 upgrade response's status, ``None`` where the connect failed before one
-        arrived; ``forbidden`` counts the 403s seen so far, this one included.
+        arrived; ``forbidden_attempts`` includes the attempt being judged.
         """
         if status is None:
             return True
-        if status == 403:
-            return forbidden < MAX_FORBIDDEN_ATTEMPTS
-        return status >= 500 or status == 429
+        if status == HTTPStatus.FORBIDDEN:
+            return forbidden_attempts < MAX_FORBIDDEN_ATTEMPTS
+        return status >= HTTPStatus.INTERNAL_SERVER_ERROR or status == HTTPStatus.TOO_MANY_REQUESTS
 
     def new_session(self) -> InferenceSession:
         """Creates a new inference session on the model the URL names."""
         deadline = time.monotonic() + self.connect_deadline
         backoff = 1.0
-        forbidden = 0
+        forbidden_attempts = 0
         while True:
             ws = None
             try:
@@ -207,9 +208,9 @@ class InferenceClient:
                 if ws is not None:
                     ws.close()
                 status = e.response.status_code if isinstance(e, InvalidStatus) else None
-                if status == 403:
-                    forbidden += 1
-                if not self._may_still_come_up(status, forbidden):
+                if status == HTTPStatus.FORBIDDEN:
+                    forbidden_attempts += 1
+                if not self._may_still_come_up(status, forbidden_attempts):
                     raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.session_url})') from e

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 # per use.
 DEFAULT_INFER_TIMEOUT = 180.0
 
+# A cold backend behind Modal's proxy refuses the upgrade with 403 and accepts the next attempt. A server
+# refusing the credential answers 403 too — ``PolicyServer`` does — so a 403 buys this many attempts rather
+# than the whole ``connect_deadline``.
+MAX_FORBIDDEN_ATTEMPTS = 3
+
 
 class InferenceSession:
     def __init__(self, websocket: Connection, infer_timeout: float = DEFAULT_INFER_TIMEOUT):
@@ -109,6 +114,19 @@ def _session_path(path: str, url: str) -> str:
     return path
 
 
+def _may_still_come_up(status: int | None, forbidden: int) -> bool:
+    """Whether a refused connect leaves the backend a chance of answering a later attempt.
+
+    ``status`` is a non-101 upgrade response's status, ``None`` where the connect failed before one arrived;
+    ``forbidden`` counts the 403s seen so far, this one included.
+    """
+    if status is None:
+        return True
+    if status == 403:
+        return forbidden < MAX_FORBIDDEN_ATTEMPTS
+    return status >= 500 or status == 429
+
+
 class InferenceClient:
     """The wire connection to one inference server, addressed by one URL.
 
@@ -162,6 +180,7 @@ class InferenceClient:
         """Creates a new inference session on the model the URL names."""
         deadline = time.monotonic() + self.connect_deadline
         backoff = 1.0
+        forbidden = 0
         while True:
             ws = None
             try:
@@ -187,11 +206,10 @@ class InferenceClient:
             except (TimeoutError, ssl.SSLError, ConnectionClosed, InvalidHandshake) as e:
                 if ws is not None:
                     ws.close()
-                # A non-101 upgrade response only means "not ready" when it's a 5xx or 429; any other status
-                # (401/403/404, …) is permanent misconfiguration and surfaces immediately.
-                if isinstance(e, InvalidStatus) and not (
-                    e.response.status_code >= 500 or e.response.status_code == 429
-                ):
+                status = e.response.status_code if isinstance(e, InvalidStatus) else None
+                if status == 403:
+                    forbidden += 1
+                if not _may_still_come_up(status, forbidden):
                     raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(f'{e} (connecting to {self.session_url})') from e

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -9,7 +9,7 @@ from websockets.http11 import Response
 
 from positronic import keys, telemetry, telemetry_keys
 from positronic.drivers.roboarm import command
-from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, MAX_FORBIDDEN_ATTEMPTS, InferenceClient
+from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _ConnectRetries
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.remote import RemoteSession
@@ -222,7 +222,8 @@ class TestNewSessionRetriesRefusedUpgrades:
     def test_a_403_gives_up_once_its_attempts_are_spent(self):
         with (
             patch(
-                'positronic.offboard.client.connect', side_effect=[_refused(403)] * (MAX_FORBIDDEN_ATTEMPTS + 5)
+                'positronic.offboard.client.connect',
+                side_effect=[_refused(403)] * (_ConnectRetries.MAX_FORBIDDEN_ATTEMPTS + 5),
             ) as mock_connect,
             patch('positronic.offboard.client.InferenceSession'),
             patch('positronic.offboard.client.time.sleep'),
@@ -230,7 +231,7 @@ class TestNewSessionRetriesRefusedUpgrades:
         ):
             InferenceClient('localhost:8000').new_session()
 
-        assert mock_connect.call_count == MAX_FORBIDDEN_ATTEMPTS
+        assert mock_connect.call_count == _ConnectRetries.MAX_FORBIDDEN_ATTEMPTS
 
     @pytest.mark.parametrize('status_code', [401, 404])
     def test_a_refusal_that_no_warm_up_clears_is_raised_at_once(self, status_code):
@@ -246,7 +247,7 @@ class TestNewSessionRetriesRefusedUpgrades:
 
     def test_each_session_opens_on_a_full_budget(self):
         """A client that spent 403s opening one session still gets all of them for the next."""
-        one_session = [_refused(403)] * (MAX_FORBIDDEN_ATTEMPTS - 1) + [MagicMock()]
+        one_session = [_refused(403)] * (_ConnectRetries.MAX_FORBIDDEN_ATTEMPTS - 1) + [MagicMock()]
         with (
             patch('positronic.offboard.client.connect', side_effect=one_session * 2) as mock_connect,
             patch('positronic.offboard.client.InferenceSession'),

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -1,4 +1,5 @@
 import time
+from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -201,8 +202,8 @@ class TestInferenceClientUrl:
                 assert call.args[0] == client.session_url == 'ws://localhost:8000/api/v1/session/10000?fps=10'
 
 
-def _refused(status_code: int) -> InvalidStatus:
-    return InvalidStatus(Response(status_code, 'refused', Headers()))
+def _refused(status: HTTPStatus) -> InvalidStatus:
+    return InvalidStatus(Response(status, 'refused', Headers()))
 
 
 class TestNewSessionRetriesRefusedUpgrades:
@@ -210,7 +211,9 @@ class TestNewSessionRetriesRefusedUpgrades:
 
     def test_a_403_retries_and_the_session_that_follows_is_returned(self):
         with (
-            patch('positronic.offboard.client.connect', side_effect=[_refused(403), MagicMock()]) as mock_connect,
+            patch(
+                'positronic.offboard.client.connect', side_effect=[_refused(HTTPStatus.FORBIDDEN), MagicMock()]
+            ) as mock_connect,
             patch('positronic.offboard.client.InferenceSession') as mock_session_cls,
             patch('positronic.offboard.client.time.sleep'),
         ):
@@ -223,7 +226,7 @@ class TestNewSessionRetriesRefusedUpgrades:
         with (
             patch(
                 'positronic.offboard.client.connect',
-                side_effect=[_refused(403)] * (_ConnectRetries.MAX_FORBIDDEN_ATTEMPTS + 5),
+                side_effect=[_refused(HTTPStatus.FORBIDDEN)] * (_ConnectRetries.MAX_FORBIDDEN_ATTEMPTS + 5),
             ) as mock_connect,
             patch('positronic.offboard.client.InferenceSession'),
             patch('positronic.offboard.client.time.sleep'),
@@ -233,10 +236,10 @@ class TestNewSessionRetriesRefusedUpgrades:
 
         assert mock_connect.call_count == _ConnectRetries.MAX_FORBIDDEN_ATTEMPTS
 
-    @pytest.mark.parametrize('status_code', [401, 404])
-    def test_a_refusal_that_no_warm_up_clears_is_raised_at_once(self, status_code):
+    @pytest.mark.parametrize('status', [HTTPStatus.UNAUTHORIZED, HTTPStatus.NOT_FOUND])
+    def test_a_refusal_that_no_warm_up_clears_is_raised_at_once(self, status):
         with (
-            patch('positronic.offboard.client.connect', side_effect=_refused(status_code)) as mock_connect,
+            patch('positronic.offboard.client.connect', side_effect=_refused(status)) as mock_connect,
             patch('positronic.offboard.client.InferenceSession'),
             patch('positronic.offboard.client.time.sleep'),
             pytest.raises(InvalidStatus),
@@ -247,7 +250,7 @@ class TestNewSessionRetriesRefusedUpgrades:
 
     def test_each_session_opens_on_a_full_budget(self):
         """A client that spent 403s opening one session still gets all of them for the next."""
-        one_session = [_refused(403)] * (_ConnectRetries.MAX_FORBIDDEN_ATTEMPTS - 1) + [MagicMock()]
+        one_session = [_refused(HTTPStatus.FORBIDDEN)] * (_ConnectRetries.MAX_FORBIDDEN_ATTEMPTS - 1) + [MagicMock()]
         with (
             patch('positronic.offboard.client.connect', side_effect=one_session * 2) as mock_connect,
             patch('positronic.offboard.client.InferenceSession'),

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -3,10 +3,13 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from websockets.datastructures import Headers
+from websockets.exceptions import InvalidStatus
+from websockets.http11 import Response
 
 from positronic import keys, telemetry, telemetry_keys
 from positronic.drivers.roboarm import command
-from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient
+from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, MAX_FORBIDDEN_ATTEMPTS, InferenceClient
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.remote import RemoteSession
@@ -196,6 +199,50 @@ class TestInferenceClientUrl:
             assert mock_connect.call_count == 2
             for call in mock_connect.call_args_list:
                 assert call.args[0] == client.session_url == 'ws://localhost:8000/api/v1/session/10000?fps=10'
+
+
+def _refused(status_code: int) -> InvalidStatus:
+    return InvalidStatus(Response(status_code, 'refused', Headers()))
+
+
+class TestNewSessionRetriesRefusedUpgrades:
+    """Which non-101 upgrade responses are a backend still coming up, and which are the endpoint saying no."""
+
+    def test_a_403_retries_and_the_session_that_follows_is_returned(self):
+        with (
+            patch('positronic.offboard.client.connect', side_effect=[_refused(403), MagicMock()]) as mock_connect,
+            patch('positronic.offboard.client.InferenceSession') as mock_session_cls,
+            patch('positronic.offboard.client.time.sleep'),
+        ):
+            session = InferenceClient('localhost:8000').new_session()
+
+            assert mock_connect.call_count == 2
+            assert session is mock_session_cls.return_value
+
+    def test_a_403_gives_up_once_its_attempts_are_spent(self):
+        with (
+            patch(
+                'positronic.offboard.client.connect', side_effect=[_refused(403)] * (MAX_FORBIDDEN_ATTEMPTS + 5)
+            ) as mock_connect,
+            patch('positronic.offboard.client.InferenceSession'),
+            patch('positronic.offboard.client.time.sleep'),
+            pytest.raises(InvalidStatus),
+        ):
+            InferenceClient('localhost:8000').new_session()
+
+        assert mock_connect.call_count == MAX_FORBIDDEN_ATTEMPTS
+
+    @pytest.mark.parametrize('status_code', [401, 404])
+    def test_a_refusal_that_no_warm_up_clears_is_raised_at_once(self, status_code):
+        with (
+            patch('positronic.offboard.client.connect', side_effect=_refused(status_code)) as mock_connect,
+            patch('positronic.offboard.client.InferenceSession'),
+            patch('positronic.offboard.client.time.sleep'),
+            pytest.raises(InvalidStatus),
+        ):
+            InferenceClient('localhost:8000').new_session()
+
+        assert mock_connect.call_count == 1
 
 
 def test_remote_policy_hands_the_url_and_headers_to_the_client():

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -244,6 +244,20 @@ class TestNewSessionRetriesRefusedUpgrades:
 
         assert mock_connect.call_count == 1
 
+    def test_each_session_opens_on_a_full_budget(self):
+        """A client that spent 403s opening one session still gets all of them for the next."""
+        one_session = [_refused(403)] * (MAX_FORBIDDEN_ATTEMPTS - 1) + [MagicMock()]
+        with (
+            patch('positronic.offboard.client.connect', side_effect=one_session * 2) as mock_connect,
+            patch('positronic.offboard.client.InferenceSession'),
+            patch('positronic.offboard.client.time.sleep'),
+        ):
+            client = InferenceClient('localhost:8000')
+            client.new_session()
+            client.new_session()
+
+            assert mock_connect.call_count == 2 * len(one_session)
+
 
 def test_remote_policy_hands_the_url_and_headers_to_the_client():
     headers = {'Modal-Key': 'k'}


### PR DESCRIPTION
A cold Modal-fronted endpoint intermittently answers the websocket upgrade with HTTP 403 about ten seconds in, and accepts the very next attempt — observed four times in one session against `gyros-nmp15k6-58k-c2s4`, a six-try probe giving `403, ok, ok, ok, ok, ok`. 403 sat outside `InferenceClient.new_session`'s retried set, so a run that dialled a cold endpoint died at startup instead of retrying to its deadline.

## Why retrying it is safe on that proxy

The fast-fail exists to surface a bad credential at once, and on the Modal proxy a credential failure is a **401**, never a 403. Probed against the endpoint: no credentials, a wrong key and a wrong secret each answer `401 modal-http: ... credentials for proxy authorization`. So retrying 403 costs nothing on the case the fast-fail was written for.

## Why it is bounded rather than retried to the deadline

403 is the one status that arrives both ways, and the second way is this repository's own server. `PolicyServer` refuses a bad bearer token on a websocket by raising before `accept()`, and uvicorn turns a pre-accept close into an HTTP 403 — verified against a live `PolicyServer`, for a missing header and for a wrong token. `connect_deadline` defaults to 900 s and is sized for a cold backend to finish booting, so retrying 403 on those terms would turn a mistyped token into a quarter-hour hang, and `test_auth_rejects_requests_without_the_token` pins that it does not.

The measured cold case does not need that window: all four observations cleared on the immediately following attempt. So 403 gets an attempt budget — `MAX_FORBIDDEN_ATTEMPTS = 3`, generous against one attempt sufficing and costing a genuine refusal the loop's first two backoffs, about three seconds. 401 and 404 stay immediate.

## Shape

`_ConnectRetries` holds the whole decision: `take` receives the exception, extracts the status itself, spends a unit of the budget where the status is a 403, and returns a `_ConnectOutcome`. The `except` block reads `if retries.take(e) is _ConnectOutcome.SURFACE: raise` and never has to know which status is counted. One instance per `new_session`, so a session that spent attempts opening does not narrow the next one's.

## Cost, stated

- A genuine authorization 403 — a workspace denial, or `PolicyServer` refusing a token — now takes three attempts and \~3 s instead of failing at once. The auth-rejection tests pay exactly that: 0.8 s → 9.7 s for the three of them.
- The cold-start 403's body was never captured; catching one needs the endpoint idle \~15 minutes and it was warm throughout. So what that 403 *means* is not established. What is established is that credential failures on that proxy are 401.

## Tests

`TestNewSessionRetriesRefusedUpgrades` in `positronic/offboard/tests/test_remote_policy.py`, beside the other `InferenceClient` tests driving a mocked `connect`: a 403 retries and the session that follows is returned; a 403 gives up once its attempts are spent; a 401 and a 404 are raised on the first attempt; each `new_session` opens on a full budget (this one fails if the counter moves to the client). The two 403 tests fail against the unfixed predicate and the 401/404 ones pass there.

`uv run --locked pytest --no-cov`: 1446 passed, 9 skipped.

## One rules finding this ships

`check-rules` and Codex both report `earn-its-place` against `_ConnectRetries`: that `new_session`'s frame already scopes a local counter, so a class for it re-encodes a lifetime the function gives free. The alternative both propose — a local counter plus a predicate applied in the handler — is the arrangement this replaced, which left the caller knowing that 403 is the counted status and that the count includes the attempt being judged. Folding that into the helper was the author's call; the finding is declined on his word.

Ticket: Positronic-Robotics/internal#463

<!-- opened-by: posi-agent -->