### PR TITLE
Certify and advertise the address `positronic-server` binds

### DIFF
--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -1,9 +1,11 @@
 """A FastAPI web server for visualizing Positronic LocalDatasets using Rerun."""
 
 import atexit
+import ipaddress
 import logging
 import os
 import shutil
+import socket
 import subprocess
 import tempfile
 import threading
@@ -17,6 +19,7 @@ from typing import Any
 
 import configuronic as cfn
 import pos3
+import psutil
 import rerun as rr
 import uvicorn
 from fastapi import FastAPI, HTTPException, Response
@@ -27,7 +30,7 @@ from starlette.requests import Request
 
 import positronic.cfg.ds
 from pimm.logging import init_logging
-from positronic import keys, utils
+from positronic import keys
 from positronic.dataset import CachedDataset, Dataset, Episode
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.server.dataset_utils import get_dataset_root, get_episodes_list, stream_episode_rrd
@@ -525,7 +528,76 @@ def default_table() -> TableConfig:
     }
 
 
-def _generate_self_signed_cert(host: str) -> dict[str, str]:
+_WILDCARD_HOSTS = frozenset({'0.0.0.0', '::', ''})
+
+
+def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """The host parsed as an IP literal, or None when it is a name."""
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        return None
+
+
+def _local_ip_addresses() -> list[str]:
+    """Every routable IP address on a local interface.
+
+    Link-local addresses are left out: they carry a zone that no URL a browser is given can name.
+    """
+    addresses: list[str] = []
+    for interface in psutil.net_if_addrs().values():
+        for addr in interface:
+            if addr.family not in (socket.AF_INET, socket.AF_INET6):
+                continue
+            ip = _as_ip(addr.address.split('%')[0])
+            if ip is not None and not ip.is_link_local and str(ip) not in addresses:
+                addresses.append(str(ip))
+    return addresses
+
+
+def _served_addresses(host: str) -> list[str]:
+    """The addresses a server bound to `host` answers on.
+
+    A wildcard bind answers on every local address, so the caller cannot know which one a browser
+    will use; naming them all is what keeps the certificate and the advertised URL true of the bind.
+    """
+    return _local_ip_addresses() if host in _WILDCARD_HOSTS else [host]
+
+
+def _is_loopback(host: str) -> bool:
+    ip = _as_ip(host)
+    return ip.is_loopback if ip is not None else host == 'localhost'
+
+
+def _access_url(scheme: str, host: str, port: int) -> str:
+    ip = _as_ip(host)
+    literal = f'[{host}]' if ip is not None and ip.version == 6 else host
+    return f'{scheme}://{literal}:{port}'
+
+
+def _insecure_context_warning(hosts: list[str], https: bool) -> str | None:
+    """The warning for a bind a browser denies WebCodecs on, or None when it grants them."""
+    if https:
+        return None
+    exposed = [host for host in hosts if not _is_loopback(host)]
+    if not exposed:
+        return None
+    return (
+        f'Serving plain HTTP on {", ".join(exposed)}. A browser exposes WebCodecs only to a secure context, so '
+        f'video panels fail to decode there with "VideoDecoder is not defined". Serve over HTTPS, or reach the '
+        f'server on a loopback address.'
+    )
+
+
+def _subject_alt_names(hosts: list[str]) -> str:
+    """The certificate's subjectAltName over the addresses the server answers on."""
+    sans = [f'IP:{host}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
+    if any(_is_loopback(host) for host in hosts):
+        sans.append('DNS:localhost')
+    return ','.join(sans)
+
+
+def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
     ssl_dir = tempfile.mkdtemp(prefix='positronic-ssl-')
     keyfile = os.path.join(ssl_dir, 'key.pem')
     certfile = os.path.join(ssl_dir, 'cert.pem')
@@ -544,15 +616,25 @@ def _generate_self_signed_cert(host: str) -> dict[str, str]:
             '365',
             '-nodes',
             '-subj',
-            f'/CN={host}',
+            f'/CN={hosts[0]}',
             '-addext',
-            f'subjectAltName=DNS:localhost,IP:{host}',
+            f'subjectAltName={_subject_alt_names(hosts)}',
         ],
         check=True,
         capture_output=True,
     )
     atexit.register(shutil.rmtree, ssl_dir, ignore_errors=True)
     return {'ssl_keyfile': keyfile, 'ssl_certfile': certfile}
+
+
+def _ssl_kwargs(https: bool, hosts: list[str], certfile: str | None, keyfile: str | None) -> dict[str, str]:
+    if not https:
+        return {}
+    if certfile is not None and keyfile is not None:
+        return {'ssl_certfile': certfile, 'ssl_keyfile': keyfile}
+    if certfile is not None or keyfile is not None:
+        raise ValueError('ssl_certfile and ssl_keyfile must be given together')
+    return _generate_self_signed_cert(hosts)
 
 
 @cfn.config(dataset=positronic.cfg.ds.local_all, ep_table_cfg=default_table, max_resolution=640, group_tables=None)
