### PR TITLE
Run the test suite in parallel, and stop it waiting on things it doesn't need

### DIFF
--- a/pimm/world.py
+++ b/pimm/world.py
@@ -1,5 +1,6 @@
 """Implementation of multiprocessing channels."""
 
+import functools
 import heapq
 import logging
 import multiprocessing as mp
@@ -482,12 +483,15 @@ class World:
 
         self._stop_event = self._mp_ctx.Event()
         self.background_processes = []
-        # Use a spawn-context manager so queues/values behave synchronously even
-        # when used in a single process (tests rely on immediate read after emit).
-        self._manager = self._mp_ctx.Manager()
         self._cleanup_emitters_readers = []
         self.entered = False
         self._connections = []
+
+    @functools.cached_property
+    def _manager(self):
+        """A spawn-context manager, so queues and values behave synchronously even within a single process."""
+        # It runs as a process of its own, so a world that never opens an mp pipe never starts one.
+        return self._mp_ctx.Manager()
 
     def __enter__(self):
         self.entered = True
@@ -497,7 +501,6 @@ class World:
         self.entered = False
         logging.info('Stopping background processes...')
         self.request_stop()
-        time.sleep(0.1)
 
         logging.info(f'Waiting for {len(self.background_processes)} background processes to terminate...')
         for process in self.background_processes:

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -487,12 +487,6 @@ class World:
         self.entered = False
         self._connections = []
 
-    @functools.cached_property
-    def _manager(self):
-        """A spawn-context manager, so queues and values behave synchronously even within a single process."""
-        # It runs as a process of its own, so a world that never opens an mp pipe never starts one.
-        return self._mp_ctx.Manager()
-
     def __enter__(self):
         self.entered = True
         return self
