### PR TITLE
Anchor a telemetry span where it was dispatched, not where it lands

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -20,8 +20,10 @@ one starts to. Code that needs timing there takes it as an opaque injected conte
 no notion of an episode, a pass or an inference call. An **anchor** is a long-running span its owner holds
 open; the spans an instrumented call site emits parent to the innermost one, which is how a phase span
 emitted by one control system lands under the rollout another control system is running (OTel's ambient
-context does not survive the scheduler's generator hops). Ownership follows the phase: the harness opens,
-stamps and closes the `episode` span, the eval CLI the `eval.pass` span.
+context does not survive the scheduler's generator hops). The anchor stack is per-context, so work the loop
+dispatches to a thread — an inference call it keeps playing through — records under the anchors that stood when
+it was dispatched rather than under whatever is anchored by the time it returns. Ownership follows the phase:
+the harness opens, stamps and closes the `episode` span, the eval CLI the `eval.pass` span.
 
 The contract literals split by who writes the bytes they name. Every span name and attribute key in the tables
 below is written by eval-domain code through the span helpers, which pass them opaquely and never match on

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import contextvars
 import logging
 import time
 from collections import deque
@@ -113,7 +114,10 @@ class _InferenceWorker:
         """Start a call on ``obs``. The moment's wait lets a wrapper that skips inference resolve in the round
         it was asked."""
         self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
-        self._call = self._executor.submit(self._session, frozen_view(self._owned(obs)))
+        # The call runs under a copy of the loop's context, so the telemetry it records anchors to the episode
+        # that asked for it even when it outlives that episode's close.
+        context = contextvars.copy_context()
+        self._call = self._executor.submit(context.run, self._session, frozen_view(self._owned(obs)))
         concurrent.futures.wait([self._call], timeout=SKIP_REPLY_SEC)
 
     def throttle(self) -> None:

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -166,13 +166,16 @@ class ChunkPolicy(StubPolicy):
 
 
 class _FakeInferenceSession(InferenceSession):
-    """A stub ``InferenceSession`` returning a canned action, so a ``RemoteSession`` over it round-trips
-    ``RemoteSession.__call__`` — the real inference boundary that records the ``policy.infer`` span."""
+    """A stub ``InferenceSession`` returning a canned action after ``wall_sec`` of real time, so a
+    ``RemoteSession`` over it round-trips ``RemoteSession.__call__`` — the real inference boundary that records
+    the ``policy.infer`` span."""
 
-    def __init__(self, action: list[dict[str, Any]]) -> None:
+    def __init__(self, action: list[dict[str, Any]], wall_sec: float = 0.0) -> None:
         self._action = action
+        self._wall_sec = wall_sec
 
     def infer(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
+        time.sleep(self._wall_sec)
         return self._action
 
     @property
@@ -187,16 +190,19 @@ class RemoteStubPolicy(Policy):
     """A stub policy served through a real ``RemoteSession`` over a fake inference session, so its inference
     round-trips ``RemoteSession.__call__`` and records the ``policy.infer`` span independent of any wrapper."""
 
-    def __init__(self, command: roboarm.command.CommandType | None = None, target_grip: float = 0.33) -> None:
+    def __init__(
+        self, command: roboarm.command.CommandType | None = None, target_grip: float = 0.33, wall_sec: float = 0.0
+    ) -> None:
         if command is None:
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
             command = CartesianPosition(pose=pose)
         self.command = command
         self.target_grip = float(target_grip)
+        self.wall_sec = wall_sec
 
     def new_session(self, context=None, now=None) -> RemoteSession:
         action = [{'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': 0.0}]
-        return RemoteSession(_FakeInferenceSession(action))
+        return RemoteSession(_FakeInferenceSession(action, self.wall_sec))
 
 
 @pytest.fixture
@@ -1479,6 +1485,37 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
     assert episode.attrs[telemetry_keys.ATTR_EPISODE_INDEX] == 0
     assert episode.attrs[telemetry_keys.ATTR_EPISODE_STEPS] == len(by_name[telemetry_keys.SPAN_POLICY_INFER])
     assert episode.attrs[telemetry_keys.ATTR_EPISODE_VIRTUAL_S] >= 0.0
+
+
+@pytest.mark.timeout(10.0)
+def test_an_inference_outliving_its_episode_parents_to_it(world, tmp_path):
+    """A trial whose deadline lapses mid-call ends the episode while the model is still inside it, so the
+    ``policy.infer`` span is recorded off the loop thread after the episode span closed. It still parents to
+    the episode that asked for it rather than to the pass: charging wall time is the mode that measures real
+    inference cost, so that span is the one a reader most wants attributed."""
+    harness = Harness(
+        ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3)),  # the call runs well past the deadline
+        make_embodiment(simulated=True),
+        task=Task(instruction='stack', timeout=0.05, reset=lambda context: None),
+        trials=[{keys.INFERENCE_LATENCY: True}],
+    )
+    p = _pair_all(world, harness)
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    producer = ManualDriver([
+        (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.01),
+        (None, 0.3),
+    ])
+
+    with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-outlive'), _eval_pass('run-outlive'):
+        scheduler = world.start([harness, producer, _Pacer()])
+        drive_scheduler(scheduler, steps=2000)
+
+    spans = list(telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS)))
+    episodes = [s for s in spans if s.name == telemetry_keys.SPAN_EPISODE]
+    infers = [s for s in spans if s.name == telemetry_keys.SPAN_POLICY_INFER]
+    assert len(episodes) == 1 and len(infers) == 1
+    assert infers[0].end_ns > episodes[0].end_ns  # the call did outlive the episode
+    assert infers[0].parent_id == episodes[0].span_id
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -99,7 +99,7 @@ GPU_PROC_UTIL_PCT = 'proc_util_pct'
 # - A span opened while no span of the bound trace is active parents to the innermost anchor.
 # - A span opened inside another parents to that one.
 # - With nothing anchored, a span roots.