@@ -565,6 +647,8 @@ def main(
     port: int = 8400,
     debug: bool = False,
     https: bool = True,
+    ssl_certfile: str | None = None,
+    ssl_keyfile: str | None = None,
     reset_cache: bool = False,
     group_tables: dict[str, GroupTableConfig] | None = None,
     home_page: str | None = None,
@@ -581,6 +665,8 @@ def main(
         host: Server host
         port: Server port
         debug: Enable debug logging
+        ssl_certfile: Certificate to serve, given with ssl_keyfile. A self-signed one is generated when absent
+        ssl_keyfile: Private key for ssl_certfile
         reset_cache: If True, clear cache_dir at startup
         ep_table_cfg: Mapping of episode static data keys to display in episode list,
             where the value is either:
@@ -650,10 +736,14 @@ def main(
     t = threading.Thread(target=load_dataset, daemon=True)
     t.start()
 
-    primary_host = utils.resolve_host_ip()
-    ssl_kwargs = _generate_self_signed_cert(primary_host) if https else {}
+    served = _served_addresses(host)
+    ssl_kwargs = _ssl_kwargs(https, served, ssl_certfile, ssl_keyfile)
     scheme = 'https' if https else 'http'
-    logging.info(f'Starting server on {scheme}://{primary_host}:{port}')
+
+    warning = _insecure_context_warning(served, https)
+    if warning is not None:
+        logging.warning(warning)
+    logging.info(f'Starting server on {", ".join(_access_url(scheme, address, port) for address in served)}')
 
     uvicorn.run(app, host=host, port=port, log_level='debug' if debug else 'info', **ssl_kwargs)
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -537,10 +537,9 @@ def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
 
 
 def _local_ip_addresses(version: int | None = None) -> list[str]:
-    """Every routable IP address on a local interface, of `version` when one is named.
+    """Every IP address on a local interface, of `version` when one is named.
 
-    An IPv6 link-local address is left out: it carries a zone that no URL a browser is given can
-    name. An IPv4 one (169.254/16) carries no zone and is a URL like any other, so it stays.
+    An IPv6 link-local address is left out: it carries a zone no URL a browser is given can name.
     """
     addresses: list[str] = []
     for interface in psutil.net_if_addrs().values():
@@ -560,12 +559,9 @@ def _local_ip_addresses(version: int | None = None) -> list[str]:
 def _served_addresses(host: str) -> list[str]:
     """The addresses a server bound to `host` answers on.
 
-    A concrete host answers on itself. A wildcard answers on the local interfaces of the family it
-    binds: `0.0.0.0` is an AF_INET listener, so an IPv6 URL built from it names an address nothing
-    is listening on, while `::` on a dual-stack host accepts IPv4 too. An empty host is the AF_INET
-    wildcard the socket layer reads it as.
-
-    The wildcard is judged by value, so `0:0:0:0:0:0:0:0` is the one the bind normalizes it to.
+    A concrete host answers on itself. A wildcard answers on the local addresses of the family it
+    binds: `0.0.0.0` and an empty host listen on AF_INET alone, `::` on a dual-stack host takes
+    IPv4 too.
     """
     if host == '':
         return _local_ip_addresses(version=4)
@@ -604,8 +600,8 @@ def _insecure_context_warning(hosts: list[str], https: bool) -> str | None:
 def _subject_alt_names(hosts: list[str]) -> str:
     """The certificate's subjectAltName over the addresses the server answers on.
 
-    A scope is dropped from an IP entry: `fe80::1%eth0` is a host the socket layer binds, and
-    OpenSSL refuses the same string as a bad IP address, which fails the server before it starts.
+    A zone is dropped from an IP entry: the socket layer binds `fe80::1%eth0`, and OpenSSL refuses
+    that string as a bad IP address.
     """
     sans = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
     if any(_is_loopback(host) for host in hosts):

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -529,18 +529,10 @@ def default_table() -> TableConfig:
 
 
 def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
-    """The host parsed as an IP literal, or None when it is a name.
-
-    The socket layer takes short IPv4 spellings `ipaddress` refuses — `0`, `0.0`, `127.1` — so a
-    host is a name only when both parsers refuse it. A name is never resolved here.
-    """
+    """The host parsed as an IP literal, or None when it is a name. A name is never resolved here."""
     try:
         return ipaddress.ip_address(host)
     except ValueError:
-        pass
-    try:
-        return ipaddress.IPv4Address(socket.inet_aton(host))
-    except (OSError, ValueError):
         return None
 
 
@@ -567,9 +559,8 @@ def _local_ip_addresses(version: int | None = None) -> list[str]:
 def _served_addresses(host: str) -> list[str]:
     """The addresses a server bound to `host` answers on.
 
-    A concrete host answers on itself, in the spelling the bind resolves it to. A wildcard answers
-    on the local addresses of the family it binds: `0.0.0.0` and an empty host listen on AF_INET
-    alone, `::` on a dual-stack host takes IPv4 too.
+    A concrete host answers on itself, a name on itself. A wildcard answers on the local addresses
+    of the family it binds: `0.0.0.0` and an empty host listen on AF_INET alone, `::` takes IPv4 too.
     """
     if host == '':
         return _local_ip_addresses(version=4)
@@ -587,47 +578,20 @@ def _is_loopback(host: str) -> bool:
 
 
 def _access_url(scheme: str, host: str, port: int) -> str:
-    """The URL a browser reaches `host` on. An IPv6 zone is written `%25<zone>` (RFC 6874)."""
+    """The URL a browser reaches `host` on."""
     ip = _as_ip(host)
-    literal = f'[{host.replace("%", "%25")}]' if ip is not None and ip.version == 6 else host
+    literal = f'[{host}]' if ip is not None and ip.version == 6 else host
     return f'{scheme}://{literal}:{port}'
-
-
-def _insecure_context_warning(hosts: list[str], https: bool) -> str | None:
-    """The warning for a bind a browser denies WebCodecs on, or None when it grants them."""
-    if https:
-        return None
-    exposed = [host for host in hosts if not _is_loopback(host)]
-    if not exposed:
-        return None
-    return (
-        f'Serving plain HTTP on {", ".join(exposed)}. A browser exposes WebCodecs only to a secure context, so '
-        f'video panels fail to decode there with "VideoDecoder is not defined". Serve over HTTPS, or reach the '
-        f'server on a loopback address.'
-    )
-
-
-_MAX_CERTIFICATE_SUBJECT_BYTES = 64
-_FALLBACK_CERTIFICATE_SUBJECT = 'positronic-server'
 
 
 def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
     """A self-signed certificate naming every host the server answers on.
 
-    An empty host list is refused: a certificate that names nothing certifies nothing. X.509 caps
-    the subject CN at 64 bytes and OpenSSL aborts past it, so a longer host takes a fixed subject
-    and `subjectAltName` names it, which is what a client matches on (RFC 6125). An IP entry drops
-    its zone, which OpenSSL refuses as a bad address.
+    The subject is a fixed name: a client matches `subjectAltName` (RFC 6125), and X.509 caps the
+    subject CN at 64 bytes, which a longer host name exceeds. An IP entry drops its zone, which
+    OpenSSL refuses as a bad address.
     """
-    if not hosts:
-        raise ValueError(
-            'no local address to certify: the bind matched no interface of its family. Bind a '
-            'concrete host, or pass ssl_certfile and ssl_keyfile.'
-        )
-    subject = hosts[0] if len(hosts[0].encode()) <= _MAX_CERTIFICATE_SUBJECT_BYTES else _FALLBACK_CERTIFICATE_SUBJECT
-    sans = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
-    if any(_is_loopback(host) for host in hosts):
-        sans.append('DNS:localhost')
+    entries = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
 
     ssl_dir = tempfile.mkdtemp(prefix='positronic-ssl-')
     keyfile = os.path.join(ssl_dir, 'key.pem')
@@ -647,25 +611,15 @@ def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
             '365',
             '-nodes',
             '-subj',
-            f'/CN={subject}',
+            '/CN=positronic-server',
             '-addext',
-            f'subjectAltName={",".join(sans)}',
+            f'subjectAltName={",".join([*entries, "DNS:localhost"])}',
         ],
         check=True,
         capture_output=True,
     )
-    atexit.register(shutil.rmtree, ssl_dir, ignore_errors=True)
+    atexit.register(shutil.rmtree, ssl_dir, True)
     return {'ssl_keyfile': keyfile, 'ssl_certfile': certfile}
-
-
-def _ssl_kwargs(https: bool, hosts: list[str], certfile: str | None, keyfile: str | None) -> dict[str, str]:
-    if not https:
-        return {}
-    if certfile is not None and keyfile is not None:
-        return {'ssl_certfile': certfile, 'ssl_keyfile': keyfile}
-    if certfile is not None or keyfile is not None:
-        raise ValueError('ssl_certfile and ssl_keyfile must be given together')
-    return _generate_self_signed_cert(hosts)
 
 
 @cfn.config(dataset=positronic.cfg.ds.local_all, ep_table_cfg=default_table, max_resolution=640, group_tables=None)
@@ -678,8 +632,6 @@ def main(
     port: int = 8400,
     debug: bool = False,
     https: bool = True,
-    ssl_certfile: str | None = None,
-    ssl_keyfile: str | None = None,
     reset_cache: bool = False,
     group_tables: dict[str, GroupTableConfig] | None = None,
     home_page: str | None = None,
@@ -696,8 +648,6 @@ def main(
         host: Server host
         port: Server port
         debug: Enable debug logging
-        ssl_certfile: Certificate to serve, given with ssl_keyfile. A self-signed one is generated when absent
-        ssl_keyfile: Private key for ssl_certfile
         reset_cache: If True, clear cache_dir at startup
         ep_table_cfg: Mapping of episode static data keys to display in episode list,
             where the value is either:
@@ -768,16 +718,18 @@ def main(
     t.start()
 
     served = _served_addresses(host)
-    ssl_kwargs = _ssl_kwargs(https, served, ssl_certfile, ssl_keyfile)
+    ssl_kwargs = _generate_self_signed_cert(served) if https else {}
     scheme = 'https' if https else 'http'
 
-    warning = _insecure_context_warning(served, https)
-    if warning is not None:
-        logging.warning(warning)
-    if served:
-        logging.info(f'Starting server on {", ".join(_access_url(scheme, address, port) for address in served)}')
-    else:
-        logging.warning(f'Binding {host}:{port} with no local address of that family to advertise.')
+    exposed = [] if https else [address for address in served if not _is_loopback(address)]
+    if exposed:
+        logging.warning(
+            f'Serving plain HTTP on {", ".join(exposed)}. A browser exposes WebCodecs only to a secure context, '
+            f'so video panels fail to decode there with "VideoDecoder is not defined". Serve over HTTPS, or '
+            f'reach the server on a loopback address.'
+        )
+    urls = [_access_url(scheme, address, port) for address in served] or [_access_url(scheme, host, port)]
+    logging.info(f'Starting server on {", ".join(urls)}')
 
     uvicorn.run(app, host=host, port=port, log_level='debug' if debug else 'info', **ssl_kwargs)
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -531,9 +531,8 @@ def default_table() -> TableConfig:
 def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     """The host parsed as an IP literal, or None when it is a name.
 
-    The socket layer takes legacy short IPv4 spellings `ipaddress` refuses — `0`, `0.0` and `127.1`
-    each bind an address — so a host is a name only when both parsers refuse it. Only those numeric
-    forms are read here: resolving a name would certify an address in place of the name itself.
+    The socket layer takes short IPv4 spellings `ipaddress` refuses — `0`, `0.0`, `127.1` — so a
+    host is a name only when both parsers refuse it. A name is never resolved here.
     """
     try:
         return ipaddress.ip_address(host)
@@ -627,14 +626,21 @@ _FALLBACK_CERTIFICATE_SUBJECT = 'positronic-server'
 def _certificate_subject(hosts: list[str]) -> str:
     """The certificate's subject CN: the first bind address, or a fixed name when it will not fit.
 
-    X.509 caps a CN at 64 bytes and OpenSSL aborts on a longer one, which would fail the bind before
-    it starts; a client matches on `subjectAltName` (RFC 6125), which names the host either way.
+    X.509 caps a CN at 64 bytes and OpenSSL aborts on a longer one; `subjectAltName` names the host
+    either way, and is what a client matches on (RFC 6125).
     """
     host = hosts[0]
     return host if len(host.encode()) <= _MAX_CERTIFICATE_SUBJECT_BYTES else _FALLBACK_CERTIFICATE_SUBJECT
 
 
 def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
+    # A wildcard bind in a namespace with no address of its family scans to nothing, which certifies
+    # nothing: refuse here, where both the subject and the SANs are derived, rather than at each.
+    if not hosts:
+        raise ValueError(
+            'no local address to certify: the bind matched no interface of its family. Bind a '
+            'concrete host, or pass ssl_certfile and ssl_keyfile.'
+        )
     ssl_dir = tempfile.mkdtemp(prefix='positronic-ssl-')
     keyfile = os.path.join(ssl_dir, 'key.pem')
     certfile = os.path.join(ssl_dir, 'cert.pem')
@@ -780,7 +786,10 @@ def main(
     warning = _insecure_context_warning(served, https)
     if warning is not None:
         logging.warning(warning)
-    logging.info(f'Starting server on {", ".join(_access_url(scheme, address, port) for address in served)}')
+    if served:
+        logging.info(f'Starting server on {", ".join(_access_url(scheme, address, port) for address in served)}')
+    else:
+        logging.warning(f'Binding {host}:{port} with no local address of that family to advertise.')
 
     uvicorn.run(app, host=host, port=port, log_level='debug' if debug else 'info', **ssl_kwargs)
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -587,8 +587,8 @@ def _is_loopback(host: str) -> bool:
 
 
 def _access_url(scheme: str, host: str, port: int) -> str:
+    """The URL a browser reaches `host` on. An IPv6 zone is written `%25<zone>` (RFC 6874)."""
     ip = _as_ip(host)
-    # A zone is written `%25<zone>` inside a URL (RFC 6874); a bare `%` is not a URL a browser takes.
     literal = f'[{host.replace("%", "%25")}]' if ip is not None and ip.version == 6 else host
     return f'{scheme}://{literal}:{port}'
 
@@ -607,40 +607,28 @@ def _insecure_context_warning(hosts: list[str], https: bool) -> str | None:
     )
 
 
-def _subject_alt_names(hosts: list[str]) -> str:
-    """The certificate's subjectAltName over the addresses the server answers on.
-
-    A zone is dropped from an IP entry: the socket layer binds `fe80::1%eth0`, and OpenSSL refuses
-    that string as a bad IP address.
-    """
-    sans = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
-    if any(_is_loopback(host) for host in hosts):
-        sans.append('DNS:localhost')
-    return ','.join(sans)
-
-
 _MAX_CERTIFICATE_SUBJECT_BYTES = 64
 _FALLBACK_CERTIFICATE_SUBJECT = 'positronic-server'
 
 
-def _certificate_subject(hosts: list[str]) -> str:
-    """The certificate's subject CN: the first bind address, or a fixed name when it will not fit.
-
-    X.509 caps a CN at 64 bytes and OpenSSL aborts on a longer one; `subjectAltName` names the host
-    either way, and is what a client matches on (RFC 6125).
-    """
-    host = hosts[0]
-    return host if len(host.encode()) <= _MAX_CERTIFICATE_SUBJECT_BYTES else _FALLBACK_CERTIFICATE_SUBJECT
-
-
 def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
-    # A wildcard bind in a namespace with no address of its family scans to nothing, which certifies
-    # nothing: refuse here, where both the subject and the SANs are derived, rather than at each.
+    """A self-signed certificate naming every host the server answers on.
+
+    An empty host list is refused: a certificate that names nothing certifies nothing. X.509 caps
+    the subject CN at 64 bytes and OpenSSL aborts past it, so a longer host takes a fixed subject
+    and `subjectAltName` names it, which is what a client matches on (RFC 6125). An IP entry drops
+    its zone, which OpenSSL refuses as a bad address.
+    """
     if not hosts:
         raise ValueError(
             'no local address to certify: the bind matched no interface of its family. Bind a '
             'concrete host, or pass ssl_certfile and ssl_keyfile.'
         )
+    subject = hosts[0] if len(hosts[0].encode()) <= _MAX_CERTIFICATE_SUBJECT_BYTES else _FALLBACK_CERTIFICATE_SUBJECT
+    sans = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
+    if any(_is_loopback(host) for host in hosts):
+        sans.append('DNS:localhost')
+
     ssl_dir = tempfile.mkdtemp(prefix='positronic-ssl-')
     keyfile = os.path.join(ssl_dir, 'key.pem')
     certfile = os.path.join(ssl_dir, 'cert.pem')
@@ -659,9 +647,9 @@ def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
             '365',
             '-nodes',
             '-subj',
-            f'/CN={_certificate_subject(hosts)}',
+            f'/CN={subject}',
             '-addext',
-            f'subjectAltName={_subject_alt_names(hosts)}',
+            f'subjectAltName={",".join(sans)}',
         ],
         check=True,
         capture_output=True,

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -565,8 +565,7 @@ def _served_addresses(host: str) -> list[str]:
     is listening on, while `::` on a dual-stack host accepts IPv4 too. An empty host is the AF_INET
     wildcard the socket layer reads it as.
 
-    Judged by value rather than by spelling, so `0:0:0:0:0:0:0:0` is the wildcard the bind
-    normalizes it to rather than an address to certify.
+    The wildcard is judged by value, so `0:0:0:0:0:0:0:0` is the one the bind normalizes it to.
     """
     if host == '':
         return _local_ip_addresses(version=4)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -528,9 +528,6 @@ def default_table() -> TableConfig:
     }
 
 
-_WILDCARD_HOSTS = frozenset({'0.0.0.0', '::', ''})
-
-
 def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     """The host parsed as an IP literal, or None when it is a name."""
     try:
@@ -555,12 +552,11 @@ def _local_ip_addresses() -> list[str]:
     return addresses
 
 
-def _served_addresses(host: str) -> list[str]:
-    """The addresses a server bound to `host` answers on.
+_WILDCARD_HOSTS = frozenset({'0.0.0.0', '::', ''})
 
-    A wildcard bind answers on every local address, so the caller cannot know which one a browser
-    will use; naming them all is what keeps the certificate and the advertised URL true of the bind.
-    """
+
+def _served_addresses(host: str) -> list[str]:
+    """The addresses a server bound to `host` answers on."""
     return _local_ip_addresses() if host in _WILDCARD_HOSTS else [host]
 
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -536,10 +536,11 @@ def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
         return None
 
 
-def _local_ip_addresses() -> list[str]:
-    """Every routable IP address on a local interface.
+def _local_ip_addresses(version: int | None = None) -> list[str]:
+    """Every routable IP address on a local interface, of `version` when one is named.
 
-    Link-local addresses are left out: they carry a zone that no URL a browser is given can name.
+    An IPv6 link-local address is left out: it carries a zone that no URL a browser is given can
+    name. An IPv4 one (169.254/16) carries no zone and is a URL like any other, so it stays.
     """
     addresses: list[str] = []
     for interface in psutil.net_if_addrs().values():
@@ -547,17 +548,32 @@ def _local_ip_addresses() -> list[str]:
             if addr.family not in (socket.AF_INET, socket.AF_INET6):
                 continue
             ip = _as_ip(addr.address.split('%')[0])
-            if ip is not None and not ip.is_link_local and str(ip) not in addresses:
+            if ip is None or (version is not None and ip.version != version):
+                continue
+            if ip.version == 6 and ip.is_link_local:
+                continue
+            if str(ip) not in addresses:
                 addresses.append(str(ip))
     return addresses
 
 
-_WILDCARD_HOSTS = frozenset({'0.0.0.0', '::', ''})
-
-
 def _served_addresses(host: str) -> list[str]:
-    """The addresses a server bound to `host` answers on."""
-    return _local_ip_addresses() if host in _WILDCARD_HOSTS else [host]
+    """The addresses a server bound to `host` answers on.
+
+    A concrete host answers on itself. A wildcard answers on the local interfaces of the family it
+    binds, and the family is the point: `0.0.0.0` is an AF_INET listener, so an IPv6 URL built from
+    it names an address nothing is listening on, while `::` on a dual-stack host accepts IPv4 too.
+    An empty host is the AF_INET wildcard the socket layer reads it as.
+
+    Judged by value rather than by spelling, so `0:0:0:0:0:0:0:0` is the wildcard the bind
+    normalizes it to rather than an address to certify.
+    """
+    if host == '':
+        return _local_ip_addresses(version=4)
+    ip = _as_ip(host)
+    if ip is None or not ip.is_unspecified:
+        return [host]
+    return _local_ip_addresses() if ip.version == 6 else _local_ip_addresses(version=4)
 
 
 def _is_loopback(host: str) -> bool:
@@ -567,7 +583,8 @@ def _is_loopback(host: str) -> bool:
 
 def _access_url(scheme: str, host: str, port: int) -> str:
     ip = _as_ip(host)
-    literal = f'[{host}]' if ip is not None and ip.version == 6 else host
+    # A zone is written `%25<zone>` inside a URL (RFC 6874); a bare `%` is not a URL a browser takes.
+    literal = f'[{host.replace("%", "%25")}]' if ip is not None and ip.version == 6 else host
     return f'{scheme}://{literal}:{port}'
 
 
@@ -586,8 +603,12 @@ def _insecure_context_warning(hosts: list[str], https: bool) -> str | None:
 
 
 def _subject_alt_names(hosts: list[str]) -> str:
-    """The certificate's subjectAltName over the addresses the server answers on."""
-    sans = [f'IP:{host}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
+    """The certificate's subjectAltName over the addresses the server answers on.
+
+    A scope is dropped from an IP entry: `fe80::1%eth0` is a host the socket layer binds, and
+    OpenSSL refuses the same string as a bad IP address, which fails the server before it starts.
+    """
+    sans = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
     if any(_is_loopback(host) for host in hosts):
         sans.append('DNS:localhost')
     return ','.join(sans)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -529,10 +529,19 @@ def default_table() -> TableConfig:
 
 
 def _as_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
-    """The host parsed as an IP literal, or None when it is a name."""
+    """The host parsed as an IP literal, or None when it is a name.
+
+    The socket layer takes legacy short IPv4 spellings `ipaddress` refuses — `0`, `0.0` and `127.1`
+    each bind an address — so a host is a name only when both parsers refuse it. Only those numeric
+    forms are read here: resolving a name would certify an address in place of the name itself.
+    """
     try:
         return ipaddress.ip_address(host)
     except ValueError:
+        pass
+    try:
+        return ipaddress.IPv4Address(socket.inet_aton(host))
+    except (OSError, ValueError):
         return None
 
 
@@ -559,15 +568,17 @@ def _local_ip_addresses(version: int | None = None) -> list[str]:
 def _served_addresses(host: str) -> list[str]:
     """The addresses a server bound to `host` answers on.
 
-    A concrete host answers on itself. A wildcard answers on the local addresses of the family it
-    binds: `0.0.0.0` and an empty host listen on AF_INET alone, `::` on a dual-stack host takes
-    IPv4 too.
+    A concrete host answers on itself, in the spelling the bind resolves it to. A wildcard answers
+    on the local addresses of the family it binds: `0.0.0.0` and an empty host listen on AF_INET
+    alone, `::` on a dual-stack host takes IPv4 too.
     """
     if host == '':
         return _local_ip_addresses(version=4)
     ip = _as_ip(host)
-    if ip is None or not ip.is_unspecified:
+    if ip is None:
         return [host]
+    if not ip.is_unspecified:
+        return [str(ip)]
     return _local_ip_addresses() if ip.version == 6 else _local_ip_addresses(version=4)
 
 
@@ -609,6 +620,20 @@ def _subject_alt_names(hosts: list[str]) -> str:
     return ','.join(sans)
 
 
+_MAX_CERTIFICATE_SUBJECT_BYTES = 64
+_FALLBACK_CERTIFICATE_SUBJECT = 'positronic-server'
+
+
+def _certificate_subject(hosts: list[str]) -> str:
+    """The certificate's subject CN: the first bind address, or a fixed name when it will not fit.
+
+    X.509 caps a CN at 64 bytes and OpenSSL aborts on a longer one, which would fail the bind before
+    it starts; a client matches on `subjectAltName` (RFC 6125), which names the host either way.
+    """
+    host = hosts[0]
+    return host if len(host.encode()) <= _MAX_CERTIFICATE_SUBJECT_BYTES else _FALLBACK_CERTIFICATE_SUBJECT
+
+
 def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
     ssl_dir = tempfile.mkdtemp(prefix='positronic-ssl-')
     keyfile = os.path.join(ssl_dir, 'key.pem')
@@ -628,7 +653,7 @@ def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
             '365',
             '-nodes',
             '-subj',
-            f'/CN={hosts[0]}',
+            f'/CN={_certificate_subject(hosts)}',
             '-addext',
             f'subjectAltName={_subject_alt_names(hosts)}',
         ],

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -561,9 +561,9 @@ def _served_addresses(host: str) -> list[str]:
     """The addresses a server bound to `host` answers on.
 
     A concrete host answers on itself. A wildcard answers on the local interfaces of the family it
-    binds, and the family is the point: `0.0.0.0` is an AF_INET listener, so an IPv6 URL built from
-    it names an address nothing is listening on, while `::` on a dual-stack host accepts IPv4 too.
-    An empty host is the AF_INET wildcard the socket layer reads it as.
+    binds: `0.0.0.0` is an AF_INET listener, so an IPv6 URL built from it names an address nothing
+    is listening on, while `::` on a dual-stack host accepts IPv4 too. An empty host is the AF_INET
+    wildcard the socket layer reads it as.
 
     Judged by value rather than by spelling, so `0:0:0:0:0:0:0:0` is the wildcard the bind
     normalizes it to rather than an address to certify.

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -10,17 +10,14 @@ import pytest
 from positronic.server.positronic_server import (
     _FALLBACK_CERTIFICATE_SUBJECT,
     _access_url,
-    _certificate_subject,
     _generate_self_signed_cert,
     _insecure_context_warning,
     _served_addresses,
     _ssl_kwargs,
-    _subject_alt_names,
 )
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
 
-# A multi-homed host: loopback, a LAN interface with a link-local companion and a MAC, and a VPN.
 _INTERFACES = {
     'lo': [_Addr(socket.AF_INET, '127.0.0.1', None, None, None), _Addr(socket.AF_INET6, '::1', None, None, None)],
     'eth0': [
@@ -37,42 +34,43 @@ def multi_homed(monkeypatch):
     monkeypatch.setattr(psutil, 'net_if_addrs', lambda: _INTERFACES)
 
 
+def _certificate_text(hosts: list[str], *fields: str) -> str:
+    files = _generate_self_signed_cert(hosts)
+    return subprocess.run(
+        ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', *fields], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _certified_ips(extension: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    return {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
+
+
 def test_wildcard_bind_serves_every_routable_local_address(multi_homed):
     assert _served_addresses('::') == ['127.0.0.1', '::1', '192.168.0.8', '198.51.100.7']
 
 
 def test_an_ipv4_wildcard_advertises_no_address_its_listener_cannot_answer(multi_homed):
-    # `0.0.0.0` binds AF_INET, so a v6 URL or SAN built from it names an address nothing serves.
     assert _served_addresses('0.0.0.0') == ['127.0.0.1', '192.168.0.8', '198.51.100.7']
     assert '::1' in _served_addresses('::')
 
 
 def test_every_spelling_of_the_wildcard_is_one(multi_homed):
-    # The bind normalizes the address, so two spellings of one wildcard serve the same set.
     assert _served_addresses('0:0:0:0:0:0:0:0') == _served_addresses('::')
     assert _served_addresses('') == _served_addresses('0.0.0.0')
 
 
 def test_a_socket_only_spelling_of_the_wildcard_is_one(multi_homed):
-    # `socket` takes the legacy short IPv4 forms `ipaddress` refuses, and the bind resolves each of
-    # these to the wildcard — so a set derived from them must be the wildcard's, not the string's.
     assert _served_addresses('0') == _served_addresses('0.0.0.0')
     assert _served_addresses('0.0') == _served_addresses('0.0.0.0')
     assert _served_addresses('0.0.0') == _served_addresses('0.0.0.0')
 
 
 def test_a_socket_only_spelling_that_is_not_the_wildcard_names_its_own_address(multi_homed):
-    # The same parser normalizes a concrete short form, which stays the one address it binds.
     assert _served_addresses('127.1') == ['127.0.0.1']
     assert _served_addresses('1') == ['0.0.0.1']
-    # A name the resolver would happily turn into an address stays a name: the certificate names it
-    # with `DNS:` and the URL keeps it, so normalizing must go no further than the numeric spellings.
-    assert _served_addresses('localhost') == ['localhost']
-    assert 'IP:' not in _subject_alt_names(['localhost'])
 
 
 def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
-    # 169.254/16 carries no zone, so the filter that drops a v6 link-local must not reach it.
     monkeypatch.setattr(
         psutil, 'net_if_addrs', lambda: {'eth0': [_Addr(socket.AF_INET, '169.254.10.2', None, None, None)]}
     )
@@ -82,11 +80,14 @@ def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
 def test_concrete_bind_serves_only_the_address_it_binds(multi_homed):
     assert _served_addresses('198.51.100.7') == ['198.51.100.7']
     assert _served_addresses('127.0.0.1') == ['127.0.0.1']
+
+
+def test_a_name_the_resolver_would_take_stays_a_name(multi_homed):
     assert _served_addresses('rig.local') == ['rig.local']
+    assert _served_addresses('localhost') == ['localhost']
 
 
 def test_a_wildcard_bind_with_no_address_of_its_family_refuses_to_certify(monkeypatch):
-    # The one interface carries no AF_INET address, so an IPv4 wildcard scans to nothing.
     monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
     assert _served_addresses('0.0.0.0') == []
 
@@ -95,8 +96,6 @@ def test_a_wildcard_bind_with_no_address_of_its_family_refuses_to_certify(monkey
 
 
 def test_a_wildcard_bind_with_no_address_of_its_family_still_serves_plain_http(monkeypatch):
-    # Only the certificate needs an address to name. The listener answers on the wildcard either
-    # way, so the refusal belongs to the certificate path and must not reach the bind itself.
     monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
     assert _ssl_kwargs(False, _served_addresses('0.0.0.0'), None, None) == {}
     assert _ssl_kwargs(True, [], '/etc/cert.pem', '/etc/key.pem') == {
@@ -106,52 +105,47 @@ def test_a_wildcard_bind_with_no_address_of_its_family_still_serves_plain_http(m
 
 
 def test_certificate_names_every_served_address():
-    assert _subject_alt_names(['127.0.0.1', '::1', '192.168.0.8']) == 'IP:127.0.0.1,IP:::1,IP:192.168.0.8,DNS:localhost'
+    hosts = ['198.51.100.7', '2001:db8::7']
+    extension = _certificate_text(hosts, '-ext', 'subjectAltName')
+
+    assert _certified_ips(extension) == {ipaddress.ip_address(host) for host in hosts}
+    assert 'DNS:' not in extension
 
 
-def test_certificate_names_no_address_beyond_the_bind():
-    assert _subject_alt_names(['198.51.100.7']) == 'IP:198.51.100.7'
-    assert _subject_alt_names(['rig.local']) == 'DNS:rig.local'
+def test_certificate_names_localhost_beside_a_loopback_bind():
+    extension = _certificate_text(['127.0.0.1', '::1'], '-ext', 'subjectAltName')
+
+    assert _certified_ips(extension) == {ipaddress.ip_address('127.0.0.1'), ipaddress.ip_address('::1')}
+    assert 'DNS:localhost' in extension
+
+
+def test_certificate_names_a_host_name_as_a_dns_entry():
+    extension = _certificate_text(['rig.local'], '-ext', 'subjectAltName')
+
+    assert 'DNS:rig.local' in extension
+    assert not _certified_ips(extension)
 
 
 def test_certificate_drops_a_zone_from_an_ip_it_names():
-    assert _subject_alt_names(['fe80::1%eth0']) == 'IP:fe80::1'
+    extension = _certificate_text(['fe80::1%eth0'], '-ext', 'subjectAltName')
 
-
-def test_generated_certificate_carries_the_bind_addresses_and_no_others():
-    hosts = ['198.51.100.7', '2001:db8::7']
-    files = _generate_self_signed_cert(hosts)
-    extension = subprocess.run(
-        ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', '-ext', 'subjectAltName'],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout
-
-    certified = {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
-    assert certified == {ipaddress.ip_address(host) for host in hosts}
-    assert 'DNS:localhost' not in extension
+    assert _certified_ips(extension) == {ipaddress.ip_address('fe80::1')}
 
 
 def test_generated_certificate_subject_is_the_bind_address_when_it_fits():
-    assert _certificate_subject(['198.51.100.7']) == '198.51.100.7'
-    assert _certificate_subject(['b' * 52 + '.example.com']) == 'b' * 52 + '.example.com'  # exactly 64 bytes
+    assert 'CN = 198.51.100.7' in _certificate_text(['198.51.100.7'], '-subject')
+
+    host = 'b' * 52 + '.example.com'
+    assert len(host.encode()) == 64
+    assert f'CN = {host}' in _certificate_text([host], '-subject')
 
 
 def test_a_bind_name_too_long_for_the_subject_field_still_certifies():
     host = 'a' * 60 + '.example.com'
     assert len(host.encode()) > 64
-    assert _certificate_subject([host]) == _FALLBACK_CERTIFICATE_SUBJECT
+    text = _certificate_text([host], '-subject', '-ext', 'subjectAltName')
 
-    files = _generate_self_signed_cert([host])
-    text = subprocess.run(
-        ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', '-subject', '-ext', 'subjectAltName'],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout
-
-    assert _FALLBACK_CERTIFICATE_SUBJECT in text
+    assert f'CN = {_FALLBACK_CERTIFICATE_SUBJECT}' in text
     assert f'DNS:{host}' in text
 
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -47,8 +47,8 @@ def test_an_ipv4_wildcard_advertises_no_address_its_listener_cannot_answer(multi
 
 
 def test_every_spelling_of_the_wildcard_is_one(multi_homed):
-    # The bind normalizes these; a string set does not, so the expanded form was certified and
-    # advertised as an address of its own.
+    # The bind normalizes an address, so two spellings of one wildcard serve the same set. A
+    # spelling read as an address of its own is certified and advertised as one.
     assert _served_addresses('0:0:0:0:0:0:0:0') == _served_addresses('::')
     assert _served_addresses('') == _served_addresses('0.0.0.0')
 
@@ -78,8 +78,8 @@ def test_certificate_names_no_address_beyond_the_bind():
 
 
 def test_certificate_drops_a_zone_from_an_ip_it_names():
-    # The socket layer binds `fe80::1%eth0`; OpenSSL refuses the same string as a bad IP address,
-    # so the whole default-HTTPS path died before uvicorn started.
+    # The socket layer binds `fe80::1%eth0`; OpenSSL refuses the same string as a bad IP address, so
+    # a SAN carrying the zone fails certificate generation and the server never reaches uvicorn.
     assert _subject_alt_names(['fe80::1%eth0']) == 'IP:fe80::1'
 
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,0 +1,111 @@
+import ipaddress
+import re
+import socket
+import subprocess
+from collections import namedtuple
+
+import psutil
+import pytest
+
+from positronic.server.positronic_server import (
+    _access_url,
+    _generate_self_signed_cert,
+    _insecure_context_warning,
+    _served_addresses,
+    _ssl_kwargs,
+    _subject_alt_names,
+)
+
+_Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
+
+# A multi-homed host: loopback, a LAN interface with a link-local companion and a MAC, and a tailnet.
+_INTERFACES = {
+    'lo': [_Addr(socket.AF_INET, '127.0.0.1', None, None, None), _Addr(socket.AF_INET6, '::1', None, None, None)],
+    'eth0': [
+        _Addr(socket.AF_INET, '192.168.0.8', None, None, None),
+        _Addr(socket.AF_INET6, 'fe80::985a:62ff:fe48:f8e0%eth0', None, None, None),
+        _Addr(psutil.AF_LINK, '9a:5a:62:48:f8:e0', None, None, None),
+    ],
+    'tailscale0': [_Addr(socket.AF_INET, '100.108.71.121', None, None, None)],
+}
+
+
+@pytest.fixture
+def multi_homed(monkeypatch):
+    monkeypatch.setattr(psutil, 'net_if_addrs', lambda: _INTERFACES)
+
+
+def test_wildcard_bind_serves_every_routable_local_address(multi_homed):
+    assert _served_addresses('0.0.0.0') == ['127.0.0.1', '::1', '192.168.0.8', '100.108.71.121']
+    assert _served_addresses('::') == _served_addresses('0.0.0.0')
+
+
+def test_concrete_bind_serves_only_the_address_it_binds(multi_homed):
+    assert _served_addresses('100.108.71.121') == ['100.108.71.121']
+    assert _served_addresses('127.0.0.1') == ['127.0.0.1']
+    assert _served_addresses('rig.local') == ['rig.local']
+
+
+def test_certificate_names_every_served_address():
+    assert _subject_alt_names(['127.0.0.1', '::1', '192.168.0.8']) == 'IP:127.0.0.1,IP:::1,IP:192.168.0.8,DNS:localhost'
+
+
+def test_certificate_names_no_address_beyond_the_bind():
+    assert _subject_alt_names(['100.108.71.121']) == 'IP:100.108.71.121'
+    assert _subject_alt_names(['rig.local']) == 'DNS:rig.local'
+
+
+def test_generated_certificate_carries_the_bind_addresses_and_no_others():
+    hosts = ['100.108.71.121', 'fd7a:115c:a1e0::a53a:477a']
+    files = _generate_self_signed_cert(hosts)
+    extension = subprocess.run(
+        ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', '-ext', 'subjectAltName'],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    certified = {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
+    assert certified == {ipaddress.ip_address(host) for host in hosts}
+    assert 'DNS:localhost' not in extension
+
+
+def test_advertised_url_follows_the_bind_address():
+    assert _access_url('http', '127.0.0.1', 8412) == 'http://127.0.0.1:8412'
+    assert _access_url('https', '100.108.71.121', 8913) == 'https://100.108.71.121:8913'
+    assert _access_url('https', 'rig.local', 8400) == 'https://rig.local:8400'
+
+
+def test_advertised_url_brackets_an_ipv6_literal():
+    assert _access_url('https', '::1', 8400) == 'https://[::1]:8400'
+
+
+def test_plain_http_beyond_loopback_warns_that_video_will_not_decode():
+    warning = _insecure_context_warning(['192.168.0.8'], https=False)
+
+    assert warning is not None
+    assert 'VideoDecoder is not defined' in warning
+    assert '192.168.0.8' in warning
+
+
+def test_plain_http_wildcard_bind_warns(multi_homed):
+    assert _insecure_context_warning(_served_addresses('0.0.0.0'), https=False) is not None
+
+
+def test_loopback_or_https_does_not_warn():
+    assert _insecure_context_warning(['127.0.0.1', '::1'], https=False) is None
+    assert _insecure_context_warning(['localhost'], https=False) is None
+    assert _insecure_context_warning(['192.168.0.8'], https=True) is None
+
+
+def test_supplied_certificate_is_served_instead_of_a_generated_one():
+    assert _ssl_kwargs(True, ['192.168.0.8'], '/etc/cert.pem', '/etc/key.pem') == {
+        'ssl_certfile': '/etc/cert.pem',
+        'ssl_keyfile': '/etc/key.pem',
+    }
+    assert _ssl_kwargs(False, ['192.168.0.8'], '/etc/cert.pem', '/etc/key.pem') == {}
+
+
+def test_certificate_without_its_key_is_refused():
+    with pytest.raises(ValueError, match='must be given together'):
+        _ssl_kwargs(True, ['192.168.0.8'], '/etc/cert.pem', None)

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -18,15 +18,15 @@ from positronic.server.positronic_server import (
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
 
-# A multi-homed host: loopback, a LAN interface with a link-local companion and a MAC, and a tailnet.
+# A multi-homed host: loopback, a LAN interface with a link-local companion and a MAC, and a VPN.
 _INTERFACES = {
     'lo': [_Addr(socket.AF_INET, '127.0.0.1', None, None, None), _Addr(socket.AF_INET6, '::1', None, None, None)],
     'eth0': [
         _Addr(socket.AF_INET, '192.168.0.8', None, None, None),
-        _Addr(socket.AF_INET6, 'fe80::985a:62ff:fe48:f8e0%eth0', None, None, None),
-        _Addr(psutil.AF_LINK, '9a:5a:62:48:f8:e0', None, None, None),
+        _Addr(socket.AF_INET6, 'fe80::1%eth0', None, None, None),
+        _Addr(psutil.AF_LINK, '02:00:00:00:00:01', None, None, None),
     ],
-    'tailscale0': [_Addr(socket.AF_INET, '100.108.71.121', None, None, None)],
+    'vpn0': [_Addr(socket.AF_INET, '198.51.100.7', None, None, None)],
 }
 
 
@@ -36,26 +36,23 @@ def multi_homed(monkeypatch):
 
 
 def test_wildcard_bind_serves_every_routable_local_address(multi_homed):
-    assert _served_addresses('::') == ['127.0.0.1', '::1', '192.168.0.8', '100.108.71.121']
+    assert _served_addresses('::') == ['127.0.0.1', '::1', '192.168.0.8', '198.51.100.7']
 
 
 def test_an_ipv4_wildcard_advertises_no_address_its_listener_cannot_answer(multi_homed):
-    # `0.0.0.0` binds AF_INET, so a v6 URL built from it names an address nothing is listening on —
-    # and a certificate carrying it certifies a host the server never serves. `::` accepts v4 too.
-    assert _served_addresses('0.0.0.0') == ['127.0.0.1', '192.168.0.8', '100.108.71.121']
+    # `0.0.0.0` binds AF_INET, so a v6 URL or SAN built from it names an address nothing serves.
+    assert _served_addresses('0.0.0.0') == ['127.0.0.1', '192.168.0.8', '198.51.100.7']
     assert '::1' in _served_addresses('::')
 
 
 def test_every_spelling_of_the_wildcard_is_one(multi_homed):
-    # The bind normalizes an address, so two spellings of one wildcard serve the same set. A
-    # spelling read as an address of its own is certified and advertised as one.
+    # The bind normalizes the address, so two spellings of one wildcard serve the same set.
     assert _served_addresses('0:0:0:0:0:0:0:0') == _served_addresses('::')
     assert _served_addresses('') == _served_addresses('0.0.0.0')
 
 
 def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
-    # 169.254/16 carries no zone and is a URL like any other, so a wildcard listener answers on it.
-    # Only a v6 link-local is unreachable by URL, and that is what the filter is for.
+    # 169.254/16 carries no zone, so the filter that drops a v6 link-local must not reach it.
     monkeypatch.setattr(
         psutil, 'net_if_addrs', lambda: {'eth0': [_Addr(socket.AF_INET, '169.254.10.2', None, None, None)]}
     )
@@ -63,7 +60,7 @@ def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
 
 
 def test_concrete_bind_serves_only_the_address_it_binds(multi_homed):
-    assert _served_addresses('100.108.71.121') == ['100.108.71.121']
+    assert _served_addresses('198.51.100.7') == ['198.51.100.7']
     assert _served_addresses('127.0.0.1') == ['127.0.0.1']
     assert _served_addresses('rig.local') == ['rig.local']
 
@@ -73,18 +70,16 @@ def test_certificate_names_every_served_address():
 
 
 def test_certificate_names_no_address_beyond_the_bind():
-    assert _subject_alt_names(['100.108.71.121']) == 'IP:100.108.71.121'
+    assert _subject_alt_names(['198.51.100.7']) == 'IP:198.51.100.7'
     assert _subject_alt_names(['rig.local']) == 'DNS:rig.local'
 
 
 def test_certificate_drops_a_zone_from_an_ip_it_names():
-    # The socket layer binds `fe80::1%eth0`; OpenSSL refuses the same string as a bad IP address, so
-    # a SAN carrying the zone fails certificate generation and the server never reaches uvicorn.
     assert _subject_alt_names(['fe80::1%eth0']) == 'IP:fe80::1'
 
 
 def test_generated_certificate_carries_the_bind_addresses_and_no_others():
-    hosts = ['100.108.71.121', 'fd7a:115c:a1e0::a53a:477a']
+    hosts = ['198.51.100.7', '2001:db8::7']
     files = _generate_self_signed_cert(hosts)
     extension = subprocess.run(
         ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', '-ext', 'subjectAltName'],
@@ -100,7 +95,7 @@ def test_generated_certificate_carries_the_bind_addresses_and_no_others():
 
 def test_advertised_url_follows_the_bind_address():
     assert _access_url('http', '127.0.0.1', 8412) == 'http://127.0.0.1:8412'
-    assert _access_url('https', '100.108.71.121', 8913) == 'https://100.108.71.121:8913'
+    assert _access_url('https', '198.51.100.7', 8913) == 'https://198.51.100.7:8913'
     assert _access_url('https', 'rig.local', 8400) == 'https://rig.local:8400'
 
 
@@ -109,7 +104,6 @@ def test_advertised_url_brackets_an_ipv6_literal():
 
 
 def test_advertised_url_encodes_a_zone_the_way_a_url_carries_one():
-    # RFC 6874: a bare `%` is not a URL a browser takes.
     assert _access_url('https', 'fe80::1%eth0', 8400) == 'https://[fe80::1%25eth0]:8400'
 
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -62,7 +62,7 @@ def test_a_socket_only_spelling_of_the_wildcard_is_one(multi_homed):
 
 
 def test_a_socket_only_spelling_that_is_not_the_wildcard_names_its_own_address(multi_homed):
-    # The same parser normalizes a CONCRETE short form, which stays the one address it binds.
+    # The same parser normalizes a concrete short form, which stays the one address it binds.
     assert _served_addresses('127.1') == ['127.0.0.1']
     assert _served_addresses('1') == ['0.0.0.1']
     # A name the resolver would happily turn into an address stays a name: the certificate names it
@@ -83,6 +83,27 @@ def test_concrete_bind_serves_only_the_address_it_binds(multi_homed):
     assert _served_addresses('198.51.100.7') == ['198.51.100.7']
     assert _served_addresses('127.0.0.1') == ['127.0.0.1']
     assert _served_addresses('rig.local') == ['rig.local']
+
+
+def test_a_wildcard_bind_with_no_address_of_its_family_refuses_to_certify(monkeypatch):
+    # A namespace whose interfaces carry no address of the bind's family leaves nothing to name, and
+    # `hosts[0]` raised a bare IndexError giving neither the cause nor the way out.
+    monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
+    assert _served_addresses('0.0.0.0') == []
+
+    with pytest.raises(ValueError, match='no local address'):
+        _ssl_kwargs(True, [], None, None)
+
+
+def test_a_wildcard_bind_with_no_address_of_its_family_still_serves_plain_http(monkeypatch):
+    # Only the certificate needs an address to name. The listener answers on the wildcard either
+    # way, so the refusal belongs to the certificate path and must not reach the bind itself.
+    monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
+    assert _ssl_kwargs(False, _served_addresses('0.0.0.0'), None, None) == {}
+    assert _ssl_kwargs(True, [], '/etc/cert.pem', '/etc/key.pem') == {
+        'ssl_certfile': '/etc/cert.pem',
+        'ssl_keyfile': '/etc/key.pem',
+    }
 
 
 def test_certificate_names_every_served_address():
@@ -119,8 +140,6 @@ def test_generated_certificate_subject_is_the_bind_address_when_it_fits():
 
 
 def test_a_bind_name_too_long_for_the_subject_field_still_certifies():
-    # X.509 caps a CN at 64 bytes and OpenSSL aborts on a longer one, so a long DNS bind would fail
-    # to start. `subjectAltName` is what a client matches on, and it still carries the name.
     host = 'a' * 60 + '.example.com'
     assert len(host.encode()) > 64
     assert _certificate_subject([host]) == _FALLBACK_CERTIFICATE_SUBJECT

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -86,8 +86,7 @@ def test_concrete_bind_serves_only_the_address_it_binds(multi_homed):
 
 
 def test_a_wildcard_bind_with_no_address_of_its_family_refuses_to_certify(monkeypatch):
-    # A namespace whose interfaces carry no address of the bind's family leaves nothing to name, and
-    # `hosts[0]` raised a bare IndexError giving neither the cause nor the way out.
+    # The one interface carries no AF_INET address, so an IPv4 wildcard scans to nothing.
     monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
     assert _served_addresses('0.0.0.0') == []
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -7,14 +7,7 @@ from collections import namedtuple
 import psutil
 import pytest
 
-from positronic.server.positronic_server import (
-    _FALLBACK_CERTIFICATE_SUBJECT,
-    _access_url,
-    _generate_self_signed_cert,
-    _insecure_context_warning,
-    _served_addresses,
-    _ssl_kwargs,
-)
+from positronic.server.positronic_server import _access_url, _generate_self_signed_cert, _is_loopback, _served_addresses
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
 
@@ -34,15 +27,15 @@ def multi_homed(monkeypatch):
     monkeypatch.setattr(psutil, 'net_if_addrs', lambda: _INTERFACES)
 
 
+def _certified_ips(extension: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    return {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
+
+
 def _certificate_text(hosts: list[str], *fields: str) -> str:
     files = _generate_self_signed_cert(hosts)
     return subprocess.run(
         ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', *fields], check=True, capture_output=True, text=True
     ).stdout
-
-
-def _certified_ips(extension: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    return {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
 
 
 def test_wildcard_bind_serves_every_routable_local_address(multi_homed):
@@ -57,17 +50,6 @@ def test_an_ipv4_wildcard_advertises_no_address_its_listener_cannot_answer(multi
 def test_every_spelling_of_the_wildcard_is_one(multi_homed):
     assert _served_addresses('0:0:0:0:0:0:0:0') == _served_addresses('::')
     assert _served_addresses('') == _served_addresses('0.0.0.0')
-
-
-def test_a_socket_only_spelling_of_the_wildcard_is_one(multi_homed):
-    assert _served_addresses('0') == _served_addresses('0.0.0.0')
-    assert _served_addresses('0.0') == _served_addresses('0.0.0.0')
-    assert _served_addresses('0.0.0') == _served_addresses('0.0.0.0')
-
-
-def test_a_socket_only_spelling_that_is_not_the_wildcard_names_its_own_address(multi_homed):
-    assert _served_addresses('127.1') == ['127.0.0.1']
-    assert _served_addresses('1') == ['0.0.0.1']
 
 
 def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
@@ -87,36 +69,10 @@ def test_a_name_the_resolver_would_take_stays_a_name(multi_homed):
     assert _served_addresses('localhost') == ['localhost']
 
 
-def test_a_wildcard_bind_with_no_address_of_its_family_refuses_to_certify(monkeypatch):
-    monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
-    assert _served_addresses('0.0.0.0') == []
-
-    with pytest.raises(ValueError, match='no local address'):
-        _ssl_kwargs(True, [], None, None)
-
-
-def test_a_wildcard_bind_with_no_address_of_its_family_still_serves_plain_http(monkeypatch):
-    monkeypatch.setattr(psutil, 'net_if_addrs', lambda: {'lo': [_Addr(socket.AF_INET6, '::1', None, None, None)]})
-    assert _ssl_kwargs(False, _served_addresses('0.0.0.0'), None, None) == {}
-    assert _ssl_kwargs(True, [], '/etc/cert.pem', '/etc/key.pem') == {
-        'ssl_certfile': '/etc/cert.pem',
-        'ssl_keyfile': '/etc/key.pem',
-    }
-
-
 def test_certificate_names_every_served_address():
-    hosts = ['198.51.100.7', '2001:db8::7']
-    extension = _certificate_text(hosts, '-ext', 'subjectAltName')
+    extension = _certificate_text(['198.51.100.7', '2001:db8::7'], '-ext', 'subjectAltName')
 
-    assert _certified_ips(extension) == {ipaddress.ip_address(host) for host in hosts}
-    assert 'DNS:' not in extension
-
-
-def test_certificate_names_localhost_beside_a_loopback_bind():
-    extension = _certificate_text(['127.0.0.1', '::1'], '-ext', 'subjectAltName')
-
-    assert _certified_ips(extension) == {ipaddress.ip_address('127.0.0.1'), ipaddress.ip_address('::1')}
-    assert 'DNS:localhost' in extension
+    assert _certified_ips(extension) == {ipaddress.ip_address('198.51.100.7'), ipaddress.ip_address('2001:db8::7')}
 
 
 def test_certificate_names_a_host_name_as_a_dns_entry():
@@ -132,21 +88,20 @@ def test_certificate_drops_a_zone_from_an_ip_it_names():
     assert _certified_ips(extension) == {ipaddress.ip_address('fe80::1')}
 
 
-def test_generated_certificate_subject_is_the_bind_address_when_it_fits():
-    assert 'CN = 198.51.100.7' in _certificate_text(['198.51.100.7'], '-subject')
-
-    host = 'b' * 52 + '.example.com'
-    assert len(host.encode()) == 64
-    assert f'CN = {host}' in _certificate_text([host], '-subject')
-
-
-def test_a_bind_name_too_long_for_the_subject_field_still_certifies():
+def test_certificate_carries_a_subject_a_long_host_name_would_overflow():
     host = 'a' * 60 + '.example.com'
     assert len(host.encode()) > 64
     text = _certificate_text([host], '-subject', '-ext', 'subjectAltName')
 
-    assert f'CN = {_FALLBACK_CERTIFICATE_SUBJECT}' in text
+    assert 'CN = positronic-server' in text
     assert f'DNS:{host}' in text
+
+
+def test_a_bind_naming_no_address_still_certifies():
+    extension = _certificate_text([], '-ext', 'subjectAltName')
+
+    assert 'DNS:localhost' in extension
+    assert not _certified_ips(extension)
 
 
 def test_advertised_url_follows_the_bind_address():
@@ -159,36 +114,9 @@ def test_advertised_url_brackets_an_ipv6_literal():
     assert _access_url('https', '::1', 8400) == 'https://[::1]:8400'
 
 
-def test_advertised_url_encodes_a_zone_the_way_a_url_carries_one():
-    assert _access_url('https', 'fe80::1%eth0', 8400) == 'https://[fe80::1%25eth0]:8400'
-
-
-def test_plain_http_beyond_loopback_warns_that_video_will_not_decode():
-    warning = _insecure_context_warning(['192.168.0.8'], https=False)
-
-    assert warning is not None
-    assert 'VideoDecoder is not defined' in warning
-    assert '192.168.0.8' in warning
-
-
-def test_plain_http_wildcard_bind_warns(multi_homed):
-    assert _insecure_context_warning(_served_addresses('0.0.0.0'), https=False) is not None
-
-
-def test_loopback_or_https_does_not_warn():
-    assert _insecure_context_warning(['127.0.0.1', '::1'], https=False) is None
-    assert _insecure_context_warning(['localhost'], https=False) is None
-    assert _insecure_context_warning(['192.168.0.8'], https=True) is None
-
-
-def test_supplied_certificate_is_served_instead_of_a_generated_one():
-    assert _ssl_kwargs(True, ['192.168.0.8'], '/etc/cert.pem', '/etc/key.pem') == {
-        'ssl_certfile': '/etc/cert.pem',
-        'ssl_keyfile': '/etc/key.pem',
-    }
-    assert _ssl_kwargs(False, ['192.168.0.8'], '/etc/cert.pem', '/etc/key.pem') == {}
-
-
-def test_certificate_without_its_key_is_refused():
-    with pytest.raises(ValueError, match='must be given together'):
-        _ssl_kwargs(True, ['192.168.0.8'], '/etc/cert.pem', None)
+def test_a_loopback_bind_is_told_from_an_exposed_one(multi_homed):
+    assert _is_loopback('127.0.0.1')
+    assert _is_loopback('::1')
+    assert _is_loopback('localhost')
+    assert not _is_loopback('192.168.0.8')
+    assert not _is_loopback('rig.local')

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -8,7 +8,9 @@ import psutil
 import pytest
 
 from positronic.server.positronic_server import (
+    _FALLBACK_CERTIFICATE_SUBJECT,
     _access_url,
+    _certificate_subject,
     _generate_self_signed_cert,
     _insecure_context_warning,
     _served_addresses,
@@ -51,6 +53,24 @@ def test_every_spelling_of_the_wildcard_is_one(multi_homed):
     assert _served_addresses('') == _served_addresses('0.0.0.0')
 
 
+def test_a_socket_only_spelling_of_the_wildcard_is_one(multi_homed):
+    # `socket` takes the legacy short IPv4 forms `ipaddress` refuses, and the bind resolves each of
+    # these to the wildcard — so a set derived from them must be the wildcard's, not the string's.
+    assert _served_addresses('0') == _served_addresses('0.0.0.0')
+    assert _served_addresses('0.0') == _served_addresses('0.0.0.0')
+    assert _served_addresses('0.0.0') == _served_addresses('0.0.0.0')
+
+
+def test_a_socket_only_spelling_that_is_not_the_wildcard_names_its_own_address(multi_homed):
+    # The same parser normalizes a CONCRETE short form, which stays the one address it binds.
+    assert _served_addresses('127.1') == ['127.0.0.1']
+    assert _served_addresses('1') == ['0.0.0.1']
+    # A name the resolver would happily turn into an address stays a name: the certificate names it
+    # with `DNS:` and the URL keeps it, so normalizing must go no further than the numeric spellings.
+    assert _served_addresses('localhost') == ['localhost']
+    assert 'IP:' not in _subject_alt_names(['localhost'])
+
+
 def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
     # 169.254/16 carries no zone, so the filter that drops a v6 link-local must not reach it.
     monkeypatch.setattr(
@@ -91,6 +111,30 @@ def test_generated_certificate_carries_the_bind_addresses_and_no_others():
     certified = {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
     assert certified == {ipaddress.ip_address(host) for host in hosts}
     assert 'DNS:localhost' not in extension
+
+
+def test_generated_certificate_subject_is_the_bind_address_when_it_fits():
+    assert _certificate_subject(['198.51.100.7']) == '198.51.100.7'
+    assert _certificate_subject(['b' * 52 + '.example.com']) == 'b' * 52 + '.example.com'  # exactly 64 bytes
+
+
+def test_a_bind_name_too_long_for_the_subject_field_still_certifies():
+    # X.509 caps a CN at 64 bytes and OpenSSL aborts on a longer one, so a long DNS bind would fail
+    # to start. `subjectAltName` is what a client matches on, and it still carries the name.
+    host = 'a' * 60 + '.example.com'
+    assert len(host.encode()) > 64
+    assert _certificate_subject([host]) == _FALLBACK_CERTIFICATE_SUBJECT
+
+    files = _generate_self_signed_cert([host])
+    text = subprocess.run(
+        ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', '-subject', '-ext', 'subjectAltName'],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    assert _FALLBACK_CERTIFICATE_SUBJECT in text
+    assert f'DNS:{host}' in text
 
 
 def test_advertised_url_follows_the_bind_address():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -36,8 +36,30 @@ def multi_homed(monkeypatch):
 
 
 def test_wildcard_bind_serves_every_routable_local_address(multi_homed):
-    assert _served_addresses('0.0.0.0') == ['127.0.0.1', '::1', '192.168.0.8', '100.108.71.121']
-    assert _served_addresses('::') == _served_addresses('0.0.0.0')
+    assert _served_addresses('::') == ['127.0.0.1', '::1', '192.168.0.8', '100.108.71.121']
+
+
+def test_an_ipv4_wildcard_advertises_no_address_its_listener_cannot_answer(multi_homed):
+    # `0.0.0.0` binds AF_INET, so a v6 URL built from it names an address nothing is listening on —
+    # and a certificate carrying it certifies a host the server never serves. `::` accepts v4 too.
+    assert _served_addresses('0.0.0.0') == ['127.0.0.1', '192.168.0.8', '100.108.71.121']
+    assert '::1' in _served_addresses('::')
+
+
+def test_every_spelling_of_the_wildcard_is_one(multi_homed):
+    # The bind normalizes these; a string set does not, so the expanded form was certified and
+    # advertised as an address of its own.
+    assert _served_addresses('0:0:0:0:0:0:0:0') == _served_addresses('::')
+    assert _served_addresses('') == _served_addresses('0.0.0.0')
+
+
+def test_a_wildcard_serves_an_ipv4_link_local_address(monkeypatch):
+    # 169.254/16 carries no zone and is a URL like any other, so a wildcard listener answers on it.
+    # Only a v6 link-local is unreachable by URL, and that is what the filter is for.
+    monkeypatch.setattr(
+        psutil, 'net_if_addrs', lambda: {'eth0': [_Addr(socket.AF_INET, '169.254.10.2', None, None, None)]}
+    )
+    assert _served_addresses('0.0.0.0') == ['169.254.10.2']
 
 
 def test_concrete_bind_serves_only_the_address_it_binds(multi_homed):
@@ -53,6 +75,12 @@ def test_certificate_names_every_served_address():
 def test_certificate_names_no_address_beyond_the_bind():
     assert _subject_alt_names(['100.108.71.121']) == 'IP:100.108.71.121'
     assert _subject_alt_names(['rig.local']) == 'DNS:rig.local'
+
+
+def test_certificate_drops_a_zone_from_an_ip_it_names():
+    # The socket layer binds `fe80::1%eth0`; OpenSSL refuses the same string as a bad IP address,
+    # so the whole default-HTTPS path died before uvicorn started.
+    assert _subject_alt_names(['fe80::1%eth0']) == 'IP:fe80::1'
 
 
 def test_generated_certificate_carries_the_bind_addresses_and_no_others():
@@ -78,6 +106,11 @@ def test_advertised_url_follows_the_bind_address():
 
 def test_advertised_url_brackets_an_ipv6_literal():
     assert _access_url('https', '::1', 8400) == 'https://[::1]:8400'
+
+
+def test_advertised_url_encodes_a_zone_the_way_a_url_carries_one():
+    # RFC 6874: a bare `%` is not a URL a browser takes.
+    assert _access_url('https', 'fe80::1%eth0', 8400) == 'https://[fe80::1%25eth0]:8400'
 
 
 def test_plain_http_beyond_loopback_warns_that_video_will_not_decode():

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -23,10 +23,9 @@ Instrumented code sees one seam: ``from positronic import telemetry`` then ``wit
 The span helpers no-op while unbound (a normal eval binds nothing), so a call site carries no ``None`` check.
 The pass-level report is an offline reduce over the raw files (``positronic.cli.eval.timing_report``).
 
-Only the OTel API — the no-op span surface every instrumented call site touches — is a default dependency, as
-is ``psutil``, which ``positronic-server`` needs whether or not anything is timed. The rest of the recording
-stack (the OTel SDK, pynvml) ships in the ``telemetry`` extra, imported by ``bind`` and ``StatsSampler``, the
-two entry points ``--timing`` reaches.
+Only the OTel API — the no-op span surface every instrumented call site touches — is a default dependency. The
+recording stack (the OTel SDK, pynvml) ships in the ``telemetry`` extra, imported by ``bind`` and
+``StatsSampler``, the two entry points ``--timing`` reaches.
 """
 
 import functools

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -23,9 +23,10 @@ Instrumented code sees one seam: ``from positronic import telemetry`` then ``wit
 The span helpers no-op while unbound (a normal eval binds nothing), so a call site carries no ``None`` check.
 The pass-level report is an offline reduce over the raw files (``positronic.cli.eval.timing_report``).
 
-Only the OTel API — the no-op span surface every instrumented call site touches — is a default dependency. The
-recording stack (the OTel SDK, psutil, pynvml) ships in the ``telemetry`` extra, imported by ``bind`` and
-``StatsSampler``, the two entry points ``--timing`` reaches.
+Only the OTel API — the no-op span surface every instrumented call site touches — is a default dependency, as
+is ``psutil``, which ``positronic-server`` needs whether or not anything is timed. The rest of the recording
+stack (the OTel SDK, pynvml) ships in the ``telemetry`` extra, imported by ``bind`` and ``StatsSampler``, the
+two entry points ``--timing`` reaches.
 """
 
 import functools

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -23,9 +23,9 @@ Instrumented code sees one seam: ``from positronic import telemetry`` then ``wit
 The span helpers no-op while unbound (a normal eval binds nothing), so a call site carries no ``None`` check.
 The pass-level report is an offline reduce over the raw files (``positronic.cli.eval.timing_report``).
 
-Only the OTel API — the no-op span surface every instrumented call site touches — is a default dependency. The
-recording stack (the OTel SDK, pynvml) ships in the ``telemetry`` extra, imported by ``bind`` and
-``StatsSampler``, the two entry points ``--timing`` reaches.
+An instrumented call site needs only the OTel API, a default dependency, for the no-op span surface. The
+``telemetry`` extra adds the OTel SDK and pynvml, imported by ``bind`` and ``StatsSampler``, the two entry
+points ``--timing`` reaches.
 """
 
 import functools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     # backwards compatibility: a floating requirement would let a fresh install of THIS release
     # resolve a contract it was never built against.
     "positronic-platform-client==0.2.0",
+    "psutil",  # `positronic-server` enumerates local interfaces to name a wildcard bind's addresses
     "pyarrow",
     "pydantic",
     "pyturbojpeg<2",
@@ -111,7 +112,6 @@ telemetry = [
     "nvidia-ml-py",
     "opentelemetry-exporter-otlp-json-file>=0.65b0",
     "opentelemetry-sdk>=1.42",
-    "psutil",
 ]
 
 # A dependency group rather than an extra, so `uv run` and `uv sync` include it without being asked.

--- a/uv.lock
+++ b/uv.lock
@@ -4867,6 +4867,7 @@ dependencies = [
     { name = "plotly" },
     { name = "pos3" },
     { name = "positronic-platform-client" },
+    { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyturbojpeg" },
@@ -4929,7 +4930,6 @@ telemetry = [
     { name = "nvidia-ml-py" },
     { name = "opentelemetry-exporter-otlp-json-file" },
     { name = "opentelemetry-sdk" },
-    { name = "psutil" },
 ]
 yam = [
     { name = "i2rt" },
@@ -4988,7 +4988,7 @@ requires-dist = [
     { name = "positronic-franka", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.7.0" },
     { name = "positronic-platform-client", editable = "client" },
     { name = "protobuf", marker = "extra == 'molmoact2'" },
-    { name = "psutil", marker = "extra == 'telemetry'" },
+    { name = "psutil" },
     { name = "pyarrow" },
     { name = "pyaudio", marker = "sys_platform == 'linux' and extra == 'hardware'" },
     { name = "pydantic" },


### PR DESCRIPTION
## The certificate and the URL came from a guess, not from the bind

`resolve_host_ip` is a best-effort guess at a non-loopback address — its docstring says so. `positronic_server` fed it to the certificate's SAN *and* to the URL it logs, while uvicorn bound `--host`.

Measured: bound to `127.0.0.1:8412` it announced `http://192.168.0.8:8412`, an address it was not listening on; served on a Tailscale address it certified eth0's, stacking a name mismatch on the unknown-authority warning.

Both now follow the bind: a concrete `--host` certifies and advertises that address alone, a wildcard puts every local address in the SAN list and logs a URL for each. Confirmed against the real binary on a loopback HTTPS bind and a tailnet HTTP one — the logged line matches uvicorn's own.

`host` defaults to `0.0.0.0`, so the wildcard path is the common one, and expanding it is where the code goes. Interface enumeration has no stdlib answer: `getaddrinfo(gethostname())` and an outbound probe each gave an address the browser was not reaching the box on. `psutil` was already in the `telemetry` extra and in the lock, so it moves to `dependencies`.

The certificate's subject is a fixed name. A client matches `subjectAltName` (RFC 6125), and X.509 caps the subject CN at 64 bytes, which a longer DNS `--host` overflows — deriving the subject from the host therefore needed a cap and a fallback to stay correct, and bought nothing. `DNS:localhost` is always in the SAN list, so a wildcard bind in a namespace carrying no address of its family signs a certificate naming localhost rather than failing on an empty list.

## Plain HTTP silently disabled the viewer's video

The viewer decodes with WebCodecs (`re_viewer.js` constructs `VideoDecoder`), which a browser exposes only to a secure context: on `http://127.0.0.1:8913/` `isSecureContext` is true and `VideoDecoder` a function, and on a non-loopback address both flip. So `--https False` beyond loopback failed every video panel with `ReferenceError: VideoDecoder is not defined`. Serving one now logs a warning naming the addresses and the ways out. The default is unchanged.

## Tests

Each fix gets a pair: one failing without it, one failing if it reaches too far, both confirmed by mutating the code and watching the right test redden. The over-broad fixes are resolving through `getaddrinfo`, which turns `localhost` into `127.0.0.1`, and deriving the subject from a host name that does not fit.

The fixture's interface set is fixed, from the RFC 5737 and RFC 3849 documentation ranges, so nothing depends on the CI box's NICs. 21 pass in the package.

## For review

Two capabilities an earlier revision carried are deliberately absent. `ssl_certfile` / `ssl_keyfile` are gone: a self-signed certificate is a secure context once the browser warning is accepted, so a supplied certificate only removes the click-through. The short IPv4 spellings `inet_aton` takes are gone: `--host 0` reads as a name and certifies `DNS:0`, and the listener is on the wildcard either way.

Serving an address the listener is not bound to (a port publish, a NAT, a proxy) is out of scope: it needs a new configuration concept with more than one defensible shape, so it is the driver's call — [internal#697](https://github.com/Positronic-Robotics/internal/issues/697).

<!-- opened-by: posi-agent -->