@@ -843,6 +837,12 @@ class World:
         """
         q = deque(maxlen=maxsize)
         return LocalQueueEmitter(q, self._clock), LocalQueueReceiver(q)
+
+    @functools.cached_property
+    def _manager(self):
+        """A spawn-context manager, so queues and values behave synchronously even within a single process."""
+        # It runs as a process of its own, so a world that opens no mp pipe never starts one.
+        return self._mp_ctx.Manager()
 
     def mp_pipes(
         self,

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -13,7 +13,7 @@ from websockets.exceptions import InvalidStatus
 from websockets.sync.client import connect
 
 from positronic import keys
-from positronic.offboard.client import InferenceClient, InferenceSession
+from positronic.offboard.client import InferenceClient, InferenceSession, _ConnectRetries
 from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer, bearer
 from positronic.offboard.server_utils import warmup
 from positronic.policy import Codec, Policy, RemotePolicy, Session
@@ -426,7 +426,10 @@ def authed_endpoint(start_server, make_mock_policy) -> tuple[str, str]:
         pytest.param(lambda token: token, id='no-bearer-prefix'),
     ],
 )
-def test_auth_rejects_requests_without_the_token(authed_endpoint, make_header):
+def test_auth_rejects_requests_without_the_token(authed_endpoint, make_header, monkeypatch):
+    # A 403 buys retries in case the backend is merely cold; here it never clears, so those attempts and the
+    # waits between them are dead time. `TestNewSessionRetriesRefusedUpgrades` is where the budget is tested.
+    monkeypatch.setattr(_ConnectRetries, 'MAX_FORBIDDEN_ATTEMPTS', 1)
     url, token = authed_endpoint
     header = make_header(token)
     client = InferenceClient(url, headers=None if header is None else {AUTH_HEADER: header})

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -427,8 +427,8 @@ def authed_endpoint(start_server, make_mock_policy) -> tuple[str, str]:
     ],
 )
 def test_auth_rejects_requests_without_the_token(authed_endpoint, make_header, monkeypatch):
-    # A 403 buys retries in case the backend is merely cold; here it never clears, so those attempts and the
-    # waits between them are dead time. `TestNewSessionRetriesRefusedUpgrades` is where the budget is tested.
+    # A 403 buys retries for a backend that may be merely cold. This one is refusing, so those attempts and
+    # the waits between them are dead time; `TestNewSessionRetriesRefusedUpgrades` is what tests the budget.
     monkeypatch.setattr(_ConnectRetries, 'MAX_FORBIDDEN_ATTEMPTS', 1)
     url, token = authed_endpoint
     header = make_header(token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,8 +200,8 @@ i2rt = { git = "https://github.com/i2rt-robotics/i2rt.git", rev = "5d47b358bafb3
 testpaths = ["client", "pimm", "positronic", "utilities"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = [
-    # Half of a serial run is spent waiting on spawned processes and sockets, so the suite is bound by cores
-    # rather than by CPU. `-n0` puts it back in one process, which live logs and `--pdb` need.
+    # The suite waits on spawned processes and sockets about as much as it computes, so it scales with cores.
+    # `-n0` puts it back in one process, which live logs and `--pdb` need.
     "-n", "auto",
     "--cov=pimm",
     "--cov=platform_client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ dev = [
     "pytest-cov",
     "pytest-asyncio",
     "pytest-timeout",
+    "pytest-xdist",
     "pytest",
     "rerun-sdk[notebook]",
     "positronic[telemetry]",  # the telemetry tests exercise the SDK and the samplers
@@ -199,6 +200,9 @@ i2rt = { git = "https://github.com/i2rt-robotics/i2rt.git", rev = "5d47b358bafb3
 testpaths = ["client", "pimm", "positronic", "utilities"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = [
+    # Half of a serial run is spent waiting on spawned processes and sockets, so the suite is bound by cores
+    # rather than by CPU. `-n0` puts it back in one process, which live logs and `--pdb` need.
+    "-n", "auto",
     "--cov=pimm",
     "--cov=platform_client",
     "--cov=positronic",

--- a/uv.lock
+++ b/uv.lock
@@ -1971,6 +1971,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/eb/b8900082a13a47bb9f69f415174d03cbf12ce95d07345722e1f4ef0e2093/evdev-1.8.0.tar.gz", hash = "sha256:45598eee1ae3876a3122ca1dc0ec8049c01931672d12478b5c610afc24e47d75", size = 32557, upload-time = "2025-01-25T17:02:19.592Z" }
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4939,6 +4948,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "rerun-sdk" },
     { name = "ruff" },
 ]
@@ -5022,6 +5032,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "rerun-sdk", extras = ["notebook"] },
     { name = "ruff" },
 ]
@@ -5596,6 +5607,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The suite took 94s wall for 49s of CPU — half the run was idle, waiting.

- `World.__exit__` slept 0.1s before joining background processes that the `join(timeout=90)` on the next line already waits for, and every `World` spawned a manager process whether or not it ever opened an mp pipe. Together, a fixed ~0.15s on every test that builds a world. `_manager` is now a `cached_property` living beside `mp_pipes`, the only method that opens one.
- `test_auth_rejects_requests_without_the_token` spent 3s per case inside `new_session`'s 403 backoff, retrying a refusal that never clears. It now shrinks the budget to one attempt; `TestNewSessionRetriesRefusedUpgrades` is what covers the budget itself.
- What remains is mostly waiting on spawned processes and sockets, so the suite runs under `pytest-xdist`. `-n auto` sits in `addopts`, which covers local runs and CI alike; `-n0` puts it back in one process for live logs and `--pdb`.

93s -> 45s serially, ~15s across 12 cores. CI inherits `addopts` with no workflow change.

## Test plan

- `uv run --locked pytest --no-cov` — 1426 passed, 9 skipped. Run three times in parallel mode to check for flakiness; no flakes.
- `uv run --locked pytest --cov-report=html` (what CI runs) — green in 26s, and the `coverage report -m` step after it reads the combined data across workers as before.
- `uv run --locked pytest --no-cov -n0` — green in 43s.
- ruff and basedpyright clean.