-# - A thread dispatched under a copied context keeps the anchors of its dispatch, whatever is popped meanwhile.
+# - A copied context carries the anchors it was copied with; a push or pop after the copy does not reach it.
 # - The stack stands in for OTel's ambient context, which does not survive the scheduler's generator hops.
 _provider: 'TracerProvider | None' = None
 _anchors: ContextVar[tuple[Span, ...]] = ContextVar('positronic_telemetry_anchors', default=())

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -93,13 +93,11 @@ GPU_POWER_W = 'power_w'
 GPU_PROC_MEM_B = 'proc_mem_b'
 GPU_PROC_UTIL_PCT = 'proc_util_pct'
 
-# The bound provider is process-global; the anchor stack is per-context. An anchor is a long-running span
-# its owner holds open (a pass, a rollout); ``span`` parents a span opened outside any active span of the
-# bound trace to the innermost anchor, while a nested span (materialize inside env.step) still parents to
-# whatever OTel span is current within its own ``with`` block. Parenting resolves through this stack rather
-# than through OTel's ambient context, which does not survive the scheduler's generator hops between the
-# cooperative control systems sharing the loop thread. Work the loop dispatches to a thread under a copied
-# context records under the anchors that stood at its dispatch, whatever the loop pops meanwhile.
+# The bound provider is process-global; the anchor stack is per-context, so a thread dispatched under a copied
+# context keeps the anchors of its dispatch. An anchor is a long-running span its owner holds open (a pass, a
+# rollout): a span opened outside any active span of the bound trace parents to the innermost one, a nested
+# span to the current OTel span. The stack stands in for OTel's ambient context, which does not survive the
+# scheduler's generator hops.
 _provider: 'TracerProvider | None' = None
 _anchors: ContextVar[tuple[Span, ...]] = ContextVar('positronic_telemetry_anchors', default=())
 

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -37,6 +37,7 @@ import threading
 import time
 from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -92,14 +93,15 @@ GPU_POWER_W = 'power_w'
 GPU_PROC_MEM_B = 'proc_mem_b'
 GPU_PROC_UTIL_PCT = 'proc_util_pct'
 
-# The bound provider and the anchor stack are process-global: the harness, env proxy and recorder run as
-# cooperative control systems in one thread and interleave their spans, so parenting is resolved here rather
-# than through OTel's ambient context (which does not survive the scheduler's generator hops). An anchor is a
-# long-running span its owner holds open (a pass, a rollout); ``span`` parents a span opened outside any
-# active span of the bound trace to the innermost anchor, while a nested span (materialize inside env.step)
-# still parents to whatever OTel span is current within its own ``with`` block.
+# The bound provider is process-global; the anchor stack is per-context. An anchor is a long-running span
+# its owner holds open (a pass, a rollout); ``span`` parents a span opened outside any active span of the
+# bound trace to the innermost anchor, while a nested span (materialize inside env.step) still parents to
+# whatever OTel span is current within its own ``with`` block. Parenting resolves through this stack rather
+# than through OTel's ambient context, which does not survive the scheduler's generator hops between the
+# cooperative control systems sharing the loop thread. Work the loop dispatches to a thread under a copied
+# context records under the anchors that stood at its dispatch, whatever the loop pops meanwhile.
 _provider: 'TracerProvider | None' = None
