### PR TITLE
Move `privileged`, `done` and `reset` from `Task` to `Eval`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,7 +133,7 @@ the wrapper stack around the policy; a session returning `None` means "keep exec
 trajectory".
 
 **Inference cost is a fact of the trial, owned by the harness.** A call costs the trial either the
-wall time it took or nothing: the trial context's `inference_latency` flag asks a sim for the former,
+wall time it took or nothing: the trial context's `charge_inference_time` flag asks a sim for the former,
 and a real rig pays it regardless. Only the harness reads the flag. Paying nothing means holding the
 world for the call, which holds a virtual clock still; paying wall time means letting the world run,
 though no further ahead of the call's start than wall time has. The clock the harness hands the

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -11,7 +11,7 @@ You ship a new checkpoint and want a clean answer to one question: is it actuall
 - **One checkpoint, every target.** Sim: LIBERO, RoboLab (NVIDIA Isaac Lab), MolmoSpaces. Real hardware: the DROID setup (Franka FR3 + Robotiq 2F-85), bimanual next. Serve a DROID policy once and it runs across all of them, and on the rig, with nothing to port. Sim for cheap, broad iteration; real hardware as ground truth.
 - **Blinded A/B.** Your checkpoint against your own previous checkpoints, or against our maintained baselines (π0.5, GR00T, SmolVLA, ACT) — randomized and blinded, so lighting and setup drift don't bias the result.
 - **Every run returned.** Multi-view video, full telemetry, and the complete run dataset — not just a success rate. Yours to analyze.
-- **Latency-honest execution.** On real hardware, inference and network delay are real — a slow model is scored as slow. In sim the world pauses during inference by default (as in other harnesses), but you can charge the model's measured inference time with `--inference_latency=True`, so sim scores reflect the delay the robot would actually feel — something sim-only harnesses can't model.
+- **Latency-honest execution.** On real hardware, inference and network delay are real — a slow model is scored as slow. In sim the world pauses during inference by default (as in other harnesses), but you can charge the model's measured inference time with `--charge_inference_time=True`, so sim scores reflect the delay the robot would actually feel — something sim-only harnesses can't model.
 
 ## How it works
 
