### PR TITLE
Drop the inference recommendation from `collision_coeff`

### DIFF
--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -124,7 +124,6 @@ class Robot(pimm.ControlSystem):
         :param home_joints: Joints of "reset" position, and the pose the arm is parked at when the run ends.
         :param home_joints_variation: Max random deviation per joint in radians. Set to [0]*7 to disable.
         :param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
-            Default 2.0 (data collection). Use 6.0 for inference.
         :param manage_desk: Run the Desk session from the driver: open the brakes and activate FCI on start, close
             them on stop. Requires ``FRANKA_DESK_USER`` and ``FRANKA_DESK_PASSWORD`` in the environment. Set to
             False to leave brakes and FCI to the operator; the driver then never contacts Desk and expects FCI to


### PR DESCRIPTION
Documentation only. No value, default or config changes — the coefficient the arm runs at is untouched.

## What the docstring says

```
:param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
    Default 2.0 (data collection). Use 6.0 for inference.
```

The second line goes. What is left states what the coefficient means and which direction it moves, both still true:

```
:param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
```

## Why

Nothing in this repository — or in the platform repository that now carries the eval console — sets 6.0. `git grep collision_coeff` on `main` returns the driver, the `positronic.cfg.hardware.roboarm.franka` wrapper, and nothing else; both carry the default of 2.0.

It was true for eight days:

- `7efe5b7b` (#337, 2026-03-05) made the coefficient a parameter, defaulting to 2.0 — the value that had been hardcoded in `_init_robot` before it — and set `robot_arm.collision_coeff: 6.0` on the `phail` inference subcommand. The docstring was written in that commit and has not been touched since.
- `b8a9bb4a` (#344, 2026-03-13) changed that override to 2.0: *"and tune `collision_coeff` to 2.0."* The docstring was left alone, and has been wrong from that day.
- `65f07eb1` (#605, 2026-08-12) deleted the `phail` subcommand along with the eval consoles, taking the last override with it. The recommended value has had no reader anywhere since.

## The `(data collection)` parenthetical goes too

It labelled 2.0 as the data-collection value, which only carries information against a contrasting inference value. With that gone, it asserts a use-split this repository no longer makes — after `65f07eb1` no path here distinguishes a data-collection run from an inference one, so a reader would be looking for a distinction that is not there.

The default itself is on the signature two lines above (`collision_coeff: float = 2.0`), so restating it in prose is a second copy that can drift.

## Scope

- One line deleted, one file. No behaviour change, and none intended: raising the threshold is a live-arm decision and is not this PR's to make.
- No other copy of the guidance exists — `git grep` for the wording and for `collision_coeff` across `main` finds this docstring and nothing else. The `positronic.cfg.hardware.roboarm` wrapper has no docstring.
- No test asserts on the docstring text.

Related and **not** in this PR: platform's `rollouts/console/rollouts_console/run.py` overrides `embodiment.robot_arm.collision_coeff` to 2.0 at two sites, which equals the driver default and so changes nothing, under a comment saying an operator jogging between episodes trips the reflex at the stock coefficient. That is a separate defect in a separate repository.

`Ticket: Positronic-Robotics/internal#564`

Rules check: 13/13 clean against this repository's `CODE_RULES.md`, commit `06c0925f`.

Codex will not review this one — the `vertix` PAT that posts the review mention is 401ing fleet-wide (internal#523).

<!-- opened-by: posi-agent -->