### PR TITLE
Carry the control mode on every robot command

### DIFF
--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -129,7 +129,7 @@ The normal response is a list of action dicts — a short trajectory. (A single 
 | `target_grip` | float | Target gripper closure in `[0, 1]`: 0 = open, 1 = closed |
 | `timestamp` | float | Execution time in seconds from the start of the returned trajectory (e.g. `i / action_fps` for the i-th action). The client runs each action at `now + timestamp`, where `now` is when the prediction arrived. A single action dict returned *outside* a list is auto-stamped `0.0`; give every action in a list its own `timestamp`, or they all collapse onto one instant and fire at once. |
 
-The `robot_command` field selects the control mode. Build one of the commands in
+The `robot_command` field says what the arm is asked to do. Build one of the commands in
 [`positronic.drivers.roboarm.command`](../positronic/drivers/roboarm/command.py):
 
 | Command | Fields | Description |
@@ -139,6 +139,11 @@ The `robot_command` field selects the control mode. Build one of the commands in
 | `JointDelta` | `velocities`: float32 (7,) | Joint velocity command |
 | `CartesianDelta` | `delta`, `frame`: `geom.Transform3D` | Relative motion, composed onto the pose the arm is at when it lands; `frame` is the frame `delta` is expressed in |
 | `Reset` | — | Return the arm to its home position |
+
+Every command but `Reset` also takes an optional `mode`, the control law it asks to execute under:
+`PositionControl(stiffness=...)` for a position servo, or `Impedance(kq, kqd, kx, kxd)` for the hybrid
+joint/Cartesian law. Omit it — the default — and the arm runs its native law. What a pinned mode does is the
+driver's: a simulator runs its own law regardless, and a driver that cannot execute the mode raises.
 
 Which command your model produces is decided by its codec.
 

--- a/positronic/cfg/codecs.py
+++ b/positronic/cfg/codecs.py
@@ -3,6 +3,7 @@
 import configuronic as cfn
 
 from positronic import geom, keys
+from positronic.drivers.roboarm import command as roboarm_command
 from positronic.policy.codec import (
     ActionHorizon,
     ActionTimestamp,
@@ -10,6 +11,7 @@ from positronic.policy.codec import (
     BinarizeGripTraining,
     ChangeEEFrame,
     FlipGrip,
+    SetControlMode,
 )
 from positronic.policy.observation import ObservationCodec
 
@@ -108,6 +110,27 @@ def joint_delta_action(num_joints: int):
     from positronic.policy.action import JointDeltaAction
 
     return JointDeltaAction(num_joints=num_joints)
+
+
+# The gains DROID's Franka ran, which its pretrained checkpoints were trained under.
+DROID_IMPEDANCE = roboarm_command.Impedance(
+    kq=(40.0, 30.0, 50.0, 25.0, 35.0, 25.0, 10.0),
+    kqd=(4.0, 6.0, 5.0, 5.0, 3.0, 2.0, 1.0),
+    kx=(750.0, 750.0, 750.0, 15.0, 15.0, 15.0),
+    kxd=(37.0, 37.0, 37.0, 2.0, 2.0, 2.0),
+)
+
+
+@cfn.config()
+def droid_execution(action):
+    """Wrap an action codec so its chunks execute under impedance, as DROID-pretrained checkpoints expect."""
+    return SetControlMode(DROID_IMPEDANCE) | action
+
+
+@cfn.config()
+def phail_v1_execution(action):
+    """Wrap an action codec so its chunks execute under the position control PhAIL v1 was trained on."""
+    return SetControlMode(roboarm_command.PositionControl()) | action
 
 
 traj_ee_action = absolute_pos_action.override(tgt_ee_pose_key=keys.EE_POSE, tgt_grip_key=keys.GRIP)

--- a/positronic/dataset/serializers.py
+++ b/positronic/dataset/serializers.py
@@ -10,8 +10,11 @@ from positronic.drivers.roboarm.command import (
     CartesianDelta,
     CartesianPosition,
     CommandType,
+    ControlModeType,
+    Impedance,
     JointDelta,
     JointPosition,
+    PositionControl,
     Reset,
 )
 
@@ -96,21 +99,45 @@ class Serializers:
         }
 
     @staticmethod
-    def robot_command(command: CommandType) -> dict[str, np.ndarray | int] | None:
+    def _mode_entries(mode: ControlModeType) -> dict[str, np.ndarray | int]:
+        match mode:
+            case PositionControl(stiffness=None):
+                return {'.mode.position_control': 1}
+            case PositionControl(stiffness=stiffness):
+                return {'.mode.position_control.stiffness': np.asarray(stiffness)}
+            case Impedance(kq=kq, kqd=kqd, kx=kx, kxd=kxd):
+                return {
+                    '.mode.impedance.kq': np.asarray(kq),
+                    '.mode.impedance.kqd': np.asarray(kqd),
+                    '.mode.impedance.kx': np.asarray(kx),
+                    '.mode.impedance.kxd': np.asarray(kxd),
+                }
+
+    # TODO: a command writes only the entries its own form has, so a signal here is sparse — `.reset` and
+    # `.mode.*` have samples at some commands and none at others. Which command a sample belongs to is
+    # then a timestamp alignment against a signal every command writes, and a reader taking the last
+    # value as still standing ascribes a pinned mode to commands that pinned none. A serializer cannot
+    # say which of its entries are sparse, and nothing downstream asks.
+    @staticmethod
+    def robot_command(command: CommandType) -> dict[str, np.ndarray | int]:
+        entries: dict[str, np.ndarray | int]
         match command:
             case CartesianPosition(pose):
-                return {'.pose': Serializers.transform_3d(pose)}
+                entries = {'.pose': Serializers.transform_3d(pose)}
             case CartesianDelta(delta, frame):
-                return {
+                entries = {
                     '.pose_delta': Serializers.transform_3d(delta),
                     '.pose_delta_frame': Serializers.transform_3d(frame),
                 }
             case JointPosition(positions):
-                return {'.joints': positions}
+                entries = {'.joints': positions}
             case JointDelta(delta):
-                return {'.joint_deltas': delta}
+                entries = {'.joint_deltas': delta}
             case Reset():
                 return {'.reset': 1}
+        if command.mode is not None:
+            entries.update(Serializers._mode_entries(command.mode))
+        return entries
 
     @staticmethod
     def camera_images(data: pimm.shared_memory.NumpySMAdapter) -> np.ndarray:

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -389,12 +389,16 @@ def test_robot_command_serializer_variants(world):
     delta = geom.Transform3D(translation=np.array([0.01, -0.02, 0.03]), rotation=geom.Rotation.identity)
     delta_frame = geom.Transform3D(translation=np.array([0.0, 0.0, 0.05]), rotation=geom.Rotation.identity)
     joints = np.arange(7, dtype=np.float32) * 0.1
+    impedance = rcmd.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
 
     script = [
         (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianPosition(pose)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianDelta(delta, delta_frame)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints)), 0.001),
+        (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=impedance)), 0.001),
+        (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=rcmd.PositionControl())), 0.001),
+        (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=rcmd.PositionControl((100.0,) * 7))), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.Reset()), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
     ]
@@ -410,6 +414,13 @@ def test_robot_command_serializer_variants(world):
     )
     np.testing.assert_allclose(items['cmd.joints'], joints)
     assert items['cmd.reset'] == 1
+    np.testing.assert_allclose(items['cmd.mode.impedance.kq'], impedance.kq)
+    # A pin naming no stiffness is a marker: a vector would fix the signal's shape, and what a mode does not
+    # name has no shape to fix it at.
+    assert items['cmd.mode.position_control'] == 1
+    np.testing.assert_allclose(items['cmd.mode.position_control.stiffness'], [100.0] * 7)
+    mode_appends = [name for (name, _, _, _) in w.appends if '.mode' in name]
+    assert len(mode_appends) == 6, 'a command pinning nothing records no mode'
 
 
 def test_multiple_timelines_recorded(world):

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -1,5 +1,14 @@
-"""Collection of commands that can be sent to the robot."""
+"""Collection of commands that can be sent to the robot.
 
+A command may pin the control mode it executes under; ``mode=None`` pins nothing, and the arm runs
+its native law. What a pinned mode does is the driver's: a simulator runs its own law and ignores it,
+a robot driver that cannot execute it raises.
+
+TODO: have an embodiment state the modes it supports, so a policy selects one it works with instead of
+pinning a mode the driver may not run.
+"""
+
+import math
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -9,12 +18,72 @@ from positronic import geom
 
 
 @dataclass
