### PR TITLE
Ready the sim's arm by a `sync_move` it answers on arrival

### DIFF
--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -145,8 +145,9 @@ def mujoco_franka(sim, camera_dict):
         descriptor='mujoco.franka',
         observations=observations,
         commands=commands,
-        # The sim has no synchronous move of its own: drawing the scene is what puts the arm at its start pose
-        prepare_handlers={keys.SCENE: sim.env_reset},
+        # Two handlers on one sim: the draw places the objects, and the move takes the arm to where the
+        # trial starts it.
+        prepare_handlers={keys.SCENE: sim.env_reset, keys.ARM: sim.sync_move},
         static_meta={**ROBOT_STATIC_META, 'simulation.mujoco_model_path': sim.mujoco_model_path},
         meta_source=sim.robot_meta,
         control_systems=(sim,),

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -94,6 +94,7 @@ class Task:
 # [✓] Homing becomes a ``prepare`` call the arm and gripper answer once in place; ``Command.home`` goes with it.
 # [✓] A trial's reset is every ``prepare`` it asks for — scene, arm, gripper, human — and it opens once all answer.
 # [ ] ``command.Reset`` goes: a robot is put home by the ``prepare`` call, not by a command on its stream.
+# [ ] The recorder keeps what is on the wire when it opens, and the sim publishes frame-0 with its prepare answers.
 # [ ] One runner builds the world for both.
 @dataclass
 class Eval:

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -12,6 +12,7 @@ from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.ik import qpos_from_site_pose
 from positronic.drivers.roboarm.models import bundled_panda_model
+from positronic.drivers.utils import Moves, MoveStatus
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
 
 logger = logging.getLogger(__name__)
@@ -97,12 +98,15 @@ class _Cadence:
 class MujocoSim(pimm.ControlSystem):
     """The MuJoCo embodiment in one control system: scene, Franka arm, gripper, and cameras.
 
-    ``reset`` rebuilds the scene and flags frame-0 publication; the run loop publishes that post-reset
-    scene on its next turn — in sequence, before any step — so the first inference reads it and the
-    recorder logs it. Every other turn applies whatever command has just arrived, steps once, and emits
-    the due streams (post-step, Gym-style). The sim sleeps one control period each turn, so it is the
-    eval's sole time-master. Each stream has an independent rate (``*_fps``, ``None`` = every physics tick).
+    ``reset`` rebuilds the scene and ``sync_move`` puts the arm where the trial starts it; the run loop
+    publishes the readied scene as frame-0 once both have answered, so the first inference reads it and the
+    recorder logs it. Every other turn applies whatever command has just arrived, steps once, and emits the
+    due streams (post-step, Gym-style). The sim sleeps one control period each turn, so it is the eval's
+    sole time-master. Each stream has an independent rate (``*_fps``, ``None`` = every physics tick).
     """
