### PR TITLE
Say whose job it is to keep the submitted image working

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -36,6 +36,11 @@ uv run positronic eval list
 uv run positronic eval cancel --submission-id=<hex id>
 ```
 
+The image is pulled as given, when the run starts, and evaluated as found. Keeping it pullable, and
+holding what you want evaluated, is yours until the run finishes: one that has gone away by then
+fails the run, and one whose tag moved is scored as it stands at pull time. Pin a digest for a fixed
+image.
+
 `positronic/cli/examples/` runs the whole flow end to end.
 
 ## Configuration

--- a/client/README.md
+++ b/client/README.md
@@ -36,8 +36,8 @@ uv run positronic eval list
 uv run positronic eval cancel --submission-id=<hex id>
 ```
 
-The image is pulled as given, when the run starts, and evaluated as found. Keeping it pullable, and
-holding what you want evaluated, is yours until the run finishes: one that has gone away by then
+The image is pulled as given, when the run starts, and evaluated as found. You keep it pullable, and
+keep it holding what you want evaluated, until the run finishes: one that has gone away by then
 fails the run, and one whose tag moved is scored as it stands at pull time. Pin a digest for a fixed
 image.
 

--- a/client/platform_client/policy_images.py
+++ b/client/platform_client/policy_images.py
@@ -23,6 +23,10 @@ class PolicyImage(str):
     """A registry reference, `name[@digest]`, as a validated `str` — no serializer, no DB adapter.
 
     `name` is everything before the digest (repository plus any tag); `digest` is what pins the bytes.
+
+    The platform pulls this reference as given, when the run starts, and evaluates what it finds.
+    Keeping it pullable, and holding what you want evaluated, is the submitter's until the run
+    finishes; a tag resolves at pull time, so pin a digest for a fixed image.
     """
 
     __slots__ = ()

--- a/client/platform_client/policy_images.py
+++ b/client/platform_client/policy_images.py
@@ -25,7 +25,7 @@ class PolicyImage(str):
     `name` is everything before the digest (repository plus any tag); `digest` is what pins the bytes.
 
     The platform pulls this reference as given, when the run starts, and evaluates what it finds.
-    Keeping it pullable, and holding what you want evaluated, is the submitter's until the run
+    The submitter keeps it pullable, and keeps it holding what they want evaluated, until the run
     finishes; a tag resolves at pull time, so pin a digest for a fixed image.
     """
 

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "positronic-platform-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Typed wire contract and HTTP client for the Positronic evaluation platform API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # (.github/workflows/release.yaml). Pinned exactly, because that package guarantees no
     # backwards compatibility: a floating requirement would let a fresh install of THIS release
     # resolve a contract it was never built against.
-    "positronic-platform-client==0.2.0",
+    "positronic-platform-client==0.2.1",
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",

--- a/uv.lock
+++ b/uv.lock
@@ -5039,7 +5039,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/45/029c72cffe797d826
 
 [[package]]
 name = "positronic-platform-client"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The platform pulls a submitted policy image **as given, when the run starts**, and evaluates what it finds. It does not rewrite the reference and does not keep a copy of the image.

Two consequences a submitter cannot read off this package today, and both are theirs to avoid:

- an image deleted, made private, retagged or rate-limited between submission and execution fails that run;
- an image whose contents moved under a tag is scored as it stands at pull time.

Said in the two places the fact is reachable without knowing to look for it: on `PolicyImage`, which is the type they hold, and in `client/README.md` beside the `eval run` example they copy. Pinning a digest is the answer to both, and is now stated as such rather than implied.

The client version goes 0.2.0 → 0.2.1 with the root's pin, per the repo's version-bump gate.

Nothing here changes behaviour. The platform side of the same contract is `Positronic-Robotics/platform#18`, which stopped rewriting the reference and now records the resolved digest as evidence rather than imposing it; that PR pins the client by git rev, so it is unaffected by this version bump until someone moves the rev.

<!-- opened-by: posi-agent -->