+class PositionControl:
+    """Arm control mode: a position servo tracking shaped references.
+
+    ``stiffness`` biases the servo's joint-space stiffness on an arm that exposes it; ``None`` names none
+    and the arm keeps its own, as damping always does.
+    """
+
+    TYPE = 'position_control'
+    stiffness: tuple[float, ...] | None = None
+
+    def __post_init__(self):
+        if self.stiffness is None:
+            return
+        self.stiffness = tuple(self.stiffness)
+        if not self.stiffness:
+            raise ValueError('stiffness must name at least one joint; naming none is None, not an empty vector')
+        if not all(math.isfinite(v) and v > 0 for v in self.stiffness):
+            raise ValueError('stiffness must be finite and strictly positive')
+
+
+@dataclass
+class Impedance:
+    """Arm control mode: the hybrid joint/Cartesian impedance law with instantly-stepped references.
+
+    ``tau = (J^T Kx J + Kq)(q_d - q) - (J^T Kxd J + Kqd) dq + coriolis``.
+    """
+
+    TYPE = 'impedance'
+    kq: tuple[float, ...]
+    kqd: tuple[float, ...]
+    kx: tuple[float, ...]
+    kxd: tuple[float, ...]
+
+    @staticmethod
+    def _validate_gains(name: str, k: tuple[float, ...], kd: tuple[float, ...]) -> None:
+        """Check one half's stiffness against its damping."""
+        if len(k) != len(kd):
+            raise ValueError(f'{name} stiffness and damping must have the same length')
+        if not k:
+            raise ValueError(f'{name} must name at least one axis; a half is disabled by zeroing it, not emptying it')
+        disabled = all(v == 0 for v in k) and all(v == 0 for v in kd)
+        active = all(math.isfinite(v) and v > 0 for v in k) and all(math.isfinite(v) and v > 0 for v in kd)
+        if not (disabled or active):
+            raise ValueError(
+                f'{name} stiffness and damping must be either all zero (half disabled) or strictly positive'
+            )
+
+    def __post_init__(self):
+        self.kq, self.kqd = tuple(self.kq), tuple(self.kqd)
+        self.kx, self.kxd = tuple(self.kx), tuple(self.kxd)
+        if len(self.kx) != 6:
+            raise ValueError('Cartesian (kx/kxd) gains must have length 6')
+        self._validate_gains('joint (kq/kqd)', self.kq, self.kqd)
+        self._validate_gains('Cartesian (kx/kxd)', self.kx, self.kxd)
+        if all(v == 0 for v in self.kq) and all(v == 0 for v in self.kx):
+            raise ValueError('at least one of the joint or Cartesian halves must be active')
+
+
+ControlModeType = PositionControl | Impedance
+
+
+@dataclass
 class Reset:
     """Reset the robot to the home position."""
 
     TYPE = 'reset'
-
-    pass
 
 
 @dataclass
@@ -23,6 +92,7 @@ class CartesianPosition:
 
     TYPE = 'cartesian_pos'
     pose: geom.Transform3D
+    mode: ControlModeType | None = None
 
 
 @dataclass
@@ -31,6 +101,7 @@ class JointPosition:
 
     TYPE = 'joint_pos'
     positions: np.ndarray
+    mode: ControlModeType | None = None
 
 
 @dataclass
@@ -39,6 +110,7 @@ class JointDelta:
 
     TYPE = 'joint_delta'
     velocities: np.ndarray
+    mode: ControlModeType | None = None
 
 
 def _compose_delta(base: geom.Transform3D, delta: geom.Transform3D) -> geom.Transform3D:
@@ -68,6 +140,7 @@ class CartesianDelta:
     # Per-command, not a shared class-level default: ``Transform3D`` attributes are writable, so one instance
     # across every frameless delta means adjusting one silently relabels the rest.
     frame: geom.Transform3D = field(default_factory=lambda: geom.Transform3D.identity)
+    mode: ControlModeType | None = None
 
     def apply(self, current: geom.Transform3D) -> geom.Transform3D:
         """The absolute target to drive to, given the pose measured at the receiver's ``default`` frame.
@@ -81,41 +154,57 @@ class CartesianDelta:
 CommandType = Reset | CartesianPosition | JointPosition | JointDelta | CartesianDelta
 
 
-def to_wire(command: CommandType) -> dict[str, Any]:
+def to_wire(command: CommandType | ControlModeType) -> dict[str, Any]:
+    wire: dict[str, Any]
+    rep = geom.Rotation.Representation.ROTATION_MATRIX
     match command:
+        case PositionControl(stiffness=stiffness):
+            return {'type': command.TYPE} if stiffness is None else {'type': command.TYPE, 'stiffness': list(stiffness)}
+        case Impedance(kq=kq, kqd=kqd, kx=kx, kxd=kxd):
+            return {'type': command.TYPE, 'kq': list(kq), 'kqd': list(kqd), 'kx': list(kx), 'kxd': list(kxd)}
         case Reset():
             return {'type': command.TYPE}
         case CartesianPosition(pose):
-            return {'type': command.TYPE, 'pose': pose.as_vector(geom.Rotation.Representation.ROTATION_MATRIX)}
+            wire = {'type': command.TYPE, 'pose': pose.as_vector(rep)}
         case JointPosition(positions):
-            return {'type': command.TYPE, 'positions': positions}
+            wire = {'type': command.TYPE, 'positions': positions}
         case JointDelta(velocities):
-            return {'type': command.TYPE, 'velocities': velocities}
+            wire = {'type': command.TYPE, 'velocities': velocities}
         case CartesianDelta(delta, frame):
-            return {
-                'type': command.TYPE,
-                'delta': delta.as_vector(geom.Rotation.Representation.ROTATION_MATRIX),
-                'frame': frame.as_vector(geom.Rotation.Representation.ROTATION_MATRIX),
-            }
+            wire = {'type': command.TYPE, 'delta': delta.as_vector(rep), 'frame': frame.as_vector(rep)}
+    if command.mode is not None:
+        wire['mode'] = to_wire(command.mode)
+    return wire
 
 
-def from_wire(wire: dict[str, Any]) -> CommandType:
+def from_wire(wire: dict[str, Any]) -> CommandType | ControlModeType:
+    mode = from_wire(wire['mode']) if 'mode' in wire else None
+    assert mode is None or isinstance(mode, PositionControl | Impedance)
+    rep = geom.Rotation.Representation.ROTATION_MATRIX
     match wire['type']:
-        case 'reset':
+        case PositionControl.TYPE:
+            return PositionControl(stiffness=wire.get('stiffness'))
+        case Impedance.TYPE:
+            return Impedance(kq=wire['kq'], kqd=wire['kqd'], kx=wire['kx'], kxd=wire['kxd'])
+        case Reset.TYPE:
             return Reset()
-        case 'cartesian_pos':
-            return CartesianPosition(
-                pose=geom.Transform3D.from_vector(wire['pose'], geom.Rotation.Representation.ROTATION_MATRIX)
-            )
-        case 'joint_pos':
-            return JointPosition(positions=wire['positions'])
-        case 'joint_delta':
-            return JointDelta(velocities=wire['velocities'])
-        case 'cartesian_delta':
-            rep = geom.Rotation.Representation.ROTATION_MATRIX
+        case CartesianPosition.TYPE:
+            return CartesianPosition(pose=geom.Transform3D.from_vector(wire['pose'], rep), mode=mode)
+        case JointPosition.TYPE:
+            return JointPosition(positions=wire['positions'], mode=mode)
+        case JointDelta.TYPE:
+            return JointDelta(velocities=wire['velocities'], mode=mode)
+        case CartesianDelta.TYPE:
             return CartesianDelta(
                 delta=geom.Transform3D.from_vector(wire['delta'], rep),
                 frame=geom.Transform3D.from_vector(wire['frame'], rep),
+                mode=mode,
             )
         case _:
             raise ValueError(f'Unknown command type: {wire["type"]}')
+
+
+def require_native_mode(cmd: CommandType | None, embodiment: str) -> None:
+    """Raises on a command that pins a control mode: ``embodiment`` runs only its native law."""
+    if not isinstance(cmd, Reset | None) and cmd.mode is not None:
+        raise NotImplementedError(f'{embodiment} cannot execute control mode {cmd.mode}')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -158,14 +158,38 @@ class _Arm(DriverRun[command.CommandType]):
             target = target + variation
         return target
 
+    @staticmethod
+    def _to_pf_mode(mode: command.ControlModeType | None) -> pf.InternalImpedance | pf.SoftwareImpedance:
+        """The pf mode carrying ``mode``'s gains; ``None`` — no pin — and a bare ``PositionControl`` take pf's own."""
+        match mode:
+            case None:
+                return pf.InternalImpedance()
+            case command.PositionControl(stiffness=stiffness):
+                return pf.InternalImpedance() if stiffness is None else pf.InternalImpedance(k_theta=list(stiffness))
+            case command.Impedance(kq=kq, kqd=kqd, kx=kx, kxd=kxd):
+                return pf.SoftwareImpedance(kq=list(kq), kqd=list(kqd), kx=list(kx), kxd=list(kxd))
+
+    def command_target(self, target: np.ndarray, mode: command.ControlModeType | None) -> None:
+        """Put the arm under ``mode`` and publish ``target`` to it, in that order with nothing in between.
+
+        Together, because either alone is a half-applied command: a law changed for a target that never
+        arrives leaves the arm holding its last one under dynamics nobody asked for.
+        """
+        self.vendor.set_control_mode(self._to_pf_mode(mode))  # the vendor no-ops a mode already running
+        self.vendor.set_target_joints(target)
+
     def await_goal(
-        self, target: np.ndarray, should_stop: Callable[[], bool], pace: Callable[[], pimm.Command]
+        self,
+        target: np.ndarray,
+        should_stop: Callable[[], bool],
+        pace: Callable[[], pimm.Command],
+        mode: command.ControlModeType | None,
     ) -> Generator[pimm.Command, None, MoveStatus]:
-        """Command ``target`` and poll the goal until the arm arrives, one poll per resume.
+        """Command ``target`` under ``mode`` and poll the goal until the arm arrives, one poll per resume.
 
         ``pace`` is what to wait between polls, and so how often the goal is asked about.
         """
-        self.vendor.set_target_joints(target)
+        self.command_target(target, mode)
         while not should_stop():
             goal = self.vendor.goal()
             if goal.status == pf.GoalStatus.REACHED:
@@ -180,8 +204,10 @@ class _Arm(DriverRun[command.CommandType]):
         cap = self._MAX_JOINT_VELOCITY * self._dynamics_factor
         return self._MOVE_GRACE_S + float(np.max(np.abs(target - q) / cap))
 