-_anchors: list[Span] = []
+_anchors: ContextVar[tuple[Span, ...]] = ContextVar('positronic_telemetry_anchors', default=())
 
 
 # The unbound fallback is a PRIVATE no-op, never ``trace.get_tracer``: a host application embedding this code
@@ -196,13 +198,13 @@ def force_flush() -> None:
 
 def push_anchor(anchor: Span) -> None:
     """Make ``anchor`` the innermost anchor: spans opened outside it from now on parent to it."""
-    _anchors.append(anchor)
+    _anchors.set((*_anchors.get(), anchor))
 
 
 def pop_anchor(anchor: Span) -> None:
     """Drop ``anchor`` from the stack, wherever in it it sits — a failure path can close anchors out of order,
     and a stale one would go on parenting later spans into a finished span's trace."""
-    _anchors[:] = [held for held in _anchors if held is not anchor]
+    _anchors.set(tuple(held for held in _anchors.get() if held is not anchor))
 
 
 def _anchor_context() -> Any:
@@ -214,7 +216,8 @@ def _anchor_context() -> Any:
     and every episode and phase anchored beneath it is dropped — the sidecar comes back empty and the report
     reads the run as untimed.
     """
-    return trace.set_span_in_context(_anchors[-1]) if _anchors else Context()
+    anchors = _anchors.get()
+    return trace.set_span_in_context(anchors[-1]) if anchors else Context()
 
 
 def _anchor_parent() -> Any:
@@ -223,9 +226,10 @@ def _anchor_parent() -> Any:
     span parents to the innermost anchor, or roots: between scheduler hops nothing of ours is current, and a
     host application's unrelated current span must not adopt telemetry spans — they would leave the trace the
     report reduces, and take its sampling decision with them."""
-    if _anchors:
+    anchors = _anchors.get()
+    if anchors:
         current = trace.get_current_span().get_span_context()
-        if current.is_valid and current.trace_id == _anchors[-1].get_span_context().trace_id:
+        if current.is_valid and current.trace_id == anchors[-1].get_span_context().trace_id:
             return None
     return _anchor_context()
 

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -93,11 +93,14 @@ GPU_POWER_W = 'power_w'
 GPU_PROC_MEM_B = 'proc_mem_b'
 GPU_PROC_UTIL_PCT = 'proc_util_pct'
 
-# The bound provider is process-global; the anchor stack is per-context, so a thread dispatched under a copied
-# context keeps the anchors of its dispatch. An anchor is a long-running span its owner holds open (a pass, a
-# rollout): a span opened outside any active span of the bound trace parents to the innermost one, a nested
-# span to the current OTel span. The stack stands in for OTel's ambient context, which does not survive the
-# scheduler's generator hops.
+# The bound provider is process-global; the anchor stack is per-context. An anchor is a long-running span its
+# owner holds open (a pass, a rollout).
+#
+# - A span opened while no span of the bound trace is active parents to the innermost anchor.
+# - A span opened inside another parents to that one.
+# - With nothing anchored, a span roots.
+# - A thread dispatched under a copied context keeps the anchors of its dispatch, whatever is popped meanwhile.
+# - The stack stands in for OTel's ambient context, which does not survive the scheduler's generator hops.
 _provider: 'TracerProvider | None' = None
 _anchors: ContextVar[tuple[Span, ...]] = ContextVar('positronic_telemetry_anchors', default=())
 
@@ -208,22 +211,16 @@ def pop_anchor(anchor: Span) -> None:
 def _anchor_context() -> Any:
     """The context parenting a span to the innermost anchor, or a root context when nothing is anchored.
 
-    Rooting is explicit rather than ``None``, which would mean "whatever is ambient": a host application
-    embedding this code can have its own OTel span current, and inheriting it makes the span a child of a
-    foreign trace. Under parent-based sampling an unsampled host span then makes ``eval.pass`` non-recording,
-    and every episode and phase anchored beneath it is dropped — the sidecar comes back empty and the report
-    reads the run as untimed.
+    Rooting is explicit rather than ``None``: a host application's current span would adopt the span into a
+    foreign trace, and under parent-based sampling an unsampled one silences the whole sidecar.
     """
     anchors = _anchors.get()
     return trace.set_span_in_context(anchors[-1]) if anchors else Context()
 
 
 def _anchor_parent() -> Any:
-    """The parent context for a span that is not nested in an active one. A currently-active span of THIS
-    provider's trace means a genuinely nested span — ``None`` lets it parent ambiently. Otherwise the
-    span parents to the innermost anchor, or roots: between scheduler hops nothing of ours is current, and a
-    host application's unrelated current span must not adopt telemetry spans — they would leave the trace the
-    report reduces, and take its sampling decision with them."""
+    """The parent context for a span opened outside an active one: ``None`` where the current span belongs to
+    this provider's trace, so a nested span parents ambiently."""
     anchors = _anchors.get()
     if anchors:
         current = trace.get_current_span().get_span_context()
