### PR TITLE
Measure the park timeout on the world's clock, not wall time

### DIFF
--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -292,7 +292,7 @@ class Robot(pimm.ControlSystem):
                     yield desk
                     return
 
-    def _park(self, robot) -> Iterator[pimm.Sleep]:
+    def _park(self, robot, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         """Move the arm to the home pose, giving up after ``park_timeout_s``. Drive with ``yield from``.
 
         Runs after the control loop rather than in its ``finally``, so that only a stop request earns it.
@@ -308,8 +308,8 @@ class Robot(pimm.ControlSystem):
         try:
             logging.info('Parking the arm at the home pose')
             robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
-            deadline = time.monotonic() + self._park_timeout_s
-            arrived = yield from self._travel(robot, target, lambda: time.monotonic() >= deadline)
+            deadline = clock.now() + self._park_timeout_s
+            arrived = yield from self._travel(robot, target, lambda: clock.now() >= deadline)
             if not arrived:
                 logging.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
@@ -372,7 +372,7 @@ class Robot(pimm.ControlSystem):
 
                     yield rate_limiter.wait()
 
-                yield from self._park(robot)
+                yield from self._park(robot, clock)
             finally:
                 # Halt the driver's control thread before _desk_session deactivates FCI, or it dies mid-control
                 # with "TCP connection got interrupted".

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -149,7 +149,7 @@ def _driver(arm: FakeArm, *, variation: list[float] | None = None, **kwargs) -> 
 
 
 def _drive(loop, clock: MockClock | None = None) -> None:
-    """Pump a driver loop to exhaustion, honouring each yielded Sleep on ``clock`` — what the world does to it."""
+    """Pump a driver loop to exhaustion, standing in for the world by advancing ``clock`` through each Sleep."""
     clock = clock or MockClock()
     for command in loop:
         clock.advance(command.seconds)
@@ -206,7 +206,7 @@ def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
 
     clock = _drive_park(_driver(arm, manage_desk=False, park_timeout_s=0.05), arm)
 
-    # It waits out the timeout and gives up within one poll interval of it, having polled all the way.
+    # It waits out the timeout and gives up within one poll interval of it.
     assert 0.05 <= clock.now() < 0.06
     assert arm.calls.count(Call.GOAL) > 1
     np.testing.assert_allclose(arm.q, JOGGED)

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -7,7 +6,7 @@ import numpy as np
 import pytest
 
 import pimm
-from pimm.world import SystemClock
+from pimm.tests.testing import MockClock
 from positronic.drivers.roboarm import franka
 
 HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
@@ -149,16 +148,24 @@ def _driver(arm: FakeArm, *, variation: list[float] | None = None, **kwargs) -> 
     return robot
 
 
-def _drive(loop) -> None:
-    """Pump a driver loop to exhaustion, honouring each yielded Sleep — what the world does to it."""
+def _drive(loop, clock: MockClock | None = None) -> None:
+    """Pump a driver loop to exhaustion, honouring each yielded Sleep on ``clock`` — what the world does to it."""
+    clock = clock or MockClock()
     for command in loop:
-        time.sleep(command.seconds)
+        clock.advance(command.seconds)
+
+
+def _drive_park(driver: franka.Robot, arm: FakeArm) -> MockClock:
+    """Park ``arm`` under a clock that moves only by the waits the park itself asks for."""
+    clock = MockClock()
+    _drive(driver._park(arm, clock), clock)
+    return clock
 
 
 def test_park_drives_the_arm_to_the_home_pose():
     arm = FakeArm(JOGGED)
 
-    _drive(_driver(arm, manage_desk=False)._park(arm))
+    _drive_park(_driver(arm, manage_desk=False), arm)
 
     np.testing.assert_allclose(arm.targets, [HOME])
     np.testing.assert_allclose(arm.q, HOME)
@@ -168,7 +175,7 @@ def test_park_commands_the_exact_home_pose_from_inside_the_homing_spread():
     variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
     arm = FakeArm(HOME + np.asarray(variation))
 
-    _drive(_driver(arm, variation=variation, manage_desk=False)._park(arm))
+    _drive_park(_driver(arm, variation=variation, manage_desk=False), arm)
 
     # An arm inside the spread, or travelling through it, is not asked to be judged already home: the
     # controller reports arrival, and a pose it already holds arrives at once.
@@ -180,7 +187,7 @@ def test_the_park_waits_by_yielding_rather_than_blocking():
     """A driver's waits are the world's to honour, teardown included: the park asks for them with Sleep."""
     arm = FakeArm(JOGGED, polls_to_reach=3)
 
-    commands = list(_driver(arm, manage_desk=False)._park(arm))
+    commands = list(_driver(arm, manage_desk=False)._park(arm, MockClock()))
 
     assert commands and all(isinstance(command, pimm.Sleep) for command in commands)
 
@@ -188,7 +195,7 @@ def test_the_park_waits_by_yielding_rather_than_blocking():
 def test_park_gives_up_when_the_goal_stops_advancing():
     arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)
 
-    _drive(_driver(arm, manage_desk=False)._park(arm))
+    _drive_park(_driver(arm, manage_desk=False), arm)
 
     assert arm.calls.count(Call.GOAL) == 1
     np.testing.assert_allclose(arm.q, JOGGED)
@@ -197,11 +204,10 @@ def test_park_gives_up_when_the_goal_stops_advancing():
 def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
     arm = FakeArm(JOGGED, polls_to_reach=10**9)
 
-    started = time.monotonic()
-    _drive(_driver(arm, manage_desk=False, park_timeout_s=0.05)._park(arm))
-    elapsed = time.monotonic() - started
+    clock = _drive_park(_driver(arm, manage_desk=False, park_timeout_s=0.05), arm)
 
-    assert 0.05 <= elapsed < 2.0
+    # It waits out the timeout and gives up within one poll interval of it, having polled all the way.
+    assert 0.05 <= clock.now() < 0.06
     assert arm.calls.count(Call.GOAL) > 1
     np.testing.assert_allclose(arm.q, JOGGED)
 
@@ -210,7 +216,7 @@ def test_park_swallows_a_robot_that_fails_mid_move():
     arm = FakeArm(JOGGED)
     arm.raises = RuntimeError('libfranka: connection lost')
 
-    _drive(_driver(arm, manage_desk=False)._park(arm))
+    _drive_park(_driver(arm, manage_desk=False), arm)
 
     np.testing.assert_allclose(arm.q, JOGGED)
 
@@ -218,14 +224,15 @@ def test_park_swallows_a_robot_that_fails_mid_move():
 def test_teardown_parks_the_arm_before_stopping_control(desk):
     arm = FakeArm(HOME)
     stop = StopFlag()
-    loop = _driver(arm).run(stop, SystemClock())
+    clock = MockClock()
+    loop = _driver(arm).run(stop, clock)
 
     for _ in range(3):
         next(loop)
     arm.q = JOGGED  # the operator jogs the arm, then finishes the run from there
     mark = len(arm.calls)
     stop.stopped = True
-    _drive(loop)
+    _drive(loop, clock)
 
     teardown = arm.calls[mark:]
     assert teardown.index(Call.SET_TARGET_JOINTS) < teardown.index(Call.STOP)
@@ -237,7 +244,8 @@ def test_teardown_parks_the_arm_before_stopping_control(desk):
 def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
     arm = FakeArm(HOME)
     stop = StopFlag()
-    loop = _driver(arm).run(stop, SystemClock())
+    clock = MockClock()
+    loop = _driver(arm).run(stop, clock)
 
     for _ in range(3):
         next(loop)
@@ -245,7 +253,7 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
     arm.raises = RuntimeError('libfranka: connection lost')
     mark = len(arm.calls)
     stop.stopped = True
-    _drive(loop)
+    _drive(loop, clock)
 
     # the park was attempted, and its failure went no further
     assert arm.calls[mark:] == [Call.RECOVER_FROM_ERRORS, Call.STOP]
@@ -255,7 +263,8 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
 def test_a_control_fault_stops_the_arm_without_parking_it(desk):
     arm = FakeArm(HOME)
     stop = StopFlag()
-    loop = _driver(arm).run(stop, SystemClock())
+    clock = MockClock()
+    loop = _driver(arm).run(stop, clock)
 
     for _ in range(3):
         next(loop)
@@ -263,7 +272,7 @@ def test_a_control_fault_stops_the_arm_without_parking_it(desk):
     arm.raises_once = RuntimeError('libfranka: connection lost')  # the fault, not a dead arm — a park could move it
     mark = len(arm.calls)
     with pytest.raises(RuntimeError):
-        _drive(loop)
+        _drive(loop, clock)
 
     assert Call.SET_TARGET_JOINTS not in arm.calls[mark:]  # a fault is not answered with autonomous motion
     assert arm.calls[-1] == Call.STOP
@@ -275,12 +284,13 @@ def test_a_stop_during_the_reset_ends_the_run_without_a_fault(desk):
     reports failure. Reading it would turn a clean shutdown into a control fault — which skips the park."""
     arm = FakeArm(JOGGED, polls_to_reach=10**9)  # the opening reset never lands on its own
     stop = StopFlag()
-    loop = _driver(arm).run(stop, SystemClock())
+    clock = MockClock()
+    loop = _driver(arm).run(stop, clock)
 
     next(loop)  # suspended inside the reset's travel
     stop.stopped = True
     arm.goal_status = franka.pf.GoalStatus.ABORTED
 
-    _drive(loop)
+    _drive(loop, clock)
 
     assert arm.calls[-1] == Call.STOP


### PR DESCRIPTION
`Robot._park` takes the `pimm.Clock` its run loop already holds and computes the park deadline from it, rather than reading `time.monotonic()`. The Franka driver tests drive every loop on a `MockClock` they advance by exactly the `Sleep` each yield asks for, so no test in that file waits on wall time.

## Why

`run` already carries the world's clock and hands it to everything it drives; the park's deadline was the one wait read off a different source. Under a simulated world that makes `park_timeout_s` mean wall seconds while every other duration the driver reasons about means world seconds.

It also made the timeout test depend on the machine underneath it. The test drove the park with real `time.sleep` and asserted the goal was polled more than once inside a 50 ms budget. On `main` at 6d6358db the macOS runner — three xdist workers sharing three cores — overshot a single 5 ms sleep past the whole budget, so exactly one poll happened and `core (macos-latest, 3.13)` failed. Virtual time removes that dependency and lets the test assert the stronger property instead: the park gives up within one poll interval of its deadline.

The live alternative was to leave the driver on wall time and fake `time.monotonic` from the test. That silences the flake and leaves the driver's only timeout measured against a clock the world does not own, which is the half worth fixing.

## Verification

Full suite in the worktree: 1479 passed, 9 skipped. `positronic/drivers/roboarm/tests/test_franka.py`: 10 passed in 0.6 s, and its timeout case now ends at exactly 0.05 virtual seconds after 10 polls rather than sleeping. `ruff check` and `ruff format --check` clean; the repo's pre-commit ratchet ran on the commit.

## Refs

Positronic-Robotics/internal#559

<!-- opened-by: posi-agent -->