-    def move_to(self, target: np.ndarray) -> Generator[pimm.Command, None, MoveStatus]:
-        """Travel to ``target``, yielding until it arrives."""
+    def move_to(
+        self, target: np.ndarray, mode: command.ControlModeType | None
+    ) -> Generator[pimm.Command, None, MoveStatus]:
+        """Travel to ``target`` under ``mode``, yielding until it arrives."""
         # The first emit must not ship an unfilled state.
         self.state.encode(self.vendor.state(), RobotStatus.BUSY)
         self.out.emit(self.state)
@@ -190,7 +216,7 @@ class _Arm(DriverRun[command.CommandType]):
         try:
             # The arm's own rate: this loop publishes every pass, so the goal is asked about that often too
             for wait in self.await_goal(
-                target, lambda: self.should_stop.value or self.clock.now() >= deadline, self.limiter.wait
+                target, lambda: self.should_stop.value or self.clock.now() >= deadline, self.limiter.wait, mode
             ):
                 st = self.vendor.state()
                 self.state.encode(st, RobotStatus.BUSY)  # the driver owns the arm until it arrives
@@ -237,10 +263,23 @@ class _Arm(DriverRun[command.CommandType]):
             case other:
                 raise NotImplementedError(f'Unsupported command {other}')
 
+    def accept(self, cmd: command.CommandType | None) -> tuple[np.ndarray, command.ControlModeType | None]:
+        """The joints ``cmd`` asks for and the law it pins, neither applied yet.
+
+        Solved here so that a command the arm cannot hold raises before anything changes; ``command_target``
+        is what applies the pair. Asking for nothing, and a ``Reset``, travel home under the native law.
+        """
+        target = self.target_joints(cmd)
+        # The vendor takes a fixed-width finite vector and raises on anything else, too late to be caught
+        # alongside the rest of what makes a command unusable.
+        if np.shape(target) != np.shape(self._home_joints) or not np.all(np.isfinite(target)):
+            raise ValueError(f'{cmd} does not name a joint target this arm can hold: {target}')
+        return target, None if isinstance(cmd, command.Reset | None) else cmd.mode
+
     def serve_sync_move(self, call: pimm.calls.Call[command.CommandType | None, None]) -> Iterator[pimm.Command]:
         """Put the arm where ``call`` asks and answer it once the state saying so is out."""
         try:
-            if (yield from self.move_to(self.target_joints(call.request))) is MoveStatus.ARRIVED:
+            if (yield from self.move_to(*self.accept(call.request))) is MoveStatus.ARRIVED:
                 call.set_result(None)
             else:
                 call.set_exception(MoveAbandoned())
@@ -262,8 +301,9 @@ class _Arm(DriverRun[command.CommandType]):
             logger.info('Parking the arm at the home pose')
             self.vendor.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = self.clock.now() + self._park_timeout_s
+            # The home pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(
-                target, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S)
+                target, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
             )
             if outcome is MoveStatus.GAVE_UP:
                 logger.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
@@ -372,7 +412,7 @@ class Robot(pimm.ControlSystem):
             lower_force_threshold_nominal=(coeff * force_threshold_nominal).tolist(),
             upper_force_threshold_nominal=(coeff * force_threshold_nominal * 2).tolist(),
         )
-        robot.set_control_mode(pf.InternalImpedance([3000, 3000, 3000, 2500, 2500, 2000, 2000]))
+        robot.set_control_mode(_Arm._to_pf_mode(None))
         if self._load is not None:
             logger.info(f'Setting load to {self._load}')
             robot.set_load(*self._load)
@@ -439,7 +479,7 @@ class Robot(pimm.ControlSystem):
             vendor.recover_from_errors()
 
             try:
-                yield from arm.move_to(arm.home_target())
+                yield from arm.move_to(arm.home_target(), None)
             # rules-allow: swallowed-error — an arm that will not home reads ERROR; it does not end the run
             except Exception as exc:
                 logger.error(f'Homing failed, the arm is not where the driver put it: {exc}')
@@ -464,10 +504,11 @@ class Robot(pimm.ControlSystem):
                     yield from arm.serve_sync_move(asked)
                 elif asked is not None:
                     with log_failure(asked):
+                        target, mode = arm.accept(asked)
                         if isinstance(asked, command.Reset):
-                            yield from arm.move_to(arm.home_target())
+                            yield from arm.move_to(target, mode)
                         else:
-                            vendor.set_target_joints(arm.target_joints(asked))
+                            arm.command_target(target, mode)
 
                 yield arm.limiter.wait()
 

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -111,6 +111,12 @@ class _Arm(DriverRun[command.CommandType]):
 
     def _target_qpos(self, cmd: command.CommandType | None) -> np.ndarray:
         """The joints ``cmd`` asks the arm to hold, solved from the joints it reports now; nothing asks for home."""
+        # `JointCompliantController` is a compliance law, not a position servo: `PositionControl` would pin
+        # a rule the arm does not run.
+        # TODO: a joint-only `Impedance` is refused for want of plumbing, not capability: the controller runs
+        # at the fixed `K_p`/`K_d` in `base.py` off Ruckig-shaped references; accepting one means feeding
+        # `kq`/`kqd` through and stepping the references.
+        command.require_native_mode(cmd, 'Kinova')
         match cmd:
             case None | command.Reset():
                 return np.asarray(self._home_joints, dtype=np.float32)

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -114,6 +114,10 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
     def _requested_qpos(self, cmd: roboarm_command.CommandType | None) -> np.ndarray:
         """The setpoint ``cmd`` asks for, in the bus's normalized units, whether or not the arm can hold it;
         asking for nothing asks for home."""
+        # TODO: accept the modes the bus can run instead of leaving them to what a command omits. Its servos
+        # are position control, so `PositionControl` names the rule already running, and a named stiffness is
+        # their gain registers.
+        roboarm_command.require_native_mode(cmd, 'SO101')
         match cmd:
             case None | roboarm_command.Reset():
                 return self._arm_rad_to_norm(np.asarray(self._home_joints, dtype=np.float32))

--- a/positronic/drivers/roboarm/tests/conftest.py
+++ b/positronic/drivers/roboarm/tests/conftest.py
@@ -17,26 +17,41 @@ import pytest
 
 import pimm
 
-
-class GoalStatus(Enum):
-    REACHED = 'reached'
-    IN_FLIGHT = 'in_flight'
-    ABORTED = 'aborted'
-
-
 PACKAGE = 'positronic_franka'
 VENDOR = f'{PACKAGE}._franka'
 DESK = f'{PACKAGE}.desk'
 
 
 def _install_vendor_stub() -> None:
+    """Bind the names ``positronic_franka`` gives the Franka driver. Reached as ``franka.pf.*``, never imported."""
+
+    class GoalStatus(Enum):
+        REACHED = 'reached'
+        IN_FLIGHT = 'in_flight'
+        ABORTED = 'aborted'
+
+    class InternalImpedance:
+        def __init__(self, k_theta=(3000.0, 3000.0, 3000.0, 2500.0, 2500.0, 2000.0, 2000.0)):
+            self.k_theta = list(k_theta)
+
+    class SoftwareImpedance:
+        def __init__(
+            self,
+            kq=(40.0, 30.0, 50.0, 25.0, 35.0, 25.0, 10.0),
+            kqd=(4.0, 6.0, 5.0, 5.0, 3.0, 2.0, 1.0),
+            kx=(750.0, 750.0, 750.0, 15.0, 15.0, 15.0),
+            kxd=(37.0, 37.0, 37.0, 2.0, 2.0, 2.0),
+        ):
+            self.kq, self.kqd, self.kx, self.kxd = list(kq), list(kqd), list(kx), list(kxd)
+
     vendor = types.ModuleType(VENDOR)
     vendor.__dict__.update(
         GoalStatus=GoalStatus,
         State=object,
         Robot=object,
         RealtimeConfig=types.SimpleNamespace(Ignore=object()),
-        InternalImpedance=lambda stiffness: ('internal_impedance', stiffness),
+        InternalImpedance=InternalImpedance,
+        SoftwareImpedance=SoftwareImpedance,
     )
 
     desk = types.ModuleType(DESK)

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -1,19 +1,22 @@
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
 
 import pimm
 from pimm.tests.testing import MockClock, wire_call
+from positronic import geom
 from positronic.drivers.roboarm import RobotStatus, command, franka
 from positronic.drivers.roboarm.tests.fakes import StopFlag
 from positronic.drivers.utils import MoveAbandoned
-from positronic.tests.testing_coutils import RecordingEmitter
+from positronic.tests.testing_coutils import ManualCommandReceiver, RecordingEmitter
 
 HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+IMPEDANCE = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
 
 
 class Call(StrEnum):
@@ -26,6 +29,7 @@ class Call(StrEnum):
     STOP = 'stop'
     SET_COLLISION_BEHAVIOR = 'set_collision_behavior'
     SET_CONTROL_MODE = 'set_control_mode'
+    INVERSE_KINEMATICS = 'inverse_kinematics'
     SET_LOAD = 'set_load'
 
 
@@ -49,7 +53,8 @@ class FakeArm:
     """In-memory ``pf.Robot``: a commanded joint target is reached after ``polls_to_reach`` reads of ``goal``.
 
     ``goal_status`` pins the reported status, so a move that never lands can be scripted; ``raises``, once
-    set, is what every call but ``stop`` raises; ``error`` is the vendor fault flag every state carries.
+    set, is what every call but ``stop`` raises, and ``ik_raises`` what only the solver raises; ``error`` is
+    the vendor fault flag every state carries.
     """
 
     def __init__(self, q, *, polls_to_reach: int = 2, goal_status: 'franka.pf.GoalStatus | None' = None):