@@ -39,7 +39,7 @@ uv run positronic-server --dataset.path=~/evals/libero \
 
 **One server, many targets.** Every target publishes the same observation keys (see [the wire format](connect-your-model.md#the-wire-format)), so a DROID policy served once is scored on LIBERO, RoboLab, MolmoSpaces and our rig without a restart. Running everywhere is not the same as being comparable everywhere: each benchmark points `image.exterior` at its own camera, so a checkpoint scored on a target it was never trained for measures the viewpoint gap as much as the policy. Your own model is served the same way — [Connect your model](connect-your-model.md).
 
-`--eval` takes any target the catalog exposes: a whole benchmark (`.sim.libero.all`), a suite or category (`.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). Add `--inference_latency=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`, carrying whatever verdict its benchmark reported.
+`--eval` takes any target the catalog exposes: a whole benchmark (`.sim.libero.all`), a suite or category (`.sim.robolab.visual`), or one task (`.sim.robolab.banana_in_bowl`). Add `--charge_inference_time=True` to charge the model's inference time in sim. Every trial is recorded as a Positronic dataset under `--output_dir`, carrying whatever verdict its benchmark reported.
 
 Real-hardware DROID evals take the same model endpoint, but we run them for you — operated and operator-scored on our fleet, not self-driven in sim. Write to hi@phail.ai for those.
 

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -57,13 +57,7 @@ def _libero_eval(
         proxy, camera_dict, descriptor='remote.libero.franka', static_meta=bundled_panda_model()
     )
     privileged = {'sim_state': Observation(proxy.privileged['sim_state'], None)}
-    task = Task(
-        instruction=lambda: proxy.meta['task'],
-        timeout=timeout,
-        privileged=privileged,
-        reset=proxy.reset,
-        done=proxy.done,
-    )
+    task = Task(instruction=lambda: proxy.meta['task'], timeout=timeout)
     # One scene per (suite, task) pair: an unbound ``task_id`` sweeps each suite, a pinned one runs that task
     # in every bound suite. The scene spec rides each trial's reset token, so the single task-agnostic env
     # server serves every trial.
@@ -78,7 +72,14 @@ def _libero_eval(
         for s in ([suite] if isinstance(suite, str) else suite)
         for t in ([task_id] if task_id is not None else range(_SUITE_NUM_TASKS[s]))
     ]
-    return Eval(embodiment, task, build_trials(seed, trial_count, scenes))
+    return Eval(
+        embodiment,
+        task,
+        build_trials(seed, trial_count, scenes),
+        privileged=privileged,
+        done=proxy.done,
+        reset=proxy.reset,
+    )
 
 
 # Each suite binds only its LIBERO ``suite``; an unbound ``task_id`` sweeps the whole suite, ``--eval.task_id``

--- a/positronic/cfg/eval/sim/positronic.py
+++ b/positronic/cfg/eval/sim/positronic.py
@@ -25,9 +25,9 @@ from positronic.utils import package_assets_path
 def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, instruction, timeout, seed, trial_count):
     """A Mujoco Franka sim eval: the eval holds the sim, the embodiment is pure robot.
 
-    The task carries the instruction, the per-trial ``timeout``, the privileged sim-state
-    ground truth (built from the eval's sim, recorded but never fed to the policy), and the
-    sim's seeded scene reset. The scene (``loaders``) is embodiment-specific and wired here,
+    The task carries the instruction and the per-trial ``timeout``; the eval carries the
+    privileged sim-state ground truth (recorded but never fed to the policy) and the sim's
+    seeded scene reset. The scene (``loaders``) is embodiment-specific and wired here,
     not a generic Task field; the loaders carry no seeds of their own — the per-trial seed
     handed to ``sim.reset`` drives the whole scene draw. ``trial_count`` seeds (from ``seed``)
     make the trial sweep; this eval has no task axis, so each is a fresh scene draw.
@@ -36,13 +36,13 @@ def _mujoco_franka_eval(mujoco_model_path, loaders, camera_fps, camera_dict, ins
     embodiment = mujoco_franka(sim, camera_dict)
     # Full sim state is the privileged ground truth; scoring is computed downstream.
     privileged = {'sim_state': Observation(sim.sim_state, None)}
-    task = Task(
-        instruction=instruction,
-        timeout=timeout,
+    return Eval(
+        embodiment,
+        Task(instruction=instruction, timeout=timeout),
+        build_trials(seed, trial_count),
         privileged=privileged,
         reset=lambda ctx: sim.reset(ctx.get('eval.seed')),
     )
-    return Eval(embodiment, task, build_trials(seed, trial_count))
 
 
 stack_cubes = _mujoco_franka_eval.override(instruction='Pick up the green cube and place it on the red cube.')

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -191,14 +191,11 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
         ctx.update({'eval.trial_index': i, 'eval.trial_count': len(trials)})
     return Eval(
         embodiment,
-        Task(
-            instruction=lambda: proxy.meta['task'],
-            timeout=timeout,
-            privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
-            reset=proxy.reset,
-            done=proxy.done,
-        ),
+        Task(instruction=lambda: proxy.meta['task'], timeout=timeout),
         trials,
+        privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
+        done=proxy.done,
+        reset=proxy.reset,
     )
 
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -193,7 +193,7 @@ def run(
     eval: Eval | str,
     policy,
     output_dir=None,
-    inference_latency: bool = False,
+    charge_inference_time: bool = False,
     timing=False,
     policy_image: str | None = None,
     alias: str | None = None,
@@ -220,10 +220,12 @@ def run(
         _refuse({'--alias': alias, '--transaction-key': transaction_key, '--platform-url': platform_url}, 'local')
         if not isinstance(eval, Eval):
             raise SystemExit(f'--eval={eval!r} is a name, not a config: pass --policy-image to run it on the platform')
-        # The eval config owns the trial sweep (seed, task range); ``inference_latency`` is the CLI's per-run knob
-        # (whether a sim charges each call its wall time). Overlay it onto every trial context, then self-drive
-        # the eval.
-        eval = replace(eval, trials=[{**trial, keys.INFERENCE_LATENCY: inference_latency} for trial in eval.trials])
+        # The eval config owns the trial sweep (seed, task range); ``charge_inference_time`` is the CLI's
+        # per-run knob (whether a sim charges each call the time it took). Overlay it onto every trial
+        # context, then self-drive the eval.
+        eval = replace(
+            eval, trials=[{**trial, keys.CHARGE_INFERENCE_TIME: charge_inference_time} for trial in eval.trials]
+        )
         main(policy=policy, evals=[eval], output_dir=output_dir, timing=timing)
         return None
 
@@ -232,5 +234,7 @@ def run(
     if not isinstance(eval, str):
         raise SystemExit('the platform names its own evals: pass --eval=<name>, e.g. --eval=robolab.public_subset')
     # The platform owns its own trial sweep, its own output and its own telemetry.
-    _refuse({'--output-dir': output_dir, '--inference-latency': inference_latency, '--timing': timing}, 'platform')
+    _refuse(
+        {'--output-dir': output_dir, '--charge-inference-time': charge_inference_time, '--timing': timing}, 'platform'
+    )
     return submit(eval, policy_image, alias=alias, transaction_key=transaction_key, platform_url=platform_url)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -17,7 +17,7 @@ from positronic.cfg.eval import placeholder
 from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
-from positronic.eval import Embodiment, Eval, Task
+from positronic.eval import Embodiment, Eval
 from positronic.policy.harness import Harness
 from positronic.simulator.env_server.telemetry import ATTR_RUN_ID, ENV_RUN_ID, ENV_TELEMETRY_DIR
 
@@ -44,20 +44,19 @@ def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
     return local_dir
 
 
-def _run_world(policy, embodiment: Embodiment, task: Task | None, trials: list[dict] | None, output_dir: Path | None):
-    """Wire one embodiment under a fresh Harness + World and run it to completion.
+def _run_world(policy, ev: Eval, output_dir: Path | None):
+    """Wire one eval's embodiment under a fresh Harness + World and run it to completion.
 
-    The harness self-drives ``trials``; the shared ``policy``'s lifetime stays with ``main``.
+    The harness self-drives ``ev.trials``; the shared ``policy``'s lifetime stays with ``main``.
     """
-    harness = Harness(policy, embodiment, task=task, trials=trials)
+    embodiment = ev.embodiment
+    harness = Harness(policy, embodiment, task=ev.task, trials=ev.trials, reset=ev.reset)
 
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
     with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
-        privileged = task.privileged if task is not None else {}
-        done = task.done if task is not None else None
         ds_agent = wire.wire_embodiment(
-            world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
+            world, harness, embodiment, dataset_writer, time_mode, privileged=ev.privileged, done=ev.done
         )
         if ds_agent is not None:
             world.connect(harness.ds_command, ds_agent.command)
@@ -173,7 +172,7 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     try:
         with timed_pass(output_dir, timing, policy):
             for ev in evals:
-                _run_world(policy, ev.embodiment, ev.task, ev.trials, output_dir)
+                _run_world(policy, ev, output_dir)
     finally:
         policy.close()
 

--- a/positronic/cli/eval/tests/test_run_on_the_platform.py
+++ b/positronic/cli/eval/tests/test_run_on_the_platform.py
@@ -120,7 +120,7 @@ def test_a_run_cannot_be_both_here_and_there(platform, run_command):
     assert platform.seen is None
 
 
-@pytest.mark.parametrize('local_only', [{'timing': True}, {'output_dir': '/tmp/x'}, {'inference_latency': True}])
+@pytest.mark.parametrize('local_only', [{'timing': True}, {'output_dir': '/tmp/x'}, {'charge_inference_time': True}])
 def test_a_platform_run_refuses_what_only_a_local_run_can_mean(platform, run_command, local_only: dict):
     # The platform owns its own trial sweep, output and telemetry, so silently dropping these would
     # hand back a run the caller believes they configured.

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -105,6 +105,14 @@ class Task:
         return self._instruction()
 
 
+# TODO: the attended and the unattended run collapse into one path.
+# Roadmap:
+# [ ] ``privileged``, ``done`` and ``reset`` are per-run: they move to ``Eval``.
+# [ ] ``trials`` becomes ``list[Task]``, one per trial; a ``Task`` carries what ``reset`` is called with.
+# [ ] The Harness takes the list and who advances it — a plan or a call.
+# [ ] One runner builds the world for both.
+# [ ] Split the reset token from the policy input: the instruction is all a trial gives the policy.
+# [ ] ``inference_latency`` is a ``Task`` field, not a context key.
 @dataclass
 class Eval:
     """An eval = embodiment + task + the trial sweep, produced by a single config.

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -92,7 +92,7 @@ class Task:
 # [ ] ``trials`` becomes ``list[Task]``, one per trial; a ``Task`` carries what ``reset`` is called with.
 # [ ] A driver walks the list and calls ``perform_task(task)``; the Harness keeps no plan.
 # [ ] ``reset`` becomes a call on the embodiment: a sim answers at once, a real rig when the human is done.
-# [ ] ``inference_latency`` is a ``Task`` field, not a context key.
+# [ ] ``charge_inference_time`` is a ``Task`` field, not a context key.
 # [ ] One runner builds the world for both.
 # [ ] Split the reset token from the policy input: the instruction is all a trial gives the policy.
 @dataclass

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -67,62 +67,46 @@ class Embodiment:
 
 
 class Task:
-    """The scenario layered on an embodiment: the policy-facing instruction plus
-    the privileged ground-truth signals to record.
+    """The scenario layered on an embodiment: the policy-facing instruction and the trial's time budget.
 
     ``instruction`` is the language goal the policy conditions on, resolved live on every read: an embodiment
     that only learns its task on reset (a remote env reporting it in meta) passes a source callable, while a
     fixed scenario passes a plain string (wrapped as a constant). ``timeout`` is the per-trial time budget in
-    seconds (sim-time for simulated embodiments, wall-clock for real). ``privileged`` maps a record key to the
-    ground-truth source to capture (the sim's full ``save_state``, a real scale) — recorded but never fed to
-    the policy.
-
-    ``reset`` re-randomizes the scene for a new trial from the per-trial run context, reading the keys it
-    needs (e.g. ``eval.seed``, and ``eval.task_id`` for a multi-task suite); ``None`` on real embodiments,
-    where reset is physical/human.
-
-    ``done`` is the optional terminating signal: a source that delivers a dict payload when the
-    trial ends. The Harness reads it to stop the trial early and records the payload into the
-    episode's static data.
+    seconds (sim-time for simulated embodiments, wall-clock for real).
     """
 
-    def __init__(
-        self,
-        instruction: str | Callable[[], str],
-        timeout: float,
-        privileged: dict[str, Observation] | None = None,
-        reset: Callable[[dict[str, Any]], None] | None = None,
-        done: pimm.SignalEmitter | None = None,
-    ):
+    def __init__(self, instruction: str | Callable[[], str], timeout: float):
         self._instruction = (lambda: instruction) if isinstance(instruction, str) else instruction
         self.timeout = timeout
-        self.privileged = privileged or {}
-        self.reset = reset
-        self.done = done
 
     @property
     def instruction(self) -> str:
         return self._instruction()
 
 
+# rules-allow: stale-doc — a plan is read for what is left, which needs the landed steps marked
+# rules-allow: diff-comments — the marks are the plan's state, not a note about an edit
 # TODO: the attended and the unattended run collapse into one path.
 # Roadmap:
-# [ ] ``privileged``, ``done`` and ``reset`` are per-run: they move to ``Eval``.
+# [✓] ``privileged``, ``done`` and ``reset`` are per-run: they move to ``Eval``.
 # [ ] ``trials`` becomes ``list[Task]``, one per trial; a ``Task`` carries what ``reset`` is called with.
-# [ ] The Harness takes the list and who advances it — a plan or a call.
+# [ ] A driver walks the list and calls ``perform_task(task)``; the Harness keeps no plan.
+# [ ] ``reset`` becomes a call on the embodiment: a sim answers at once, a real rig when the human is done.
+# [ ] ``inference_latency`` is a ``Task`` field, not a context key.
 # [ ] One runner builds the world for both.
 # [ ] Split the reset token from the policy input: the instruction is all a trial gives the policy.
-# [ ] ``inference_latency`` is a ``Task`` field, not a context key.
 @dataclass
 class Eval:
     """An eval = embodiment + task + the trial sweep, produced by a single config.
 
-    For a sim eval that config holds the shared ``MujocoSim`` both are built from, so the
-    embodiment stays pure robot while the task carries the scene's privileged signals. ``trials`` is the
-    sequence of task contexts the self-driving Harness runs — one per (task variant, seed) the config sweeps;
-    empty for an attended/real eval, whose episodes begin on a call rather than on a trial plan.
+    ``privileged``, ``done`` and ``reset`` are per-run, not per-trial: the World wires the signals once,
+    before it runs. ``trials`` is the sequence of task contexts the self-driving Harness runs — one per
+    (task variant, seed) the config sweeps; empty for an attended/real eval, whose episodes begin on a call.
     """
 
     embodiment: Embodiment
     task: Task
     trials: list[dict[str, Any]] = field(default_factory=list)
+    privileged: dict[str, Observation] = field(default_factory=dict)
+    done: pimm.SignalEmitter | None = None
+    reset: Callable[[dict[str, Any]], None] | None = None

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -101,7 +101,7 @@ EVAL_TERMINATED = 'eval.terminated'
 EVAL_ENDED_BY = 'eval.ended_by'
 ENDED_BY_OPERATOR = 'operator'
 
-# Whether a model call charges the world clock its own wall duration. A flag: any other type is rejected
+# Whether a model call charges the world clock the time it really took. A flag: any other type is rejected
 # when the episode starts. A sim trial without it charges nothing (the world holds still per call);
-# hardware always pays wall whatever the trial asks.
-INFERENCE_LATENCY = 'inference_latency'
+# hardware always pays whatever the trial asks.
+CHARGE_INFERENCE_TIME = 'charge_inference_time'

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -357,12 +357,12 @@ class Harness(pimm.ControlSystem):
         # rather than overhead the timing reducer attributes to this one.
         self._reap_worker()
         self.context = context
-        latency = self.context.get(keys.INFERENCE_LATENCY, False)
-        if not isinstance(latency, bool):
-            raise ValueError(f'{keys.INFERENCE_LATENCY} is a flag, got {latency!r}')
+        charge_inference_time = self.context.get(keys.CHARGE_INFERENCE_TIME, False)
+        if not isinstance(charge_inference_time, bool):
+            raise ValueError(f'{keys.CHARGE_INFERENCE_TIME} is a flag, got {charge_inference_time!r}')
         # A real rig pays wall time whatever the trial asks: the knob is sim-only, and the eval CLI writes it
         # into every trial.
-        charge_wall = latency or not self._embodiment.simulated
+        charge_wall = charge_inference_time or not self._embodiment.simulated
         self._awaiting_obs = set(self._embodiment.observations)
         self._rollout_started = False
         # Before the reset, so the reset and the rollout's other phase spans parent to the episode span.

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -3,7 +3,7 @@ import contextvars
 import logging
 import time
 from collections import deque
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
@@ -214,11 +214,14 @@ class Harness(pimm.ControlSystem):
         *,
         task: Task | None = None,
         trials: Iterable[dict[str, Any]] | None = None,
+        reset: Callable[[dict[str, Any]], None] | None = None,
         static_meta: dict[str, Any] | None = None,
     ):
         assert trials is None or task is not None, 'A trial plan needs a task: its timeout bounds each trial'
         self._embodiment = embodiment
         self._task = task
+        # Re-randomizes the scene from the trial's context; ``None`` where reset is physical/human.
+        self._reset = reset
         # Each entry is a task context; when None, ``perform_task`` is the only lifecycle source.
         self._trials = iter(trials) if trials is not None else None
         self.policy: Policy = policy
@@ -344,9 +347,9 @@ class Harness(pimm.ControlSystem):
     ) -> None:
         """Open a fresh episode: reset the scene, fix the task context and session, and open the recording.
 
-        A resettable task's ``reset`` only arms the producer; the first observation lands a later round. The
-        recorder drains its channels the turn it opens, so the pre-reset frame and the inter-episode home
-        command drop out. The deadline is armed here and moved to that first observation once it lands.
+        ``reset`` only arms the producer; the first observation lands a later round. The recorder drains its
+        channels the turn it opens, so the pre-reset frame and the inter-episode home command drop out. The
+        deadline is armed here and moved to that first observation once it lands.
         """
         # Before anything that can raise, so an episode that fails to open still answers whoever asked for it.
         self._call = call
@@ -364,11 +367,11 @@ class Harness(pimm.ControlSystem):
         self._rollout_started = False
         # Before the reset, so the reset and the rollout's other phase spans parent to the episode span.
         self._telemetry.begin(context)
-        # Reset before opening the session: a resettable task only learns its instruction on reset (a remote
-        # env reports it then), so the session context — and the sampling it drives — must read it here.
-        if self._task is not None and self._task.reset is not None:
+        # Reset before opening the session: an env may only learn its instruction on reset (a remote env
+        # reports it then), so the session context — and the sampling it drives — must read it here.
+        if self._reset is not None:
             with telemetry.span(telemetry_keys.SPAN_RESET):
-                self._task.reset(self.context)
+                self._reset(self.context)
         if self._task is not None:
             self.context = {**self.context, keys.TASK: self._task.instruction}
         self._worker = _InferenceWorker(self.policy, self.context, charge_wall, clock)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -943,7 +943,7 @@ def test_timeout_during_inference_drops_the_chunk(world):
         ChunkedSchedule().wrap(SlowPolicy(wall_sec=0.3)),  # the call runs well past the deadline
         make_embodiment(simulated=True),
         task=Task(instruction='test', timeout=0.05),
-        trials=[{keys.INFERENCE_LATENCY: True}],
+        trials=[{keys.CHARGE_INFERENCE_TIME: True}],
     )
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
@@ -1051,7 +1051,7 @@ def test_a_producer_reusing_its_buffer_cannot_rewrite_a_pending_observation(worl
         p['grip_em'].emit(0.25)
 
     driver = ManualDriver([
-        (partial(p['perform_task'], {keys.TASK: 't', keys.INFERENCE_LATENCY: True}), 0.0),
+        (partial(p['perform_task'], {keys.TASK: 't', keys.CHARGE_INFERENCE_TIME: True}), 0.0),
         (partial(emit_frame, 1), 0.01),
         (partial(emit_frame, 9), 0.05),  # rewrites the buffer while the first call is still running
         (None, 0.4),
@@ -1506,7 +1506,7 @@ def test_an_inference_outliving_its_episode_parents_to_it(world, tmp_path):
         ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3)),  # the call runs well past the deadline
         make_embodiment(simulated=True),
         task=Task(instruction='stack', timeout=0.05),
-        trials=[{keys.INFERENCE_LATENCY: True}],
+        trials=[{keys.CHARGE_INFERENCE_TIME: True}],
         reset=lambda context: None,
     )
     p = _pair_all(world, harness)
@@ -1759,7 +1759,7 @@ def _run_episode(
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
-        (partial(perform_task, {keys.TASK: 't', keys.INFERENCE_LATENCY: latency}), 0.0),
+        (partial(perform_task, {keys.TASK: 't', keys.CHARGE_INFERENCE_TIME: latency}), 0.0),
         (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.001),
         (None, run_sec),
     ])
@@ -1780,7 +1780,7 @@ def test_default_latency_pauses_the_world_for_the_call(world):
 
 @pytest.mark.timeout(20.0)
 def test_measured_latency_charges_the_calls_own_wall_duration(world):
-    """``inference_latency=True`` charges the world what the model really took, so a slow server is scored
+    """``charge_inference_time=True`` charges the world what the model really took, so a slow server is scored
     as slow — at the cost of a trace that inherits the machine's noise."""
     played = _run_episode(world, SlowPolicy(wall_sec=0.2), ChunkedSchedule(), latency=True)
 
@@ -2198,7 +2198,7 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
-        (partial(perform_task, {keys.TASK: 't', keys.INFERENCE_LATENCY: True}), 0.0),
+        (partial(perform_task, {keys.TASK: 't', keys.CHARGE_INFERENCE_TIME: True}), 0.0),
         (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.001),
         (None, 0.05),  # well inside the 1.0s the call takes
         (partial(done_em.emit, OPERATOR_DONE), 0.0),

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -809,9 +809,8 @@ def test_policy_first_obs_is_frame0(world):
         control_systems=(device,),
         simulated=True,
     )
-    task = Task(instruction='t', timeout=100.0, reset=device.reset)
     policy = StubPolicy()
-    harness = Harness(policy, embodiment, task=task, trials=[{}])
+    harness = Harness(policy, embodiment, task=Task(instruction='t', timeout=100.0), trials=[{}], reset=device.reset)
     wire.wire_embodiment(world, harness, embodiment, None)
 
     scheduler = world.start([harness, device])
@@ -824,7 +823,7 @@ def test_policy_first_obs_is_frame0(world):
 
 @pytest.mark.timeout(3.0)
 def test_task_done_terminates_through_wire_embodiment(world):
-    """A Task's ``done`` source reaches ``harness.done`` through ``wire_embodiment`` and ends the
+    """An eval's ``done`` source reaches ``harness.done`` through ``wire_embodiment`` and ends the
     trial, recording its payload — the production wiring path, not a direct port pairing."""
 
     class _Device(pimm.ControlSystem):
@@ -850,13 +849,12 @@ def test_task_done_terminates_through_wire_embodiment(world):
         static_meta={},
         meta_source=None,
     )
-    task = Task(instruction='t', timeout=100.0, done=device.done)
     # Termination is independent of the policy wrappers; the minimal embodiment has no
     # ``robot_state``, so run the stub policy bare.
-    harness = Harness(StubPolicy(), embodiment, task=task, trials=[{}])
+    harness = Harness(StubPolicy(), embodiment, task=Task(instruction='t', timeout=100.0), trials=[{}])
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
-    wire.wire_embodiment(world, harness, embodiment, None, done=task.done)
+    wire.wire_embodiment(world, harness, embodiment, None, done=device.done)
 
     scheduler = world.start([harness, device])
     drive_scheduler(scheduler, steps=60)
@@ -903,8 +901,8 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
         seeds.append(context.get('eval.seed'))
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
-    task = Task(instruction='stack', timeout=0.05, reset=reset)
-    harness = Harness(policy, make_embodiment(), task=task, trials=trials)
+    task = Task(instruction='stack', timeout=0.05)
+    harness = Harness(policy, make_embodiment(), task=task, trials=trials, reset=reset)
     p = _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -1139,8 +1137,8 @@ def test_task_instruction_reaches_session_context_after_reset(world):
     def reset(_context):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
-    task = Task(instruction=lambda: scene['task'], timeout=0.05, reset=reset)
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{}])
+    task = Task(instruction=lambda: scene['task'], timeout=0.05)
+    harness = Harness(policy, make_embodiment(), task=task, trials=[{}], reset=reset)
     _pair_all(world, harness)
 
     scheduler = world.start([harness])
@@ -1415,8 +1413,10 @@ def test_stop_mid_episode_keeps_episode_open_for_recorder_flush(tmp_path):
     shutdown-flush ``record.io`` span parents to the episode, not the pass. Driven straight through the
     generator protocol: the yield after the queued STOP is the recorder's flush slot."""
     policy = StubPolicy()
-    task = Task(instruction='stack', timeout=10.0, reset=lambda context: None)  # never ends within the drive
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}])
+    task = Task(instruction='stack', timeout=10.0)  # never ends within the drive
+    harness = Harness(
+        policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}], reset=lambda context: None
+    )
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     stop = SimpleNamespace(value=False)
@@ -1459,8 +1459,10 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
     ``policy.infer`` span is recorded at the remote inference boundary, so the terminal is a ``RemoteStubPolicy``
     (a real ``RemoteSession`` over a fake inference session)."""
     policy = ChunkedSchedule().wrap(RemoteStubPolicy())
-    task = Task(instruction='stack', timeout=0.05, reset=lambda context: None)
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}])
+    task = Task(instruction='stack', timeout=0.05)
+    harness = Harness(
+        policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}], reset=lambda context: None
+    )
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A latched observation set makes every step's inference fire (the harness reads the latest value).
@@ -1503,8 +1505,9 @@ def test_an_inference_outliving_its_episode_parents_to_it(world, tmp_path):
     harness = Harness(
         ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3)),  # the call runs well past the deadline
         make_embodiment(simulated=True),
-        task=Task(instruction='stack', timeout=0.05, reset=lambda context: None),
+        task=Task(instruction='stack', timeout=0.05),
         trials=[{keys.INFERENCE_LATENCY: True}],
+        reset=lambda context: None,
     )
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -1527,7 +1530,7 @@ def test_an_inference_outliving_its_episode_parents_to_it(world, tmp_path):
 
 @pytest.mark.timeout(3.0)
 def test_failed_pass_seals_open_episode_span(tmp_path):
-    """A ``task.reset`` raising after the episode span was opened must seal that span before the
+    """A ``reset`` raising after the episode span was opened must seal that span before the
     provider flushes on exit. Ending it is what exports it at all: an unended span never leaves the batch
     processor, so its finished ``reset`` child orphans (unknown parent) and the report loses that phase and
     charges the episode's whole wall to ``between_episodes``. Sealed and marked ``episode.partial`` — with its
@@ -1538,8 +1541,8 @@ def test_failed_pass_seals_open_episode_span(tmp_path):
         raise RuntimeError('reset boom')
 
     policy = StubPolicy()
-    task = Task(instruction='stack', timeout=10.0, reset=boom)
-    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}])
+    task = Task(instruction='stack', timeout=10.0)
+    harness = Harness(policy, make_embodiment(), task=task, trials=[{'eval.trial_index': 0}], reset=boom)
     harness.ds_command._bind(RecordingEmitter())
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -1,7 +1,7 @@
 """``RemoteEnvControlSystem``: a remote env server driven as one pimm control system.
 
 A dumb translator: it owns the pimm ports (command receivers, observation + privileged emitters,
-``robot_meta``, the Task's ``done``), the trial lifecycle, and the lifetime of the ``serve`` server it talks
+``robot_meta``, the eval's ``done``), the trial lifecycle, and the lifetime of the ``serve`` server it talks
 to, but no command logic. Each control period it hands the latest command messages to the ``EnvAdapter``,
 round-trips the raw action it returns over the wire, and re-emits the canonical signals the adapter maps
 back — so only raw arrays cross the boundary and the World's virtual clock advances by the env's

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -191,12 +191,11 @@ def remote_stack_cubes_eval(host: str, port: int, *, camera_dict: dict[str, str]
     # The server is already up (the test fixture owns it), so the proxy just receives its address.
     proxy = RemoteEnvControlSystem(StackCubesAdapter(camera_dict), nullcontext((host, port)))
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.mujoco.franka')
-    privileged = {'sim_state': Observation(proxy.privileged['sim_state'], None)}
-    task = Task(
-        instruction='Pick up the green cube and place it on the red cube.',
-        timeout=15.0,
-        privileged=privileged,
-        reset=proxy.reset,
+    task = Task(instruction='Pick up the green cube and place it on the red cube.', timeout=15.0)
+    return Eval(
+        embodiment,
+        task,
+        privileged={'sim_state': Observation(proxy.privileged['sim_state'], None)},
         done=proxy.done,
+        reset=proxy.reset,
     )
-    return Eval(embodiment, task)

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -292,7 +292,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
     cached value holds across the steps that follow."""
     with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
-        task = Task(instruction=lambda: proxy.meta['task'], timeout=1.0, reset=proxy.reset)
+        task = Task(instruction=lambda: proxy.meta['task'], timeout=1.0)
         scheduler = world.start([proxy])
 
         proxy.reset({'eval.seed': 0})

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -206,8 +206,8 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float) -> Eval:
         control_systems=(producer,),
         simulated=True,
     )
-    task = Task(instruction='count', timeout=timeout, privileged={}, reset=producer.reset, done=producer.done)
-    return Eval(embodiment, task)
+    task = Task(instruction='count', timeout=timeout)
+    return Eval(embodiment, task, done=producer.done, reset=producer.reset)
 
 
 @pytest.mark.timeout(30.0)

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -79,7 +79,7 @@ def wire_embodiment(
 
     Connects device observation sources -> ``harness.observations`` and
     ``harness.commands`` -> device receivers, and records observations, command
-    chunks, and the task's privileged ground-truth into the dataset. The task's ``done``
+    chunks, and the eval's privileged ground-truth into the dataset. The ``done``
     terminating signal, when present, is connected to ``harness.done``. GUI camera wiring
     stays with the caller — it is a presentation concern, not part of the embodiment contract.
     """

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -138,7 +138,7 @@ class FakeGenerator(pimm.ControlSystem):
                 'eval.tote_placement': random.choice(['left', 'right']),
                 'eval.external_camera': random.choices(['left', 'right', 'NA'], [5, 5, 1])[0],
                 'inference.policy_fps': self.fps,
-                keys.INFERENCE_LATENCY: False,
+                keys.CHARGE_INFERENCE_TIME: False,
                 **self.policy_meta,
             }
 


### PR DESCRIPTION
## Summary

`privileged`, `done` and `reset` are properties of a run, not of a task: the World wires the first two once, before it runs, and a pimm receiver binds one emitter. They move from `Task` to `Eval`, which is the object with the World's lifetime.

- `Task` is now `(instruction, timeout)`
- `Eval` gains `privileged`, `done`, `reset`
- `Harness` takes `reset` directly; the `task is not None` guards in `_run_world` are gone, and it takes the `Eval`

This is the first step of a roadmap now stated on `Eval`: the attended and the unattended run collapse into one path. Nothing could merge `trials` into `list[Task]` while the wired signals lived on `Task` — N tasks each carrying a `done` is an assertion failure in `World.connect`, and the alternative is a World rebuild (and an env-server restart) per trial.

## Test plan

- `uv run --locked pytest` — 1480 passed, 9 skipped
- `uv run --locked ruff check .` and `ruff format` clean
- `check-rules` over the branch diff: no findings; the roadmap block carries `rules-allow` waivers for `stale-doc` and `diff-comments`, since a plan is read for what is left and that needs the landed steps marked
