### PR TITLE
Add the fault guard to a declared stack that carries none

### DIFF
--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -9,7 +9,7 @@ from websockets.exceptions import InvalidStatus
 from websockets.http11 import Response
 
 from positronic import keys, telemetry, telemetry_keys
-from positronic.drivers.roboarm import command
+from positronic.drivers.roboarm import RobotStatus, command
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _ConnectRetries
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
@@ -401,6 +401,30 @@ def test_unknown_declared_entry_fails_before_motion():
     policy, _ = _mock_remote_policy({'local_stack': {'name': 'run_arbitrary_code'}, keys.POSITRONIC_VERSION: '9.9.9'})
     with pytest.raises(ValueError, match='9.9.9'):
         policy.new_session()
+
+
+def test_a_declared_stack_without_the_fault_guard_is_given_one():
+    """A faulted arm reports its status and no pose, which a declared stack reading poses by name cannot
+    answer. The rig adds ``stop_on_fault`` outside such a stack, so the observation is answered rather
+    than raised on (Positronic-Robotics/internal#558)."""
+    policy, _ = _mock_remote_policy({
+        'local_stack': {
+            'seq': [
+                {'name': 'temporal_stack', 'args': {'keys': [keys.EE_POSE], 'offsets_sec': [0.0]}},
+                {'name': 'chunked_schedule'},
+            ]
+        }
+    })
+    session = policy.new_session(now=lambda: 0.0)
+    assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: RobotStatus.ERROR}) == []
+
+
+def test_a_declared_fault_guard_is_built_exactly_as_declared():
+    """A stack that declares the guard itself is built as declared — same wrappers, same order — so the
+    rig adds nothing and the declaration keeps deciding where the guard sits."""
+    declared = {'seq': [{'name': 'stop_on_fault'}, {'name': 'chunked_schedule'}]}
+    policy, _ = _mock_remote_policy({'local_stack': declared})
+    assert policy._resolve_stack().to_spec() == declared
 
 
 def test_compression_follows_the_server_declaration():

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -1,4 +1,5 @@
 import collections.abc as cabc
+import logging
 import time
 from typing import Any
 
@@ -13,6 +14,7 @@ from positronic.utils.serialization import encode_jpeg
 from .base import Policy, PolicyWrapper, Session
 from .recording import Recorder
 from .spec import from_spec
+from .wrappers import StopOnFault
 
 
 class RemoteSession(Session):
@@ -74,6 +76,8 @@ class _Endpoint(Policy):
     """
 
     def __init__(self, url: str, *, headers: dict[str, str] | None, infer_timeout: float):
+        # Credentials travel in ``headers``, never here, so this is safe to log.
+        self.url = url
         self._client = InferenceClient(url, headers=headers, infer_timeout=infer_timeout)
         # Filled on first contact, via a throwaway session if ``meta`` is read before any real one exists.
         self._server_meta: dict[str, Any] | None = None
@@ -140,6 +144,19 @@ class RemotePolicy(Policy):
                 f'Server declares no rig-side stack (server positronic {version}); the rig runs what the '
                 f'handshake declares and nothing else, so serve it from a pipeline that declares one'
             )
+        # The one departure from "the rig runs what the handshake declares and nothing else": an arm that
+        # faults reports its status and no q/dq/ee_pose, and a declared stack reading those by name raises
+        # on the control loop's thread, ending the run (Positronic-Robotics/internal#558). The guard goes
+        # outermost, where it answers that observation before anything declared sees it.
+        if not any(isinstance(component, StopOnFault) for component in stack._wrappers()):
+            logging.warning(
+                'Endpoint %s declares a rig-side stack with no %r, so the rig is adding one in front of it: '
+                'without it a faulted arm ends the run. The stack being run is NOT the one the handshake '
+                'declares (Positronic-Robotics/internal#558).',
+                self._endpoint.url,
+                StopOnFault.WIRE_NAME,
+            )
+            stack = StopOnFault() | stack
         return stack
 
     def _policy(self) -> Policy:


### PR DESCRIPTION
An arm that faults reports its status and no `q`/`dq`/`ee_pose`. A rig-side stack that reads
those by name raises on the control loop's thread, which ends the run.

Both of today's lab rollouts died that way, the second at 8 of 30 episodes:
`KeyError: 'robot_state.ee_pose'` in `TemporalStack._Session.__call__`.

All three Runway endpoints declare, verbatim in every episode's `static.json`:
`temporal_stack | chunked_schedule | restrict_image_size` — no `stop_on_fault` on any of
them, so nothing answered that observation.

## What changes

`RemotePolicy._resolve_stack` prepends `StopOnFault()` when the declared stack contains
none, so the guard sits outside everything the handshake declared and answers the
pose-less observation before any declared wrapper sees it. A declared `stop_on_fault` is
left exactly as declared — same wrappers, same order.

This deliberately bends the documented contract that "the rig runs what the handshake
declares and nothing else", so every injection logs at WARNING naming the endpoint. A rig
silently running a stack the partner did not declare is the thing that must not become
invisible.

## Tests

- `test_a_declared_stack_without_the_fault_guard_is_given_one` — fails without the change
  with the production `KeyError` at `wrappers.py:196`, passes with it.
- `test_a_declared_fault_guard_is_built_exactly_as_declared` — pins the boundary: a stack
  declaring the guard is built as declared, so nothing is added and the declaration keeps
  deciding where the guard sits.

`positronic/tests/test_keys.py` + `positronic/offboard/tests/` + `positronic/policy/tests/`:
305 passed, 1 skipped. CI green on `175ff1a1`, all 17 jobs.

## Rules check

13 rules, 2 findings, both now resolved.

`diff-comments` — applied: a comment justified a field by naming a distant consumer.

`hardcoded-keys` on the test's `robot_state.ee_pose` — I first declined this, reasoning that a
fixture should spell the wire name rather than import a constant, since a shared constant makes
client and wire agree whatever the value. This repository settles that question the other way
and enforces it mechanically: `positronic/tests/test_keys.py::test_no_guarded_key_literals`
fails on exactly that literal. The repo's own executable rule wins, so the test now imports
`keys.EE_POSE`. The other accepted literals are unguarded handshake field names, which that
test does not cover.

## Deployment note

The lab rig cannot run this commit: `#641` removed `positronic.policy.harness.Directive`,
which the rollouts console's `eval_ui` imports, so a console pinned to `main` dies at
launcher import. The rig runs `14354007f6dca7b435280c06144fc11d26e8e116` (branch
`rollouts/inject-stop-on-fault-rig`) on the pre-`#641` base. `positronic/policy/remote.py` is
byte-identical between that commit and this PR's head; they differ only in the one test line
above, which the rig does not import. The console has to be updated for the `#641` API change
before its pin can follow main.

Not for merge without a named human's go.

Ticket: Positronic-Robotics/internal#558