@@ -57,8 +62,10 @@ class FakeArm:
         self.error = 0
         self.calls: list[Call] = []
         self.targets: list[np.ndarray] = []
+        self.modes: list[Any] = []
         self.raises: Exception | None = None
         self.raises_once: Exception | None = None
+        self.ik_raises: Exception | None = None
         self.polls_to_reach = polls_to_reach
         self._polls = 0
         self.goal_status = goal_status
@@ -103,8 +110,15 @@ class FakeArm:
     def set_collision_behavior(self, **thresholds) -> None:
         self._record(Call.SET_COLLISION_BEHAVIOR)
 
+    def inverse_kinematics_with_limits(self, pose) -> np.ndarray:
+        self._record(Call.INVERSE_KINEMATICS)
+        if self.ik_raises is not None:
+            raise self.ik_raises
+        return self.q.copy()
+
     def set_control_mode(self, mode) -> None:
         self._record(Call.SET_CONTROL_MODE)
+        self.modes.append(mode)
 
     def set_load(self, *load) -> None:
         self._record(Call.SET_LOAD)
@@ -214,6 +228,82 @@ def test_park_swallows_a_robot_that_fails_mid_move():
     _drive_park(_driver(arm, manage_desk=False), arm)
 
     np.testing.assert_allclose(arm.q, JOGGED)
+
+
+def test_a_command_the_arm_cannot_reach_leaves_the_running_law_alone(desk):
+    """A rejected command must not half-apply: the arm would hold its old target under new dynamics."""
+    arm = FakeArm(HOME)
+    driver = _driver(arm)
+    feed = ManualCommandReceiver()
+    driver.commands._bind(feed)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = driver.run(stop, clock)
+
+    for _ in range(3):
+        next(loop)
+    mark = len(arm.modes)
+    arm.ik_raises = ValueError('out of reach')
+    feed.push(command.CartesianPosition(pose=geom.Transform3D.identity, mode=IMPEDANCE))
+    for _ in range(2):
+        next(loop)
+
+    assert arm.modes[mark:] == [], 'the arm changed law for a command it never executed'
+
+
+def test_the_law_changes_only_where_the_target_is_published(desk):
+    """A switch with anything between it and the target can leave the arm holding its last one under it."""
+    arm = FakeArm(HOME)
+    driver = _driver(arm)
+    feed = ManualCommandReceiver()
+    driver.commands._bind(feed)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = driver.run(stop, clock)
+
+    for _ in range(3):
+        next(loop)  # init + opening reset
+    mark = len(arm.calls)
+    feed.push(command.JointPosition(positions=JOGGED, mode=IMPEDANCE))
+    for _ in range(2):
+        next(loop)
+    feed.push(command.Reset())
+    for _ in range(6):
+        next(loop)
+
+    switches = [i for i, c in enumerate(arm.calls[mark:], start=mark) if c is Call.SET_CONTROL_MODE]
+    assert switches, 'the commands applied no mode at all'
+    assert all(arm.calls[i + 1] is Call.SET_TARGET_JOINTS for i in switches), arm.calls[mark:]
+
+
+def test_a_joint_target_the_vendor_would_refuse_leaves_the_running_law_alone(desk):
+    """A joint command is passed straight through, so what the vendor rejects has to be caught here."""
+    arm = FakeArm(HOME)
+    driver = _driver(arm)
+    feed = ManualCommandReceiver()
+    driver.commands._bind(feed)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = driver.run(stop, clock)
+
+    for _ in range(3):
+        next(loop)
+    mark = len(arm.modes)
+    feed.push(command.JointPosition(positions=np.full(7, np.nan), mode=IMPEDANCE))
+    for _ in range(2):
+        next(loop)
+
+    assert arm.modes[mark:] == [], 'the arm changed law for a target it never held'
+    assert not any(np.isnan(t).any() for t in arm.targets), 'a NaN target reached the arm'
+
+
+def test_park_puts_the_arm_under_its_native_law():
+    """The home pose is far off, and only the native law shapes the reference on the way there."""
+    arm = FakeArm(JOGGED)
+
+    _drive_park(_driver(arm, manage_desk=False), arm)
+
+    assert isinstance(arm.modes[0], franka.pf.InternalImpedance)
 
 
 def test_teardown_parks_the_arm_before_stopping_control(desk):
@@ -453,7 +543,7 @@ def test_a_move_that_lands_as_its_deadline_expires_is_an_arrival():
     driver = _driver(arm, manage_desk=False)
     driver.state._bind(RecordingEmitter())
     clock = MockClock()
-    travel = driver._arm(StopFlag(), clock).move_to(JOGGED)
+    travel = driver._arm(StopFlag(), clock).move_to(JOGGED, None)
 
     next(travel)  # the first poll: the goal is in flight
     clock.advance(60.0)  # the deadline expires
@@ -472,7 +562,7 @@ def test_a_fault_that_lands_with_the_arrival_reads_error_rather_than_available()
     driver = _driver(arm, manage_desk=False)
     states = RecordingEmitter()
     driver.state._bind(states)
-    travel = driver._arm(StopFlag(), MockClock()).move_to(JOGGED)
+    travel = driver._arm(StopFlag(), MockClock()).move_to(JOGGED, None)
 
     arm.error = 1
     with pytest.raises(StopIteration) as done:
@@ -510,3 +600,51 @@ def test_a_sync_move_that_never_arrives_times_out_and_holds_where_the_arm_stoppe
     np.testing.assert_allclose(arm.targets[-2], JOGGED)
     # Published before the asker heard: a caller that starts recovering must not read the arm as available
     assert states.emitted[-1][1].status == RobotStatus.ERROR
+
+
+def test_a_commands_mode_reaches_the_arm_with_the_gains_it_named(desk):
+    """Skipping a mode already running is the vendor's, so the driver hands over every command's."""
+    arm = FakeArm(HOME)
+    driver = _driver(arm)
+    feed = ManualCommandReceiver()
+    driver.commands._bind(feed)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = driver.run(stop, clock)
+
+    for _ in range(3):
+        next(loop)  # init + opening reset
+    feed.push(command.JointPosition(positions=JOGGED, mode=IMPEDANCE))
+    for _ in range(2):
+        next(loop)
+    stop.stopped = True
+    _drive(loop, clock)
+
+    assert isinstance(arm.modes[0], franka.pf.InternalImpedance), 'the arm did not start in its native law'
+    applied = [m for m in arm.modes if isinstance(m, franka.pf.SoftwareImpedance)]
+    assert applied, 'the command named a mode the arm was never put under'
+    assert applied[-1].kq == list(IMPEDANCE.kq), 'the gains the command named did not reach the arm'
+
+
+def test_homing_returns_the_arm_to_its_native_law(desk):
+    arm = FakeArm(HOME)
+    driver = _driver(arm)
+    feed = ManualCommandReceiver()
+    driver.commands._bind(feed)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = driver.run(stop, clock)
+
+    for _ in range(3):
+        next(loop)
+    feed.push(command.JointPosition(positions=JOGGED, mode=IMPEDANCE))
+    for _ in range(2):
+        next(loop)
+    mark = len(arm.modes)
+    feed.push(command.Reset())
+    for _ in range(6):
+        next(loop)
+    stop.stopped = True
+    _drive(loop, clock)
+
+    assert isinstance(arm.modes[mark], franka.pf.InternalImpedance)

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -293,6 +293,9 @@ class _Chain(DriverRun[command.CommandType]):
         """
         request = call.request
         try:
+            # TODO: accept the modes the chain can run instead of leaving them to what a command omits. Its
+            # joints are position-servoed, so `PositionControl` names the rule already running.
+            command.require_native_mode(request, 'YAM')
             if request is None or isinstance(request, command.Reset):
                 target = self.home_joints
             else:
@@ -397,6 +400,7 @@ class Robot(pimm.ControlSystem):
                     q_target, grip_target = yield from chain.serve_sync_move(asked, q, grip_target)
                 elif asked is not None:
                     with log_failure(asked):
+                        command.require_native_mode(asked, 'YAM')
                         if isinstance(asked, command.Reset):
                             grip_target = 0.0
                             q_target, grip_target = yield from chain.home(grip_target)

--- a/positronic/offboard/README.md
+++ b/positronic/offboard/README.md
@@ -166,7 +166,9 @@ Keys are flat strings — the dots are literal, not nesting. Arrays travel as nu
 }
 ```
 
-A command's `type` selects the control mode and the fields beside it: `cartesian_pos` (`pose`), `joint_pos` (`positions`), `joint_delta` (`velocities`), `cartesian_delta` (`delta`, `frame`), and `reset` (no fields). A pose is translation followed by a row-major 3x3 rotation. `positronic.offboard.protocol` reads that mapping into the typed command the drivers dispatch on, so a server written against another stack sends it as plain data; one built on positronic may instead put a `positronic.drivers.roboarm.command` instance here and let `serialise` encode it.
+A command's `type` selects the fields beside it: `cartesian_pos` (`pose`), `joint_pos` (`positions`), `joint_delta` (`velocities`), `cartesian_delta` (`delta`, `frame`), and `reset` (no fields). A pose is translation followed by a row-major 3x3 rotation.
+
+Every command but `reset` may carry a `mode`, itself a tagged mapping naming the control law to execute under: `{"type": "position_control", "stiffness": [...]}` or `{"type": "impedance", "kq": [...], "kqd": [...], "kx": [...], "kxd": [...]}`. Omit `stiffness` to take the arm's own gains — an empty list is refused. Omit `mode` entirely and the arm runs its native law. `positronic.offboard.protocol` reads that mapping into the typed command the drivers dispatch on, so a server written against another stack sends it as plain data; one built on positronic may instead put a `positronic.drivers.roboarm.command` instance here and let `serialise` encode it.
 
 **Server → Client (Error):**
 ```json

--- a/positronic/offboard/protocol.py
+++ b/positronic/offboard/protocol.py
@@ -57,12 +57,18 @@ def serialise(obj: Any) -> bytes:
 deserialise = functools.partial(msgpack.unpackb, object_hook=_unpack)
 
 
+def _as_wire(value: Any) -> Any:
+    """A wire field as ``from_wire`` reads it: vectors as arrays, strings and nested mappings as they are."""
+    if isinstance(value, cabc.Mapping):
+        return {k: _as_wire(v) for k, v in value.items()}
+    return value if isinstance(value, str) else np.asarray(value)
+
+
 def _typed(value: Any) -> Any:
     """One command channel's value, typed."""
     if not isinstance(value, cabc.Mapping):
         return value
