### PR TITLE
Recover from an aborted homing move instead of leaving the arm short

### DIFF
--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -110,8 +110,8 @@ class _Arm(DriverRun[command.CommandType]):
     _MOVE_GRACE_S = 5.0
     # Parking publishes nothing, so it comes back only as often as it needs to ask again
     _PARK_POLL_S = 0.005
-    # How many times a move the vendor aborted is commanded again. A reflex clears and the arm goes on; an arm
-    # held against something spends the attempts instead of driving at it for as long as the deadline allows.
+    # How many times a move the vendor aborted is commanded again — a bound a deadline cannot give, since a
+    # reflex trips in milliseconds
     _MOVE_ATTEMPTS = 3
 
     def __init__(
@@ -204,8 +204,7 @@ class _Arm(DriverRun[command.CommandType]):
                 stopped_short = f'the arm stopped short of its target: {goal.reason or goal.status}'
                 if attempts_left == 0:
                     raise RuntimeError(f'{stopped_short}, on all {self._MOVE_ATTEMPTS} attempts')
-                # A target commanded while the arm holds an error is refused outright, and the vendor leaves
-                # the clearing to the caller: only the caller knows whether going again is safe.
+                # A target commanded while the arm holds an error is refused outright
                 if not self.vendor.recover_from_errors():
                     raise RuntimeError(f'{stopped_short}, and its error will not clear')
                 logger.warning(f'{stopped_short}; cleared it, commanding again with {attempts_left} attempts left')
@@ -313,8 +312,6 @@ class _Arm(DriverRun[command.CommandType]):
         target = np.asarray(self._home_joints, dtype=np.float64)
         try:
             logger.info('Parking the arm at the home pose')
-            # Clears an error the run ended in, so the first attempt is a move rather than a refusal
-            self.vendor.recover_from_errors()
             deadline = self.clock.now() + self._park_timeout_s
             # The home pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -110,6 +110,9 @@ class _Arm(DriverRun[command.CommandType]):
     _MOVE_GRACE_S = 5.0
     # Parking publishes nothing, so it comes back only as often as it needs to ask again
     _PARK_POLL_S = 0.005
+    # How many times a move the vendor aborted is commanded again. A reflex clears and the arm goes on; an arm
+    # held against something spends the attempts instead of driving at it for as long as the deadline allows.
+    _MOVE_ATTEMPTS = 3
 
     def __init__(
         self,
@@ -185,17 +188,28 @@ class _Arm(DriverRun[command.CommandType]):
         pace: Callable[[], pimm.Command],
         mode: command.ControlModeType | None,
     ) -> Generator[pimm.Command, None, MoveStatus]:
-        """Command ``target`` under ``mode`` and poll the goal until the arm arrives, one poll per resume.
+        """Command ``target`` under ``mode`` and poll the goal until the arm arrives, one poll per resume,
+        clearing the arm and commanding it again over an abort.
 
         ``pace`` is what to wait between polls, and so how often the goal is asked about.
         """
+        attempts_left = self._MOVE_ATTEMPTS
         self.command_target(target, mode)
         while not should_stop():
             goal = self.vendor.goal()
             if goal.status == pf.GoalStatus.REACHED:
                 return MoveStatus.ARRIVED
             if goal.status != pf.GoalStatus.IN_FLIGHT:
-                raise RuntimeError(f'the arm stopped short of its target: {goal.reason or goal.status}')
+                attempts_left -= 1
+                stopped_short = f'the arm stopped short of its target: {goal.reason or goal.status}'
+                if attempts_left == 0:
+                    raise RuntimeError(f'{stopped_short}, on all {self._MOVE_ATTEMPTS} attempts')
+                # A target commanded while the arm holds an error is refused outright, and the vendor leaves
+                # the clearing to the caller: only the caller knows whether going again is safe.
+                if not self.vendor.recover_from_errors():
+                    raise RuntimeError(f'{stopped_short}, and its error will not clear')
+                logger.warning(f'{stopped_short}; cleared it, commanding again with {attempts_left} attempts left')
+                self.command_target(target, mode)
             yield pace()
         return MoveStatus.GAVE_UP
 
@@ -299,7 +313,8 @@ class _Arm(DriverRun[command.CommandType]):
         target = np.asarray(self._home_joints, dtype=np.float64)
         try:
             logger.info('Parking the arm at the home pose')
-            self.vendor.recover_from_errors()  # once, before the move: a reflex during the move ends the park
+            # Clears an error the run ended in, so the first attempt is a move rather than a refusal
+            self.vendor.recover_from_errors()
             deadline = self.clock.now() + self._park_timeout_s
             # The home pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -11,12 +11,14 @@ from pimm.tests.testing import MockClock, wire_call
 from positronic import geom
 from positronic.drivers.roboarm import RobotStatus, command, franka
 from positronic.drivers.roboarm.tests.fakes import StopFlag
-from positronic.drivers.utils import MoveAbandoned
+from positronic.drivers.utils import MoveAbandoned, MoveStatus
 from positronic.tests.testing_coutils import ManualCommandReceiver, RecordingEmitter
 
 HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 IMPEDANCE = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
+# What libfranka calls a collision reflex, as it reaches the driver in an aborted goal's reason
+REFLEX = 'libfranka: Move command aborted: motion aborted by reflex! ["cartesian_reflex"]'
 
 
 class Call(StrEnum):
@@ -52,12 +54,15 @@ class _ArmState:
 class FakeArm:
     """In-memory ``pf.Robot``: a commanded joint target is reached after ``polls_to_reach`` reads of ``goal``.
 
-    ``goal_status`` pins the reported status, so a move that never lands can be scripted; ``raises``, once
-    set, is what every call but ``stop`` raises, and ``ik_raises`` what only the solver raises; ``error`` is
-    the vendor fault flag every state carries.
+    ``goal_status`` pins the reported status, so a move that never lands can be scripted; ``aborts`` is how
+    many polls report a reflex before the arm behaves; ``recovers`` is whether its error clears; ``raises``,
+    once set, is what every call but ``stop`` raises, and ``ik_raises`` what only the solver raises; ``error``
+    is the vendor fault flag every state carries.
     """
 
-    def __init__(self, q, *, polls_to_reach: int = 2, goal_status: 'franka.pf.GoalStatus | None' = None):
+    def __init__(
+        self, q, *, polls_to_reach: int = 2, goal_status: 'franka.pf.GoalStatus | None' = None, aborts: int = 0
+    ):
         self.q = np.asarray(q, dtype=np.float64)
         self.error = 0
         self.calls: list[Call] = []
@@ -69,6 +74,8 @@ class FakeArm:
         self.polls_to_reach = polls_to_reach
         self._polls = 0
         self.goal_status = goal_status
+        self.aborts = aborts
+        self.recovers = True
 
     def _record(self, call: Call) -> None:
         self.calls.append(call)
@@ -88,6 +95,10 @@ class FakeArm:
         self._polls += 1
         if self.goal_status is not None:
             return _Goal(self.goal_status, 'scripted')
+        if self.aborts:
+            self.aborts -= 1
+            self.error = 1
+            return _Goal(franka.pf.GoalStatus.ABORTED, REFLEX)
         if self._polls >= self.polls_to_reach:
             self.q = self.targets[-1].copy()
             return _Goal(franka.pf.GoalStatus.REACHED, None)
@@ -98,8 +109,11 @@ class FakeArm:
         self.targets.append(np.asarray(target, dtype=np.float64))
         self._polls = 0
 
-    def recover_from_errors(self) -> None:
+    def recover_from_errors(self) -> bool:
         self._record(Call.RECOVER_FROM_ERRORS)
+        if self.recovers:
+            self.error = 0
+        return self.recovers
 
     def stop(self) -> None:
         self.calls.append(Call.STOP)
@@ -157,11 +171,17 @@ def _driver(arm: FakeArm, *, variation: list[float] | None = None, **kwargs) -> 
     return robot
 
 
-def _drive(loop, clock: MockClock | None = None) -> None:
-    """Pump a driver loop to exhaustion, standing in for the world by advancing ``clock`` through each Sleep."""
+def _drive(loop, clock: MockClock | None = None) -> MoveStatus | None:
+    """Pump a driver loop to exhaustion, standing in for the world by advancing ``clock`` through each Sleep,
+    and hand back what it returned."""
     clock = clock or MockClock()
-    for sleep in loop:
-        clock.advance(sleep.seconds)
+    while True:
+        try:
+            wait = next(loop)
+        except StopIteration as end:
+            return end.value
+        if isinstance(wait, pimm.Sleep):
+            clock.advance(wait.seconds)
 
 
 def _drive_park(driver: franka.Robot, arm: FakeArm) -> MockClock:
@@ -206,7 +226,7 @@ def test_park_gives_up_when_the_goal_stops_advancing():
 
     _drive_park(_driver(arm, manage_desk=False), arm)
 
-    assert arm.calls.count(Call.GOAL) == 1
+    assert arm.calls.count(Call.GOAL) == franka._Arm._MOVE_ATTEMPTS  # one poll each, and no waiting between
     np.testing.assert_allclose(arm.q, JOGGED)
 
 
@@ -404,6 +424,45 @@ def test_an_arm_that_will_not_home_reads_error_rather_than_ending_the_run():
 
     assert states.emitted, 'the driver published nothing'
     assert states.emitted[-1][1].status == RobotStatus.ERROR
+
+
+def test_a_reflex_during_the_opening_home_is_cleared_and_the_arm_sent_again(desk):
+    """A reflex aborts the goal and leaves the arm in error, so the home it cut short has to be commanded
+    again to happen at all."""
+    arm = FakeArm(JOGGED, aborts=1)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = _driver(arm).run(stop, clock)
+
+    for _ in range(4):
+        next(loop)
+
+    np.testing.assert_allclose(arm.q, HOME)
+    commanded = [i for i, call in enumerate(arm.calls) if call is Call.SET_TARGET_JOINTS]
+    assert len(commanded) == 2, 'the home was commanded once and never again'
+    assert Call.RECOVER_FROM_ERRORS in arm.calls[commanded[0] : commanded[1]]
+
+
+def test_a_move_that_keeps_aborting_gives_up_rather_than_driving_at_it_again():
+    arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)
+    clock = MockClock()
+
+    with pytest.raises(RuntimeError, match='on all 3 attempts'):
+        _drive(_driver(arm, manage_desk=False)._arm(StopFlag(), clock).move_to(HOME, None), clock)
+
+    assert arm.calls.count(Call.SET_TARGET_JOINTS) == franka._Arm._MOVE_ATTEMPTS
+
+
+def test_a_move_gives_up_at_once_on_an_error_the_arm_will_not_clear():
+    """An arm that cannot be cleared cannot be commanded either, so the attempts left are worth nothing."""
+    arm = FakeArm(JOGGED, aborts=1)
+    arm.recovers = False
+    clock = MockClock()
+
+    with pytest.raises(RuntimeError, match='will not clear'):
+        _drive(_driver(arm, manage_desk=False)._arm(StopFlag(), clock).move_to(HOME, None), clock)
+
+    assert arm.calls.count(Call.SET_TARGET_JOINTS) == 1
 
 
 def test_a_sync_move_answers_once_the_arm_is_there(world):

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -17,8 +17,6 @@ from positronic.tests.testing_coutils import ManualCommandReceiver, RecordingEmi
 HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 IMPEDANCE = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
-# What libfranka calls a collision reflex, as it reaches the driver in an aborted goal's reason
-REFLEX = 'libfranka: Move command aborted: motion aborted by reflex! ["cartesian_reflex"]'
 
 
 class Call(StrEnum):
@@ -60,6 +58,9 @@ class FakeArm:
     is the vendor fault flag every state carries.
     """
 
+    # What libfranka calls a collision reflex, as it reaches the driver in an aborted goal's reason
+    REFLEX = 'libfranka: Move command aborted: motion aborted by reflex! ["cartesian_reflex"]'
+
     def __init__(
         self, q, *, polls_to_reach: int = 2, goal_status: 'franka.pf.GoalStatus | None' = None, aborts: int = 0
     ):
@@ -98,7 +99,7 @@ class FakeArm:
         if self.aborts:
             self.aborts -= 1
             self.error = 1
-            return _Goal(franka.pf.GoalStatus.ABORTED, REFLEX)
+            return _Goal(franka.pf.GoalStatus.ABORTED, self.REFLEX)
         if self._polls >= self.polls_to_reach:
             self.q = self.targets[-1].copy()
             return _Goal(franka.pf.GoalStatus.REACHED, None)

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -362,7 +362,7 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
     _drive(loop, clock)
 
     # the park was attempted, and its failure went no further
-    assert arm.calls[mark:] == [Call.RECOVER_FROM_ERRORS, Call.STOP]
+    assert arm.calls[mark:] == [Call.SET_CONTROL_MODE, Call.STOP]
     assert desk.released
 
 


### PR DESCRIPTION
A `cartesian_reflex` aborts the vendor goal in flight. `await_goal` read the abort and raised, so the move that was meant to put the arm somewhere known simply did not happen — the arm stayed where the reflex stopped it.

It now clears the arm's error and commands the same target again, up to `_MOVE_ATTEMPTS` (3).

## Why the recovery belongs to the driver

The vendor is explicit that it does not do this itself. From `positronic-franka`'s `set_target_joints`:

> Clearing is the caller's call: a reflex means the arm hit something, and only the caller knows whether resuming is safe.

So an aborted goal leaves two facts standing: the arm holds an error, and a target commanded under one is refused outright. Clearing then re-commanding is the documented way back, and nothing was doing it.

## Recoverable vs terminal — where the distinction lives

Not in `GoalStatus`, which has one failure value: `NONE`, `IN_FLIGHT`, `REACHED`, `ABORTED`. Not in `Goal.reason` either — libfranka's own free text, carrying a reflex, a rejected plan, a lost connection and an expired deadline alike.

It lives in `recover_from_errors() -> bool`, documented as *"returns True if cleared"* and discarded at every call site until now. So the code asks it rather than classifying the reason:

- it clears → command the target again;
- it will not clear → raise at once, since the arm cannot be commanded either way;
- it keeps clearing and keeps aborting → the attempts run out and the raise stands.

The re-command goes through `command_target`, so the control law is re-applied with the target rather than left to whatever the abort dropped — the same pairing #651 requires of a first command.

## The bound

Both callers already pass a time-based `should_stop` (a travel deadline, or `park_timeout_s`), and a reflex trips in milliseconds — time alone would allow hundreds of retries into whatever the arm is against. The attempt count is what stops that: enough for a trip on the way past something, few enough that an arm genuinely held against something gives up rather than driving at it repeatedly with an operator nearby.

Homing still raises when the arm does not arrive; it gets a few chances to arrive first.

## Scope

`Robot.run` already logs and carries on at both homing call sites, so this does not change whether a failed home ends a run — it changes whether the home happens.

`park` used to clear the error itself before its move, because a reflex during that move ended the park. `await_goal` clears now, so that call had one owner too many and is gone; a park that starts on an errored arm spends its first attempt on the refusal and no wall clock.

## Tests

- `test_a_reflex_during_the_opening_home_is_cleared_and_the_arm_sent_again` — the incident. Against the current driver the arm finishes at `JOGGED`, logging `Homing failed … motion aborted by reflex! ["cartesian_reflex"]`; with the change it reaches `HOME`, with a clear between the two commands.
- `test_a_move_that_keeps_aborting_gives_up_rather_than_driving_at_it_again` — the other boundary: exactly `_MOVE_ATTEMPTS` commands, then the raise. Without it the retry is bounded only by the deadline.
- `test_a_move_gives_up_at_once_on_an_error_the_arm_will_not_clear` — a terminal fault still surfaces, on the first abort, having commanded once.

`FakeArm.recover_from_errors` returned `None`, which is not what the vendor returns; it now returns a `bool` and clears the fault flag, with `recovers` to script an arm that will not.

Lint, format, the basedpyright ratchet and the 251 tests under `positronic/drivers/` and `pimm/` pass.

## Not shipped here

The rig runs a pinned positronic (`661cd32a`), which predates #650 — there the raise escapes `Robot.run` and takes the whole World down, which is how two rounds died on 21 August at 6 of 30 and 17 of 24 episodes. Reaching the rig needs a later pin bump in `platform`, separately.

Ticket: Positronic-Robotics/internal#620

<!-- opened-by: posi-agent -->