+
+    _MOVE_TOL = 0.05  # radians; the position actuators hold the arm a few hundredths short of their ctrl
+    _MOVE_TIMEOUT_S = 5.0  # sim seconds a move gets before it gives up on the arm reaching its target
 
     def __init__(
         self,
@@ -141,10 +145,11 @@ class MujocoSim(pimm.ControlSystem):
         self._error = False
         self._adapters: dict[str, pimm.shared_memory.NumpySMAdapter] | None = None
         self._last_grip = 0.0
-        # Set by ``reset``; the run loop publishes frame-0 (instead of stepping) on its next turn and clears it.
+        # Set by ``reset``; the run loop publishes frame-0 (instead of stepping) once the trial is readied.
         self._reset_pending = False
 
         self.commands = pimm.ControlSystemReceiver[roboarm_command.CommandType](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[roboarm_command.CommandType | None, None](self)
         self.env_reset = pimm.calls.ControlSystemHandler[Any, None](self)
         self.state = pimm.ControlSystemEmitter[MujocoFrankaState](self)
         self.robot_meta = pimm.ControlSystemEmitter(self)
@@ -157,67 +162,92 @@ class MujocoSim(pimm.ControlSystem):
         # replays these states through it (``mj_setState`` + ``mj_forward``).
         self.sim_state = pimm.ControlSystemEmitter[dict[str, np.ndarray]](self)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
-        self._emit_robot_meta()
-        streams = [
+        self._moves = Moves[roboarm_command.CommandType](self.sync_move, self.commands)
+        self._streams = [
             (_Cadence(self._state_fps), self._emit_state),
             (_Cadence(self._grip_fps), self._emit_grip),
             (_Cadence(self._sim_state_fps), self._emit_sim_state),
             (_Cadence(self._camera_fps), self._emit_cameras),
         ]
 
-        while not should_stop.value:
-            yield pimm.Sleep(self.model.opt.timestep)
-            if self._reset_pending:
-                # The reset is this turn's step: publish the prepared scene as frame-0 (no ``mj_step``), so
-                # the recorder samples it before any step advances the sim. ``reset`` already loaded the scene.
-                self._reset_pending = False
-                self._emit_robot_meta()
-                # Rendering frame-0 is reset cost: it is work the reset asked for, and left untimed it would
-                # land in overhead.
-                with telemetry.span(telemetry_keys.SPAN_RESET):
-                    self._publish_frame()
-            elif (call := next(self.env_reset.incoming(), None)) is not None:
-                with pimm.calls.raise_to(call):
-                    self.reset(dict(call.request or {}).get(keys.EVAL_SEED))
-                    # Answered before frame-0 goes out: the recorder opens on this answer and drains its
-                    # channels as it opens, so a frame published first would be dropped. Frame-0 itself is
-                    # the next turn's, so no step comes between it and the reset.
-                    call.set_result(None)
-            else:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+        self._emit_robot_meta()
+        with self._moves:
+            while not should_stop.value:
+                yield pimm.Sleep(self.model.opt.timestep)
                 now = clock.now()
-                cmd = pimm.value_updated(self.commands)
-                if self._error:
-                    self._error = False
-                elif cmd is not None:
-                    self._apply_command(cmd)
-                if (grip := pimm.value_updated(self.target_grip)) is not None:
-                    self._last_grip = grip
-                self._apply_grip(self._last_grip)
+                # The scene is drawn and the arm readied in one turn, so a trial answers everything at once.
+                redraw = next(self.env_reset.incoming(), None)
+                if redraw is not None:
+                    with pimm.calls.raise_to(redraw):
+                        self.reset(dict(redraw.request or {}).get(keys.EVAL_SEED))
+                        redraw.set_result(None)
 
-                # An env step is the sim advance plus the observations it produces, rendering included
-                # (``_emit_cameras``): on an image-heavy scene the rendering is most of the step, and outside
-                # this span the wall split reads it as overhead.
-                with telemetry.span(telemetry_keys.SPAN_ENV_STEP):
-                    self.step()
-                    self.fps_counter.tick()
-                    for due, emit in streams:
-                        if due(now):
-                            emit()
+                command = self._moves.next_request()
+                if isinstance(command, pimm.calls.Call):
+                    self._accept_move(command, now)
+                elif self._error:
+                    self._error = False
+                elif command is not None:
+                    self._apply_command(command)
+                if redraw is None:  # a redraw is the turn's whole work
+                    self._advance(now)
 
         if self._renderer is not None:
             self._renderer.close()
             self._renderer = None
 
+    def _accept_move(self, call: pimm.calls.Call[roboarm_command.CommandType | None, None], now: float) -> None:
+        """Aim the actuators at what ``call`` asks for; the arm is that move's until it reads back there."""
+        with pimm.calls.raise_to(call):
+            target = self._target_joints(call.request)
+            self._set_actuator_values(target)
+            self._moves.accept(call, target, self._MOVE_TOL, now, self._MOVE_TIMEOUT_S)
+            # Already there: no travel to publish before the answer, and no step before frame-0.
+            if self._moves.settle(self._q, now) is MoveStatus.ARRIVED:
+                self._moves.answer()
+
+    def _step_and_emit(self, now: float) -> None:
+        if (grip := pimm.value_updated(self.target_grip)) is not None:
+            self._last_grip = grip
+        self._apply_grip(self._last_grip)
+
+        # An env step is the sim advance plus the observations it produces, rendering included
+        # (``_emit_cameras``): on an image-heavy scene the rendering is most of the step, and outside
+        # this span the wall split reads it as overhead.
+        with telemetry.span(telemetry_keys.SPAN_ENV_STEP):
+            self.step()
+            self.fps_counter.tick()
+            if self._moves.active and self._moves.settle(self._q, now) is MoveStatus.GAVE_UP:
+                self._error = True  # the arm is not where the move sent it
+            for due, emit in self._streams:
+                if due(now):
+                    emit()
+        self._moves.answer()  # after the state that says where the arm got to, never mid-travel
+
+    def _advance(self, now: float) -> None:
+        """Carry the sim through one turn: frame-0 for a scene just redrawn, otherwise a step."""
+        # Frame-0 goes out after the last answer a trial waits on, and before any step: the recorder opens
+        # on that answer and drains its channels as it opens.
+        if self._reset_pending and not self._moves.busy:
+            self._reset_pending = False
+            self._emit_robot_meta()
+            # Rendering frame-0 is reset cost: it is work the reset asked for, and left untimed it would
+            # land in overhead.
+            with telemetry.span(telemetry_keys.SPAN_RESET):
+                self._publish_frame()
+        else:
+            self._step_and_emit(now)
+
     def reset(self, seed: int | None = None):
-        """Re-randomize the scene from ``seed`` and arm frame-0 publication for the next turn.
+        """Re-randomize the scene from ``seed`` and flag frame-0 for publication.
 
         The model and data are rebuilt wholesale, so model-level loader effects (fixed-body poses,
         colors, cameras) re-randomize too; the renderer and IK physics rebind lazily. The run loop
-        publishes the prepared scene as frame-0 on its next turn — in sequence, before any step — so the
-        first inference reads the reset state and the recorder logs it. Stale commands queued while idle
-        are dropped and the held grip is cleared, so the first step does not apply a queued command on the
-        freshly reset scene.
+        publishes the prepared scene as frame-0 — in sequence, before any step — so the first inference
+        reads the readied state and the recorder logs it. Stale commands queued while idle are dropped and
+        the held grip is cleared, so the first step does not apply a queued command on the freshly reset
+        scene.
         """
         self._load_scene(seed)
         self._home()
@@ -271,6 +301,7 @@ class MujocoSim(pimm.ControlSystem):
         """Derive everything that hangs off ``self.model``; runs at construction and on every rebuild."""
         self.data = mj.MjData(self.model)
         self.initial_ctrl = [float(x) for x in self.metadata.get('initial_ctrl').split(',')]
+        self._home_joints = np.array([self.initial_ctrl[self.model.actuator(n).id] for n in self._actuator_names])
         self._joint_qpos_ids = [self.model.joint(name).qposadr.item() for name in self._joint_names]
         min_grip, max_grip = self.model.actuator(self._gripper_actuator).ctrlrange
         self._grip_range = (float(min_grip), float(max_grip))
@@ -320,34 +351,37 @@ class MujocoSim(pimm.ControlSystem):
         while self.data.time < target_time:
             mj.mj_step(self.model, self.data)
 
-    def _apply_command(self, cmd):
-        """Drive the actuators to the setpoint ``cmd`` asks for; a control mode it pins is not honored."""
+    def _target_joints(self, cmd: roboarm_command.CommandType | None) -> np.ndarray:
+        """The joints ``cmd`` asks the arm to hold; asking for nothing asks for home. A control mode it
+        pins is not honored: the sim runs its own law."""
         match cmd:
+            case None | roboarm_command.Reset():
+                return self._home_joints
             case roboarm_command.CartesianPosition(pose=pose):
-                q = self._recalculate_ik(pose)
-                if q is not None:
-                    self._set_actuator_values(q)
-                else:
-                    logger.warning(f'IK failed for ee_pose: {pose}')
-                    self._error = True
+                return self._ik(pose)
             case roboarm_command.CartesianDelta() as delta_cmd:
-                target = delta_cmd.apply(self._ee_pose)
-                q = self._recalculate_ik(target)
-                if q is not None:
-                    self._set_actuator_values(q)
-                else:
-                    logger.warning(f'IK failed for delta target: {target}')
-                    self._error = True
+                return self._ik(delta_cmd.apply(self._ee_pose))
             case roboarm_command.JointPosition(positions=positions):
-                self._set_actuator_values(positions)
+                return np.asarray(positions, dtype=np.float64)
             case roboarm_command.JointDelta(velocities=delta):
-                self._set_actuator_values(self._q + delta)
-            case roboarm_command.Reset():
-                self._home()  # the Reset command homes the arm; re-randomizing the scene is ``reset``'s job
-            case _:
-                raise ValueError(f'Unknown command type: {type(cmd)}')
+                return self._q + delta
+            case other:
+                raise NotImplementedError(f'Unsupported command {other}')
 
-    def _recalculate_ik(self, target: geom.Transform3D) -> np.ndarray | None:
+    def _apply_command(self, cmd: roboarm_command.CommandType) -> None:
+        """Aim the actuators at what ``cmd`` asks for, leaving the arm where it is if it cannot be met."""
+        if isinstance(cmd, roboarm_command.Reset):
+            self._home()  # the Reset command homes the arm; re-randomizing the scene is ``reset``'s job
+        else:
+            try:
+                self._set_actuator_values(self._target_joints(cmd))
+            # rules-allow: swallowed-error — a command stream cannot end the run; the arm reads ERROR instead
+            except ValueError as exc:
+                logger.warning(f'{cmd} not applied: {exc}')
+                self._error = True
+
+    def _ik(self, target: geom.Transform3D) -> np.ndarray:
+        """The joints that put the end effector at ``target``; raises what the arm cannot reach."""
         if self._ik_data is None:
             self._ik_data = mj.MjData(self.model)
             self._ik_site_id = mj.mj_name2id(self.model, mj.mjtObj.mjOBJ_SITE, self._ee_name)
@@ -363,7 +397,9 @@ class MujocoSim(pimm.ControlSystem):
             target.rotation.as_quat,
             rot_weight=0.5,
         )
-        return qpos[self._joint_qpos_ids] if success else None
+        if not success:
+            raise ValueError(f'{target} is out of reach')
+        return qpos[self._joint_qpos_ids]
 
     def _set_actuator_values(self, values: np.ndarray):
         for name, value in zip(self._actuator_names, values, strict=True):

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -99,10 +99,10 @@ class MujocoSim(pimm.ControlSystem):
     """The MuJoCo embodiment in one control system: scene, Franka arm, gripper, and cameras.
 
     ``reset`` rebuilds the scene and ``sync_move`` puts the arm where the trial starts it; the run loop
-    publishes the readied scene as frame-0 once both have answered, so the first inference reads it and the
-    recorder logs it. Every other turn applies whatever command has just arrived, steps once, and emits the
-    due streams (post-step, Gym-style). The sim sleeps one control period each turn, so it is the eval's
-    sole time-master. Each stream has an independent rate (``*_fps``, ``None`` = every physics tick).
+    publishes the readied scene as frame-0 once both have answered, before any step advances it. Every other
+    turn applies whatever command has just arrived, steps once, and emits the due streams (post-step,
+    Gym-style). The sim sleeps one control period each turn, so it is the eval's sole time-master. Each
+    stream has an independent rate (``*_fps``, ``None`` = every physics tick).
     """
 
     _MOVE_TOL = 0.05  # radians; the position actuators hold the arm a few hundredths short of their ctrl
@@ -177,7 +177,8 @@ class MujocoSim(pimm.ControlSystem):
             while not should_stop.value:
                 yield pimm.Sleep(self.model.opt.timestep)
                 now = clock.now()
-                # The scene is drawn and the arm readied in one turn, so a trial answers everything at once.
+                # The scene is drawn before the arm is asked for anything, so a move's target is computed
+                # against the model the redraw just built.
                 redraw = next(self.env_reset.incoming(), None)
                 if redraw is not None:
                     with pimm.calls.raise_to(redraw):
@@ -204,8 +205,10 @@ class MujocoSim(pimm.ControlSystem):
             target = self._target_joints(call.request)
             self._set_actuator_values(target)
             self._moves.accept(call, target, self._MOVE_TOL, now, self._MOVE_TIMEOUT_S)
-            # Already there: no travel to publish before the answer, and no step before frame-0.
+            # Already there: answered on the spot, after its state and without a step, so the scene a
+            # redraw just built reaches frame-0 untouched.
             if self._moves.settle(self._q, now) is MoveStatus.ARRIVED:
+                self._emit_state()
                 self._moves.answer()
 
     def _step_and_emit(self, now: float) -> None:
@@ -249,10 +252,9 @@ class MujocoSim(pimm.ControlSystem):
 
         The model and data are rebuilt wholesale, so model-level loader effects (fixed-body poses,
         colors, cameras) re-randomize too; the renderer and IK physics rebind lazily. The run loop
-        publishes the prepared scene as frame-0 — in sequence, before any step — so the first inference
-        reads the readied state and the recorder logs it. Stale commands queued while idle are dropped and
-        the held grip is cleared, so the first step does not apply a queued command on the freshly reset
-        scene.
+        publishes the prepared scene as frame-0 — in sequence, before any step advances it. Stale commands
+        queued while idle are dropped and the held grip is cleared, so the first step does not apply a
+        queued command on the freshly reset scene.
         """
         self._load_scene(seed)
         self._home()
@@ -406,8 +408,10 @@ class MujocoSim(pimm.ControlSystem):
             raise ValueError(f'{target} is out of reach')
         return qpos[self._joint_qpos_ids]
 
-    def _set_actuator_values(self, values: np.ndarray):
-        for name, value in zip(self._actuator_names, values, strict=True):
+    def _set_actuator_values(self, values: np.ndarray) -> None:
+        """Aim every arm actuator at ``values``; one that does not name them all leaves the arm alone."""
+        # Paired up front, so a refused target is refused before any actuator has been retargeted
+        for name, value in list(zip(self._actuator_names, values, strict=True)):
             self.data.actuator(name).ctrl = value
 
     def _apply_grip(self, target: float):

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -207,9 +207,20 @@ class MujocoSim(pimm.ControlSystem):
             self._moves.accept(call, target, self._MOVE_TOL, now, self._MOVE_TIMEOUT_S)
             # Already there: answered on the spot, after its state and without a step, so the scene a
             # redraw just built reaches frame-0 untouched.
-            if self._moves.settle(self._q, now) is MoveStatus.ARRIVED:
+            if self._settle_move(now) is MoveStatus.ARRIVED:
                 self._emit_state()
                 self._moves.answer()
+
+    def _settle_move(self, now: float) -> MoveStatus:
+        """Where the move in flight stands, once the arm it leaves behind is accounted for."""
+        status = self._moves.settle(self._q, now)
+        if status is not MoveStatus.MOVING:
+            self._error = self._moves.errored  # a move that lands clears what one that gave up left
+            if self._error:
+                # The actuators still drive at the target the move never reached; left there, the arm
+                # would resume it the moment whatever held it back goes away.
+                self._set_actuator_values(self._q)
+        return status
 
     def _step_and_emit(self, now: float) -> None:
         if (grip := pimm.value_updated(self.target_grip)) is not None:
@@ -222,13 +233,7 @@ class MujocoSim(pimm.ControlSystem):
         with telemetry.span(telemetry_keys.SPAN_ENV_STEP):
             self.step()
             self.fps_counter.tick()
-            ended = self._moves.active and self._moves.settle(self._q, now) is not MoveStatus.MOVING
-            if ended:
-                self._error = self._moves.errored  # a move that lands clears what one that gave up left
-                if self._error:
-                    # The actuators still drive at the target the move never reached; left there, the arm
-                    # would resume it the moment whatever held it back goes away.
-                    self._set_actuator_values(self._q)
+            ended = self._moves.active and self._settle_move(now) is not MoveStatus.MOVING
             # A move that ended says where the arm got to, whatever rate the state stream runs at
             if self._state_due(now) or ended:
                 self._emit_state()
@@ -375,11 +380,18 @@ class MujocoSim(pimm.ControlSystem):
             case roboarm_command.CartesianDelta() as delta_cmd:
                 return self._ik(delta_cmd.apply(self._ee_pose))
             case roboarm_command.JointPosition(positions=positions):
-                return np.asarray(positions, dtype=np.float64)
+                return self._joints(positions)
             case roboarm_command.JointDelta(velocities=delta):
-                return self._q + delta
+                return self._q + self._joints(delta)
             case other:
                 raise NotImplementedError(f'Unsupported command {other}')
+
+    def _joints(self, values: np.ndarray) -> np.ndarray:
+        """``values`` as a joint vector; NumPy would broadcast one that names fewer joints across them all."""
+        joints = np.asarray(values, dtype=np.float64)
+        if joints.shape != (len(self._joint_names),):
+            raise ValueError(f'{joints} does not name every joint')
+        return joints
 
     def _apply_command(self, cmd: roboarm_command.CommandType) -> None:
         """Aim the actuators at what ``cmd`` asks for, leaving the arm where it is if it cannot be met."""

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -163,8 +163,9 @@ class MujocoSim(pimm.ControlSystem):
         self.sim_state = pimm.ControlSystemEmitter[dict[str, np.ndarray]](self)
 
         self._moves = Moves[roboarm_command.CommandType](self.sync_move, self.commands)
+        # The state has a second reason to go out — a move that ended — so it is not one of ``_streams``.
+        self._state_due = _Cadence(self._state_fps)
         self._streams = [
-            (_Cadence(self._state_fps), self._emit_state),
             (_Cadence(self._grip_fps), self._emit_grip),
             (_Cadence(self._sim_state_fps), self._emit_sim_state),
             (_Cadence(self._camera_fps), self._emit_cameras),
@@ -218,8 +219,12 @@ class MujocoSim(pimm.ControlSystem):
         with telemetry.span(telemetry_keys.SPAN_ENV_STEP):
             self.step()
             self.fps_counter.tick()
-            if self._moves.active and self._moves.settle(self._q, now) is MoveStatus.GAVE_UP:
+            ended = self._moves.active and self._moves.settle(self._q, now) is not MoveStatus.MOVING
+            if ended and self._moves.errored:
                 self._error = True  # the arm is not where the move sent it
+            # A move that ended says where the arm got to, whatever rate the state stream runs at
+            if self._state_due(now) or ended:
+                self._emit_state()
             for due, emit in self._streams:
                 if due(now):
                     emit()

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -68,8 +68,8 @@ class MujocoFrankaState(State, pimm.shared_memory.NumpySMAdapter):
     def status(self) -> RobotStatus:
         return RobotStatus(int(self.array[14 + 7]))
 
-    def set_error(self):
-        self.array[14 + 7] = RobotStatus.ERROR.value
+    def set_status(self, status: RobotStatus):
+        self.array[14 + 7] = status.value
 
     def encode(self, q, dq, ee_pose):
         self.array[:7] = q
@@ -223,8 +223,12 @@ class MujocoSim(pimm.ControlSystem):
             self.step()
             self.fps_counter.tick()
             ended = self._moves.active and self._moves.settle(self._q, now) is not MoveStatus.MOVING
-            if ended and self._moves.errored:
-                self._error = True  # the arm is not where the move sent it
+            if ended:
+                self._error = self._moves.errored  # a move that lands clears what one that gave up left
+                if self._error:
+                    # The actuators still drive at the target the move never reached; left there, the arm
+                    # would resume it the moment whatever held it back goes away.
+                    self._set_actuator_values(self._q)
             # A move that ended says where the arm got to, whatever rate the state stream runs at
             if self._state_due(now) or ended:
                 self._emit_state()
@@ -288,7 +292,9 @@ class MujocoSim(pimm.ControlSystem):
         state = MujocoFrankaState()
         state.encode(self._q, self._dq, self._ee_pose)
         if self._error:
-            state.set_error()
+            state.set_status(RobotStatus.ERROR)
+        elif self._moves.active:
+            state.set_status(RobotStatus.BUSY)  # a move owns the arm, and the command stream goes unread
         self.state.emit(state)
 
     def _emit_grip(self):

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -415,8 +415,11 @@ class MujocoSim(pimm.ControlSystem):
         return qpos[self._joint_qpos_ids]
 
     def _set_actuator_values(self, values: np.ndarray) -> None:
-        """Aim every arm actuator at ``values``; one that does not name them all leaves the arm alone."""
-        # Paired up front, so a refused target is refused before any actuator has been retargeted
+        """Aim every arm actuator at ``values``; a target the arm cannot be put at leaves it alone."""
+        # Checked whole before the first write, so a refused target retargets nothing. A non-finite one
+        # steps the sim to NaN, and no comparison against NaN ever reports the arm arrived.
+        if not np.all(np.isfinite(values)):
+            raise ValueError(f'{np.asarray(values)} is not a joint target')
         for name, value in list(zip(self._actuator_names, values, strict=True)):
             self.data.actuator(name).ctrl = value
 

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -102,6 +102,41 @@ def test_a_move_that_ends_publishes_the_arm_before_it_answers():
         np.testing.assert_allclose(state.value.q, target, atol=sim._MOVE_TOL)
 
 
+def test_a_move_that_is_already_there_publishes_before_it_answers():
+    """The immediate answer owes its asker a state as much as one that travelled does."""
+    sim = MujocoSim(MODEL, loaders=(), state_fps=1.0)
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+        pimm.value_updated(state)  # drained, so what is read below is what the move published
+
+        answer = move(roboarm_command.JointPosition(home))
+
+        _answered(scheduler, answer, _turns(sim, 0.05)).result()
+        assert pimm.value_updated(state) is not None
+
+
+def test_a_move_naming_the_wrong_joints_leaves_the_arm_alone():
+    """The vector is paired with the actuators before any is written, so a refused move retargets none."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+
+        answer = move(roboarm_command.JointPosition(np.full(6, 1.0)))
+
+        with pytest.raises(ValueError):
+            _answered(scheduler, answer, _turns(sim, 1.0)).result()
+        drive_scheduler(scheduler, steps=_turns(sim, 1.0))
+        np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
+
+
 def test_a_move_the_arm_never_finishes_hands_its_asker_the_timeout():
     """The joints stop at their limits, so a target beyond them is one the arm can be held short of forever."""
     sim = MujocoSim(MODEL, loaders=())
@@ -132,7 +167,7 @@ def test_a_move_to_a_pose_the_arm_cannot_reach_hands_its_asker_the_reason():
 
 
 def test_frame_zero_waits_for_the_arm_a_trial_readies():
-    """The recorder opens on the last prepare's answer and drains as it opens, so frame-0 comes after it."""
+    """Frame-0 follows both prepare answers, so it is the first thing an episode opening on them can see."""
     sim = MujocoSim(MODEL, loaders=())
 
     with pimm.World(virtual_time=True) as world:

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -155,6 +155,24 @@ def test_a_move_to_joints_that_are_no_target_is_refused_rather_than_applied():
         np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
 
 
+def test_a_move_by_a_delta_that_names_fewer_joints_is_refused():
+    """NumPy broadcasts a one-element delta across every joint, so arity alone would accept it."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+
+        answer = move(roboarm_command.JointDelta(np.full(1, 0.3)))
+
+        with pytest.raises(ValueError, match='does not name every joint'):
+            _answered(scheduler, answer, _turns(sim, 1.0)).result()
+        drive_scheduler(scheduler, steps=_turns(sim, 0.5))
+        np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
+
+
 def test_a_move_the_arm_never_finishes_hands_its_asker_the_timeout():
     """The joints stop at their limits, so a target beyond them is one the arm can be held short of forever."""
     sim = MujocoSim(MODEL, loaders=())

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -1,0 +1,138 @@
+"""The sim's arm under a synchronous move: it travels through the physics, and answers once it is there."""
+
+import numpy as np
+import pytest
+
+import pimm
+from positronic.drivers.roboarm import RobotStatus
+from positronic.drivers.roboarm import command as roboarm_command
+from positronic.geom import Transform3D
+from positronic.simulator.mujoco.sim import MujocoSim
+from positronic.tests.testing_coutils import drive_scheduler
+
+MODEL = 'positronic/assets/mujoco/franka_table.xml'
+
+
+def _turns(sim: MujocoSim, seconds: float) -> int:
+    """How many run-loop turns cover ``seconds`` of sim time; a turn is one physics step."""
+    return int(seconds / sim.model.opt.timestep) + 10
+
+
+def _at_rest(scheduler, state, sim: MujocoSim) -> np.ndarray:
+    """Pump the world until the arm reports itself, and hand back the joints it rests at."""
+    drive_scheduler(scheduler, steps=_turns(sim, 0.1))
+    return state.value.q
+
+
+def _answered(scheduler, answer, turns: int):
+    """Pump the world until ``answer`` comes back, and hand it over."""
+    for _ in range(turns):
+        if answer.done():
+            return answer
+        next(scheduler)
+    raise AssertionError('the move never answered')
+
+
+def test_a_sync_move_travels_the_arm_to_the_joints_it_asks_for():
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        target = _at_rest(scheduler, state, sim) + 0.2
+
+        answer = move(roboarm_command.JointPosition(target))
+
+        assert _answered(scheduler, answer, _turns(sim, 5.0)).result() is None
+        np.testing.assert_allclose(state.value.q, target, atol=sim._MOVE_TOL)
+
+
+def test_a_sync_move_that_asks_for_nothing_puts_the_arm_home():
+    """Readying a rig is this call with nothing in it, so where it goes is the sim's own home pose."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        commands = world.pair(sim.commands)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+
+        commands.emit(roboarm_command.JointPosition(home + 0.3))
+        drive_scheduler(scheduler, steps=_turns(sim, 2.0))
+        assert np.max(np.abs(state.value.q - home)) > sim._MOVE_TOL, 'the arm never left home'
+
+        _answered(scheduler, move(None), _turns(sim, 5.0)).result()
+        np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
+
+
+def test_a_streamed_command_leaves_the_arm_alone_while_a_move_is_in_flight():
+    """A setpoint applied mid-travel fights the move, and its asker is owed the arrival it was promised."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        commands = world.pair(sim.commands)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+
+        answer = move(roboarm_command.JointPosition(home + 0.2))
+        drive_scheduler(scheduler, steps=2)
+        commands.emit(roboarm_command.JointPosition(home - 0.5))
+
+        _answered(scheduler, answer, _turns(sim, 5.0)).result()
+        np.testing.assert_allclose(state.value.q, home + 0.2, atol=sim._MOVE_TOL)
+
+
+def test_a_move_the_arm_never_finishes_hands_its_asker_the_timeout():
+    """The joints stop at their limits, so a target beyond them is one the arm can be held short of forever."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+
+        answer = move(roboarm_command.JointPosition(np.full(7, 10.0)))
+
+        with pytest.raises(TimeoutError):
+            _answered(scheduler, answer, _turns(sim, sim._MOVE_TIMEOUT_S + 1.0)).result()
+        assert state.value.status is RobotStatus.ERROR
+
+
+def test_a_move_to_a_pose_the_arm_cannot_reach_hands_its_asker_the_reason():
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        scheduler = world.start([sim])
+
+        answer = move(roboarm_command.CartesianPosition(Transform3D([10.0, 10.0, 10.0])))
+
+        with pytest.raises(ValueError, match='out of reach'):
+            _answered(scheduler, answer, _turns(sim, 1.0)).result()
+
+
+def test_frame_zero_waits_for_the_arm_a_trial_readies():
+    """The recorder opens on the last prepare's answer and drains as it opens, so frame-0 comes after it."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        draw = world.pair(sim.env_reset)
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        meta = world.pair(sim.robot_meta)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+        meta.read()  # the run start emits it too; frame-0 is the next one
+
+        drawn, readied = draw({}), move(roboarm_command.JointPosition(home + 0.3))
+
+        for _ in range(_turns(sim, 5.0)):
+            next(scheduler)
+            if pimm.value_updated(meta) is not None:
+                assert drawn.done() and readied.done(), 'frame-0 went out while the trial was still being readied'
+                return
+        pytest.fail('frame-0 never went out')

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -137,6 +137,24 @@ def test_a_move_naming_the_wrong_joints_leaves_the_arm_alone():
         np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
 
 
+def test_a_move_to_joints_that_are_no_target_is_refused_rather_than_applied():
+    """NaN controls step the sim to NaN, and no comparison against NaN ever reports the arm arrived."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        home = _at_rest(scheduler, state, sim)
+
+        answer = move(roboarm_command.JointPosition(np.full(7, float('nan'))))
+
+        with pytest.raises(ValueError, match='not a joint target'):
+            _answered(scheduler, answer, _turns(sim, 1.0)).result()
+        drive_scheduler(scheduler, steps=_turns(sim, 0.5))
+        np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
+
+
 def test_a_move_the_arm_never_finishes_hands_its_asker_the_timeout():
     """The joints stop at their limits, so a target beyond them is one the arm can be held short of forever."""
     sim = MujocoSim(MODEL, loaders=())

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -86,6 +86,22 @@ def test_a_streamed_command_leaves_the_arm_alone_while_a_move_is_in_flight():
         np.testing.assert_allclose(state.value.q, home + 0.2, atol=sim._MOVE_TOL)
 
 
+def test_a_move_that_ends_publishes_the_arm_before_it_answers():
+    """The state stream can run slower than the physics, and its asker still reads where the arm got to."""
+    sim = MujocoSim(MODEL, loaders=(), state_fps=1.0)
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        target = _at_rest(scheduler, state, sim) + 0.2
+
+        answer = move(roboarm_command.JointPosition(target))
+
+        _answered(scheduler, answer, _turns(sim, 5.0)).result()
+        np.testing.assert_allclose(state.value.q, target, atol=sim._MOVE_TOL)
+
+
 def test_a_move_the_arm_never_finishes_hands_its_asker_the_timeout():
     """The joints stop at their limits, so a target beyond them is one the arm can be held short of forever."""
     sim = MujocoSim(MODEL, loaders=())

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -153,6 +153,44 @@ def test_a_move_the_arm_never_finishes_hands_its_asker_the_timeout():
         assert state.value.status is RobotStatus.ERROR
 
 
+def test_the_arm_reads_busy_while_a_move_owns_it():
+    """BUSY is what an unread command stream looks like, and a move in flight is why it goes unread."""
+    sim = MujocoSim(MODEL, loaders=())
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        target = _at_rest(scheduler, state, sim) + 0.3
+
+        answer = move(roboarm_command.JointPosition(target))
+        drive_scheduler(scheduler, steps=5)
+
+        assert state.value.status is RobotStatus.BUSY
+        _answered(scheduler, answer, _turns(sim, 5.0)).result()
+        assert state.value.status is RobotStatus.AVAILABLE
+
+
+def test_a_move_that_gives_up_leaves_the_arm_where_it_stopped():
+    """The actuators keep driving at the last target they were given, so a move that fails hands them back."""
+    sim = MujocoSim(MODEL, loaders=())
+    sim._MOVE_TIMEOUT_S = 0.05  # the arm is still travelling when the move gives up
+
+    with pimm.World(virtual_time=True) as world:
+        move = world.pair(sim.sync_move)
+        state = world.pair(sim.state)
+        scheduler = world.start([sim])
+        target = _at_rest(scheduler, state, sim) + 0.5
+
+        answer = move(roboarm_command.JointPosition(target))
+
+        with pytest.raises(TimeoutError):
+            _answered(scheduler, answer, _turns(sim, 1.0)).result()
+        stopped = state.value.q
+        drive_scheduler(scheduler, steps=_turns(sim, 1.0))
+        np.testing.assert_allclose(state.value.q, stopped, atol=sim._MOVE_TOL)
+
+
 def test_a_move_to_a_pose_the_arm_cannot_reach_hands_its_asker_the_reason():
     sim = MujocoSim(MODEL, loaders=())
 

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -112,6 +112,8 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     # own post-reset scene (seeds 100 and 101), bit-reproducible from a fresh reset on the same seed. A
     # dropped frame-0 — or a stale step from the prior trial's run loop bleeding in — would record a
     # post-step state instead.
+    # TODO: the reference is a bare reset because no config asks for a starting arm pose. A task that sets
+    # ``keys.ARM`` in ``prepare_args`` moves the arm before frame-0, and the reference needs the same move.
     for i, seed in enumerate((100, 101)):
         reference = MujocoSim(
             'positronic/assets/mujoco/franka_table.xml', positronic.cfg.simulator.stack_cubes_loaders()


### PR DESCRIPTION
## Summary

`MujocoSim` gains `sync_move`, the same synchronous-move call every arm driver serves: the actuators are
aimed at what the call asks for, the sim steps until the joints read back there, and the call is answered
on arrival. This is not a reset — the arm travels through the physics. Asking for nothing asks for home;
a target the arm cannot reach comes back as `ValueError`, one it never reaches as `TimeoutError`.

The selection between a call and a streamed setpoint is the drivers' own `Moves`, so a move in flight
owns the arm and a policy command arriving mid-travel is ignored.

`mujoco_franka` now readies two things instead of one: `{SCENE: sim.env_reset, ARM: sim.sync_move}`. Both
are served in a single run-loop turn — the scene is drawn, then the arm readied on the scene it will run
on — so a trial answers everything it readies at once and frame-0 still lands after the recorder opens.
A move that asks for where the arm already stands settles as it is taken, costing no step, which keeps
frame-0 bit-identical to a fresh reset.

`_apply_command` splits: `_target_joints` turns any command into joints for both the streamed and the
called path, mirroring `franka.py` and `yam.py`, and `_ik` raises what the arm cannot reach rather than
returning `None`.

`Reset` on the command stream is untouched; the roadmap line that removes it is still open.

## Test plan

New `positronic/simulator/mujoco/tests/test_sim.py` — nothing existing covered `MujocoSim` as a subject:

- a move travels the arm to the joints it asks for
- a move asking for nothing puts the arm home
- a streamed command leaves the arm alone while a move is in flight
- a move the arm never finishes hands its asker the timeout, and the state reads ERROR
- a pose out of reach hands its asker the reason
- frame-0 waits for the arm a trial readies

`test_inference_integration` already pins frame-0 bit-for-bit against a fresh reset on the same seed, and
covers this change end to end.

Full suite: 1611 passed, 8 skipped. ruff and basedpyright clean, type-check baseline unchanged.