-    # ``from_wire`` reads the vectors as arrays; the wire carries sequences, and ``type`` is its one string.
-    return command.from_wire({k: v if isinstance(v, str) else np.asarray(v) for k, v in value.items()})
+    return command.from_wire(_as_wire(value))
 
 
 def typed_commands(result: Any) -> Any:

--- a/positronic/offboard/tests/test_offboard.py
+++ b/positronic/offboard/tests/test_offboard.py
@@ -1,9 +1,18 @@
 from types import MappingProxyType
 
 import numpy as np
+import pytest
 
 from positronic import keys
-from positronic.drivers.roboarm.command import CartesianPosition, JointDelta, JointPosition, Reset
+from positronic.drivers.roboarm.command import (
+    CartesianPosition,
+    Impedance,
+    JointDelta,
+    JointPosition,
+    PositionControl,
+    Reset,
+    to_wire,
+)
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceClient
 from positronic.offboard.protocol import deserialise, serialise, typed_commands
@@ -132,6 +141,40 @@ class TestCommandEnvelope:
         result = deserialise(serialise(JointDelta(velocities=velocities)))
         assert isinstance(result, JointDelta)
         np.testing.assert_allclose(result.velocities, velocities)
+
+    def test_control_modes(self):
+        zeros = np.zeros(3)
+        impedance = Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+        assert deserialise(serialise(JointDelta(velocities=zeros))).mode is None
+        pinned = PositionControl()
+        assert deserialise(serialise(JointDelta(velocities=zeros, mode=pinned))).mode == pinned
+        assert deserialise(serialise(JointDelta(velocities=zeros, mode=impedance))).mode == impedance
+        custom = Impedance(kq=(20.0,) * 7, kqd=(2.0,) * 7, kx=(0.0,) * 6, kxd=(0.0,) * 6)
+        assert deserialise(serialise(JointDelta(velocities=zeros, mode=custom))).mode == custom
+        stiff = PositionControl(stiffness=(100.0,) * 7)
+        assert deserialise(serialise(JointDelta(velocities=zeros, mode=stiff))).mode == stiff
+
+    def test_a_stiffness_the_mode_does_not_name_is_absent_from_the_wire(self):
+        """Naming no gains is `None`, as pinning no mode is: neither is a value with a width."""
+        with pytest.raises(ValueError, match='at least one joint'):
+            PositionControl(stiffness=())
+        assert 'stiffness' not in to_wire(PositionControl())
+        assert deserialise(serialise(JointDelta(velocities=np.zeros(3), mode=PositionControl()))).mode.stiffness is None
+
+    def test_an_impedance_half_is_disabled_by_zeroing_it(self):
+        """An empty half would record as a zero-width vector, which no later gain vector could follow."""
+        with pytest.raises(ValueError, match='at least one axis'):
+            Impedance(kq=(), kqd=(), kx=(750.0,) * 6, kxd=(37.0,) * 6)
+        cartesian_only = Impedance(kq=(0.0,) * 7, kqd=(0.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+        assert deserialise(serialise(JointDelta(velocities=np.zeros(3), mode=cartesian_only))).mode == cartesian_only
+
+    def test_a_bare_wire_mapping_carries_a_nested_mode(self):
+        """A server built on another stack sends plain data, mode included, and it types like any other."""
+        impedance = Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+        wire = to_wire(JointDelta(velocities=np.zeros(7), mode=impedance))
+        typed = typed_commands({keys.ROBOT_COMMAND: wire})[keys.ROBOT_COMMAND]
+        assert isinstance(typed, JointDelta)
+        assert typed.mode == impedance
 
     def test_action_trajectory_payload(self):
         """The actual server→client payload: a list of action dicts with embedded Commands."""

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -10,6 +10,7 @@ Two composition operators:
 """
 
 import collections.abc as cabc
+from dataclasses import replace
 from functools import partial
 from typing import Any, final
 
@@ -509,10 +510,10 @@ class ChangeEEFrame(Codec):
     def _move(value: Any, transform: geom.Transform3D) -> Any:
         """A pose vector or an arm command, re-expressed through ``transform``."""
         match value:
-            case command.CartesianPosition(pose):
-                return command.CartesianPosition(pose=pose * transform)
-            case command.CartesianDelta(delta, frame):
-                return command.CartesianDelta(delta=delta, frame=transform.inv * frame)
+            case command.CartesianPosition(pose, mode):
+                return command.CartesianPosition(pose=pose * transform, mode=mode)
+            case command.CartesianDelta(delta, frame, mode):
+                return command.CartesianDelta(delta=delta, frame=transform.inv * frame, mode=mode)
             case command.Reset() | command.JointPosition() | command.JointDelta():
                 return value
             case _:
@@ -582,3 +583,30 @@ class ChangeEEFrame(Codec):
             'name': self.WIRE_NAME,
             'args': {'transform': self._transform.as_vector(_QUAT).tolist(), 'keys': list(self._keys)},
         }
+
+
+class SetControlMode(Codec):
+    """Sets the control mode a chunk executes under on every robot command it carries (inference only).
+
+    Composes left of an action decoder (``SetControlMode(mode) | action``). Every command of every arm
+    carries the mode, not only the first of the unsuffixed channel; a ``Reset`` pins none and passes
+    through untouched.
+    """
+
+    def __init__(self, mode: command.ControlModeType):
+        self._mode = mode
+
+    def encode(self, data):
+        return data
+
+    def _decode_single(self, data: dict, context: dict | None) -> dict:
+        # The command family also holds the pose/joint vectors a recording unfolds into, so what carries a
+        # mode is decided by type rather than by name.
+        stamped = {
+            key: replace(cmd, mode=self._mode)
+            for key, cmd in data.items()
+            if obs_keys.is_robot_command(key)
+            and isinstance(cmd, command.CommandType)
+            and not isinstance(cmd, command.Reset)
+        }
+        return {**data, **stamped} if stamped else data

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -147,6 +147,19 @@ def _build_blueprint(
     return rrb.Blueprint(rrb.Grid(*grids)) if grids else None
 
 
+def _flat_wire(wire: dict) -> dict:
+    """A command wire as numeric leaves, its type dropped: a nested control mode becomes ``mode.<type>.<gain>``."""
+    flat = {}
+    for name, value in wire.items():
+        if isinstance(value, dict):
+            gains = {f'{name}.{value["type"]}.{k}': v for k, v in value.items() if k != 'type' and len(v)}
+            # A mode naming no gains has no numeric leaf to plot, so the marker is what says it was pinned.
+            flat.update(gains or {f'{name}.{value["type"]}': 1})
+        elif name != 'type':
+            flat[name] = value
+    return flat
+
+
 def _command_field_arrays(key: str, commands: list, horizons: np.ndarray) -> list[tuple[str, np.ndarray, np.ndarray]]:
     """Stack robot commands grouped by type, each group's fields and horizons as arrays."""
     groups: dict[str, list] = {}
@@ -154,12 +167,16 @@ def _command_field_arrays(key: str, commands: list, horizons: np.ndarray) -> lis
         groups.setdefault(cmd.TYPE, []).append((cmd, h))
     out: list[tuple[str, np.ndarray, np.ndarray]] = []
     for type_name, group in groups.items():
-        wires = [roboarm_command.to_wire(c) for c, _ in group]
-        group_horizon = np.array([h for _, h in group], dtype=np.float64)
-        for field in (k for k in wires[0] if k != 'type'):
-            arr = _stack_numeric([w[field] for w in wires])
+        wires = [_flat_wire(roboarm_command.to_wire(c)) for c, _ in group]
+        group_horizons = [h for _, h in group]
+        # Commands of one type still differ in what they carry — an unpinned mode beside a pinned one, or two
+        # commands pinning different laws — so each field is stacked over the commands that have it.
+        for field in dict.fromkeys(name for wire in wires for name in wire):
+            present = [(wire[field], h) for wire, h in zip(wires, group_horizons, strict=True) if field in wire]
+            arr = _stack_numeric([value for value, _ in present])
             if arr is not None:
-                out.append((f'{key}/{type_name}/{field}', arr, group_horizon))
+                field_horizon = np.array([h for _, h in present], dtype=np.float64)
+                out.append((f'{key}/{type_name}/{field}', arr, field_horizon))
     return out
 
 
@@ -413,19 +430,23 @@ class _RecordingTapSession(DelegatingSession):
             h = horizon[idx]
             path = f'{prefix}/{key}'
             series_path = f'{prefix}/series/{key}'
+            fields: list[tuple[str, np.ndarray, np.ndarray]] = []
             if all(isinstance(v, roboarm_command.CartesianPosition) for v in values):
                 grip_sub = grip[idx] if grip is not None else None
                 pose = _log_ee_pose_chunk(path, values, h, grip_sub, actual_pos, actual_g)
                 _log_action_series(series_path, pose, h, base_ns, names=_POSE_LABELS)
                 self._rec._path3d_paths.append(f'{path}/trajectory')
                 self._rec._series_paths.append(series_path)
+                # The pose is the trajectory drawn above; what is left of the command is the mode it pins.
+                fields = [f for f in _command_field_arrays(key, values, h) if not f[0].endswith('/pose')]
             elif all(isinstance(v, roboarm_command.CommandType) for v in values):
-                for suffix, arr, group_h in _command_field_arrays(key, values, h):
-                    _log_action_series(f'{prefix}/series/{suffix}', arr, group_h, base_ns, names=None)
-                    self._rec._series_paths.append(f'{prefix}/series/{suffix}')
+                fields = _command_field_arrays(key, values, h)
             elif (arr := _stack_numeric(values)) is not None:
                 _log_action_series(series_path, arr, h, base_ns, names=[key])
                 self._rec._series_paths.append(series_path)
+            for suffix, field_arr, group_h in fields:
+                _log_action_series(f'{prefix}/series/{suffix}', field_arr, group_h, base_ns, names=None)
+                self._rec._series_paths.append(f'{prefix}/series/{suffix}')
 
     def _send_blueprint(self) -> None:
         rec = self._rec

--- a/positronic/policy/tests/test_change_ee_frame.py
+++ b/positronic/policy/tests/test_change_ee_frame.py
@@ -47,6 +47,21 @@ def test_decode_maps_action_back_to_canonical():
     assert decoded['target_grip'] == 1.0
 
 
+def test_decode_keeps_the_control_mode_a_command_pinned():
+    """Re-expressing a pose does not change what law drives to it."""
+    mode = cmd_module.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+    pose = _pose([0.3, 0.1, 0.4], [0.2, -0.3, 0.5])
+    action = {
+        keys.ROBOT_COMMAND: cmd_module.CartesianPosition(pose=pose, mode=mode),
+        'other': cmd_module.CartesianDelta(delta=pose, mode=mode),
+    }
+
+    decoded = ChangeEEFrame(TO_DROID, keys=(keys.ROBOT_COMMAND, 'other'))._decode_single(action, context=None)
+
+    assert decoded[keys.ROBOT_COMMAND].mode == mode
+    assert decoded['other'].mode == mode
+
+
 def test_decode_hands_a_delta_the_frame_it_was_meant_for():
     """A delta has no anchor to convert against, so it travels with its frame for the driver to apply."""
     delta = _pose([0.01, 0.0, -0.02], [0.0, 0.0, 0.1])

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -1,10 +1,18 @@
 import numpy as np
 
 from positronic import keys
+from positronic.drivers.roboarm import command
 from positronic.drivers.roboarm.command import CartesianPosition
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import Policy, Session
-from positronic.policy.recording import Recorder, _build_blueprint, _squeeze_batch, _stack_numeric
+from positronic.policy.recording import (
+    Recorder,
+    _build_blueprint,
+    _command_field_arrays,
+    _flat_wire,
+    _squeeze_batch,
+    _stack_numeric,
+)
 
 
 class _TrackingSession(Session):
@@ -80,6 +88,65 @@ def test_stack_numeric():
     assert _stack_numeric(['a', 'b']) is None
     # Ragged fields can't form a homogeneous tensor.
     assert _stack_numeric([np.zeros(7), np.ones(3)]) is None
+
+
+_GAINS = ('kq', 'kqd', 'kx', 'kxd')
+
+
+def test_flat_wire_unfolds_a_nested_control_mode():
+    """The mode is a mapping inside the wire; a recording plots numeric leaves, so it has to come apart."""
+    mode = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+    flat = _flat_wire(command.to_wire(command.JointPosition(np.zeros(7), mode=mode)))
+
+    assert set(flat) == {'positions'} | {f'mode.impedance.{k}' for k in _GAINS}
+    np.testing.assert_allclose(flat['mode.impedance.kq'], mode.kq)
+
+
+def test_flat_wire_marks_a_mode_that_names_no_gains():
+    """`PositionControl()` names no gains, so it has no numeric leaf to plot; the marker is what shows it."""
+    flat = _flat_wire(command.to_wire(command.JointPosition(np.zeros(7), mode=command.PositionControl())))
+
+    assert flat == {'positions': flat['positions'], 'mode.position_control': 1}
+
+
+def test_a_cartesian_chunk_records_the_mode_beside_its_trajectory(tmp_path):
+    """A pose is drawn as a 3D path rather than a field series, so a mode pinned on it has nowhere else to go."""
+    mode = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+    pose = Transform3D(translation=np.array([0.1, 0.2, 0.3], dtype=np.float32), rotation=Rotation.identity)
+    actions = [{keys.ROBOT_COMMAND: CartesianPosition(pose=pose, mode=mode), 'timestamp': 0.0}]
+
+    rec = Recorder(tmp_path)
+    rec.tap('t').wrap(_TrackingPolicy(actions)).new_session()({'x': 1.0, keys.WALL_TIME_NS: 1})
+
+    assert any('mode.impedance.kq' in path for path in rec._series_paths), rec._series_paths
+    assert not any(path.endswith('cartesian_pos/pose') for path in rec._series_paths), 'the pose is the trajectory'
+
+
+def test_a_field_only_some_commands_carry_is_stacked_over_those():
+    """A chunk may pin a mode on one command and not the next, and the pinned one is still worth plotting."""
+    mode = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+    cmds = [command.JointPosition(np.zeros(7), mode=mode), command.JointPosition(np.ones(7))]
+
+    out = {name: (arr, horizon) for name, arr, horizon in _command_field_arrays('cmd', cmds, np.array([0.0, 0.1]))}
+
+    assert set(out) == {'cmd/joint_pos/positions'} | {f'cmd/joint_pos/mode.impedance.{k}' for k in _GAINS}
+    kq, kq_horizon = out['cmd/joint_pos/mode.impedance.kq']
+    assert kq.shape == (1, 7), 'the unpinned command has no gains to stack'
+    np.testing.assert_allclose(kq_horizon, [0.0])  # stacked against the command that carries it, not both
+
+
+def test_a_chunk_that_switches_law_records_both():
+    """Two commands pinning different laws share no mode field, and dropping what they disagree on loses both."""
+    impedance = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+    cmds = [
+        command.JointPosition(np.zeros(7), mode=command.PositionControl()),
+        command.JointPosition(np.ones(7), mode=impedance),
+    ]
+
+    names = {name for name, _, _ in _command_field_arrays('cmd', cmds, np.array([0.0, 0.1]))}
+
+    assert 'cmd/joint_pos/mode.position_control' in names
+    assert {f'cmd/joint_pos/mode.impedance.{k}' for k in _GAINS} <= names
 
 
 def test_single_tap_file_per_episode(tmp_path):

--- a/positronic/policy/tests/test_wrappers.py
+++ b/positronic/policy/tests/test_wrappers.py
@@ -7,6 +7,7 @@ import pytest
 
 from positronic import keys
 from positronic.drivers.roboarm import RobotStatus
+from positronic.drivers.roboarm.command import Impedance, JointDelta, Reset
 from positronic.geom import Rotation, Transform3D
 from positronic.policy import spec
 from positronic.policy.action import (
@@ -26,6 +27,7 @@ from positronic.policy.codec import (
     Codec,
     FlipGrip,
     RestrictImageSize,
+    SetControlMode,
 )
 from positronic.policy.observation import ObservationCodec
 from positronic.policy.wrappers import ChunkedSchedule, StopOnFault, TemporalStack
@@ -313,6 +315,49 @@ class _CapturePolicy(Policy):
 
 def _stack_obs(now_sec, value):
     return {keys.OBS_TIME_NS: int(now_sec * 1e9), 'v': np.array([value])}
+
+
+IMPEDANCE = Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+
+
+class TestSetControlMode:
+    def test_every_command_in_a_chunk_carries_the_mode(self):
+        chunk = [
+            {keys.ROBOT_COMMAND: JointDelta(velocities=np.zeros(7)), keys.ACTION_TIMESTAMP: 0.0},
+            {keys.ROBOT_COMMAND: JointDelta(velocities=np.ones(7)), keys.ACTION_TIMESTAMP: 0.1},
+            {keys.ACTION_TIMESTAMP: 0.2},  # the horizon sentinel carries no command
+        ]
+        decoded = SetControlMode(IMPEDANCE).decode(chunk)
+        assert isinstance(decoded, list)
+        for action in decoded[:2]:
+            assert isinstance(action, dict)
+            assert action[keys.ROBOT_COMMAND].mode == IMPEDANCE
+        assert keys.ROBOT_COMMAND not in decoded[2]
+
+    def test_a_single_action_carries_the_mode(self):
+        decoded = SetControlMode(IMPEDANCE).decode({keys.ROBOT_COMMAND: JointDelta(velocities=np.zeros(7))})
+        assert isinstance(decoded, dict)
+        assert decoded[keys.ROBOT_COMMAND].mode == IMPEDANCE
+
+    def test_every_arm_channel_is_stamped(self):
+        """A bimanual action names a channel per arm, and both execute under the mode."""
+        action = {
+            f'{keys.ROBOT_COMMAND}.left': JointDelta(velocities=np.zeros(7)),
+            f'{keys.ROBOT_COMMAND}.right': JointDelta(velocities=np.ones(7)),
+            keys.TARGET_JOINTS: np.zeros(7),  # in the command family by name, but a vector
+            'target_grip': 0.5,
+        }
+        decoded = SetControlMode(IMPEDANCE).decode(action)
+        assert isinstance(decoded, dict)
+        assert decoded[f'{keys.ROBOT_COMMAND}.left'].mode == IMPEDANCE
+        assert decoded[f'{keys.ROBOT_COMMAND}.right'].mode == IMPEDANCE
+        np.testing.assert_array_equal(decoded[keys.TARGET_JOINTS], np.zeros(7))
+
+    def test_a_reset_passes_through_unchanged(self):
+        """A reset names no mode: how the arm travels home is the driver's."""
+        decoded = SetControlMode(IMPEDANCE).decode({keys.ROBOT_COMMAND: Reset()})
+        assert isinstance(decoded, dict)
+        assert decoded[keys.ROBOT_COMMAND] == Reset()
 
 
 class TestTemporalStack:

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -62,33 +62,41 @@ class EnvAdapter(ABC):
 def _in_env_control_frame(cmd: Any, env_control_frame: geom.Transform3D) -> Any:
     """A command against the embodiment's ``default``, re-expressed in the frame the env measures and drives."""
     match cmd:
-        case roboarm_command.CartesianPosition(pose):
-            return roboarm_command.CartesianPosition(pose=pose * env_control_frame)
-        case roboarm_command.CartesianDelta(delta, frame):
-            return roboarm_command.CartesianDelta(delta, env_control_frame.inv * frame)
+        case roboarm_command.CartesianPosition(pose, mode):
+            return roboarm_command.CartesianPosition(pose=pose * env_control_frame, mode=mode)
+        case roboarm_command.CartesianDelta(delta, frame, mode):
+            return roboarm_command.CartesianDelta(delta, env_control_frame.inv * frame, mode)
         case _:
             return cmd
 
 
 def _wire_command(cmd: Any) -> dict[str, Any]:
-    """The held command as a positronic-free payload the server decodes (no ``geom``/``roboarm`` on its side)."""
+    """The held command as a positronic-free payload the server decodes (no ``geom``/``roboarm`` on its side).
+
+    A pinned control mode rides along under ``mode``; whether the env honors it is the env's.
+    """
+    wire: dict[str, Any]
+    rep = geom.Rotation.Representation.ROTATION_MATRIX
     match cmd:
         case roboarm_command.CartesianPosition(pose):
-            return {'type': 'cartesian', 'pose': pose.as_vector(geom.Rotation.Representation.ROTATION_MATRIX)}
+            wire = {'type': 'cartesian', 'pose': pose.as_vector(rep)}
         case roboarm_command.JointPosition(positions):
-            return {'type': 'joint_pos', 'q': positions}
+            wire = {'type': 'joint_pos', 'q': positions}
         case roboarm_command.JointDelta(velocities):
-            return {'type': 'joint_vel', 'dq': velocities}
+            wire = {'type': 'joint_vel', 'dq': velocities}
         case roboarm_command.CartesianDelta(delta, frame):
             # The env anchors a delta on the pose it measures, which is its control frame and nowhere else, so
             # a delta still expressed somewhere else has no faithful wire form.
             if not np.allclose(frame.as_matrix, np.eye(4)):
                 raise ValueError('CartesianDelta outside the env control frame cannot be sent to a remote env')
-            return {'type': 'cartesian_delta', 'delta': delta.as_vector(geom.Rotation.Representation.ROTATION_MATRIX)}
+            wire = {'type': 'cartesian_delta', 'delta': delta.as_vector(rep)}
         case None:
             return {'type': 'hold'}
         case other:
             raise ValueError(f'no wire encoding for robot_command {type(other).__name__}')
+    if cmd.mode is not None:
+        wire['mode'] = roboarm_command.to_wire(cmd.mode)
+    return wire
 
 
 class WireCommandAdapter(EnvAdapter):

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -147,6 +147,14 @@ def _settle(env, action: dict, steps: int) -> np.ndarray:
     return np.asarray(out['obs']['ee_pos'])
 
 
+def test_a_pinned_control_mode_rides_the_wire():
+    """Honoring a mode is the env's, so the adapter delivers it rather than deciding for every env."""
+    mode = roboarm_command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+    wired = _wire_command(roboarm_command.JointPosition(np.zeros(7), mode=mode))
+    assert wired['mode'] == roboarm_command.to_wire(mode)
+    assert 'mode' not in _wire_command(roboarm_command.JointPosition(np.zeros(7)))
+
+
 class TestEnvControlFrame:
     """An env measuring somewhere other than the embodiment's ``default`` gets commands re-expressed for it.
 
@@ -167,6 +175,15 @@ class TestEnvControlFrame:
         cmd = roboarm_command.CartesianDelta(delta, frame=self.frame)
         wired = _wire_command(_in_env_control_frame(cmd, self.frame))
         np.testing.assert_allclose(wired['delta'], delta.as_vector(self.rotmat), atol=1e-12)
+
+    def test_a_command_re_expressed_for_the_env_keeps_its_mode(self):
+        """The frame a command is measured in has nothing to do with the law that drives to it."""
+        mode = roboarm_command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+        pose = geom.Transform3D(np.array([0.4, 0.1, 0.3]), geom.Rotation.identity)
+        moved = _in_env_control_frame(roboarm_command.CartesianPosition(pose, mode=mode), self.frame)
+        assert moved.mode == mode
+        delta = _in_env_control_frame(roboarm_command.CartesianDelta(pose, mode=mode), self.frame)
+        assert delta.mode == mode
 
     def test_a_delta_outside_the_env_frame_is_refused(self):
         """The env anchors on its own measured pose, so a delta meant for another frame has no wire form."""

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -321,6 +321,7 @@ class MujocoSim(pimm.ControlSystem):
             mj.mj_step(self.model, self.data)
 
     def _apply_command(self, cmd):
+        """Drive the actuators to the setpoint ``cmd`` asks for; a control mode it pins is not honored."""
         match cmd:
             case roboarm_command.CartesianPosition(pose=pose):
                 q = self._recalculate_ik(pose)

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -11,6 +11,7 @@ from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, D
 from positronic.dataset.episode import Episode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
+from positronic.drivers.roboarm import command as roboarm_command
 from positronic.geom import Rotation, Transform3D
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.tests.testing_coutils import ManualDriver, drive_scheduler
@@ -235,6 +236,30 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
 
     for name in [keys.JOINTS, keys.JOINT_VEL, keys.GRIP]:
         assert_strictly_increasing(ep[name])
+
+
+@pytest.mark.parametrize(
+    'mode',
+    [
+        roboarm_command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6),
+        roboarm_command.PositionControl(),
+    ],
+    ids=['impedance', 'position_control'],
+)
+def test_mujoco_runs_a_command_that_pins_a_control_mode(mode):
+    """The actuators run their own law, so what a command pins makes no difference to what it does."""
+    sim = MujocoSim('positronic/assets/mujoco/franka_table.xml', loaders=())
+    target = np.asarray(sim.initial_ctrl[:7], dtype=np.float64).copy()
+    target[0] += 0.1
+    cmd = roboarm_command.JointPosition(positions=target, mode=mode)
+
+    with pimm.World(virtual_time=True) as world:
+        commands = world.pair(sim.commands)
+        driver = ManualDriver([(lambda: commands.emit(cmd), 0.1)])
+        scheduler = world.start([sim, driver])
+        drive_scheduler(scheduler, steps=50)
+
+    np.testing.assert_allclose(sim.data.ctrl[:7], target)
 
 
 def test_mujoco_grip_one_is_closed():

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -215,10 +215,15 @@ def dreamzero_action(tgt_joints_key: str, tgt_grip_key: str, num_joints: int):
 # frame-stack window.
 _action = dreamzero_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key=keys.TARGET_GRIP)
 joints = codecs.compose.override(obs=dreamzero_obs, action=_action, fps=15.0)
+phail_v1 = joints.override(action=codecs.phail_v1_execution.override(action=_action))
 
 # The pretrained DROID model (wan2.1) asserts exactly 320x180 frames; the wan2.2 fine-tunes resize the
 # 176-tall codec output at load, so only the DROID-serving codec needs the taller image.
-droid = codecs.compose.override(obs=dreamzero_obs.override(image_size=(IMAGE_WIDTH, 180)), action=_action, fps=15.0)
+droid = codecs.compose.override(
+    obs=dreamzero_obs.override(image_size=(IMAGE_WIDTH, 180)),
+    action=codecs.droid_execution.override(action=_action),
+    fps=15.0,
+)
 
 _traj_action = dreamzero_action.override(tgt_joints_key=keys.JOINTS, tgt_grip_key=keys.GRIP)
 joints_traj = codecs.compose.override(obs=dreamzero_obs, action=_traj_action, fps=15.0)

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -399,7 +399,7 @@ COMMANDS = {
     # TODO: publish this checkpoint to positronic-public and point here, as the other PhAIL models are
     # (`utilities/release_phail.py`, `positronic.cfg.phail.v1_0.models`). Reading it needs credentials until then.
     'phail': serve.override(
-        pipeline=joints,
+        pipeline=joints.override(codec=codecs.phail_v1),
         recording_dir='s3://inference/phail_unified/server_recordings/dreamzero/w22f1_100k_200626/',
         **{
             'pipeline.source.model_path': 's3://checkpoints/phail/dreamzero/w22f1_100k_200626/',

--- a/positronic/vendors/gr00t/codecs.py
+++ b/positronic/vendors/gr00t/codecs.py
@@ -202,6 +202,7 @@ _rot6d_action = _ee_action.override(**{'base.rotation_rep': 'rot6d', 'action_dim
 ee_quat = codecs.compose.override(obs=groot_obs, action=_ee_action)
 ee_quat_joints = ee_quat.override(**{'obs.include_joints': True})
 ee_rot6d = codecs.compose.override(obs=_rot6d_obs, action=_rot6d_action)
+phail_v1 = ee_rot6d.override(action=codecs.phail_v1_execution.override(action=_rot6d_action))
 ee_rot6d_joints = ee_rot6d.override(**{'obs.include_joints': True})
 
 _traj_action = _ee_action.override(base=codecs.traj_ee_action)

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -380,9 +380,10 @@ COMMANDS = {
     'ee_rot6d_rel': serve.override(pipeline=ee_rot6d_rel),
     'ee_rot6d_joints_rel': serve.override(pipeline=ee_rot6d_joints_rel),
     'phail': serve.override(
-        pipeline=ee_rot6d_rel.override(**{
-            'source.checkpoints_dir': 's3://checkpoints/phail_unified/groot/270226-ee_rot6d_rel/'
-        }),
+        pipeline=ee_rot6d_rel.override(
+            codec=codecs.phail_v1,
+            **{'source.checkpoints_dir': 's3://checkpoints/phail_unified/groot/270226-ee_rot6d_rel/'},
+        ),
         recording_dir='s3://inference/phail_unified/server_recordings/groot/270226-ee_rot6d_rel/',
     ),
     'sim_stack': serve.override(

--- a/positronic/vendors/lerobot/codecs.py
+++ b/positronic/vendors/lerobot/codecs.py
@@ -5,6 +5,7 @@ from positronic.cfg import codecs
 ee = codecs.compose.override(
     obs=codecs.eepose_obs.override(image_size=(512, 512)), action=codecs.absolute_pos_action, horizon=1.0
 )
+phail_v1 = ee.override(action=codecs.phail_v1_execution.override(action=codecs.absolute_pos_action))
 joints = codecs.compose.override(
     obs=codecs.joints_obs.override(image_size=(512, 512)), action=codecs.absolute_pos_action, horizon=1.0
 )

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -78,7 +78,10 @@ COMMANDS = {
     'joints_ik': serve.override(pipeline=joints_ik),
     'joints_ik_sim': serve.override(pipeline=joints_ik_sim),
     'phail': serve.override(
-        pipeline=ee.override(**{'source.checkpoints_dir': 's3://checkpoints/phail_unified/smolvla/170316_ee/'}),
+        pipeline=ee.override(
+            codec=lerobot_codecs.phail_v1,
+            **{'source.checkpoints_dir': 's3://checkpoints/phail_unified/smolvla/170316_ee/'},
+        ),
         recording_dir='s3://inference/phail_unified/server_recordings/smolvla/170316_ee/',
     ),
 }

--- a/positronic/vendors/lerobot_0_3_3/codecs.py
+++ b/positronic/vendors/lerobot_0_3_3/codecs.py
@@ -4,6 +4,7 @@ from positronic import keys
 from positronic.cfg import codecs
 
 ee = codecs.compose.override(obs=codecs.eepose_obs, action=codecs.absolute_pos_action, horizon=1.0)
+phail_v1 = ee.override(action=codecs.phail_v1_execution.override(action=codecs.absolute_pos_action))
 joints = ee.override(obs=codecs.joints_obs)
 
 # Trajectory variants: use actual robot trajectory as action target instead of commanded targets

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -109,7 +109,10 @@ COMMANDS = {
     'joints_ik_sim': serve.override(pipeline=joints_ik_sim),
     'ee_flip': serve.override(pipeline=ee_flip),
     'phail': serve.override(
-        pipeline=ee.override(**{'source.checkpoints_dir': 's3://checkpoints/phail_unified/lerobot/270226-ee/'}),
+        pipeline=ee.override(
+            codec=lerobot_codecs.phail_v1,
+            **{'source.checkpoints_dir': 's3://checkpoints/phail_unified/lerobot/270226-ee/'},
+        ),
         recording_dir='s3://inference/phail_unified/server_recordings/lerobot/270226-ee/',
     ),
     'sim_stack': serve.override(

--- a/positronic/vendors/molmoact2/codecs.py
+++ b/positronic/vendors/molmoact2/codecs.py
@@ -58,4 +58,4 @@ molmoact2_obs = cfn.Config(MolmoAct2ObservationCodec)
 _action = codecs.absolute_joints_action.override(tgt_joints_key=keys.TARGET_JOINTS, tgt_grip_key=keys.TARGET_GRIP)
 
 # franka_droid runs at 15 Hz; the model emits a 15-step horizon and compose executes all steps by default.
-droid = codecs.compose.override(obs=molmoact2_obs, action=_action, fps=15.0)
+droid = codecs.compose.override(obs=molmoact2_obs, action=codecs.droid_execution.override(action=_action), fps=15.0)

--- a/positronic/vendors/openpi/codecs.py
+++ b/positronic/vendors/openpi/codecs.py
@@ -140,6 +140,7 @@ droid_obs = cfn.Config(
 )
 
 ee = codecs.compose.override(obs=ee_obs, action=codecs.absolute_pos_action)
+phail_v1 = ee.override(action=codecs.phail_v1_execution.override(action=codecs.absolute_pos_action))
 ee_joints = ee.override(obs=ee_joints_obs)
 
 ee_traj = ee.override(action=codecs.traj_ee_action, binarize_grip=(keys.GRIP,))
@@ -159,7 +160,9 @@ joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 
 # DROID re-queries after its 8-step open-loop horizon; truncate the served chunk to match (8/15 s
 # at 15 fps) so the client re-queries every 8 steps instead of playing the full chunk open-loop.
-droid = codecs.compose.override(obs=droid_obs, action=codecs.joint_delta_action, horizon=8 / 15)
+droid = codecs.compose.override(
+    obs=droid_obs, action=codecs.droid_execution.override(action=codecs.joint_delta_action), horizon=8 / 15
+)
 
 # The DROID jointpos models (openpi `*_droid_jointpos` configs — the RoboLab leaderboard policies): the
 # server returns absolute joint-position chunks ``(action_horizon, 8)`` and RoboLab's client
@@ -169,7 +172,9 @@ droid = codecs.compose.override(obs=droid_obs, action=codecs.joint_delta_action,
 # after the full chunk executes, whatever each variant's length.
 droid_jointpos = codecs.compose.override(
     obs=droid_obs,
-    action=codecs.absolute_joints_action.override(tgt_joints_key=keys.JOINTS, tgt_grip_key=keys.GRIP),
+    action=codecs.droid_execution.override(
+        action=codecs.absolute_joints_action.override(tgt_joints_key=keys.JOINTS, tgt_grip_key=keys.GRIP)
+    ),
     binarize_grip=(keys.GRIP,),
 )
 

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -297,6 +297,7 @@ COMMANDS = {
     # TODO(#550): that rig's ``default`` moves to the flange, so this checkpoint will need a transform here.
     'phail': serve.override(
         pipeline=ee.override(
+            codec=codecs.phail_v1,
             ee_frame=None,
             **{'source.checkpoints_dir': 's3://checkpoints/phail_unified/openpi/pi05_positronic_lowmem/270226-ee/'},
         ),


### PR DESCRIPTION
## Summary

Part of #476 (DROID-parity execution for Franka). The arm's control mode stops being a separate
settings channel and becomes part of the command vocabulary every driver already speaks.

- Every roboarm command carries a `mode`: `PositionControl(stiffness=())` (the default) or
  `Impedance(kq, kqd, kx, kxd)`. Empty gains mean "whatever the driver deploys", so no
  Franka- or DROID-specific numbers live in the shared command module, and no command is
  stateful about the mode left in effect by the previous one.
- The Franka driver resolves empty gains against `positronic-franka`'s `InternalImpedance` /
  `SoftwareImpedance` defaults, switches the arm only when the resolved gains differ from what
  is running, and re-emits `robot_meta` under `keys.CONTROL_MODE` with the numeric gains in
  effect — so a recording says `kq = [40, 30, …]`, not "defaults".
- Arms that only do position control — MuJoCo sim, yam, so101, kinova, and the remote env
  adapter — raise on any other mode rather than executing it as if it were position control.
- `StampControlMode` is an inference-side codec that stamps the mode onto *every* command in a
  chunk (an unstamped one would run under the home default). `codecs.droid_execution` wraps the
  DROID action codecs — openpi `droid`, dreamzero `droid`, molmoact2 `droid` — so those chunks
  execute under the DROID impedance law.
- Recording: a mode other than the default serializes sparsely as `robot_command.mode.*`, the
  way `.reset` does.
- Wire: `mode` nests inside each command's mapping; a wire that carries no `mode` (a foreign
  server hand-building the bare form) reads as `PositionControl()`.

Not in this PR: `droid_jointpos` (the RoboLab leaderboard configs) still runs the default
position control — whether it should also execute under impedance is an open call.

## Test plan

- `uv run --locked pytest` — 1486 passed, 8 skipped
- `uv run --locked ruff check .` clean; `basedpyright` clean with no baseline additions
- New tests: the Franka driver switching mode once and reporting resolved gains; `Reset`
  restoring the home mode; MuJoCo rejecting a foreign mode; modes round-tripping inside
  commands over the wire; `StampControlMode` stamping a whole chunk
- Not verified: nothing ran on hardware. The arm-side validation from #476 — trace check, step
  response, `pi05_droid` eval — is still outstanding.