### PR TITLE
The sound driver takes a Path, and closes a wav when it ends

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -4190,14 +4190,6 @@
             {
                 "code": "reportReturnType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 30,
                     "lineCount": 1

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import nullcontext
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import configuronic as cfn
@@ -123,10 +124,11 @@ class DataCollectionController(pimm.ControlSystem):
         self.sound = pimm.ControlSystemEmitter(self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
-        start_wav_path = 'positronic/assets/sounds/recording-has-started.wav'
-        end_wav_path = 'positronic/assets/sounds/recording-has-stopped.wav'
-        abort_wav_path = 'positronic/assets/sounds/recording-has-been-aborted.wav'
-        error_wav_path = 'positronic/assets/sounds/error-occurred.wav'
+        sounds = Path(package_assets_path('assets/sounds'))
+        start_wav_path = sounds / 'recording-has-started.wav'
+        end_wav_path = sounds / 'recording-has-stopped.wav'
+        abort_wav_path = sounds / 'recording-has-been-aborted.wav'
+        error_wav_path = sounds / 'error-occurred.wav'
 
         tracker = _Tracker(self.operator_position)
         button_handler = ButtonHandler()

--- a/positronic/drivers/sound.py
+++ b/positronic/drivers/sound.py
@@ -2,6 +2,7 @@ import logging
 import math
 import wave
 from collections.abc import Iterator
+from pathlib import Path
 
 import numpy as np
 
@@ -49,7 +50,7 @@ class SoundSystem(pimm.ControlSystem):
         self.active = True
         self.current_phase = 0.0
         self.level = pimm.DefaultingReceiver(self, default=0.0)
-        self.wav_path = pimm.DefaultingReceiver(self, default='')
+        self.wav_path = pimm.ControlSystemReceiver[Path](self)
 
     def _level_to_frequency(self, level: float) -> tuple[float, float]:
         level_f = float(level)
@@ -83,7 +84,9 @@ class SoundSystem(pimm.ControlSystem):
         while not should_stop.value:
             if (wav_path := pimm.value_updated(self.wav_path)) is not None:
                 logging.info('Playing %s', wav_path)
-                audio_files[file_idx] = wave.open(wav_path, 'rb')
+                # wave.open takes a filename or an already-open file, never a Path. Handing it the name
+                # keeps wave the opener, so its close() closes the file.
+                audio_files[file_idx] = wave.open(str(wav_path), 'rb')
                 assert audio_files[file_idx].getframerate() == 44100, 'Only 44100Hz wav files are currently supported'
                 assert audio_files[file_idx].getsampwidth() == 2, 'Only 16-bit wav files are currently supported'
                 file_idx += 1
@@ -102,10 +105,9 @@ class SoundSystem(pimm.ControlSystem):
             finished_files = []
             for name, wave_file in audio_files.items():
                 wave_chunk = wave_file.readframes(chunk_size)
-                if wave_chunk is None:
+                if not wave_chunk:  # readframes returns b'' once the file is drained
                     wave_file.close()
                     finished_files.append(name)
-                    yield pimm.Yield()
                     continue
                 wave_chunk = np.frombuffer(wave_chunk, dtype=np.int16)
 

--- a/positronic/drivers/tests/conftest.py
+++ b/positronic/drivers/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Stand-in for the PyAudio vendor package.
+
+``pyaudio`` ships only in the ``hardware`` extra, so the sound driver cannot be imported from a default
+sync. The tests drive its loop against their own fake stream and never call into the vendor, so a bare
+module carrying the name the driver binds at import is enough. Installed here, before any test module
+imports the driver, and only when the real package is absent.
+"""
+
+import importlib.util
+import sys
+import types
+
+PACKAGE = 'pyaudio'
+
+if importlib.util.find_spec(PACKAGE) is None:
+    sys.modules[PACKAGE] = types.ModuleType(PACKAGE)

--- a/positronic/drivers/tests/test_sound.py
+++ b/positronic/drivers/tests/test_sound.py
@@ -1,0 +1,122 @@
+"""What the sound driver does with the wav its ``wav_path`` signal names."""
+
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import pimm
+from positronic.drivers import sound
+from positronic.tests.testing_coutils import ManualCommandReceiver
+
+# Captured before any test patches `wave.open`, so writing the fixture wav never goes through the spy.
+_WAVE_OPEN = wave.open
+
+SAMPLE_RATE = 44100
+CHUNK_FRAMES = 64
+WAV_FRAMES = 100  # one full chunk and a short one, so the file drains part-way through a run
+WAV_AMPLITUDE = 8000  # int16, well clear of silence
+
+
+class FakeStream:
+    """Sound card that always has room for one chunk and keeps what it was handed."""
+
+    def __init__(self):
+        self.written: list[bytes] = []
+
+    def get_write_available(self) -> int:
+        return CHUNK_FRAMES
+
+    def write(self, data: bytes) -> None:
+        self.written.append(data)
+
+
+class SpyWave:
+    """A ``Wave_read`` that records having been closed."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.closed = False
+
+    def getframerate(self) -> int:
+        return self._inner.getframerate()
+
+    def getsampwidth(self) -> int:
+        return self._inner.getsampwidth()
+
+    def readframes(self, n: int) -> bytes:
+        return self._inner.readframes(n)
+
+    def close(self) -> None:
+        self.closed = True
+        self._inner.close()
+
+
+@pytest.fixture
+def wav(tmp_path: Path) -> Path:
+    path = tmp_path / 'beep.wav'
+    with _WAVE_OPEN(str(path), 'wb') as f:
+        f.setnchannels(1)
+        f.setsampwidth(2)
+        f.setframerate(SAMPLE_RATE)
+        f.writeframes(np.full(WAV_FRAMES, WAV_AMPLITUDE, dtype=np.int16).tobytes())
+    return path
+
+
+@pytest.fixture
+def stream(monkeypatch) -> FakeStream:
+    fake = FakeStream()
+    monkeypatch.setattr(
+        sound,
+        'pyaudio',
+        SimpleNamespace(paFloat32=object(), PyAudio=lambda: SimpleNamespace(open=lambda **kwargs: fake)),
+    )
+    return fake
+
+
+@pytest.fixture
+def opened(monkeypatch) -> list[SpyWave]:
+    spies: list[SpyWave] = []
+
+    def spy_open(path, mode):
+        spies.append(SpyWave(_WAVE_OPEN(path, mode)))
+        return spies[-1]
+
+    monkeypatch.setattr(sound.wave, 'open', spy_open)
+    return spies
+
+
+def _play(system: sound.SoundSystem, path: Path, ticks: int) -> None:
+    """Send ``path`` into the driver and run its loop ``ticks`` times."""
+    commands: ManualCommandReceiver[Path] = ManualCommandReceiver()
+    commands.push(path)
+    system.wav_path._bind(commands)
+
+    should_stop: ManualCommandReceiver[bool] = ManualCommandReceiver()
+    should_stop.push(False)
+
+    loop = system.run(should_stop, pimm.world.SystemClock())
+    for _ in range(ticks):
+        next(loop)
+
+
+def _as_samples(chunk: bytes) -> np.ndarray:
+    return np.frombuffer(chunk, dtype=np.float32)
+
+
+def test_the_driver_plays_a_wav_named_by_a_path(wav: Path, stream: FakeStream):
+    """`wave.open` opens a `str` and assumes anything else is an already-open file, so a Path reaching
+    it raises `AttributeError`."""
+    _play(sound.SoundSystem(), wav, ticks=1)
+
+    assert _as_samples(stream.written[0]) == pytest.approx(np.full(CHUNK_FRAMES, WAV_AMPLITUDE / 32768.0))
+
+
+def test_a_drained_wav_is_closed_and_stops_being_mixed(wav: Path, stream: FakeStream, opened: list[SpyWave]):
+    # 64 + 36 frames drain the file; the third read comes back empty and ends it.
+    _play(sound.SoundSystem(), wav, ticks=4)
+
+    assert [spy.closed for spy in opened] == [True]
+    assert _as_samples(stream.written[-1]) == pytest.approx(np.zeros(CHUNK_FRAMES))


### PR DESCRIPTION
## What

`SoundSystem.wav_path` is a `pimm.ControlSystemReceiver[Path]`. The driver opens the file it is
given, and `DataCollectionController` sends the four announcement wavs as absolute `Path`s resolved
against the installed package.

Two defects found in that loop and fixed here:

- **`wave.open` does not take a `Path`.** CPython's `wave.py` does `if isinstance(f, str): f =
  builtins.open(f, 'rb')` and otherwise assumes an already-open file, so a `Path` reaches
  `_Chunk.__init__` and raises `AttributeError: 'PosixPath' object has no attribute 'read'`. The
  driver hands `wave.open` the name.
- **A drained wav was never closed.** `readframes` returns `b''` at end of file, never `None`, so
  `if wave_chunk is None:` was dead: the file stayed in `audio_files` forever, reading empty frames,
  one leaked handle per sound played. The stray `yield` inside that branch went with it — it
  suspended mid-iteration over the very dict the branch was building a deletion list for.

The four asset paths in `data_collection.py` were also **relative** (`'positronic/assets/sounds/…'`),
so they only resolved when the process was launched from the checkout root. They now go through
`package_assets_path`, like the mujoco assets beside them.

## Why

`wav_path` carried a filesystem path typed as `str` with `default=''` — `primitive-type` twice over,
once for the path and once for the empty string standing in for "nothing to play".
`ControlSystemReceiver` with no default says that directly: `read()` returns `None` until something
is sent, which is what `pimm.value_updated` already tests for.

At the `wave.open` boundary the choice is `str(path)` or `path.open('rb')`. `str` wins: `wave` then
owns the handle it opened, so `Wave_read.close()` closes it. Handing it an open file makes the
handle the driver's to close as well — a second thing to get right in the branch whose whole defect
was a close that never ran.

`package_assets_path` still returns `str` and is left alone. Its other callers are configuronic
config params, which receive an uncoerced `str` from the CLI, so a `Path` annotation there would
lie.

Not covered: the `hardware` extra is not installed in the default sync, so the new tests reach the
driver through a `pyaudio` stub in `positronic/drivers/tests/conftest.py`, on the pattern
`positronic/drivers/roboarm/tests/conftest.py` already sets for `positronic_franka`. They exercise
the driver's own loop against a fake stream; nothing here plays audio.

`Positronic-Robotics/platform` composes this driver and already sends a `Path` into `wav_path` from
its rollout console, so this makes the annotation honest rather than breaking that side.

## Verification

- `positronic/drivers/tests/test_sound.py`, two tests, each pinned against the defect it covers:
  reverting only the `str()` fails the first, reverting only `not wave_chunk` fails the second
  (`assert [False] == [True]`).
- `uv run --locked pytest positronic pimm utilities` — 1244 passed, 8 skipped.
- `uv run --locked pre-commit run` over the changed files — clean. basedpyright's baseline lost one
  entry on `sound.py` and no file gained any.

## Refs

Positronic-Robotics/internal#572. Reported from the rollout console work in
`Positronic-Robotics/platform`, whose announcement path hit the `wave.open` `AttributeError`.

<!-- opened-by: posi-agent -->