@@ -233,10 +230,8 @@ def _anchor_parent() -> Any:
 
 
 def start_span(name: str, **attrs: Any) -> Span:
-    """Start a span its caller holds and ends itself, without entering it as the OTel-current span — so it
-    never becomes the ambient parent of the enclosed code's spans. It parents to the innermost anchor, and
-    roots when nothing is anchored. Anchor it (``push_anchor``) to collect the spans opened under it.
-    A no-op while unbound returns an invalid span the caller ends harmlessly."""
+    """Start a span its caller holds and ends itself, without entering it as the OTel-current span. A no-op
+    while unbound returns an invalid span the caller ends harmlessly."""
     return _tracer().start_span(name, context=_anchor_context(), attributes=_encode_attrs(attrs))
 
 
@@ -246,9 +241,8 @@ def set_attrs(span: Span, **attrs: Any) -> None:
 
 
 def span(name: str, **attrs: Any):
-    """A wall-clock span named ``name``, entered as the current span for the enclosed block. A span opened
-    while no OTel span is active parents to the innermost anchor; a span opened inside another parents to
-    it. A no-op while unbound."""
+    """A wall-clock span named ``name``, entered as the current span for the enclosed block. A no-op while
+    unbound."""
     return _tracer().start_as_current_span(name, context=_anchor_parent(), attributes=_encode_attrs(attrs))
 
 

--- a/positronic/tests/test_telemetry.py
+++ b/positronic/tests/test_telemetry.py
@@ -1,7 +1,10 @@
+import contextvars
 import json
 import os
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
 import psutil
@@ -134,6 +137,32 @@ def test_anchor_popped_out_of_order_stops_parenting(tmp_path):
     spans = _spans_by_name(telemetry.spans_path(tmp_path, HARNESS_PROCESS))
     assert spans['probe'].parent_id == spans['inner'].span_id  # the innermost anchor still stands
     assert spans['after'].parent_id is None  # nothing anchored: the span roots rather than adopting a corpse
+
+
+def test_a_thread_records_under_the_anchor_it_was_dispatched_under(tmp_path):
+    """The anchor stack is per-context, so work handed to a thread under a copy of it records where it was
+    dispatched: a call outliving the anchor that asked for it still parents to that anchor, and the one
+    anchored in its place does not adopt it."""
+    with telemetry.bind(tmp_path, HARNESS_PROCESS, 'run-dispatch'), _anchored('pass'):
+        asked = telemetry.start_span('asked')
+        telemetry.push_anchor(asked)
+        proceed = threading.Event()
+
+        def late():
+            proceed.wait(5)
+            with telemetry.span('probe'):
+                pass
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            call = pool.submit(contextvars.copy_context().run, late)
+            asked.end()
+            telemetry.pop_anchor(asked)
+            with _anchored('next'):
+                proceed.set()
+                call.result(timeout=5)
+
+    spans = _spans_by_name(telemetry.spans_path(tmp_path, HARNESS_PROCESS))
+    assert spans['probe'].parent_id == spans['asked'].span_id
 
 
 def test_unbound_span_is_inert(tmp_path):


### PR DESCRIPTION
Closes #629.

A `policy.infer` span recorded by a call that outlived its episode parented to the pass or to the next episode, so the timing report attributed that inference to the wrong episode — in `--inference-latency` mode, the one built to measure real inference cost.

- `telemetry.py`: the anchor stack moves from a module-level list to a `ContextVar` holding an immutable tuple; `push_anchor`/`pop_anchor` rebind it.
- `harness.py`: the session call is dispatched under `contextvars.copy_context()`, so the worker keeps the anchors as they stood at dispatch whatever the loop pops meanwhile.
- `docs/telemetry.md`: states the per-context scoping, which is what makes the `policy.infer → episode` row of the span table hold for a call that outlives its episode.

## Test plan

- `test_a_thread_records_under_the_anchor_it_was_dispatched_under` (telemetry): a span emitted on a dispatched thread parents to the anchor that stood at dispatch, not to the one anchored in its place.
- `test_an_inference_outliving_its_episode_parents_to_it` (harness): a trial whose deadline lapses mid-call records `policy.infer` after the episode span closed; the test asserts the call really did outlive the episode and that the span still parents to it.
- Both fail on `main` and pass here; full suite green (1465 passed, 9 skipped).