### PR TITLE
Take home out of the robots: a caller names where the arm goes

### DIFF
--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -138,9 +138,8 @@ The `robot_command` field says what the arm is asked to do. Build one of the com
 | `JointPosition` | `positions`: float32 (7,) | Target joint angles (radians) |
 | `JointDelta` | `velocities`: float32 (7,) | Joint velocity command |
 | `CartesianDelta` | `delta`, `frame`: `geom.Transform3D` | Relative motion, composed onto the pose the arm is at when it lands; `frame` is the frame `delta` is expressed in |
-| `Reset` | — | Return the arm to its home position |
 
-Every command but `Reset` also takes an optional `mode`, the control law it asks to execute under:
+Every command also takes an optional `mode`, the control law it asks to execute under:
 `PositionControl(stiffness=...)` for a position servo, or `Impedance(kq, kqd, kx, kxd)` for the hybrid
 joint/Cartesian law. Omit it — the default — and the arm runs its native law. What a pinned mode does is the
 driver's: a simulator runs its own law regardless, and a driver that cannot execute the mode raises.

--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -25,7 +25,7 @@ uv run positronic-data-collection sim \
     --webxr=.iphone
 ```
 
-Install **XR Browser** or **WebXR Viewer** on iPhone. The script prints the URL in console. Open in browser, tap **Enter AR**, grant permissions. Hold phone upright (reticle = virtual controller). Use HUD: **Track** (start/stop positional tracking), **Record** (start/stop episode), **Reset** (abort/reset scene), **Gripper slider** (0-1).
+Install **XR Browser** or **WebXR Viewer** on iPhone. The script prints the URL in console. Open in browser, tap **Enter AR**, grant permissions. Hold phone upright (reticle = virtual controller). Use HUD: **Track** (start/stop positional tracking), **Record** (start/stop episode), **Reset** (abort recording, return the arm to its start pose), **Gripper slider** (0-1).
 
 ### Android
 ```bash
@@ -48,11 +48,11 @@ uv run positronic-data-collection sim \
 
 Open Oculus Browser, navigate to `https://<host-ip>:5005/`. Browser shows "Dangerous connection" warning (expected with self-signed certificates) – click Advanced → Proceed. Click "Enter AR" and approve permissions.
 
-**Controls:** Right B (start/stop recording), Right A (toggle tracking), Right stick press (abort/reset), Right trigger (gripper).
+**Controls:** Right B (start/stop recording), Right A (toggle tracking), Right stick press (abort recording, return the arm to its start pose), Right trigger (gripper).
 
 ## Collection Workflow
 
-Press **Track** (or Right A) to enable controller. Press **Record** (or Right B) to start episode. Perform task (e.g., grasp cube, move, place). Press **Record** again to save. Press **Reset** (or Right stick press) to randomize scene and start next episode. Press **Reset** during recording to abort and discard.
+Press **Track** (or Right A) to enable controller. Press **Record** (or Right B) to start episode. Perform task (e.g., grasp cube, move, place). Press **Record** again to save. Press **Reset** (or Right stick press) to put the arm back at a start pose for the next episode. Press **Reset** during recording to abort and discard.
 
 **Best practices:** Record calibration runs first and review in Positronic server (`uv run positronic-server --dataset.path=~/datasets/my_task`). Collect 50+ demonstrations for single-task scenarios (minimum 30, multi-task needs 100-500+). Randomize object positions, vary approach angles, keep episodes short (10-30s), demonstrate successful and near-failure cases (not catastrophic failures).
 

--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -25,7 +25,7 @@ uv run positronic-data-collection sim \
     --webxr=.iphone
 ```
 
-Install **XR Browser** or **WebXR Viewer** on iPhone. The script prints the URL in console. Open in browser, tap **Enter AR**, grant permissions. Hold phone upright (reticle = virtual controller). Use HUD: **Track** (start/stop positional tracking), **Record** (start/stop episode), **Reset** (abort recording, return the arm to its start pose), **Gripper slider** (0-1).
+Install **XR Browser** or **WebXR Viewer** on iPhone. The script prints the URL in console. Open in browser, tap **Enter AR**, grant permissions. Hold phone upright (reticle = virtual controller). Use HUD: **Track** (start/stop positional tracking), **Record** (start/stop episode), **Reset** (abort recording, return the arm to its start pose; in sim the scene is drawn again too), **Gripper slider** (0-1).
 
 ### Android
 ```bash
@@ -48,11 +48,11 @@ uv run positronic-data-collection sim \
 
 Open Oculus Browser, navigate to `https://<host-ip>:5005/`. Browser shows "Dangerous connection" warning (expected with self-signed certificates) – click Advanced → Proceed. Click "Enter AR" and approve permissions.
 
-**Controls:** Right B (start/stop recording), Right A (toggle tracking), Right stick press (abort recording, return the arm to its start pose), Right trigger (gripper).
+**Controls:** Right B (start/stop recording), Right A (toggle tracking), Right stick press (abort recording, return the arm to its start pose; in sim the scene is drawn again too), Right trigger (gripper).
 
 ## Collection Workflow
 
-Press **Track** (or Right A) to enable controller. Press **Record** (or Right B) to start episode. Perform task (e.g., grasp cube, move, place). Press **Record** again to save. Press **Reset** (or Right stick press) to put the arm back at a start pose for the next episode. Press **Reset** during recording to abort and discard.
+Press **Track** (or Right A) to enable controller. Press **Record** (or Right B) to start episode. Perform task (e.g., grasp cube, move, place). Press **Record** again to save. Press **Reset** (or Right stick press) to ready the rig for the next episode: the arm goes back to a start pose, and in sim the scene is drawn again. Teleoperation is held until every device is there. Press **Reset** during recording to abort and discard.
 
 **Best practices:** Record calibration runs first and review in Positronic server (`uv run positronic-server --dataset.path=~/datasets/my_task`). Collect 50+ demonstrations for single-task scenarios (minimum 30, multi-task needs 100-500+). Randomize object positions, vary approach angles, keep episodes short (10-30s), demonstrate successful and near-failure cases (not catastrophic failures).
 

--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -68,7 +68,7 @@ uv run positronic-data-collection real \
 Requires Franka Panda with FCI, gripper, cameras. Install extras: `uv sync --locked --extra hardware` (Linux only). Configure network connection and udev rules (see [Drivers](../positronic/drivers/)).
 
 ### Other Platforms
-- **Kinova Gen3**: Add `--robot_arm=@positronic.cfg.hardware.roboarm.kinova`
+- **Kinova Gen3**: Add `--robot_arm=@positronic.cfg.hardware.roboarm.kinova --nominal_joints=[0.0,0.0,0.5,-1.5,0.0,-0.5,1.5708]` — the start pose the right stick puts the arm at belongs to the arm, so it is named with it
 - **SO101**: Use `positronic-data-collection so101` (bimanual setup)
 - **DROID**: Use `positronic-data-collection droid` (joint-space control)
 

--- a/positronic/cfg/codecs.py
+++ b/positronic/cfg/codecs.py
@@ -3,6 +3,7 @@
 import configuronic as cfn
 
 from positronic import geom, keys
+from positronic.cfg.hardware.roboarm import DROID_IMPEDANCE
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.policy.codec import (
     ActionHorizon,
@@ -110,15 +111,6 @@ def joint_delta_action(num_joints: int):
     from positronic.policy.action import JointDeltaAction
 
     return JointDeltaAction(num_joints=num_joints)
-
-
-# The gains DROID's Franka ran, which its pretrained checkpoints were trained under.
-DROID_IMPEDANCE = roboarm_command.Impedance(
-    kq=(40.0, 30.0, 50.0, 25.0, 35.0, 25.0, 10.0),
-    kqd=(4.0, 6.0, 5.0, 5.0, 3.0, 2.0, 1.0),
-    kx=(750.0, 750.0, 750.0, 15.0, 15.0, 15.0),
-    kxd=(37.0, 37.0, 37.0, 2.0, 2.0, 2.0),
-)
 
 
 @cfn.config()

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -74,16 +74,13 @@ def yam(robot_arm, cameras):
     # World-frame arm-base mount positions of the sim scene the training data uses: tabletop z=0.30 plus the
     # 0.011 base plate, arms at (0.30, ±0.305) facing +x.
     mounts={'left': [0.30, 0.305, 0.311], 'right': [0.30, -0.305, 0.311]},
-    park_joints=positronic.cfg.hardware.roboarm.YAM_NOMINAL_JOINTS,
     cameras={
         keys.EXTERIOR_IMAGE: positronic.cfg.hardware.camera.zed_x_top.override(resolution='svga', fps=30),
         'image.wrist_left': positronic.cfg.hardware.camera.zed_x_one_left.override(resolution='svga', fps=30),
         'image.wrist_right': positronic.cfg.hardware.camera.zed_x_one_right.override(resolution='svga', fps=30),
     },
 )
-def yam_bimanual(
-    left_channel: str, right_channel: str, mounts: dict[str, list[float]], park_joints: list[float], cameras
-):
+def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[float]], cameras):
     """Real bimanual i2rt YAM on two CAN chains.
 
     Per-arm channels are the flat names the whole stack shares: ``robot_state.{side}`` expands into
@@ -96,7 +93,11 @@ def yam_bimanual(
     from positronic.drivers.roboarm import yam as yam_driver
 
     arms = {
-        side: yam_driver.Robot(channel, park_joints=park_joints, base_pose=geom.Transform3D(mounts[side]))
+        side: yam_driver.Robot(
+            channel,
+            park_joints=positronic.cfg.hardware.roboarm.YAM_NOMINAL_JOINTS,
+            base_pose=geom.Transform3D(mounts[side]),
+        )
         for side, channel in (('left', left_channel), ('right', right_channel))
     }
     observations = {

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -74,13 +74,16 @@ def yam(robot_arm, cameras):
     # World-frame arm-base mount positions of the sim scene the training data uses: tabletop z=0.30 plus the
     # 0.011 base plate, arms at (0.30, ±0.305) facing +x.
     mounts={'left': [0.30, 0.305, 0.311], 'right': [0.30, -0.305, 0.311]},
+    park_joints=positronic.cfg.hardware.roboarm.YAM_NOMINAL_JOINTS,
     cameras={
         keys.EXTERIOR_IMAGE: positronic.cfg.hardware.camera.zed_x_top.override(resolution='svga', fps=30),
         'image.wrist_left': positronic.cfg.hardware.camera.zed_x_one_left.override(resolution='svga', fps=30),
         'image.wrist_right': positronic.cfg.hardware.camera.zed_x_one_right.override(resolution='svga', fps=30),
     },
 )
-def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[float]], cameras):
+def yam_bimanual(
+    left_channel: str, right_channel: str, mounts: dict[str, list[float]], park_joints: list[float], cameras
+):
     """Real bimanual i2rt YAM on two CAN chains.
 
     Per-arm channels are the flat names the whole stack shares: ``robot_state.{side}`` expands into
@@ -93,7 +96,7 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
     from positronic.drivers.roboarm import yam as yam_driver
 
     arms = {
-        side: yam_driver.Robot(channel, base_pose=geom.Transform3D(mounts[side]))
+        side: yam_driver.Robot(channel, park_joints=park_joints, base_pose=geom.Transform3D(mounts[side]))
         for side, channel in (('left', left_channel), ('right', right_channel))
     }
     observations = {
@@ -145,8 +148,8 @@ def mujoco_franka(sim, camera_dict):
         descriptor='mujoco.franka',
         observations=observations,
         commands=commands,
-        # Two handlers on one sim: the draw places the objects, and the move takes the arm to where the
-        # trial starts it.
+        # Two handlers on one sim: the draw places the objects and leaves the arm at the pose the scene
+        # itself starts from; the move is what a trial names to put the arm somewhere else.
         prepare_handlers={keys.SCENE: sim.env_reset, keys.ARM: sim.sync_move},
         static_meta={**ROBOT_STATIC_META, 'simulation.mujoco_model_path': sim.mujoco_model_path},
         meta_source=sim.robot_meta,

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -93,11 +93,7 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
     from positronic.drivers.roboarm import yam as yam_driver
 
     arms = {
-        side: yam_driver.Robot(
-            channel,
-            park_joints=positronic.cfg.hardware.roboarm.YAM_NOMINAL_JOINTS,
-            base_pose=geom.Transform3D(mounts[side]),
-        )
+        side: yam_driver.Robot(channel, base_pose=geom.Transform3D(mounts[side]))
         for side, channel in (('left', left_channel), ('right', right_channel))
     }
     observations = {

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -7,17 +7,13 @@ from positronic.cfg.hardware.roboarm import franka_start_pose
 from positronic.eval import Eval, Task
 
 
-@cfn.config(
-    embodiment=droid,
-    timeout=180,
-    trial_count=1,
-    setup='Fill the transparent tote with the items to pick, and empty the large grey one.',
-)
-def _droid_pick_place(embodiment, instruction, timeout, trial_count, setup):
+@cfn.config(embodiment=droid, timeout=180, trial_count=1)
+def _droid_pick_place(embodiment, instruction, timeout, trial_count):
     """A real droid tote pick-and-place eval: the embodiment is the physical Franka, the task carries the instruction.
 
-    ``setup`` names what a person puts in front of the arm — the rig has no scene of its own to seed. The
-    outcome is the operator's annotation, since real has no ground-truth source to compute one from.
+    The rig has no scene of its own to seed, so nothing asks for one: filling the tote is a person's, and
+    they do it before the sweep starts. The outcome is the operator's annotation, since real has no
+    ground-truth source to compute one from.
     """
     return Eval(
         embodiment,
@@ -25,7 +21,7 @@ def _droid_pick_place(embodiment, instruction, timeout, trial_count, setup):
             Task(
                 instruction_source=instruction,
                 timeout_sec=timeout,
-                prepare_args={keys.ARM: franka_start_pose(), keys.GRIPPER: 0.0, keys.SCENE: setup},
+                prepare_args={keys.ARM: franka_start_pose(), keys.GRIPPER: 0.0},
                 meta={keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count},
             )
             for trial in range(trial_count)

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -1,21 +1,43 @@
 import configuronic as cfn
 
+from positronic import keys
 from positronic.cfg.embodiment import droid
-from positronic.cfg.eval import build_tasks
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
+from positronic.cfg.hardware.roboarm import FRANKA_JOINTS_SPREAD, FRANKA_NOMINAL_JOINTS
+from positronic.drivers.roboarm import command
 from positronic.eval import Eval, Task
 
 
-@cfn.config(embodiment=droid, timeout=180, trial_count=1)
-def _droid_pick_place(embodiment, instruction, timeout, trial_count):
+@cfn.config(
+    embodiment=droid,
+    timeout=180,
+    trial_count=1,
+    setup='Fill the transparent tote with the items to pick, and empty the large grey one.',
+)
+def _droid_pick_place(embodiment, instruction, timeout, trial_count, setup):
     """A real droid tote pick-and-place eval: the embodiment is the physical Franka, the task carries the instruction.
 
-    Real has no scene to seed (``reset=None`` — reset is physical and human) and no privileged ground-truth source
-    to record (``privileged={}`` — the droid exposes none), so the outcome is the operator's annotation rather than
-    a computed criterion. ``timeout`` is the per-trial wall-clock budget the Harness applies on the unattended path;
-    ``trial_count`` is how many such trials it sweeps (real has no seed or task axis, so each is a bare timed trial).
+    Every trial starts the arm at a pose drawn around the Franka's nominal joints with the fingers open, and asks
+    whoever runs it for ``setup`` — the rig has no scene of its own to seed. ``timeout`` is the per-trial
+    wall-clock budget the Harness applies; the outcome is the operator's annotation, since real has no
+    ground-truth source to compute one from.
     """
-    return Eval(embodiment, build_tasks(Task(instruction_source=instruction, timeout_sec=timeout), None, trial_count))
+    return Eval(
+        embodiment,
+        [
+            Task(
+                instruction_source=instruction,
+                timeout_sec=timeout,
+                prepare_args={
+                    keys.ARM: command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD),
+                    keys.GRIPPER: 0.0,
+                    keys.SCENE: setup,
+                },
+                meta={keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count},
+            )
+            for trial in range(trial_count)
+        ],
+    )
 
 
 pick_place = _droid_pick_place.override(instruction=UNIFIED_TASK)

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -3,8 +3,7 @@ import configuronic as cfn
 from positronic import keys
 from positronic.cfg.embodiment import droid
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
-from positronic.cfg.hardware.roboarm import FRANKA_JOINTS_SPREAD, FRANKA_NOMINAL_JOINTS
-from positronic.drivers.roboarm import command
+from positronic.cfg.hardware.roboarm import franka_start_pose
 from positronic.eval import Eval, Task
 
 
@@ -26,11 +25,7 @@ def _droid_pick_place(embodiment, instruction, timeout, trial_count, setup):
             Task(
                 instruction_source=instruction,
                 timeout_sec=timeout,
-                prepare_args={
-                    keys.ARM: command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD),
-                    keys.GRIPPER: 0.0,
-                    keys.SCENE: setup,
-                },
+                prepare_args={keys.ARM: franka_start_pose(), keys.GRIPPER: 0.0, keys.SCENE: setup},
                 meta={keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count},
             )
             for trial in range(trial_count)

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -17,10 +17,8 @@ from positronic.eval import Eval, Task
 def _droid_pick_place(embodiment, instruction, timeout, trial_count, setup):
     """A real droid tote pick-and-place eval: the embodiment is the physical Franka, the task carries the instruction.
 
-    Every trial starts the arm at a pose drawn around the Franka's nominal joints with the fingers open, and asks
-    whoever runs it for ``setup`` — the rig has no scene of its own to seed. ``timeout`` is the per-trial
-    wall-clock budget the Harness applies; the outcome is the operator's annotation, since real has no
-    ground-truth source to compute one from.
+    ``setup`` names what a person puts in front of the arm — the rig has no scene of its own to seed. The
+    outcome is the operator's annotation, since real has no ground-truth source to compute one from.
     """
     return Eval(
         embodiment,

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -3,7 +3,7 @@ import configuronic as cfn
 from positronic import keys
 from positronic.cfg.embodiment import droid
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
-from positronic.cfg.hardware.roboarm import franka_start_pose
+from positronic.cfg.hardware.roboarm import droid_start_pose
 from positronic.eval import Eval, Task
 
 
@@ -21,7 +21,7 @@ def _droid_pick_place(embodiment, instruction, timeout, trial_count):
             Task(
                 instruction_source=instruction,
                 timeout_sec=timeout,
-                prepare_args={keys.ARM: franka_start_pose(), keys.GRIPPER: 0.0},
+                prepare_args={keys.ARM: droid_start_pose(), keys.GRIPPER: 0.0},
                 meta={keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count},
             )
             for trial in range(trial_count)

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -2,8 +2,8 @@ import configuronic as cfn
 
 import positronic.cfg.hardware.motors
 
-# The pose each arm is drawn around at the start of a trial, and — where its driver parks — the pose it is
-# left at when the driver takes control and hands it back.
+# The pose each arm is drawn around at the start of a trial. An arm whose driver parks is also left here
+# when the driver takes control and again when it hands it back.
 FRANKA_NOMINAL_JOINTS = [0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0]
 YAM_NOMINAL_JOINTS = [0.0, 1.047, 1.047, 0.0, 0.0, 0.0]
 SO101_NOMINAL_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0]

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -10,11 +10,22 @@ YAM_NOMINAL_JOINTS = [0.0, 1.047, 1.047, 0.0, 0.0, 0.0]
 SO101_NOMINAL_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0]
 # How far, per joint, a start pose drawn around the Franka's nominal may sit from it.
 FRANKA_JOINTS_SPREAD = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
+# The gains DROID's Franka ran, which its pretrained checkpoints were trained under.
+DROID_IMPEDANCE = command.Impedance(
+    kq=(40.0, 30.0, 50.0, 25.0, 35.0, 25.0, 10.0),
+    kqd=(4.0, 6.0, 5.0, 5.0, 3.0, 2.0, 1.0),
+    kx=(750.0, 750.0, 750.0, 15.0, 15.0, 15.0),
+    kxd=(37.0, 37.0, 37.0, 2.0, 2.0, 2.0),
+)
 
 
 def franka_start_pose() -> command.JointPosition:
-    """Where a Franka trial puts the arm before it opens, drawn afresh on every call."""
-    return command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD)
+    """Where a Franka trial puts the arm before it opens, drawn afresh on every call.
+
+    It travels under the same impedance law the rollout runs, so the arm is no stiffer getting to the
+    start pose than it is once the policy has it.
+    """
+    return command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD, DROID_IMPEDANCE)
 
 
 @cfn.config(

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -20,11 +20,7 @@ DROID_IMPEDANCE = command.Impedance(
 
 
 def franka_start_pose() -> command.JointPosition:
-    """Where a Franka trial puts the arm before it opens, drawn afresh on every call.
-
-    It travels under the same impedance law the rollout runs, so the arm is no stiffer getting to the
-    start pose than it is once the policy has it.
-    """
+    """Where a Franka trial puts the arm before it opens, drawn afresh on every call."""
     return command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD, DROID_IMPEDANCE)
 
 

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -2,11 +2,19 @@ import configuronic as cfn
 
 import positronic.cfg.hardware.motors
 
+# The pose each arm is drawn around at the start of a trial, and — where its driver parks — the pose it is
+# left at when the driver takes control and hands it back.
+FRANKA_NOMINAL_JOINTS = [0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0]
+YAM_NOMINAL_JOINTS = [0.0, 1.047, 1.047, 0.0, 0.0, 0.0]
+SO101_NOMINAL_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0]
+# How far, per joint, a start pose drawn around the Franka's nominal may sit from it.
+FRANKA_JOINTS_SPREAD = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
+
 
 @cfn.config(
     ip='172.168.0.2',
     relative_dynamics_factor=0.2,
-    home_joints=[0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0],
+    park_joints=FRANKA_NOMINAL_JOINTS,
     load=None,
     collision_coeff=2.0,
     manage_desk=True,
@@ -15,7 +23,7 @@ import positronic.cfg.hardware.motors
 def franka(
     ip: str,
     relative_dynamics_factor: float,
-    home_joints: list[float],
+    park_joints: list[float],
     load: tuple | None = None,
     collision_coeff: float = 2.0,
     manage_desk: bool = True,
@@ -26,7 +34,7 @@ def franka(
     return franka.Robot(
         ip=ip,
         relative_dynamics_factor=relative_dynamics_factor,
-        home_joints=home_joints,
+        park_joints=park_joints,
         load=load,
         collision_coeff=collision_coeff,
         manage_desk=manage_desk,
@@ -51,8 +59,8 @@ def so101(motor_bus):
     return Robot(motor_bus=motor_bus)
 
 
-@cfn.config(channel='can0', home_joints=None, sim=False, base_pose=None)
-def yam(channel: str, home_joints: list[float] | None, sim: bool, base_pose):
+@cfn.config(channel='can0', park_joints=YAM_NOMINAL_JOINTS, sim=False, base_pose=None)
+def yam(channel: str, park_joints: list[float], sim: bool, base_pose):
     from positronic.drivers.roboarm.yam import Robot
 
-    return Robot(channel, home_joints=home_joints, base_pose=base_pose, sim=sim)
+    return Robot(channel, park_joints=park_joints, base_pose=base_pose, sim=sim)

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -1,6 +1,7 @@
 import configuronic as cfn
 
 import positronic.cfg.hardware.motors
+from positronic.drivers.roboarm import command
 
 # The pose each arm is drawn around at the start of a trial. An arm whose driver parks is also left here
 # when the driver takes control and again when it hands it back.
@@ -11,10 +12,14 @@ SO101_NOMINAL_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0]
 FRANKA_JOINTS_SPREAD = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
 
 
+def franka_start_pose() -> command.JointPosition:
+    """Where a Franka trial puts the arm before it opens, drawn afresh on every call."""
+    return command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD)
+
+
 @cfn.config(
     ip='172.168.0.2',
     relative_dynamics_factor=0.2,
-    park_joints=FRANKA_NOMINAL_JOINTS,
     load=None,
     collision_coeff=2.0,
     manage_desk=True,
@@ -23,7 +28,6 @@ FRANKA_JOINTS_SPREAD = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
 def franka(
     ip: str,
     relative_dynamics_factor: float,
-    park_joints: list[float],
     load: tuple | None = None,
     collision_coeff: float = 2.0,
     manage_desk: bool = True,
@@ -34,7 +38,7 @@ def franka(
     return franka.Robot(
         ip=ip,
         relative_dynamics_factor=relative_dynamics_factor,
-        park_joints=park_joints,
+        park_joints=FRANKA_NOMINAL_JOINTS,
         load=load,
         collision_coeff=collision_coeff,
         manage_desk=manage_desk,
@@ -59,8 +63,8 @@ def so101(motor_bus):
     return Robot(motor_bus=motor_bus)
 
 
-@cfn.config(channel='can0', park_joints=YAM_NOMINAL_JOINTS, sim=False, base_pose=None)
-def yam(channel: str, park_joints: list[float], sim: bool, base_pose):
+@cfn.config(channel='can0', sim=False, base_pose=None)
+def yam(channel: str, sim: bool, base_pose):
     from positronic.drivers.roboarm.yam import Robot
 
-    return Robot(channel, park_joints=park_joints, base_pose=base_pose, sim=sim)
+    return Robot(channel, park_joints=YAM_NOMINAL_JOINTS, base_pose=base_pose, sim=sim)

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -18,8 +18,8 @@ DROID_IMPEDANCE = command.Impedance(
 )
 
 
-def franka_start_pose() -> command.JointPosition:
-    """Where a Franka trial puts the arm before it opens, drawn afresh on every call."""
+def droid_start_pose() -> command.JointPosition:
+    """The command a DROID trial opens with: joints drawn afresh around the Franka's nominal, under DROID's gains."""
     return command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD, DROID_IMPEDANCE)
 
 

--- a/positronic/cfg/hardware/roboarm/__init__.py
+++ b/positronic/cfg/hardware/roboarm/__init__.py
@@ -3,8 +3,7 @@ import configuronic as cfn
 import positronic.cfg.hardware.motors
 from positronic.drivers.roboarm import command
 
-# The pose each arm is drawn around at the start of a trial. An arm whose driver parks is also left here
-# when the driver takes control and again when it hands it back.
+# The pose each arm is drawn around at the start of a trial. Where a driver parks is its own and lives with it.
 FRANKA_NOMINAL_JOINTS = [0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0]
 YAM_NOMINAL_JOINTS = [0.0, 1.047, 1.047, 0.0, 0.0, 0.0]
 SO101_NOMINAL_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0]
@@ -45,7 +44,6 @@ def franka(
     return franka.Robot(
         ip=ip,
         relative_dynamics_factor=relative_dynamics_factor,
-        park_joints=FRANKA_NOMINAL_JOINTS,
         load=load,
         collision_coeff=collision_coeff,
         manage_desk=manage_desk,
@@ -74,4 +72,4 @@ def so101(motor_bus):
 def yam(channel: str, sim: bool, base_pose):
     from positronic.drivers.roboarm.yam import Robot
 
-    return Robot(channel, park_joints=YAM_NOMINAL_JOINTS, base_pose=base_pose, sim=sim)
+    return Robot(channel, base_pose=base_pose, sim=sim)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -13,7 +13,7 @@ from platform_client.responses import SubmissionCreateResponse
 
 import pimm
 import positronic.cfg.policy as policy_cfg
-from positronic import keys, telemetry, telemetry_keys, utils, wire
+from positronic import telemetry, telemetry_keys, utils, wire
 from positronic.cfg.eval import placeholder
 from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
@@ -51,15 +51,11 @@ class TaskDriver(pimm.ControlSystem):
 
     One task is in flight at a time: the next is asked for only when the previous episode's terminal comes
     back, so the plan never overlaps two episodes.
-
-    ``scene_ready`` answers for the operator an unattended run has not got: the setup a trial asks for is
-    logged and answered on the spot.
     """
 
     def __init__(self, tasks: list[Task]):
         self._tasks = tasks
         self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
-        self.scene_ready = pimm.calls.ControlSystemHandler[str, None](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks:
@@ -67,10 +63,6 @@ class TaskDriver(pimm.ControlSystem):
             while not answer.done():
                 if should_stop.value:
                     return
-                # The episode being waited on is what asks, so a wait that served nothing would deadlock.
-                for call in self.scene_ready.incoming():
-                    logger.info('Unattended run, so nobody sets this up: %s', call.request)
-                    call.set_result(None)
                 yield pimm.Yield()  # A sleep here would step the virtual clock on the driver's account.
             answer.result()  # raises if the episode failed
         # Let the recorder commit the final episode before this return brings the world down.
@@ -83,14 +75,8 @@ def _run_world(policy, ev: Eval, output_dir: Path | None):
     The driver walks ``ev.tasks``; the shared ``policy``'s lifetime stays with ``main``.
     """
     embodiment = ev.embodiment
-    driver = TaskDriver(ev.tasks)
-    # A real rig's scene is a person's to set up, and there is no person here. A sim draws its own, so one
-    # that reaches this without a scene handler is miswired and must still trip the Harness rather than run
-    # every trial against whatever the last one left standing.
-    if not embodiment.simulated and keys.SCENE not in embodiment.prepare_handlers:
-        handlers = {**embodiment.prepare_handlers, keys.SCENE: driver.scene_ready}
-        embodiment = replace(embodiment, prepare_handlers=handlers)
     harness = Harness(policy, embodiment)
+    driver = TaskDriver(ev.tasks)
 
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -52,8 +52,8 @@ class TaskDriver(pimm.ControlSystem):
     One task is in flight at a time: the next is asked for only when the previous episode's terminal comes
     back, so the plan never overlaps two episodes.
 
-    ``scene_ready`` answers for a person nobody has: an unattended run has no operator, so the setup a trial
-    asks for is logged and answered on the spot.
+    ``scene_ready`` answers for the operator an unattended run has not got: the setup a trial asks for is
+    logged and answered on the spot.
     """
 
     def __init__(self, tasks: list[Task]):

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -13,7 +13,7 @@ from platform_client.responses import SubmissionCreateResponse
 
 import pimm
 import positronic.cfg.policy as policy_cfg
-from positronic import telemetry, telemetry_keys, utils, wire
+from positronic import keys, telemetry, telemetry_keys, utils, wire
 from positronic.cfg.eval import placeholder
 from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
@@ -51,11 +51,15 @@ class TaskDriver(pimm.ControlSystem):
 
     One task is in flight at a time: the next is asked for only when the previous episode's terminal comes
     back, so the plan never overlaps two episodes.
+
+    ``scene_ready`` answers for a person nobody has: an unattended run has no operator, so the setup a trial
+    asks for is logged and answered on the spot.
     """
 
     def __init__(self, tasks: list[Task]):
         self._tasks = tasks
         self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
+        self.scene_ready = pimm.calls.ControlSystemHandler[str, None](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks:
@@ -63,6 +67,10 @@ class TaskDriver(pimm.ControlSystem):
             while not answer.done():
                 if should_stop.value:
                     return
+                # The episode being waited on is what asks, so a wait that served nothing would deadlock.
+                for call in self.scene_ready.incoming():
+                    logger.info('Unattended run, so nobody sets this up: %s', call.request)
+                    call.set_result(None)
                 yield pimm.Yield()  # A sleep here would step the virtual clock on the driver's account.
             answer.result()  # raises if the episode failed
         # Let the recorder commit the final episode before this return brings the world down.
@@ -75,8 +83,14 @@ def _run_world(policy, ev: Eval, output_dir: Path | None):
     The driver walks ``ev.tasks``; the shared ``policy``'s lifetime stays with ``main``.
     """
     embodiment = ev.embodiment
-    harness = Harness(policy, embodiment)
     driver = TaskDriver(ev.tasks)
+    # A real rig's scene is a person's to set up, and there is no person here. A sim draws its own, so one
+    # that reaches this without a scene handler is miswired and must still trip the Harness rather than run
+    # every trial against whatever the last one left standing.
+    if not embodiment.simulated and keys.SCENE not in embodiment.prepare_handlers:
+        handlers = {**embodiment.prepare_handlers, keys.SCENE: driver.scene_ready}
+        embodiment = replace(embodiment, prepare_handlers=handlers)
+    harness = Harness(policy, embodiment)
 
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -7,7 +8,7 @@ import pytest
 
 import pimm
 from positronic import keys, telemetry, telemetry_keys
-from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
+from positronic.cli.eval.run import TaskDriver, _pass_span, _run_world, main, timed_pass
 from positronic.eval import Embodiment, Eval, Task
 from positronic.tests.testing_coutils import drive_scheduler
 
@@ -23,29 +24,71 @@ def test_timed_sweep_rejects_real_embodiment(tmp_path):
         main(policy=object(), evals=[_eval(True), _eval(False)], output_dir=tmp_path, timing=True)
 
 
-class _IdlePolicy:
-    """Enough policy for ``main`` to warm up and close; it is never asked for an action."""
+class _IdleSession:
+    def __init__(self, policy):
+        self._policy = policy
 
-    def new_session(self, *_args, **_kwargs):
-        return SimpleNamespace(close=lambda: None)
+    def __call__(self, obs):
+        self._policy.observations.append(obs)
+        return []  # nothing to place, so the trial runs out its budget with the channels idle
+
+    @property
+    def meta(self):
+        return {}
 
     def close(self):
         pass
 
 
-@pytest.mark.timeout(30.0)
-def test_an_exhausted_trial_plan_ends_the_sweep():
-    """How an unattended run finishes: the driver runs out of tasks, the world stops, ``main`` returns."""
-    embodiment = Embodiment(
+class _IdlePolicy:
+    """Enough policy for a trial to open, run and close; it commands nothing."""
+
+    def __init__(self):
+        self.observations: list[dict] = []
+
+    def new_session(self, *_args, **_kwargs):
+        return _IdleSession(self)
+
+    @property
+    def meta(self):
+        return {}
+
+    def close(self):
+        pass
+
+
+def _embodiment(simulated: bool = True) -> Embodiment:
+    """A rig with nothing on it: no signals to read, nothing to command, and nothing of its own to ready."""
+    return Embodiment(
         descriptor='stub',
         observations={},
         commands={},
         prepare_handlers={},
         static_meta={},
         meta_source=None,
-        simulated=True,
+        simulated=simulated,
     )
-    main(policy=_IdlePolicy(), evals=[Eval(embodiment=embodiment, tasks=[])])
+
+
+@pytest.mark.timeout(30.0)
+def test_an_exhausted_trial_plan_ends_the_sweep():
+    """How an unattended run finishes: the driver runs out of tasks, the world stops, ``main`` returns."""
+    main(policy=_IdlePolicy(), evals=[Eval(embodiment=_embodiment(), tasks=[])])
+
+
+@pytest.mark.timeout(30.0)
+def test_a_scene_nobody_readies_is_answered_by_the_runner(caplog):
+    """A rig whose scene a person would set up runs unattended: the driver answers for the absent person,
+    so the trial opens, and the setup it asked for is logged for whoever reads the run."""
+    setup = 'Fill the transparent tote with the items to pick.'
+    task = Task(instruction_source='pick', timeout_sec=0.05, prepare_args={keys.SCENE: setup})
+    policy = _IdlePolicy()
+
+    with caplog.at_level(logging.INFO, logger='positronic.cli.eval.run'):
+        _run_world(policy, Eval(embodiment=_embodiment(simulated=False), tasks=[task]), None)
+
+    assert setup in caplog.text
+    assert policy.observations, 'the trial never opened'
 
 
 class _EpisodeStub(pimm.ControlSystem):

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -8,9 +7,9 @@ import pytest
 
 import pimm
 from positronic import keys, telemetry, telemetry_keys
-from positronic.cli.eval.run import TaskDriver, _pass_span, _run_world, main, timed_pass
+from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
 from positronic.eval import Embodiment, Eval, Task
-from positronic.tests.testing_coutils import IdleSession, drive_scheduler
+from positronic.tests.testing_coutils import drive_scheduler
 
 
 def _eval(simulated: bool) -> Eval:
@@ -25,56 +24,28 @@ def test_timed_sweep_rejects_real_embodiment(tmp_path):
 
 
 class _IdlePolicy:
-    """Enough policy for a trial to open, run and close; it commands nothing."""
-
-    def __init__(self):
-        self.observations: list[dict] = []
+    """Enough policy for ``main`` to warm up and close; it is never asked for an action."""
 
     def new_session(self, *_args, **_kwargs):
-        return IdleSession(self)
-
-    @property
-    def meta(self):
-        return {}
+        return SimpleNamespace(close=lambda: None)
 
     def close(self):
         pass
 
 
-def _embodiment(simulated: bool = True) -> Embodiment:
-    """A rig with nothing on it: no signals to read, nothing to command, and nothing of its own to ready."""
-    return Embodiment(
+@pytest.mark.timeout(30.0)
+def test_an_exhausted_trial_plan_ends_the_sweep():
+    """How an unattended run finishes: the driver runs out of tasks, the world stops, ``main`` returns."""
+    embodiment = Embodiment(
         descriptor='stub',
         observations={},
         commands={},
         prepare_handlers={},
         static_meta={},
         meta_source=None,
-        simulated=simulated,
+        simulated=True,
     )
-
-
-@pytest.mark.timeout(30.0)
-def test_an_exhausted_trial_plan_ends_the_sweep():
-    """How an unattended run finishes: the driver runs out of tasks, the world stops, ``main`` returns."""
-    main(policy=_IdlePolicy(), evals=[Eval(embodiment=_embodiment(), tasks=[])])
-
-
-@pytest.mark.timeout(30.0)
-def test_a_scene_nobody_readies_is_answered_by_the_runner(caplog):
-    """A rig whose scene a person would set up runs unattended: the driver answers for the absent person,
-    so the trial opens, and the setup it asked for is logged for whoever reads the run."""
-    setup = 'Fill the transparent tote with the items to pick.'
-    # A real rig runs on the wall clock and the Harness polls at 0.01s, so the budget has to cover the rounds
-    # the episode takes to open. Trimmed to a few of them, a loaded machine ends the trial before it opens.
-    task = Task(instruction_source='pick', timeout_sec=0.5, prepare_args={keys.SCENE: setup})
-    policy = _IdlePolicy()
-
-    with caplog.at_level(logging.INFO, logger='positronic.cli.eval.run'):
-        _run_world(policy, Eval(embodiment=_embodiment(simulated=False), tasks=[task]), None)
-
-    assert setup in caplog.text
-    assert policy.observations, 'the trial never opened'
+    main(policy=_IdlePolicy(), evals=[Eval(embodiment=embodiment, tasks=[])])
 
 
 class _EpisodeStub(pimm.ControlSystem):

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -65,7 +65,9 @@ def test_a_scene_nobody_readies_is_answered_by_the_runner(caplog):
     """A rig whose scene a person would set up runs unattended: the driver answers for the absent person,
     so the trial opens, and the setup it asked for is logged for whoever reads the run."""
     setup = 'Fill the transparent tote with the items to pick.'
-    task = Task(instruction_source='pick', timeout_sec=0.05, prepare_args={keys.SCENE: setup})
+    # A real rig runs on the wall clock and the Harness polls at 0.01s, so the budget has to cover the rounds
+    # the episode takes to open. Trimmed to a few of them, a loaded machine ends the trial before it opens.
+    task = Task(instruction_source='pick', timeout_sec=0.5, prepare_args={keys.SCENE: setup})
     policy = _IdlePolicy()
 
     with caplog.at_level(logging.INFO, logger='positronic.cli.eval.run'):

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -10,7 +10,7 @@ import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.cli.eval.run import TaskDriver, _pass_span, _run_world, main, timed_pass
 from positronic.eval import Embodiment, Eval, Task
-from positronic.tests.testing_coutils import drive_scheduler
+from positronic.tests.testing_coutils import IdleSession, drive_scheduler
 
 
 def _eval(simulated: bool) -> Eval:
@@ -24,22 +24,6 @@ def test_timed_sweep_rejects_real_embodiment(tmp_path):
         main(policy=object(), evals=[_eval(True), _eval(False)], output_dir=tmp_path, timing=True)
 
 
-class _IdleSession:
-    def __init__(self, policy):
-        self._policy = policy
-
-    def __call__(self, obs):
-        self._policy.observations.append(obs)
-        return []  # nothing to place, so the trial runs out its budget with the channels idle
-
-    @property
-    def meta(self):
-        return {}
-
-    def close(self):
-        pass
-
-
 class _IdlePolicy:
     """Enough policy for a trial to open, run and close; it commands nothing."""
 
@@ -47,7 +31,7 @@ class _IdlePolicy:
         self.observations: list[dict] = []
 
     def new_session(self, *_args, **_kwargs):
-        return _IdleSession(self)
+        return IdleSession(self)
 
     @property
     def meta(self):

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -255,7 +255,7 @@ def main(
     webxr: WebXR,
     sound: pimm.ControlSystem | None,
     cameras: dict[str, pimm.ControlSystem] | None,
-    # The start pose the right stick puts the arm at, drawn around the nominal. A station with no arm names none.
+    # The start pose the right stick puts the arm at: drawn around ``nominal_joints``, within ``joints_spread``.
     nominal_joints: Sequence[float] = (),
     joints_spread: Sequence[float] = (),
     output_dir: str | None = None,

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -267,10 +267,10 @@ def main(
     video_options: dict[str, str] | None = None,
 ):
     """Runs data collection in real hardware."""
-    if robot_arm is not None and not len(nominal_joints):
+    if (robot_arm is not None) != (len(nominal_joints) > 0):
         raise ValueError(
-            'an arm needs the joints its start pose is drawn around: pass --nominal_joints alongside '
-            '--robot_arm, or the right stick has nowhere to put it'
+            '--robot_arm and --nominal_joints are named together or not at all: the right stick puts the arm '
+            'a station has at the pose it measured, and either one alone leaves the other with nothing'
         )
     camera_instances = cameras or {}
     camera_emitters = {name: cam.frame for name, cam in camera_instances.items()}

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -276,6 +276,11 @@ def main(
             '--robot_arm and --nominal_joints are named together or not at all: the right stick puts the arm '
             'a station has at the pose it measured, and either one alone leaves the other with nothing'
         )
+    if len(joints_spread) not in (0, len(nominal_joints)):
+        raise ValueError(
+            f'--joints_spread names {len(joints_spread)} joints and --nominal_joints names {len(nominal_joints)}: '
+            'the spread is jitter measured per joint, so it carries one value for each, or none at all'
+        )
     camera_instances = cameras or {}
     camera_emitters = {name: cam.frame for name, cam in camera_instances.items()}
     static_meta = {}

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -110,8 +110,11 @@ class DataCollectionController(pimm.ControlSystem):
         metadata_getter: Callable[[], dict] | None = None,
     ):
         self.operator_position = operator_position
-        self._nominal_joints = nominal_joints
-        self._joints_spread = joints_spread
+        self._nominal_joints = np.asarray(nominal_joints, dtype=np.float64)
+        # A station that measured no jitter sends the arm exactly to its nominal.
+        self._joints_spread = (
+            np.asarray(joints_spread, dtype=np.float64) if len(joints_spread) else np.zeros_like(self._nominal_joints)
+        )
         self._static_meta = static_meta or {}
         self.metadata_getter = metadata_getter or (lambda: {})
         self.controller_positions = pimm.DefaultingReceiver(self, default={})

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -103,11 +103,15 @@ class DataCollectionController(pimm.ControlSystem):
     def __init__(
         self,
         operator_position: geom.Transform3D | None,
+        nominal_joints: Sequence[float] | np.ndarray,
+        joints_spread: Sequence[float] | np.ndarray = (),
         *,
         static_meta: dict | None = None,
         metadata_getter: Callable[[], dict] | None = None,
     ):
         self.operator_position = operator_position
+        self._nominal_joints = nominal_joints
+        self._joints_spread = joints_spread
         self._static_meta = static_meta or {}
         self.metadata_getter = metadata_getter or (lambda: {})
         self.controller_positions = pimm.DefaultingReceiver(self, default={})
@@ -118,10 +122,21 @@ class DataCollectionController(pimm.ControlSystem):
         self.robot_meta_in = pimm.DefaultingReceiver(self, default={})
 
         self.robot_commands = pimm.ControlSystemEmitter(self)
+        self.sync_move = pimm.calls.ControlSystemCaller[roboarm.command.CommandType, None](self)
         self.target_grip = pimm.ControlSystemEmitter(self)
 
         self.ds_agent_commands = pimm.ControlSystemEmitter(self)
         self.sound = pimm.ControlSystemEmitter(self)
+
+    def _move_to_start(self, should_stop: pimm.SignalReceiver) -> Iterator[pimm.Sleep]:
+        """Put the arm at a start pose drawn around the nominal joints, yielding until it is there."""
+        logging.info('Moving the arm to a start pose')
+        answer = self.sync_move(roboarm.command.sampled_joints(self._nominal_joints, self._joints_spread))
+        while not answer.done():
+            if should_stop.value:
+                return
+            yield pimm.Sleep(0.001)
+        answer.result()
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         sounds = Path(package_assets_path('assets/sounds'))
@@ -156,13 +171,18 @@ class DataCollectionController(pimm.ControlSystem):
                     else:
                         tracker.turn_on(self.robot_state.value.ee_pose)
                 elif button_handler.just_pressed('right_stick') and not tracker.umi_mode:
-                    logging.info('Resetting robot')
                     if recording:
                         self.ds_agent_commands.emit(DsWriterCommand.ABORT())
                         self.sound.emit(abort_wav_path)
                     tracker.turn_off()
                     recording = False
-                    self.robot_commands.emit(roboarm.command.Reset())
+                    if self.sync_move.connected:
+                        try:
+                            yield from self._move_to_start(should_stop)
+                        # rules-allow: swallowed-error — the operator hears it and asks again, session goes on
+                        except Exception as e:
+                            logging.error(f'The arm did not reach its start pose: {e}')
+                            self.sound.emit(error_wav_path)
 
                 self.target_grip.emit(button_handler.get_value('right_trigger'))
                 cp_msg = self.controller_positions.read()
@@ -211,6 +231,10 @@ def _wire(
     world.connect(webxr.controller_positions, data_collection.controller_positions)
     world.connect(webxr.buttons, data_collection.buttons_receiver)
 
+    if robot_arm is not None:
+        # A driver's ports are its own: ``pimm.ControlSystem`` declares none for the checker to find.
+        world.connect(data_collection.sync_move, robot_arm.sync_move)  # pyright: ignore[reportAttributeAccessIssue]
+
     if sound is not None:
         world.connect(data_collection.sound, sound.wav_path)
         if robot_arm is not None:
@@ -231,6 +255,9 @@ def main(
     webxr: WebXR,
     sound: pimm.ControlSystem | None,
     cameras: dict[str, pimm.ControlSystem] | None,
+    # The start pose the right stick puts the arm at, drawn around the nominal. A station with no arm names none.
+    nominal_joints: Sequence[float] = (),
+    joints_spread: Sequence[float] = (),
     output_dir: str | None = None,
     stream_video_to_webxr: str | None = None,
     operator_position: OperatorPosition = OperatorPosition.FRONT,
@@ -245,7 +272,9 @@ def main(
         static_meta[keys.TASK] = task
     if robot_arm is not None:
         static_meta.update(wire.ROBOT_STATIC_META)
-    data_collection = DataCollectionController(operator_position.value, static_meta=static_meta)
+    data_collection = DataCollectionController(
+        operator_position.value, nominal_joints, joints_spread, static_meta=static_meta
+    )
 
     if output_dir is not None:
         output_dir = pos3.sync(output_dir, sync_on_error=True)
@@ -305,6 +334,7 @@ def main_sim(
 
     data_collection = DataCollectionController(
         operator_position.value,
+        sim.initial_joints,
         static_meta=static_meta,
         metadata_getter=lambda: {k: v.tolist() for k, v in sim.save_state().items()},
     )
@@ -340,6 +370,8 @@ main_cfg = cfn.Config(
     main,
     robot_arm=None,
     gripper=positronic.cfg.hardware.gripper.dh_gripper,
+    nominal_joints=positronic.cfg.hardware.roboarm.FRANKA_NOMINAL_JOINTS,
+    joints_spread=positronic.cfg.hardware.roboarm.FRANKA_JOINTS_SPREAD,
     webxr=positronic.cfg.webxr.oculus,
     sound=positronic.cfg.sound.sound,
     cameras={
@@ -356,6 +388,7 @@ main_cfg = cfn.Config(
     sound=positronic.cfg.sound.sound,
     operator_position=OperatorPosition.BACK,
     cameras={'image.right': positronic.cfg.hardware.camera.arducam_right},
+    nominal_joints=positronic.cfg.hardware.roboarm.SO101_NOMINAL_JOINTS,
 )
 def so101cfg(robot_arm, **kwargs):
     """Runs data collection on SO101 robot"""
@@ -368,6 +401,7 @@ def so101cfg(robot_arm, **kwargs):
     sound=positronic.cfg.sound.sound,
     operator_position=OperatorPosition.BACK,
     cameras={},
+    nominal_joints=positronic.cfg.hardware.roboarm.YAM_NOMINAL_JOINTS,
     # The YAM station records several cameras on a weak CPU; x264's default preset can't keep up with the
     # camera rate, so trade ~2x bitrate for ~2.5x faster encoding.
     video_options={'preset': 'ultrafast', 'tune': 'zerolatency'},
@@ -381,6 +415,8 @@ droid = cfn.Config(
     main,
     robot_arm=positronic.cfg.hardware.roboarm.franka_droid,
     gripper=positronic.cfg.hardware.gripper.robotiq,
+    nominal_joints=positronic.cfg.hardware.roboarm.FRANKA_NOMINAL_JOINTS,
+    joints_spread=positronic.cfg.hardware.roboarm.FRANKA_JOINTS_SPREAD,
     webxr=positronic.cfg.webxr.oculus,
     sound=positronic.cfg.sound.sound,
     cameras={

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -125,24 +125,31 @@ class DataCollectionController(pimm.ControlSystem):
 
         self.robot_commands = pimm.ControlSystemEmitter(self)
         self.sync_move = pimm.calls.ControlSystemCaller[roboarm.command.CommandType, None](self)
+        self.redraw_scene = pimm.calls.ControlSystemCaller[Any, None](self)
         self.target_grip = pimm.ControlSystemEmitter(self)
 
         self.ds_agent_commands = pimm.ControlSystemEmitter(self)
         self.sound = pimm.ControlSystemEmitter(self)
 
-    def _move_to_start(self, should_stop: pimm.SignalReceiver) -> Iterator[pimm.Sleep]:
-        """Put the arm at a start pose drawn around the nominal joints, yielding until it is there.
+    def _ready(self, should_stop: pimm.SignalReceiver) -> Iterator[pimm.Sleep]:
+        """Redraw the scene and put the arm at a start pose drawn around the nominal joints, yielding until
+        both are done.
 
-        Raises whatever the arm's driver failed the move with: a call hands its handler's exception back, so
-        the vocabulary is the driver's — a move abandoned, a target it cannot hold, a fault from the vendor.
+        Raises whatever a device failed on: a call hands its handler's exception back, so the vocabulary is
+        the driver's — a move abandoned, a target it cannot hold, a fault from the vendor.
         """
-        logging.info('Moving the arm to a start pose')
-        answer = self.sync_move(roboarm.command.sampled_joints(self._nominal_joints, self._joints_spread))
-        while not answer.done():
+        logging.info('Readying the rig for the next episode')
+        asks = []
+        if self.redraw_scene.connected:  # a real scene is a person's to set up, and nothing here is asked
+            asks.append(self.redraw_scene(None))
+        if len(self._nominal_joints):  # a station with no arm has none to put anywhere
+            asks.append(self.sync_move(roboarm.command.sampled_joints(self._nominal_joints, self._joints_spread)))
+        ready = pimm.calls.all_of(asks)
+        while not ready.done():
             if should_stop.value:
                 return
             yield pimm.Sleep(0.001)
-        answer.result()
+        ready.result()
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
         sounds = Path(package_assets_path('assets/sounds'))
@@ -182,13 +189,12 @@ class DataCollectionController(pimm.ControlSystem):
                         self.sound.emit(abort_wav_path)
                     tracker.turn_off()
                     recording = False
-                    if len(self._nominal_joints):  # a station with no arm has none to put anywhere
-                        try:
-                            yield from self._move_to_start(should_stop)
-                        # rules-allow: swallowed-error — the operator hears it and asks again, session goes on
-                        except Exception as e:
-                            logging.error(f'The arm did not reach its start pose: {e}')
-                            self.sound.emit(error_wav_path)
+                    try:
+                        yield from self._ready(should_stop)
+                    # rules-allow: swallowed-error — the operator hears it and asks again, session goes on
+                    except Exception as e:
+                        logging.error(f'The rig was not readied: {e}')
+                        self.sound.emit(error_wav_path)
 
                 self.target_grip.emit(button_handler.get_value('right_trigger'))
                 cp_msg = self.controller_positions.read()
@@ -363,6 +369,7 @@ def main_sim(
         # The sim carries both the arm and the gripper ports, so it fills both slots.
         ds_agent = wire.wire(world, data_collection, dataset_writer, cameras, sim, sim, gui, TimeMode.MESSAGE)
         _wire(world, ds_agent, data_collection, webxr, sim, sound)
+        world.connect(data_collection.redraw_scene, sim.env_reset)
 
         sim_iter = world.start([sim, data_collection], [webxr, gui, ds_agent, sound])
         sim_iter = iter(sim_iter)

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -112,9 +112,8 @@ class DataCollectionController(pimm.ControlSystem):
         self.operator_position = operator_position
         self._nominal_joints = np.asarray(nominal_joints, dtype=np.float64)
         # A station that measured no jitter sends the arm exactly to its nominal.
-        self._joints_spread = (
-            np.asarray(joints_spread, dtype=np.float64) if len(joints_spread) else np.zeros_like(self._nominal_joints)
-        )
+        spread = joints_spread if len(joints_spread) else np.zeros_like(self._nominal_joints)
+        self._joints_spread = np.asarray(spread, dtype=np.float64)
         self._static_meta = static_meta or {}
         self.metadata_getter = metadata_getter or (lambda: {})
         self.controller_positions = pimm.DefaultingReceiver(self, default={})
@@ -179,7 +178,7 @@ class DataCollectionController(pimm.ControlSystem):
                         self.sound.emit(abort_wav_path)
                     tracker.turn_off()
                     recording = False
-                    if self.sync_move.connected:
+                    if len(self._nominal_joints):  # a station with no arm has none to put anywhere
                         try:
                             yield from self._move_to_start(should_stop)
                         # rules-allow: swallowed-error — the operator hears it and asks again, session goes on

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -287,6 +287,11 @@ def main(
             f'--joints_spread names {len(joints_spread)} joints and --nominal_joints names {len(nominal_joints)}: '
             'the spread is jitter measured per joint, so it carries one value for each, or none at all'
         )
+    if not np.all(np.isfinite([*nominal_joints, *joints_spread])):
+        raise ValueError(
+            '--nominal_joints and --joints_spread name joint angles: every value has to be finite, or the '
+            'draw between them raises instead of reaching the arm'
+        )
     camera_instances = cameras or {}
     camera_emitters = {name: cam.frame for name, cam in camera_instances.items()}
     static_meta = {}

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -265,6 +265,11 @@ def main(
     video_options: dict[str, str] | None = None,
 ):
     """Runs data collection in real hardware."""
+    if robot_arm is not None and not len(nominal_joints):
+        raise ValueError(
+            'an arm needs the joints its start pose is drawn around: pass --nominal_joints alongside '
+            '--robot_arm, or the right stick has nowhere to put it'
+        )
     camera_instances = cameras or {}
     camera_emitters = {name: cam.frame for name, cam in camera_instances.items()}
     static_meta = {}
@@ -370,8 +375,6 @@ main_cfg = cfn.Config(
     main,
     robot_arm=None,
     gripper=positronic.cfg.hardware.gripper.dh_gripper,
-    nominal_joints=positronic.cfg.hardware.roboarm.FRANKA_NOMINAL_JOINTS,
-    joints_spread=positronic.cfg.hardware.roboarm.FRANKA_JOINTS_SPREAD,
     webxr=positronic.cfg.webxr.oculus,
     sound=positronic.cfg.sound.sound,
     cameras={

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -131,7 +131,11 @@ class DataCollectionController(pimm.ControlSystem):
         self.sound = pimm.ControlSystemEmitter(self)
 
     def _move_to_start(self, should_stop: pimm.SignalReceiver) -> Iterator[pimm.Sleep]:
-        """Put the arm at a start pose drawn around the nominal joints, yielding until it is there."""
+        """Put the arm at a start pose drawn around the nominal joints, yielding until it is there.
+
+        Raises whatever the arm's driver failed the move with: a call hands its handler's exception back, so
+        the vocabulary is the driver's — a move abandoned, a target it cannot hold, a fault from the vendor.
+        """
         logging.info('Moving the arm to a start pose')
         answer = self.sync_move(roboarm.command.sampled_joints(self._nominal_joints, self._joints_spread))
         while not answer.done():

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -373,9 +373,8 @@ Built‑in serializers (`positronic.dataset.serializers.Serializers`)
   - Expands to `{'.status': status, '.q': q, '.dq': dq, '.ee_pose': transform_3d(ee)}`; every sample is
     recorded whatever the status.
 - `robot_command(command) -> dict`
-  - `CartesianMove(pose)` -> `{'.pose': transform_3d(pose)}`
-  - `JointMove(positions)` -> `{'.joints': positions}`
-  - `Reset()` -> `{'.reset': 1}`
+  - `CartesianPosition(pose)` -> `{'.pose': transform_3d(pose)}`
+  - `JointPosition(positions)` -> `{'.joints': positions}`
 
 Lifecycle
 - `START_EPISODE`: allocates a new episode writer and applies provided static

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -82,8 +82,8 @@ class DsWriterAgent(pimm.ControlSystem):
     that turn's inputs, so the trial's last frame is recorded before STOP
     finalizes the writer; samples timestamped after STOP — whatever the next
     trial's prepare moves, or sensor data the async real path queues — are
-    dropped, and ABORT discards
-    the episode. Invalid or out-of-order commands are ignored with a log message.
+    dropped, and ABORT discards the episode. Invalid or out-of-order commands
+    are ignored with a log message.
 
     `TimeMode` selects whether timestamps come from the control loop clock
     (`CLOCK`) or from the producing message (`MESSAGE`).

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -74,14 +74,15 @@ class DsWriterAgent(pimm.ControlSystem):
 
     On `START_EPISODE`, opens a new `EpisodeWriter` from the provided
     `DatasetWriter` and applies `static_data`. On the opening turn, samples that
-    predate START — the inter-episode home command and any pre-reset frame — are
-    dropped, while a genuine post-START value is kept; the producer's post-reset
+    predate START — the previous episode's last command and any pre-reset frame —
+    are dropped, while a genuine post-START value is kept; the producer's post-reset
     frame-0 arrives the next turn and is the first recorded sample. While open,
     each updated input signal (from `inputs`) is appended with the current
     timestamp from `clock`. `STOP_EPISODE` and `ABORT_EPISODE` are handled after
     that turn's inputs, so the trial's last frame is recorded before STOP
-    finalizes the writer; samples timestamped after STOP — post-episode home or
-    sensor data the async real path may queue — are dropped, and ABORT discards
+    finalizes the writer; samples timestamped after STOP — whatever the next
+    trial's prepare moves, or sensor data the async real path queues — are
+    dropped, and ABORT discards
     the episode. Invalid or out-of-order commands are ignored with a log message.
 
     `TimeMode` selects whether timestamps come from the control loop clock

--- a/positronic/dataset/serializers.py
+++ b/positronic/dataset/serializers.py
@@ -15,7 +15,6 @@ from positronic.drivers.roboarm.command import (
     JointDelta,
     JointPosition,
     PositionControl,
-    Reset,
 )
 
 # Serializer contract for values:
@@ -113,11 +112,11 @@ class Serializers:
                     '.mode.impedance.kxd': np.asarray(kxd),
                 }
 
-    # TODO: a command writes only the entries its own form has, so a signal here is sparse — `.reset` and
-    # `.mode.*` have samples at some commands and none at others. Which command a sample belongs to is
-    # then a timestamp alignment against a signal every command writes, and a reader taking the last
-    # value as still standing ascribes a pinned mode to commands that pinned none. A serializer cannot
-    # say which of its entries are sparse, and nothing downstream asks.
+    # TODO: a command writes only the entries its own form has, so a signal here is sparse — `.mode.*` has
+    # samples at some commands and none at others. Which command a sample belongs to is then a timestamp
+    # alignment against a signal every command writes, and a reader taking the last value as still standing
+    # ascribes a pinned mode to commands that pinned none. A serializer cannot say which of its entries are
+    # sparse, and nothing downstream asks.
     @staticmethod
     def robot_command(command: CommandType) -> dict[str, np.ndarray | int]:
         entries: dict[str, np.ndarray | int]
@@ -133,8 +132,6 @@ class Serializers:
                 entries = {'.joints': positions}
             case JointDelta(delta):
                 entries = {'.joint_deltas': delta}
-            case Reset():
-                return {'.reset': 1}
         if command.mode is not None:
             entries.update(Serializers._mode_entries(command.mode))
         return entries

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -174,8 +174,8 @@ def test_appends_only_on_updates_and_timestamps_from_clock(world):
 
 
 def test_drains_inputs_latched_before_start(world):
-    """The opening turn drains the input channels without recording: a value latched before START — an
-    inter-episode home command or a pre-reset frame — is consumed, not appended, so the first recorded
+    """The opening turn drains the input channels without recording: a value latched before START — the
+    previous episode's last command or a pre-reset frame — is consumed, not appended, so the first recorded
     sample is the next value to arrive (the post-reset scene), never a pre-episode leftover."""
     ds = FakeDatasetWriter()
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
@@ -399,7 +399,6 @@ def test_robot_command_serializer_variants(world):
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=impedance)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=rcmd.PositionControl())), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=rcmd.PositionControl((100.0,) * 7))), 0.001),
-        (lambda: emitters['cmd'].emit(rcmd.Reset()), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
     ]
 
@@ -413,7 +412,6 @@ def test_robot_command_serializer_variants(world):
         items['cmd.pose_delta_frame'], np.concatenate([delta_frame.translation, delta_frame.rotation.as_quat])
     )
     np.testing.assert_allclose(items['cmd.joints'], joints)
-    assert items['cmd.reset'] == 1
     np.testing.assert_allclose(items['cmd.mode.impedance.kq'], impedance.kq)
     # A pin naming no stiffness is a marker: a vector would fix the signal's shape, and what a mode does not
     # name has no shape to fix it at.

--- a/positronic/drivers/gripper/dh.py
+++ b/positronic/drivers/gripper/dh.py
@@ -11,12 +11,11 @@ with vendor_import('pymodbus', 'Gripper support'):
 
 
 class DHGripper(pimm.ControlSystem):
-    def __init__(self, port: str, home_grip: float = 0.0):
+    def __init__(self, port: str):
         self.port = port
-        self._home_grip = home_grip
         self.grip = pimm.ControlSystemEmitter[float](self)
         self.target_grip = pimm.ControlSystemReceiver[float](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[float | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[float, None](self)
         self.force = pimm.DefaultingReceiver(self, default=100)
         self.speed = pimm.DefaultingReceiver(self, default=100)
 
@@ -60,7 +59,7 @@ class DHGripper(pimm.ControlSystem):
                     current_grip = self._width(client)
                     self.grip.emit(current_grip)
 
-                    target = grip_setpoint(moves, self._home_grip, current_grip, clock.now())
+                    target = grip_setpoint(moves, current_grip, clock.now())
                     if target is not None:
                         last_grip = target
                     self._command(client, last_grip)

--- a/positronic/drivers/gripper/robotiq.py
+++ b/positronic/drivers/gripper/robotiq.py
@@ -19,12 +19,11 @@ _STOPBITS = 1
 
 
 class Robotiq2F(pimm.ControlSystem):
-    def __init__(self, port: str, home_grip: float = 0.0):
+    def __init__(self, port: str):
         self._port = port
-        self._home_grip = home_grip
         self.grip = pimm.ControlSystemEmitter(self)
         self.target_grip = pimm.ControlSystemReceiver[float](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[float | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[float, None](self)
         self.force = pimm.DefaultingReceiver(self, default=255)  # device scale 0..255
         self.speed = pimm.DefaultingReceiver(self, default=255)  # device scale 0..255
 
@@ -56,7 +55,7 @@ class Robotiq2F(pimm.ControlSystem):
                     grip = self._width(client)
                     self.grip.emit(grip)
 
-                    target = grip_setpoint(moves, self._home_grip, grip, clock.now())
+                    target = grip_setpoint(moves, grip, clock.now())
                     if target is not None:
                         self._command(client, target)
                     moves.answer()  # the width a settled move is answered with is on the fingers

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -99,10 +99,9 @@ class JointPosition:
 
 
 def sampled_joints(nominal: Sequence[float] | np.ndarray, spread: Sequence[float] | np.ndarray) -> JointPosition:
-    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint. An empty ``spread`` draws
-    the nominal itself."""
+    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint."""
     nominal = np.asarray(nominal, dtype=np.float64)
-    spread = np.zeros_like(nominal) if len(spread) == 0 else np.asarray(spread, dtype=np.float64)
+    spread = np.asarray(spread, dtype=np.float64)
     return JointPosition(nominal + np.random.uniform(-spread, spread))
 
 

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -9,6 +9,7 @@ pinning a mode the driver may not run.
 """
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -80,13 +81,6 @@ ControlModeType = PositionControl | Impedance
 
 
 @dataclass
-class Reset:
-    """Reset the robot to the home position."""
-
-    TYPE = 'reset'
-
-
-@dataclass
 class CartesianPosition:
     """Move the robot end-effector to the given pose."""
 
@@ -102,6 +96,16 @@ class JointPosition:
     TYPE = 'joint_pos'
     positions: np.ndarray
     mode: ControlModeType | None = None
+
+
+def sampled_joints(nominal: Sequence[float] | np.ndarray, spread: Sequence[float] | np.ndarray) -> JointPosition:
+    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint.
+
+    An empty ``spread`` names no variation, which is how a rig configured without any asks for its nominal.
+    """
+    nominal = np.asarray(nominal, dtype=np.float64)
+    spread = np.zeros_like(nominal) if len(spread) == 0 else np.asarray(spread, dtype=np.float64)
+    return JointPosition(nominal + np.random.uniform(-spread, spread))
 
 
 @dataclass
@@ -151,7 +155,7 @@ class CartesianDelta:
         return _compose_delta(current * self.frame, self.delta) * self.frame.inv
 
 
-CommandType = Reset | CartesianPosition | JointPosition | JointDelta | CartesianDelta
+CommandType = CartesianPosition | JointPosition | JointDelta | CartesianDelta
 
 
 def to_wire(command: CommandType | ControlModeType) -> dict[str, Any]:
@@ -162,8 +166,6 @@ def to_wire(command: CommandType | ControlModeType) -> dict[str, Any]:
             return {'type': command.TYPE} if stiffness is None else {'type': command.TYPE, 'stiffness': list(stiffness)}
         case Impedance(kq=kq, kqd=kqd, kx=kx, kxd=kxd):
             return {'type': command.TYPE, 'kq': list(kq), 'kqd': list(kqd), 'kx': list(kx), 'kxd': list(kxd)}
-        case Reset():
-            return {'type': command.TYPE}
         case CartesianPosition(pose):
             wire = {'type': command.TYPE, 'pose': pose.as_vector(rep)}
         case JointPosition(positions):
@@ -186,8 +188,6 @@ def from_wire(wire: dict[str, Any]) -> CommandType | ControlModeType:
             return PositionControl(stiffness=wire.get('stiffness'))
         case Impedance.TYPE:
             return Impedance(kq=wire['kq'], kqd=wire['kqd'], kx=wire['kx'], kxd=wire['kxd'])
-        case Reset.TYPE:
-            return Reset()
         case CartesianPosition.TYPE:
             return CartesianPosition(pose=geom.Transform3D.from_vector(wire['pose'], rep), mode=mode)
         case JointPosition.TYPE:
@@ -204,7 +204,7 @@ def from_wire(wire: dict[str, Any]) -> CommandType | ControlModeType:
             raise ValueError(f'Unknown command type: {wire["type"]}')
 
 
-def require_native_mode(cmd: CommandType | None, embodiment: str) -> None:
+def require_native_mode(cmd: CommandType, embodiment: str) -> None:
     """Raises on a command that pins a control mode: ``embodiment`` runs only its native law."""
-    if not isinstance(cmd, Reset | None) and cmd.mode is not None:
+    if cmd.mode is not None:
         raise NotImplementedError(f'{embodiment} cannot execute control mode {cmd.mode}')

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -98,11 +98,13 @@ class JointPosition:
     mode: ControlModeType | None = None
 
 
-def sampled_joints(nominal: Sequence[float] | np.ndarray, spread: Sequence[float] | np.ndarray) -> JointPosition:
-    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint."""
+def sampled_joints(
+    nominal: Sequence[float] | np.ndarray, spread: Sequence[float] | np.ndarray, mode: ControlModeType | None = None
+) -> JointPosition:
+    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint, to run under ``mode``."""
     nominal = np.asarray(nominal, dtype=np.float64)
     spread = np.asarray(spread, dtype=np.float64)
-    return JointPosition(nominal + np.random.uniform(-spread, spread))
+    return JointPosition(nominal + np.random.uniform(-spread, spread), mode)
 
 
 @dataclass

--- a/positronic/drivers/roboarm/command.py
+++ b/positronic/drivers/roboarm/command.py
@@ -99,10 +99,8 @@ class JointPosition:
 
 
 def sampled_joints(nominal: Sequence[float] | np.ndarray, spread: Sequence[float] | np.ndarray) -> JointPosition:
-    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint.
-
-    An empty ``spread`` names no variation, which is how a rig configured without any asks for its nominal.
-    """
+    """A joint target drawn uniformly from ``nominal`` ± ``spread``, per joint. An empty ``spread`` draws
+    the nominal itself."""
     nominal = np.asarray(nominal, dtype=np.float64)
     spread = np.zeros_like(nominal) if len(spread) == 0 else np.asarray(spread, dtype=np.float64)
     return JointPosition(nominal + np.random.uniform(-spread, spread))

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -269,19 +269,15 @@ class _Arm(DriverRun[command.CommandType]):
                 call.set_exception(exc)  # an arm the driver cannot read still leaves nobody waiting
 
     def park(self, *, at_teardown: bool = False) -> Iterator[pimm.Command]:
-        """Move the arm to ``_PARK_JOINTS``, logging a failure rather than raising it. Drive with ``yield from``.
-
-        A run that ends by raising skips the park on the way out, because moving an arm in answer to a fault
-        is the driver deciding on its own to move.
-        """
+        """Move the arm to ``_PARK_JOINTS``, logging a failure rather than raising it."""
         try:
-            logger.info('Parking the arm')
-            self.robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
+            logger.info('Moving the arm to the park pose')
+            self.robot.recover_from_errors()
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
             yield from self.move_to(_PARK_JOINTS, None, at_teardown=at_teardown)
         # rules-allow: swallowed-error — a failed park reads ERROR on the arm and ends neither run nor shutdown
         except Exception:
-            logger.exception('Parking failed, the arm stays where it stands')
+            logger.exception('The arm did not reach the park pose, it stays where it stands')
 
 
 class Robot(pimm.ControlSystem):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -230,7 +230,7 @@ class _Arm(DriverRun[command.CommandType]):
         self.publish(self.vendor.state())
         return MoveStatus.ARRIVED
 
-    def _joints_at(self, pose: geom.Transform3D) -> np.ndarray:
+    def _ik(self, pose: geom.Transform3D) -> np.ndarray:
         """The joints that put the end effector at ``pose``, within the arm's limits."""
         return self.vendor.inverse_kinematics_with_limits(np.asarray([*pose.translation, *pose.rotation.as_quat]))
 
@@ -242,9 +242,9 @@ class _Arm(DriverRun[command.CommandType]):
         """
         match cmd:
             case command.CartesianPosition(pose):
-                target = self._joints_at(pose)
+                target = self._ik(pose)
             case command.CartesianDelta() as delta_cmd:
-                target = self._joints_at(delta_cmd.apply(self.state.ee_pose))
+                target = self._ik(delta_cmd.apply(self.state.ee_pose))
             case command.JointPosition(positions):
                 target = np.asarray(positions, dtype=np.float64)
             case command.JointDelta(velocities=joint_delta):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -256,7 +256,7 @@ class _Arm(DriverRun[command.CommandType]):
             raise ValueError(f'{cmd} does not name a joint target this arm can hold: {target}')
         return target
 
-    def serve_sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> Iterator[pimm.Command]:
+    def sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> Iterator[pimm.Command]:
         """Put the arm where ``call`` asks and answer it once the state saying so is out."""
         cmd = call.request
         try:
@@ -460,7 +460,7 @@ class Robot(pimm.ControlSystem):
 
                 asked = arm.moves.next_request()
                 if isinstance(asked, pimm.calls.Call):
-                    yield from arm.serve_sync_move(asked)
+                    yield from arm.sync_move(asked)
                 elif asked is not None:
                     with log_failure(asked):
                         arm.command_target(arm.to_joints(asked), asked.mode)

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import logging
 import os
 import time
@@ -102,13 +103,13 @@ _PARK_JOINTS = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 
 
 class _Arm(DriverRun[command.CommandType]):
-    """The arm the driver drives: the vendor handle, and the state and moves that go with it."""
+    """The arm the driver drives: the robot handle, and the state and moves that go with it."""
 
-    # A move needs a deadline at all because the vendor reports a goal it abandons, but a goal it never
+    # A move needs a deadline at all because the robot reports a goal it abandons, but a goal it never
     # converges on stays in flight for as long as the arm is pushed off course.
     # FR3 joint velocity limits in rad/s, from the bundled ``fr3.urdf``; ``relative_dynamics_factor`` scales them
     _MAX_JOINT_VELOCITY = np.array([2.62, 2.62, 2.62, 2.62, 5.26, 4.18, 5.26])
-    # On top of the travel itself: the vendor controller ramps in and out of its speed cap, and settles late
+    # On top of the travel itself: the robot's controller ramps in and out of its speed cap, and settles late
     _MOVE_GRACE_S = 5.0
     # Parking publishes nothing, so it comes back only as often as it needs to ask again
     _PARK_POLL_S = 0.005
@@ -117,7 +118,7 @@ class _Arm(DriverRun[command.CommandType]):
 
     def __init__(
         self,
-        vendor: pf.Robot,
+        robot: pf.Robot,
         sync_move: pimm.calls.ControlSystemHandler[command.CommandType, None],
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[FrankaState],
@@ -126,7 +127,7 @@ class _Arm(DriverRun[command.CommandType]):
         clock: pimm.Clock,
     ):
         super().__init__(sync_move, async_move, should_stop, clock, hz=2000)
-        self.vendor = vendor
+        self.robot = robot
         self.out = out
         self.state = FrankaState()
         self._dynamics_factor = dynamics_factor
@@ -138,11 +139,11 @@ class _Arm(DriverRun[command.CommandType]):
         """Halt the control thread."""
         # Before ``_desk_session`` deactivates FCI, or the thread dies mid-control with
         # "TCP connection got interrupted".
-        self.vendor.stop()
+        self.robot.stop()
 
     def publish(self, st: pf.State) -> None:
-        """Ship the arm as the vendor reports it, marked ERROR while it is not where the driver put it."""
-        faulted = self.moves.errored or st.error != 0  # the vendor reports its own faults; a stall is not one
+        """Ship the arm as it is reported, marked ERROR while it is not where the driver put it."""
+        faulted = self.moves.errored or st.error != 0  # the robot reports its own faults; a stall is not one
         self.state.encode(st, RobotStatus.ERROR if faulted else RobotStatus.AVAILABLE)
         self.out.emit(self.state)
 
@@ -158,13 +159,9 @@ class _Arm(DriverRun[command.CommandType]):
                 return pf.SoftwareImpedance(kq=list(kq), kqd=list(kqd), kx=list(kx), kxd=list(kxd))
 
     def command_target(self, target: np.ndarray, mode: command.ControlModeType | None) -> None:
-        """Put the arm under ``mode`` and publish ``target`` to it, in that order with nothing in between.
-
-        Together, because either alone is a half-applied command: a law changed for a target that never
-        arrives leaves the arm holding its last one under dynamics nobody asked for.
-        """
-        self.vendor.set_control_mode(self._to_pf_mode(mode))  # the vendor no-ops a mode already running
-        self.vendor.set_target_joints(target)
+        """Put the arm under ``mode`` and publish ``target`` to it, in that order with nothing in between."""
+        self.robot.set_control_mode(self._to_pf_mode(mode))  # the robot no-ops a mode already running
+        self.robot.set_target_joints(target)
 
     def await_goal(
         self,
@@ -179,7 +176,7 @@ class _Arm(DriverRun[command.CommandType]):
         """
         self.command_target(target, mode)
         while not should_stop():
-            goal = self.vendor.goal()
+            goal = self.robot.goal()
             if goal.status == pf.GoalStatus.REACHED:
                 return MoveStatus.ARRIVED
             if goal.status != pf.GoalStatus.IN_FLIGHT:
@@ -197,7 +194,7 @@ class _Arm(DriverRun[command.CommandType]):
     ) -> Generator[pimm.Command, None, MoveStatus]:
         """Travel to ``target`` under ``mode``, yielding until it arrives."""
         # The first emit must not ship an unfilled state.
-        self.state.encode(self.vendor.state(), RobotStatus.BUSY)
+        self.state.encode(self.robot.state(), RobotStatus.BUSY)
         self.out.emit(self.state)
 
         deadline = self.clock.now() + self._travel_s(self.state.q, target)
@@ -210,16 +207,16 @@ class _Arm(DriverRun[command.CommandType]):
 
         try:
             for wait in self.await_goal(target, should_stop, self.limiter.wait, mode):
-                st = self.vendor.state()
+                st = self.robot.state()
                 self.state.encode(st, RobotStatus.BUSY)
                 self.out.emit(self.state)
                 if st.error != 0:
-                    self.vendor.recover_from_errors()
+                    self.robot.recover_from_errors()
                 yield wait
             # The loop exits before it polls again, so a goal that landed as the deadline passed is unseen.
-            if expired() and self.vendor.goal().status != pf.GoalStatus.REACHED:
-                # The vendor still tracks the goal it missed, and would resume the move once the arm comes free.
-                self.vendor.set_target_joints(self.vendor.state().q)
+            if expired() and self.robot.goal().status != pf.GoalStatus.REACHED:
+                # The robot still tracks the goal it missed, and would resume the move once the arm comes free.
+                self.robot.set_target_joints(self.robot.state().q)
                 raise TimeoutError(f'the arm stopped short of {target}')
         except Exception:
             self.moves.errored = True
@@ -229,12 +226,12 @@ class _Arm(DriverRun[command.CommandType]):
             return MoveStatus.GAVE_UP
         self.moves.errored = False
         # The poll that reports arrival ends the loop, so the sample before it was taken mid-travel
-        self.publish(self.vendor.state())
+        self.publish(self.robot.state())
         return MoveStatus.ARRIVED
 
     def _ik(self, pose: geom.Transform3D) -> np.ndarray:
         """The joints that put the end effector at ``pose``, within the arm's limits."""
-        return self.vendor.inverse_kinematics_with_limits(np.asarray([*pose.translation, *pose.rotation.as_quat]))
+        return self.robot.inverse_kinematics_with_limits(np.asarray([*pose.translation, *pose.rotation.as_quat]))
 
     def to_joints(self, cmd: command.CommandType) -> np.ndarray:
         """The joints ``cmd`` asks for, not applied yet.
@@ -253,7 +250,7 @@ class _Arm(DriverRun[command.CommandType]):
                 target = self.state.q + joint_delta
             case other:
                 raise NotImplementedError(f'Unsupported command {other}')
-        # The vendor raises on a bad target too late to name the command; one velocity limit per joint sets the width.
+        # The robot raises on a bad target too late to name the command; one velocity limit per joint sets the width.
         if np.shape(target) != self._MAX_JOINT_VELOCITY.shape or not np.all(np.isfinite(target)):
             raise ValueError(f'{cmd} does not name a joint target this arm can hold: {target}')
         return target
@@ -268,7 +265,7 @@ class _Arm(DriverRun[command.CommandType]):
                 call.set_exception(MoveAbandoned())
         except Exception as exc:
             try:
-                self.publish(self.vendor.state())
+                self.publish(self.robot.state())
             finally:
                 call.set_exception(exc)  # an arm the driver cannot read still leaves nobody waiting
 
@@ -281,7 +278,7 @@ class _Arm(DriverRun[command.CommandType]):
         """
         try:
             logger.info('Parking the arm')
-            self.vendor.recover_from_errors()  # once, before the move: a reflex during the move ends the park
+            self.robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = self.clock.now() + self._PARK_TIMEOUT_S
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(
@@ -326,7 +323,6 @@ class Robot(pimm.ControlSystem):
         self.robot_meta = pimm.ControlSystemEmitter(self)
         self._load = load
         self._collision_coeff = collision_coeff
-        self._robot: pf.Robot | None = None
         self._desk_credentials = _read_desk_credentials() if manage_desk else None
         self._reboot_on_safety_error = reboot_on_safety_error
 
@@ -415,29 +411,25 @@ class Robot(pimm.ControlSystem):
                     yield desk
                     return
 
-    @property
-    def _vendor(self) -> pf.Robot:
+    @functools.cached_property
+    def _robot(self) -> pf.Robot:
         """The libfranka handle, connected on first use."""
-        if self._robot is None:
-            self._robot = pf.Robot(
-                self._ip,
-                realtime_config=pf.RealtimeConfig.Ignore,
-                relative_dynamics_factor=self._relative_dynamics_factor,
-            )
-        return self._robot
+        return pf.Robot(
+            self._ip, realtime_config=pf.RealtimeConfig.Ignore, relative_dynamics_factor=self._relative_dynamics_factor
+        )
 
     def _arm(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> _Arm:
         """The arm this run drives, built from the driver's configuration."""
         return _Arm(
-            self._vendor, self.sync_move, self.commands, self.state, self._relative_dynamics_factor, should_stop, clock
+            self._robot, self.sync_move, self.commands, self.state, self._relative_dynamics_factor, should_stop, clock
         )
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         with self._desk_session(), self._arm(should_stop, clock) as arm:
-            vendor = arm.vendor
-            self._init_robot(vendor)
-            self.robot_meta.emit(Robot._build_robot_meta(vendor))
-            vendor.recover_from_errors()
+            robot = arm.robot
+            self._init_robot(robot)
+            self.robot_meta.emit(Robot._build_robot_meta(robot))
+            robot.recover_from_errors()
 
             try:
                 yield from arm.move_to(_PARK_JOINTS, None)
@@ -448,7 +440,7 @@ class Robot(pimm.ControlSystem):
             in_error = False
 
             while not should_stop.value:
-                st = vendor.state()
+                st = robot.state()
                 arm.publish(st)
 
                 in_error, entered_error = _check_error(st.error != 0, in_error)
@@ -456,7 +448,7 @@ class Robot(pimm.ControlSystem):
                     logger.warning(f'Robot error: {st.error_message}')
 
                 if in_error:
-                    vendor.recover_from_errors()
+                    robot.recover_from_errors()
                     yield arm.limiter.wait()
                     continue
 

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -251,9 +251,7 @@ class _Arm(DriverRun[command.CommandType]):
                 target = self.state.q + joint_delta
             case other:
                 raise NotImplementedError(f'Unsupported command {other}')
-        # The vendor takes a fixed-width finite vector and raises on anything else, too late to be caught
-        # alongside the rest of what makes a command unusable. The arm has one velocity limit per joint, so
-        # that vector's width is how many joints a target must name.
+        # The vendor raises on a bad target too late to name the command; one velocity limit per joint sets the width.
         if np.shape(target) != self._MAX_JOINT_VELOCITY.shape or not np.all(np.isfinite(target)):
             raise ValueError(f'{cmd} does not name a joint target this arm can hold: {target}')
         return target

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -114,11 +114,10 @@ class _Arm(DriverRun[command.CommandType]):
     def __init__(
         self,
         vendor: pf.Robot,
-        sync_move: pimm.calls.ControlSystemHandler[command.CommandType | None, None],
+        sync_move: pimm.calls.ControlSystemHandler[command.CommandType, None],
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[FrankaState],
-        home_joints: list[float],
-        home_joints_variation: list[float],
+        park_joints: list[float],
         park_timeout_s: float,
         dynamics_factor: float,
         should_stop: pimm.SignalReceiver,
@@ -128,8 +127,7 @@ class _Arm(DriverRun[command.CommandType]):
         self.vendor = vendor
         self.out = out
         self.state = FrankaState()
-        self._home_joints = home_joints
-        self._home_joints_variation = home_joints_variation
+        self.park_joints = np.asarray(park_joints, dtype=np.float64)
         self._park_timeout_s = park_timeout_s
         self._dynamics_factor = dynamics_factor
 
@@ -147,16 +145,6 @@ class _Arm(DriverRun[command.CommandType]):
         faulted = self.moves.errored or st.error != 0  # the vendor reports its own faults; a stall is not one
         self.state.encode(st, RobotStatus.ERROR if faulted else RobotStatus.AVAILABLE)
         self.out.emit(self.state)
-
-    def home_target(self) -> np.ndarray:
-        """The home joints this trip aims for, drawn afresh from the spread each time."""
-        target = np.asarray(self._home_joints, dtype=np.float64)
-        if any(v > 0 for v in self._home_joints_variation):
-            variation = np.random.uniform(
-                -np.asarray(self._home_joints_variation), np.asarray(self._home_joints_variation)
-            )
-            target = target + variation
-        return target
 
     @staticmethod
     def _to_pf_mode(mode: command.ControlModeType | None) -> pf.InternalImpedance | pf.SoftwareImpedance:
@@ -242,11 +230,9 @@ class _Arm(DriverRun[command.CommandType]):
         self.publish(self.vendor.state())
         return MoveStatus.ARRIVED
 
-    def target_joints(self, cmd: command.CommandType | None) -> np.ndarray:
-        """The joints ``cmd`` asks the arm to hold; asking for nothing asks for home."""
+    def target_joints(self, cmd: command.CommandType) -> np.ndarray:
+        """The joints ``cmd`` asks the arm to hold."""
         match cmd:
-            case None | command.Reset():
-                return self.home_target()
             case command.CartesianPosition(pose):
                 return self.vendor.inverse_kinematics_with_limits(
                     np.asarray([*pose.translation, *pose.rotation.as_quat])
@@ -263,20 +249,21 @@ class _Arm(DriverRun[command.CommandType]):
             case other:
                 raise NotImplementedError(f'Unsupported command {other}')
 
-    def accept(self, cmd: command.CommandType | None) -> tuple[np.ndarray, command.ControlModeType | None]:
+    def accept(self, cmd: command.CommandType) -> tuple[np.ndarray, command.ControlModeType | None]:
         """The joints ``cmd`` asks for and the law it pins, neither applied yet.
 
         Solved here so that a command the arm cannot hold raises before anything changes; ``command_target``
-        is what applies the pair. Asking for nothing, and a ``Reset``, travel home under the native law.
+        is what applies the pair.
         """
         target = self.target_joints(cmd)
         # The vendor takes a fixed-width finite vector and raises on anything else, too late to be caught
-        # alongside the rest of what makes a command unusable.
-        if np.shape(target) != np.shape(self._home_joints) or not np.all(np.isfinite(target)):
+        # alongside the rest of what makes a command unusable. The arm has one velocity limit per joint, so
+        # that vector's width is how many joints a target must name.
+        if np.shape(target) != self._MAX_JOINT_VELOCITY.shape or not np.all(np.isfinite(target)):
             raise ValueError(f'{cmd} does not name a joint target this arm can hold: {target}')
-        return target, None if isinstance(cmd, command.Reset | None) else cmd.mode
+        return target, cmd.mode
 
-    def serve_sync_move(self, call: pimm.calls.Call[command.CommandType | None, None]) -> Iterator[pimm.Command]:
+    def serve_sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> Iterator[pimm.Command]:
         """Put the arm where ``call`` asks and answer it once the state saying so is out."""
         try:
             if (yield from self.move_to(*self.accept(call.request))) is MoveStatus.ARRIVED:
@@ -290,20 +277,19 @@ class _Arm(DriverRun[command.CommandType]):
                 call.set_exception(exc)  # an arm the driver cannot read still leaves nobody waiting
 
     def park(self) -> Iterator[pimm.Command]:
-        """Move the arm to the home pose, giving up after ``park_timeout_s``. Drive with ``yield from``.
+        """Move the arm to the park pose, giving up after ``park_timeout_s``. Drive with ``yield from``.
 
         Only a stop gets here: a run that ends by raising skips the park, because moving an arm in answer to
-        a fault is the driver deciding on its own to move. Where it goes is fixed — ``home_joints``, at the
+        a fault is the driver deciding on its own to move. Where it goes is fixed — ``park_joints``, at the
         configured dynamics factor. Nothing here can fail the shutdown; failures are logged and no more.
         """
-        target = np.asarray(self._home_joints, dtype=np.float64)
         try:
-            logger.info('Parking the arm at the home pose')
+            logger.info('Parking the arm')
             self.vendor.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = self.clock.now() + self._park_timeout_s
-            # The home pose is a long way off, and only the native law shapes the reference on the way there.
+            # The park pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(
-                target, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
+                self.park_joints, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
             )
             if outcome is MoveStatus.GAVE_UP:
                 logger.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
@@ -318,8 +304,7 @@ class Robot(pimm.ControlSystem):
         ip: str,
         *,
         relative_dynamics_factor=0.2,
-        home_joints: list[float] | None = None,
-        home_joints_variation: list[float] | None = None,
+        park_joints: list[float],
         load: tuple | None = None,
         collision_coeff: float = 2.0,
         manage_desk: bool = True,
@@ -329,8 +314,7 @@ class Robot(pimm.ControlSystem):
         """
         :param ip: IP address of the robot.
         :param relative_dynamics_factor: Relative dynamics factor in (0, 1]. Smaller values are more conservative.
-        :param home_joints: Joints of "reset" position, and the pose the arm is parked at when the run ends.
-        :param home_joints_variation: Max random deviation per joint in radians. Set to [0]*7 to disable.
+        :param park_joints: Joints the arm is put at when the driver takes control, and again when it hands it back.
         :param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
         :param manage_desk: Run the Desk session from the driver: open the brakes and activate FCI on start, close
             them on stop. Requires ``FRANKA_DESK_USER`` and ``FRANKA_DESK_PASSWORD`` in the environment. Set to
@@ -339,18 +323,15 @@ class Robot(pimm.ControlSystem):
         :param reboot_on_safety_error: When the control box is in an unrecoverable ``SafetyError`` on start, reboot
             it, wait for it to come back, and try once more before giving up. Only applies when ``manage_desk`` is
             set.
-        :param park_timeout_s: How long the arm may travel back to ``home_joints`` when the run ends before the
+        :param park_timeout_s: How long the arm may travel back to ``park_joints`` when the run ends before the
             driver gives up and stops control where it stands. It is spent inside the world's teardown budget.
         """
         assert 0 < relative_dynamics_factor <= 1, relative_dynamics_factor
         self._ip = ip
         self._relative_dynamics_factor = relative_dynamics_factor
-        self._home_joints = home_joints if home_joints is not None else [0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0]
-        self._home_joints_variation = (
-            home_joints_variation if home_joints_variation is not None else [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
-        )
+        self._park_joints = park_joints
         self.commands = pimm.ControlSystemReceiver[command.CommandType](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType, None](self)
         self.state = pimm.ControlSystemEmitter[FrankaState](self)
         self.robot_meta = pimm.ControlSystemEmitter(self)
         self._load = load
@@ -463,8 +444,7 @@ class Robot(pimm.ControlSystem):
             self.sync_move,
             self.commands,
             self.state,
-            self._home_joints,
-            self._home_joints_variation,
+            self._park_joints,
             self._park_timeout_s,
             self._relative_dynamics_factor,
             should_stop,
@@ -479,10 +459,10 @@ class Robot(pimm.ControlSystem):
             vendor.recover_from_errors()
 
             try:
-                yield from arm.move_to(arm.home_target(), None)
-            # rules-allow: swallowed-error — an arm that will not home reads ERROR; it does not end the run
+                yield from arm.move_to(arm.park_joints, None)
+            # rules-allow: swallowed-error — an arm that will not park reads ERROR; it does not end the run
             except Exception as exc:
-                logger.error(f'Homing failed, the arm is not where the driver put it: {exc}')
+                logger.error(f'The arm did not reach the park pose, it is not where the driver put it: {exc}')
 
             in_error = False
 
@@ -504,11 +484,7 @@ class Robot(pimm.ControlSystem):
                     yield from arm.serve_sync_move(asked)
                 elif asked is not None:
                     with log_failure(asked):
-                        target, mode = arm.accept(asked)
-                        if isinstance(asked, command.Reset):
-                            yield from arm.move_to(target, mode)
-                        else:
-                            arm.command_target(target, mode)
+                        arm.command_target(*arm.accept(asked))
 
                 yield arm.limiter.wait()
 
@@ -517,7 +493,9 @@ class Robot(pimm.ControlSystem):
 
 if __name__ == '__main__':
     with pimm.World() as world:
-        robot = Robot('172.168.0.2', relative_dynamics_factor=0.2)
+        robot = Robot(
+            '172.168.0.2', relative_dynamics_factor=0.2, park_joints=[0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0]
+        )
         commands = world.pair(robot.commands)
         state = world.pair(robot.state)
         world.start([], background=robot)

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -201,11 +201,13 @@ class _Arm(DriverRun[command.CommandType]):
         self.out.emit(self.state)
 
         deadline = self.clock.now() + self._travel_s(self.state.q, target)
+
+        def should_stop() -> bool:
+            return self.should_stop.value or self.clock.now() >= deadline
+
         try:
             # The arm's own rate: this loop publishes every pass, so the goal is asked about that often too
-            for wait in self.await_goal(
-                target, lambda: self.should_stop.value or self.clock.now() >= deadline, self.limiter.wait, mode
-            ):
+            for wait in self.await_goal(target, should_stop, self.limiter.wait, mode):
                 st = self.vendor.state()
                 self.state.encode(st, RobotStatus.BUSY)  # the driver owns the arm until it arrives
                 self.out.emit(self.state)

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -234,11 +234,11 @@ class _Arm(DriverRun[command.CommandType]):
         """The joints that put the end effector at ``pose``, within the arm's limits."""
         return self.vendor.inverse_kinematics_with_limits(np.asarray([*pose.translation, *pose.rotation.as_quat]))
 
-    def accept(self, cmd: command.CommandType) -> tuple[np.ndarray, command.ControlModeType | None]:
-        """The joints ``cmd`` asks for and the law it pins, neither applied yet.
+    def to_joints(self, cmd: command.CommandType) -> np.ndarray:
+        """The joints ``cmd`` asks for, not applied yet.
 
         Solved here so that a command the arm cannot hold raises before anything changes; ``command_target``
-        is what applies the pair.
+        is what applies the result.
         """
         match cmd:
             case command.CartesianPosition(pose):
@@ -256,12 +256,13 @@ class _Arm(DriverRun[command.CommandType]):
         # that vector's width is how many joints a target must name.
         if np.shape(target) != self._MAX_JOINT_VELOCITY.shape or not np.all(np.isfinite(target)):
             raise ValueError(f'{cmd} does not name a joint target this arm can hold: {target}')
-        return target, cmd.mode
+        return target
 
     def serve_sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> Iterator[pimm.Command]:
         """Put the arm where ``call`` asks and answer it once the state saying so is out."""
+        cmd = call.request
         try:
-            if (yield from self.move_to(*self.accept(call.request))) is MoveStatus.ARRIVED:
+            if (yield from self.move_to(self.to_joints(cmd), cmd.mode)) is MoveStatus.ARRIVED:
                 call.set_result(None)
             else:
                 call.set_exception(MoveAbandoned())
@@ -464,7 +465,7 @@ class Robot(pimm.ControlSystem):
                     yield from arm.serve_sync_move(asked)
                 elif asked is not None:
                     with log_failure(asked):
-                        arm.command_target(*arm.accept(asked))
+                        arm.command_target(arm.to_joints(asked), asked.mode)
 
                 yield arm.limiter.wait()
 

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -97,6 +97,8 @@ def _revolute_joint_names(urdf_xml):
 
 
 _MESH_DIR = Path(__file__).resolve().parent.parent.parent / 'assets/fr3_collision'
+# Where the driver leaves the arm: taking control it travels here, and handing it back it returns here.
+_PARK_JOINTS = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 
 
 class _Arm(DriverRun[command.CommandType]):
@@ -117,7 +119,6 @@ class _Arm(DriverRun[command.CommandType]):
         sync_move: pimm.calls.ControlSystemHandler[command.CommandType, None],
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[FrankaState],
-        park_joints: list[float],
         park_timeout_s: float,
         dynamics_factor: float,
         should_stop: pimm.SignalReceiver,
@@ -127,7 +128,6 @@ class _Arm(DriverRun[command.CommandType]):
         self.vendor = vendor
         self.out = out
         self.state = FrankaState()
-        self.park_joints = np.asarray(park_joints, dtype=np.float64)
         self._park_timeout_s = park_timeout_s
         self._dynamics_factor = dynamics_factor
 
@@ -275,7 +275,7 @@ class _Arm(DriverRun[command.CommandType]):
         """Move the arm to the park pose, giving up after ``park_timeout_s``. Drive with ``yield from``.
 
         Only a stop gets here: a run that ends by raising skips the park, because moving an arm in answer to
-        a fault is the driver deciding on its own to move. Where it goes is fixed — ``park_joints``, at the
+        a fault is the driver deciding on its own to move. Where it goes is fixed — ``_PARK_JOINTS``, at the
         configured dynamics factor. Nothing here can fail the shutdown; failures are logged and no more.
         """
         try:
@@ -284,7 +284,7 @@ class _Arm(DriverRun[command.CommandType]):
             deadline = self.clock.now() + self._park_timeout_s
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(
-                self.park_joints, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
+                _PARK_JOINTS, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
             )
             if outcome is MoveStatus.GAVE_UP:
                 logger.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
@@ -299,7 +299,6 @@ class Robot(pimm.ControlSystem):
         ip: str,
         *,
         relative_dynamics_factor=0.2,
-        park_joints: list[float],
         load: tuple | None = None,
         collision_coeff: float = 2.0,
         manage_desk: bool = True,
@@ -309,7 +308,6 @@ class Robot(pimm.ControlSystem):
         """
         :param ip: IP address of the robot.
         :param relative_dynamics_factor: Relative dynamics factor in (0, 1]. Smaller values are more conservative.
-        :param park_joints: Joints the arm is put at when the driver takes control, and again when it hands it back.
         :param collision_coeff: Multiplier for collision thresholds. Higher = more tolerant.
         :param manage_desk: Run the Desk session from the driver: open the brakes and activate FCI on start, close
             them on stop. Requires ``FRANKA_DESK_USER`` and ``FRANKA_DESK_PASSWORD`` in the environment. Set to
@@ -318,13 +316,12 @@ class Robot(pimm.ControlSystem):
         :param reboot_on_safety_error: When the control box is in an unrecoverable ``SafetyError`` on start, reboot
             it, wait for it to come back, and try once more before giving up. Only applies when ``manage_desk`` is
             set.
-        :param park_timeout_s: How long the arm may travel back to ``park_joints`` when the run ends before the
+        :param park_timeout_s: How long the arm may travel back to its park pose when the run ends before the
             driver gives up and stops control where it stands. It is spent inside the world's teardown budget.
         """
         assert 0 < relative_dynamics_factor <= 1, relative_dynamics_factor
         self._ip = ip
         self._relative_dynamics_factor = relative_dynamics_factor
-        self._park_joints = park_joints
         self.commands = pimm.ControlSystemReceiver[command.CommandType](self)
         self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType, None](self)
         self.state = pimm.ControlSystemEmitter[FrankaState](self)
@@ -439,7 +436,6 @@ class Robot(pimm.ControlSystem):
             self.sync_move,
             self.commands,
             self.state,
-            self._park_joints,
             self._park_timeout_s,
             self._relative_dynamics_factor,
             should_stop,
@@ -454,7 +450,7 @@ class Robot(pimm.ControlSystem):
             vendor.recover_from_errors()
 
             try:
-                yield from arm.move_to(arm.park_joints, None)
+                yield from arm.move_to(_PARK_JOINTS, None)
             # rules-allow: swallowed-error — an arm that will not park reads ERROR; it does not end the run
             except Exception as exc:
                 logger.error(f'The arm did not reach the park pose, it is not where the driver put it: {exc}')
@@ -488,9 +484,7 @@ class Robot(pimm.ControlSystem):
 
 if __name__ == '__main__':
     with pimm.World() as world:
-        robot = Robot(
-            '172.168.0.2', relative_dynamics_factor=0.2, park_joints=[0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0]
-        )
+        robot = Robot('172.168.0.2', relative_dynamics_factor=0.2)
         commands = world.pair(robot.commands)
         state = world.pair(robot.state)
         world.start([], background=robot)

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -202,30 +202,30 @@ class _Arm(DriverRun[command.CommandType]):
 
         deadline = self.clock.now() + self._travel_s(self.state.q, target)
 
+        def expired() -> bool:
+            return self.clock.now() >= deadline
+
         def should_stop() -> bool:
-            return self.should_stop.value or self.clock.now() >= deadline
+            return self.should_stop.value or expired()
 
         try:
-            # The arm's own rate: this loop publishes every pass, so the goal is asked about that often too
             for wait in self.await_goal(target, should_stop, self.limiter.wait, mode):
                 st = self.vendor.state()
-                self.state.encode(st, RobotStatus.BUSY)  # the driver owns the arm until it arrives
+                self.state.encode(st, RobotStatus.BUSY)
                 self.out.emit(self.state)
                 if st.error != 0:
                     self.vendor.recover_from_errors()
                 yield wait
-            # The deadline stops the poll loop before it asks, so a goal that landed as it expired has not
-            # been seen yet; reading a timeout off the clock alone would fail a move the arm completed.
-            if self.clock.now() >= deadline and self.vendor.goal().status != pf.GoalStatus.REACHED:
-                # The vendor controller is still tracking the goal it did not reach; left alone it would
-                # resume the move once whatever held the arm back goes away.
+            # The loop exits before it polls again, so a goal that landed as the deadline passed is unseen.
+            if expired() and self.vendor.goal().status != pf.GoalStatus.REACHED:
+                # The vendor still tracks the goal it missed, and would resume the move once the arm comes free.
                 self.vendor.set_target_joints(self.vendor.state().q)
                 raise TimeoutError(f'the arm stopped short of {target}')
         except Exception:
             self.moves.errored = True
             raise
 
-        if self.should_stop.value:  # the travel gave up on the stop rather than on arrival
+        if self.should_stop.value:
             return MoveStatus.GAVE_UP
         self.moves.errored = False
         # The poll that reports arrival ends the loop, so the sample before it was taken mid-travel

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -268,19 +268,18 @@ class _Arm(DriverRun[command.CommandType]):
             finally:
                 call.set_exception(exc)  # an arm the driver cannot read still leaves nobody waiting
 
-    def park(self) -> Iterator[pimm.Command]:
-        """Move the arm to the park pose. Drive with ``yield from``.
+    def park(self, *, at_teardown: bool = False) -> Iterator[pimm.Command]:
+        """Move the arm to ``_PARK_JOINTS``, logging a failure rather than raising it. Drive with ``yield from``.
 
-        Only a stop gets here: a run that ends by raising skips the park, because moving an arm in answer to
-        a fault is the driver deciding on its own to move. Where it goes is fixed — ``_PARK_JOINTS``, at the
-        configured dynamics factor. Nothing here can fail the shutdown; failures are logged and no more.
+        A run that ends by raising skips the park on the way out, because moving an arm in answer to a fault
+        is the driver deciding on its own to move.
         """
         try:
             logger.info('Parking the arm')
             self.robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
-            yield from self.move_to(_PARK_JOINTS, None, at_teardown=True)
-        # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
+            yield from self.move_to(_PARK_JOINTS, None, at_teardown=at_teardown)
+        # rules-allow: swallowed-error — a failed park reads ERROR on the arm and ends neither run nor shutdown
         except Exception:
             logger.exception('Parking failed, the arm stays where it stands')
 
@@ -423,13 +422,8 @@ class Robot(pimm.ControlSystem):
             robot = arm.robot
             self._init_robot(robot)
             self.robot_meta.emit(Robot._build_robot_meta(robot))
-            robot.recover_from_errors()
 
-            try:
-                yield from arm.move_to(_PARK_JOINTS, None)
-            # rules-allow: swallowed-error — an arm that will not park reads ERROR; it does not end the run
-            except Exception as exc:
-                logger.error(f'The arm did not reach the park pose, it is not where the driver put it: {exc}')
+            yield from arm.park()
 
             in_error = False
 
@@ -455,7 +449,7 @@ class Robot(pimm.ControlSystem):
 
                 yield arm.limiter.wait()
 
-            yield from arm.park()
+            yield from arm.park(at_teardown=True)
 
 
 if __name__ == '__main__':

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -111,10 +111,6 @@ class _Arm(DriverRun[command.CommandType]):
     _MAX_JOINT_VELOCITY = np.array([2.62, 2.62, 2.62, 2.62, 5.26, 4.18, 5.26])
     # On top of the travel itself: the robot's controller ramps in and out of its speed cap, and settles late
     _MOVE_GRACE_S = 5.0
-    # Parking publishes nothing, so it comes back only as often as it needs to ask again
-    _PARK_POLL_S = 0.005
-    # Spent inside the world's teardown budget; past it the driver stops control where the arm stands
-    _PARK_TIMEOUT_S = 10.0
 
     def __init__(
         self,
@@ -185,9 +181,13 @@ class _Arm(DriverRun[command.CommandType]):
         return self._MOVE_GRACE_S + float(np.max(np.abs(target - q) / cap))
 
     def move_to(
-        self, target: np.ndarray, mode: command.ControlModeType | None
+        self, target: np.ndarray, mode: command.ControlModeType | None, *, at_teardown: bool = False
     ) -> Generator[pimm.Command, None, MoveStatus]:
-        """Travel to ``target`` under ``mode``, yielding until it arrives."""
+        """Travel to ``target`` under ``mode``, yielding until it arrives.
+
+        ``at_teardown`` is for the move the driver makes on its way out. The stop is already set by then, so
+        heeding it would abandon the move before it began, and recovering from a fault cancels the goal.
+        """
         # The first emit must not ship an unfilled state.
         self.state.encode(self.robot.state(), RobotStatus.BUSY)
         self.out.emit(self.state)
@@ -197,8 +197,11 @@ class _Arm(DriverRun[command.CommandType]):
         def expired() -> bool:
             return self.clock.now() >= deadline
 
+        def abandoned() -> bool:
+            return self.should_stop.value and not at_teardown
+
         def should_stop() -> bool:
-            return self.should_stop.value or expired()
+            return abandoned() or expired()
 
         try:
             self.command_target(target, mode)
@@ -206,7 +209,7 @@ class _Arm(DriverRun[command.CommandType]):
                 st = self.robot.state()
                 self.state.encode(st, RobotStatus.BUSY)
                 self.out.emit(self.state)
-                if st.error != 0:
+                if st.error != 0 and not at_teardown:
                     self.robot.recover_from_errors()
                 yield wait
             # The loop exits before it polls again, so a goal that landed as the deadline passed is unseen.
@@ -218,7 +221,7 @@ class _Arm(DriverRun[command.CommandType]):
             self.moves.errored = True
             raise
 
-        if self.should_stop.value:
+        if abandoned():
             return MoveStatus.GAVE_UP
         self.moves.errored = False
         # The poll that reports arrival ends the loop, so the sample before it was taken mid-travel
@@ -266,7 +269,7 @@ class _Arm(DriverRun[command.CommandType]):
                 call.set_exception(exc)  # an arm the driver cannot read still leaves nobody waiting
 
     def park(self) -> Iterator[pimm.Command]:
-        """Move the arm to the park pose, giving up after ``_PARK_TIMEOUT_S``. Drive with ``yield from``.
+        """Move the arm to the park pose. Drive with ``yield from``.
 
         Only a stop gets here: a run that ends by raising skips the park, because moving an arm in answer to
         a fault is the driver deciding on its own to move. Where it goes is fixed — ``_PARK_JOINTS``, at the
@@ -275,14 +278,8 @@ class _Arm(DriverRun[command.CommandType]):
         try:
             logger.info('Parking the arm')
             self.robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
-            deadline = self.clock.now() + self._PARK_TIMEOUT_S
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
-            self.command_target(_PARK_JOINTS, None)
-            outcome = yield from self.await_goal(
-                lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S)
-            )
-            if outcome is MoveStatus.GAVE_UP:
-                logger.error(f'Parking timed out after {self._PARK_TIMEOUT_S}s, the arm stays where it stands')
+            yield from self.move_to(_PARK_JOINTS, None, at_teardown=True)
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
         except Exception:
             logger.exception('Parking failed, the arm stays where it stands')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -164,17 +164,12 @@ class _Arm(DriverRun[command.CommandType]):
         self.robot.set_target_joints(target)
 
     def await_goal(
-        self,
-        target: np.ndarray,
-        should_stop: Callable[[], bool],
-        pace: Callable[[], pimm.Command],
-        mode: command.ControlModeType | None,
+        self, should_stop: Callable[[], bool], pace: Callable[[], pimm.Command]
     ) -> Generator[pimm.Command, None, MoveStatus]:
-        """Command ``target`` under ``mode`` and poll the goal until the arm arrives, one poll per resume.
+        """Poll the goal until the arm arrives, one poll per resume.
 
         ``pace`` is what to wait between polls, and so how often the goal is asked about.
         """
-        self.command_target(target, mode)
         while not should_stop():
             goal = self.robot.goal()
             if goal.status == pf.GoalStatus.REACHED:
@@ -206,7 +201,8 @@ class _Arm(DriverRun[command.CommandType]):
             return self.should_stop.value or expired()
 
         try:
-            for wait in self.await_goal(target, should_stop, self.limiter.wait, mode):
+            self.command_target(target, mode)
+            for wait in self.await_goal(should_stop, self.limiter.wait):
                 st = self.robot.state()
                 self.state.encode(st, RobotStatus.BUSY)
                 self.out.emit(self.state)
@@ -281,8 +277,9 @@ class _Arm(DriverRun[command.CommandType]):
             self.robot.recover_from_errors()  # once, before the move: a reflex during the move ends the park
             deadline = self.clock.now() + self._PARK_TIMEOUT_S
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
+            self.command_target(_PARK_JOINTS, None)
             outcome = yield from self.await_goal(
-                _PARK_JOINTS, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
+                lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S)
             )
             if outcome is MoveStatus.GAVE_UP:
                 logger.error(f'Parking timed out after {self._PARK_TIMEOUT_S}s, the arm stays where it stands')

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -230,24 +230,9 @@ class _Arm(DriverRun[command.CommandType]):
         self.publish(self.vendor.state())
         return MoveStatus.ARRIVED
 
-    def target_joints(self, cmd: command.CommandType) -> np.ndarray:
-        """The joints ``cmd`` asks the arm to hold."""
-        match cmd:
-            case command.CartesianPosition(pose):
-                return self.vendor.inverse_kinematics_with_limits(
-                    np.asarray([*pose.translation, *pose.rotation.as_quat])
-                )
-            case command.CartesianDelta() as delta_cmd:
-                target = delta_cmd.apply(self.state.ee_pose)
-                return self.vendor.inverse_kinematics_with_limits(
-                    np.asarray([*target.translation, *target.rotation.as_quat])
-                )
-            case command.JointPosition(positions):
-                return np.asarray(positions, dtype=np.float64)
-            case command.JointDelta(velocities=joint_delta):
-                return self.state.q + joint_delta
-            case other:
-                raise NotImplementedError(f'Unsupported command {other}')
+    def _joints_at(self, pose: geom.Transform3D) -> np.ndarray:
+        """The joints that put the end effector at ``pose``, within the arm's limits."""
+        return self.vendor.inverse_kinematics_with_limits(np.asarray([*pose.translation, *pose.rotation.as_quat]))
 
     def accept(self, cmd: command.CommandType) -> tuple[np.ndarray, command.ControlModeType | None]:
         """The joints ``cmd`` asks for and the law it pins, neither applied yet.
@@ -255,7 +240,17 @@ class _Arm(DriverRun[command.CommandType]):
         Solved here so that a command the arm cannot hold raises before anything changes; ``command_target``
         is what applies the pair.
         """
-        target = self.target_joints(cmd)
+        match cmd:
+            case command.CartesianPosition(pose):
+                target = self._joints_at(pose)
+            case command.CartesianDelta() as delta_cmd:
+                target = self._joints_at(delta_cmd.apply(self.state.ee_pose))
+            case command.JointPosition(positions):
+                target = np.asarray(positions, dtype=np.float64)
+            case command.JointDelta(velocities=joint_delta):
+                target = self.state.q + joint_delta
+            case other:
+                raise NotImplementedError(f'Unsupported command {other}')
         # The vendor takes a fixed-width finite vector and raises on anything else, too late to be caught
         # alongside the rest of what makes a command unusable. The arm has one velocity limit per joint, so
         # that vector's width is how many joints a target must name.

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -112,6 +112,8 @@ class _Arm(DriverRun[command.CommandType]):
     _MOVE_GRACE_S = 5.0
     # Parking publishes nothing, so it comes back only as often as it needs to ask again
     _PARK_POLL_S = 0.005
+    # Spent inside the world's teardown budget; past it the driver stops control where the arm stands
+    _PARK_TIMEOUT_S = 10.0
 
     def __init__(
         self,
@@ -119,7 +121,6 @@ class _Arm(DriverRun[command.CommandType]):
         sync_move: pimm.calls.ControlSystemHandler[command.CommandType, None],
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[FrankaState],
-        park_timeout_s: float,
         dynamics_factor: float,
         should_stop: pimm.SignalReceiver,
         clock: pimm.Clock,
@@ -128,7 +129,6 @@ class _Arm(DriverRun[command.CommandType]):
         self.vendor = vendor
         self.out = out
         self.state = FrankaState()
-        self._park_timeout_s = park_timeout_s
         self._dynamics_factor = dynamics_factor
 
     def __enter__(self) -> '_Arm':
@@ -272,7 +272,7 @@ class _Arm(DriverRun[command.CommandType]):
                 call.set_exception(exc)  # an arm the driver cannot read still leaves nobody waiting
 
     def park(self) -> Iterator[pimm.Command]:
-        """Move the arm to the park pose, giving up after ``park_timeout_s``. Drive with ``yield from``.
+        """Move the arm to the park pose, giving up after ``_PARK_TIMEOUT_S``. Drive with ``yield from``.
 
         Only a stop gets here: a run that ends by raising skips the park, because moving an arm in answer to
         a fault is the driver deciding on its own to move. Where it goes is fixed — ``_PARK_JOINTS``, at the
@@ -281,13 +281,13 @@ class _Arm(DriverRun[command.CommandType]):
         try:
             logger.info('Parking the arm')
             self.vendor.recover_from_errors()  # once, before the move: a reflex during the move ends the park
-            deadline = self.clock.now() + self._park_timeout_s
+            deadline = self.clock.now() + self._PARK_TIMEOUT_S
             # The park pose is a long way off, and only the native law shapes the reference on the way there.
             outcome = yield from self.await_goal(
                 _PARK_JOINTS, lambda: self.clock.now() >= deadline, lambda: pimm.Sleep(self._PARK_POLL_S), None
             )
             if outcome is MoveStatus.GAVE_UP:
-                logger.error(f'Parking timed out after {self._park_timeout_s}s, the arm stays where it stands')
+                logger.error(f'Parking timed out after {self._PARK_TIMEOUT_S}s, the arm stays where it stands')
         # rules-allow: swallowed-error — parking is best-effort; brakes and control release must run regardless.
         except Exception:
             logger.exception('Parking failed, the arm stays where it stands')
@@ -303,7 +303,6 @@ class Robot(pimm.ControlSystem):
         collision_coeff: float = 2.0,
         manage_desk: bool = True,
         reboot_on_safety_error: bool = False,
-        park_timeout_s: float = 10.0,
     ) -> None:
         """
         :param ip: IP address of the robot.
@@ -316,8 +315,6 @@ class Robot(pimm.ControlSystem):
         :param reboot_on_safety_error: When the control box is in an unrecoverable ``SafetyError`` on start, reboot
             it, wait for it to come back, and try once more before giving up. Only applies when ``manage_desk`` is
             set.
-        :param park_timeout_s: How long the arm may travel back to its park pose when the run ends before the
-            driver gives up and stops control where it stands. It is spent inside the world's teardown budget.
         """
         assert 0 < relative_dynamics_factor <= 1, relative_dynamics_factor
         self._ip = ip
@@ -331,7 +328,6 @@ class Robot(pimm.ControlSystem):
         self._robot: pf.Robot | None = None
         self._desk_credentials = _read_desk_credentials() if manage_desk else None
         self._reboot_on_safety_error = reboot_on_safety_error
-        self._park_timeout_s = park_timeout_s
 
     @staticmethod
     def _build_robot_meta(robot) -> dict:
@@ -432,14 +428,7 @@ class Robot(pimm.ControlSystem):
     def _arm(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> _Arm:
         """The arm this run drives, built from the driver's configuration."""
         return _Arm(
-            self._vendor,
-            self.sync_move,
-            self.commands,
-            self.state,
-            self._park_timeout_s,
-            self._relative_dynamics_factor,
-            should_stop,
-            clock,
+            self._vendor, self.sync_move, self.commands, self.state, self._relative_dynamics_factor, should_stop, clock
         )
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -75,10 +75,9 @@ class _Arm(DriverRun[command.CommandType]):
     def __init__(
         self,
         api: KinovaAPI,
-        sync_move: pimm.calls.ControlSystemHandler[command.CommandType | None, None],
+        sync_move: pimm.calls.ControlSystemHandler[command.CommandType, None],
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[KinovaState],
-        home_joints: list[float],
         dynamics_factor: float,
         should_stop: pimm.SignalReceiver,
         clock: pimm.Clock,
@@ -91,7 +90,6 @@ class _Arm(DriverRun[command.CommandType]):
         self.state = KinovaState()
         self.solver = KinematicsSolver()
         self.controller = JointCompliantController(actuator_count=actuators, relative_dynamics_factor=dynamics_factor)
-        self._home_joints = home_joints
         self._current = np.zeros(actuators, dtype=np.float32)
         # Read here rather than left empty: every setpoint below is solved from where the arm is now
         self.q, self.dq, self.tau = api.apply_current_command(None)
@@ -109,8 +107,8 @@ class _Arm(DriverRun[command.CommandType]):
             # once whatever blocked it goes away, long after its asker was told it failed.
             self.controller.set_target_qpos(self.q)
 
-    def _target_qpos(self, cmd: command.CommandType | None) -> np.ndarray:
-        """The joints ``cmd`` asks the arm to hold, solved from the joints it reports now; nothing asks for home."""
+    def _target_qpos(self, cmd: command.CommandType) -> np.ndarray:
+        """The joints ``cmd`` asks the arm to hold, solved from the joints it reports now."""
         # `JointCompliantController` is a compliance law, not a position servo: `PositionControl` would pin
         # a rule the arm does not run.
         # TODO: a joint-only `Impedance` is refused for want of plumbing, not capability: the controller runs
@@ -118,8 +116,6 @@ class _Arm(DriverRun[command.CommandType]):
         # `kq`/`kqd` through and stepping the references.
         command.require_native_mode(cmd, 'Kinova')
         match cmd:
-            case None | command.Reset():
-                return np.asarray(self._home_joints, dtype=np.float32)
             case command.CartesianPosition(pose):
                 return self.solver.inverse(pose, self.q)
             case command.CartesianDelta() as delta_cmd:
@@ -130,7 +126,7 @@ class _Arm(DriverRun[command.CommandType]):
             case other:
                 raise NotImplementedError(f'Unsupported command {other}')
 
-    def track(self, cmd: command.CommandType | None) -> None:
+    def track(self, cmd: command.CommandType) -> None:
         """Put the controller on the setpoint ``cmd`` asks for, with nobody waiting on the arrival."""
         self.controller.set_target_qpos(self._target_qpos(cmd))
 
@@ -138,7 +134,7 @@ class _Arm(DriverRun[command.CommandType]):
         """How long the arm may take to reach ``target``, from the speed its controller is capped at."""
         return self._MOVE_GRACE_S + float(np.max(np.abs(target - self.q)) / np.min(self.controller.max_velocity))
 
-    def serve_sync_move(self, call: pimm.calls.Call[command.CommandType | None, None]) -> None:
+    def serve_sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> None:
         """Put the controller where ``call`` asks; ``settle`` answers it once the arm reads back there."""
         with pimm.calls.raise_to(call):
             target = self._target_qpos(call.request)
@@ -173,28 +169,18 @@ class _Arm(DriverRun[command.CommandType]):
 
 
 class Robot(pimm.ControlSystem):
-    def __init__(self, ip: str, relative_dynamics_factor=0.2, home_joints: list[float] | None = None) -> None:
+    def __init__(self, ip: str, relative_dynamics_factor=0.2) -> None:
         # A zero factor caps every joint at zero speed: the arm would never travel and no move could land
         assert 0 < relative_dynamics_factor <= 1, relative_dynamics_factor
         self.ip = ip
         self.relative_dynamics_factor = relative_dynamics_factor
-        self.home_joints = home_joints if home_joints is not None else [0.0, -0, 0.5, -1.5, 0.0, -0.5, 1.57079633]
         self.commands = pimm.ControlSystemReceiver[command.CommandType](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType, None](self)
         self.state = pimm.ControlSystemEmitter[KinovaState](self)
 
     def _arm(self, api: KinovaAPI, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> _Arm:
         """The arm this run drives, built from the driver's configuration."""
-        return _Arm(
-            api,
-            self.sync_move,
-            self.commands,
-            self.state,
-            self.home_joints,
-            self.relative_dynamics_factor,
-            should_stop,
-            clock,
-        )
+        return _Arm(api, self.sync_move, self.commands, self.state, self.relative_dynamics_factor, should_stop, clock)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         _set_realtime_priority()

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -107,7 +107,7 @@ class _Arm(DriverRun[command.CommandType]):
             # once whatever blocked it goes away, long after its asker was told it failed.
             self.controller.set_target_qpos(self.q)
 
-    def _target_qpos(self, cmd: command.CommandType) -> np.ndarray:
+    def _to_joints(self, cmd: command.CommandType) -> np.ndarray:
         """The joints ``cmd`` asks the arm to hold, solved from the joints it reports now."""
         # `JointCompliantController` is a compliance law, not a position servo: `PositionControl` would pin
         # a rule the arm does not run.
@@ -128,7 +128,7 @@ class _Arm(DriverRun[command.CommandType]):
 
     def track(self, cmd: command.CommandType) -> None:
         """Put the controller on the setpoint ``cmd`` asks for, with nobody waiting on the arrival."""
-        self.controller.set_target_qpos(self._target_qpos(cmd))
+        self.controller.set_target_qpos(self._to_joints(cmd))
 
     def _travel_s(self, target: np.ndarray) -> float:
         """How long the arm may take to reach ``target``, from the speed its controller is capped at."""
@@ -137,7 +137,7 @@ class _Arm(DriverRun[command.CommandType]):
     def sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> None:
         """Put the controller where ``call`` asks; ``settle`` answers it once the arm reads back there."""
         with pimm.calls.raise_to(call):
-            target = self._target_qpos(call.request)
+            target = self._to_joints(call.request)
             self.controller.set_target_qpos(target)
             # The branch the controller tracks: it wraps the target once, when it is set
             wrapped = wrap_joint_angle(target, self.q)

--- a/positronic/drivers/roboarm/kinova/driver.py
+++ b/positronic/drivers/roboarm/kinova/driver.py
@@ -134,7 +134,7 @@ class _Arm(DriverRun[command.CommandType]):
         """How long the arm may take to reach ``target``, from the speed its controller is capped at."""
         return self._MOVE_GRACE_S + float(np.max(np.abs(target - self.q)) / np.min(self.controller.max_velocity))
 
-    def serve_sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> None:
+    def sync_move(self, call: pimm.calls.Call[command.CommandType, None]) -> None:
         """Put the controller where ``call`` asks; ``settle`` answers it once the arm reads back there."""
         with pimm.calls.raise_to(call):
             target = self._target_qpos(call.request)
@@ -190,7 +190,7 @@ class Robot(pimm.ControlSystem):
                     arm.settle()
                     asked = arm.moves.next_request()
                     if isinstance(asked, pimm.calls.Call):
-                        arm.serve_sync_move(asked)
+                        arm.sync_move(asked)
                     elif asked is not None:
                         with log_failure(asked):
                             arm.track(asked)

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -68,11 +68,10 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
     def __init__(
         self,
         bus: MotorBus,
-        sync_move: pimm.calls.ControlSystemHandler[roboarm_command.CommandType | None, None],
+        sync_move: pimm.calls.ControlSystemHandler[roboarm_command.CommandType, None],
         async_move: pimm.SignalReceiver[roboarm_command.CommandType],
         out: pimm.SignalEmitter[SO101State],
         grip_out: pimm.SignalEmitter[float],
-        home_joints: list[float],
         should_stop: pimm.SignalReceiver,
         clock: pimm.Clock,
     ):
@@ -83,7 +82,6 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
         self.state = SO101State()
         self.kinematic = Kinematics(_SO101_URDF_PATH, _SO101_EE_JOINT)
         self._joint_limits = self.kinematic.joint_limits
-        self._home_joints = home_joints
         # Read here rather than left empty: every setpoint below is solved from where the arm is now, and the
         # arm holds where the bus finds it until something asks otherwise
         self.q_norm = bus.position
@@ -111,16 +109,13 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
         """Normalize the five arm joints. ``_rad_to_norm`` spans the bus, whose last entry is the gripper."""
         return self._rad_to_norm(np.append(q_rad, 0.0))[:-1]
 
-    def _requested_qpos(self, cmd: roboarm_command.CommandType | None) -> np.ndarray:
-        """The setpoint ``cmd`` asks for, in the bus's normalized units, whether or not the arm can hold it;
-        asking for nothing asks for home."""
+    def _requested_qpos(self, cmd: roboarm_command.CommandType) -> np.ndarray:
+        """The setpoint ``cmd`` asks for, in the bus's normalized units, whether or not the arm can hold it."""
         # TODO: accept the modes the bus can run instead of leaving them to what a command omits. Its servos
         # are position control, so `PositionControl` names the rule already running, and a named stiffness is
         # their gain registers.
         roboarm_command.require_native_mode(cmd, 'SO101')
         match cmd:
-            case None | roboarm_command.Reset():
-                return self._arm_rad_to_norm(np.asarray(self._home_joints, dtype=np.float32))
             case roboarm_command.CartesianPosition(pose):
                 return self._solve_ik(pose)
             case roboarm_command.CartesianDelta() as delta_cmd:
@@ -131,7 +126,7 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
             case other:
                 raise ValueError(f'Unknown command: {other}')
 
-    def _target_qpos(self, cmd: roboarm_command.CommandType | None) -> np.ndarray:
+    def _target_qpos(self, cmd: roboarm_command.CommandType) -> np.ndarray:
         """The setpoint ``cmd`` asks the arm to hold, clipped to the calibrated range the bus reports from."""
         return np.clip(self._requested_qpos(cmd), 0.0, 1.0)
 
@@ -156,7 +151,7 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
         """Hold the arm at the setpoint ``cmd`` asks for, with nobody waiting on the arrival."""
         self._qpos, self._unsent = self._target_qpos(cmd), True
 
-    def serve_sync_move(self, call: pimm.calls.Call[roboarm_command.CommandType | None, None]) -> None:
+    def serve_sync_move(self, call: pimm.calls.Call[roboarm_command.CommandType, None]) -> None:
         """Hold the arm where ``call`` asks; ``settle`` answers it once the bus reads back there."""
         with pimm.calls.raise_to(call):
             target = self._target_qpos(call.request)
@@ -199,12 +194,11 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
 
 
 class Robot(pimm.ControlSystem):
-    def __init__(self, motor_bus: MotorBus, home_joints: list[float] | None = None):
+    def __init__(self, motor_bus: MotorBus):
         self.motor_bus = motor_bus
         self.mujoco_model_path = 'positronic/drivers/roboarm/so101/so101.xml'
-        self.home_joints = home_joints if home_joints is not None else [0.0, 0.0, 0.0, 0.0, 0.0]
         self.commands = pimm.ControlSystemReceiver[roboarm_command.CommandType](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[roboarm_command.CommandType | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[roboarm_command.CommandType, None](self)
         self.target_grip = pimm.ControlSystemReceiver[float](self)
 
         self.grip = pimm.ControlSystemEmitter[float](self)
@@ -217,9 +211,7 @@ class Robot(pimm.ControlSystem):
 
     def _arm(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> _Arm:
         """The arm this run drives, built from the driver's configuration."""
-        return _Arm(
-            self.motor_bus, self.sync_move, self.commands, self.state, self.grip, self.home_joints, should_stop, clock
-        )
+        return _Arm(self.motor_bus, self.sync_move, self.commands, self.state, self.grip, should_stop, clock)
 
     @staticmethod
     def _build_robot_meta() -> dict:

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -151,7 +151,7 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
         """Hold the arm at the setpoint ``cmd`` asks for, with nobody waiting on the arrival."""
         self._qpos, self._unsent = self._target_qpos(cmd), True
 
-    def serve_sync_move(self, call: pimm.calls.Call[roboarm_command.CommandType, None]) -> None:
+    def sync_move(self, call: pimm.calls.Call[roboarm_command.CommandType, None]) -> None:
         """Hold the arm where ``call`` asks; ``settle`` answers it once the bus reads back there."""
         with pimm.calls.raise_to(call):
             target = self._target_qpos(call.request)
@@ -235,7 +235,7 @@ class Robot(pimm.ControlSystem):
                 arm.settle()
                 asked = arm.moves.next_request()
                 if isinstance(asked, pimm.calls.Call):
-                    arm.serve_sync_move(asked)
+                    arm.sync_move(asked)
                 elif asked is not None:
                     with log_failure(asked):
                         arm.track(asked)

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -100,7 +100,7 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
     def _forward_kinematics(self, q_norm: np.ndarray) -> tuple[geom.Transform3D, float]:
         return self.kinematic.forward(self._norm_to_rad(q_norm)), q_norm[-1]
 
-    def _solve_ik(self, pose: geom.Transform3D) -> np.ndarray:
+    def _ik(self, pose: geom.Transform3D) -> np.ndarray:
         q = self._norm_to_rad(self.q_norm).tolist()
         q[-1] = 0.0  # ignore gripper in ik
         return self._rad_to_norm(self.kinematic.inverse(q, pose, n_iter=10))[:-1]
@@ -117,10 +117,10 @@ class _Arm(DriverRun[roboarm_command.CommandType]):
         roboarm_command.require_native_mode(cmd, 'SO101')
         match cmd:
             case roboarm_command.CartesianPosition(pose):
-                return self._solve_ik(pose)
+                return self._ik(pose)
             case roboarm_command.CartesianDelta() as delta_cmd:
                 ee_pose, _ = self._forward_kinematics(self.q_norm)
-                return self._solve_ik(delta_cmd.apply(ee_pose))
+                return self._ik(delta_cmd.apply(ee_pose))
             case roboarm_command.JointPosition(qpos):
                 return self._arm_rad_to_norm(np.asarray(qpos, dtype=np.float32))
             case other:

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -14,8 +14,8 @@ from positronic.drivers.roboarm.tests.fakes import StopFlag
 from positronic.drivers.utils import MoveAbandoned
 from positronic.tests.testing_coutils import ManualCommandReceiver, RecordingEmitter
 
-HOME = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
-JOGGED = HOME + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+PARK = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
+JOGGED = PARK + np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 IMPEDANCE = command.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
 
 
@@ -151,8 +151,8 @@ def desk(monkeypatch) -> FakeDesk:
     return session
 
 
-def _driver(arm: FakeArm, *, variation: list[float] | None = None, **kwargs) -> franka.Robot:
-    robot = franka.Robot('192.0.2.1', home_joints=list(HOME), home_joints_variation=variation or [0.0] * 7, **kwargs)
+def _driver(arm: FakeArm, **kwargs) -> franka.Robot:
+    robot = franka.Robot('192.0.2.1', park_joints=list(PARK), **kwargs)
     robot._robot = arm  # `_vendor` hands back an already-set handle, which is how the fake arm gets in
     return robot
 
@@ -171,25 +171,20 @@ def _drive_park(driver: franka.Robot, arm: FakeArm) -> MockClock:
     return clock
 
 
-def test_park_drives_the_arm_to_the_home_pose():
+def _mover(world: pimm.World, driver: franka.Robot) -> pimm.calls.Caller[command.CommandType, None]:
+    """A caller on ``driver.sync_move``, for a test that pumps its generator rather than running a World."""
+    caller = pimm.calls.ControlSystemCaller[command.CommandType, None](driver)
+    wire_call(world, caller, driver.sync_move)
+    return caller
+
+
+def test_park_drives_the_arm_to_the_park_pose():
     arm = FakeArm(JOGGED)
 
     _drive_park(_driver(arm, manage_desk=False), arm)
 
-    np.testing.assert_allclose(arm.targets, [HOME])
-    np.testing.assert_allclose(arm.q, HOME)
-
-
-def test_park_commands_the_exact_home_pose_from_inside_the_homing_spread():
-    variation = [0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10]
-    arm = FakeArm(HOME + np.asarray(variation))
-
-    _drive_park(_driver(arm, variation=variation, manage_desk=False), arm)
-
-    # An arm inside the spread, or travelling through it, is not asked to be judged already home: the
-    # controller reports arrival, and a pose it already holds arrives at once.
-    np.testing.assert_allclose(arm.targets, [HOME])
-    np.testing.assert_allclose(arm.q, HOME)
+    np.testing.assert_allclose(arm.targets, [PARK])
+    np.testing.assert_allclose(arm.q, PARK)
 
 
 def test_the_park_waits_by_yielding_rather_than_blocking():
@@ -230,9 +225,21 @@ def test_park_swallows_a_robot_that_fails_mid_move():
     np.testing.assert_allclose(arm.q, JOGGED)
 
 
+def test_the_driver_puts_the_arm_at_the_park_pose_when_it_takes_control():
+    """Both ends of a run leave the arm at the same pose, so a run starts from where the last one left off."""
+    arm = FakeArm(JOGGED)
+    loop = _driver(arm, manage_desk=False).run(StopFlag(), MockClock())
+
+    for _ in range(2):  # through the opening move
+        next(loop)
+
+    np.testing.assert_allclose(arm.targets, [PARK])
+    np.testing.assert_allclose(arm.q, PARK)
+
+
 def test_a_command_the_arm_cannot_reach_leaves_the_running_law_alone(desk):
     """A rejected command must not half-apply: the arm would hold its old target under new dynamics."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm)
     feed = ManualCommandReceiver()
     driver.commands._bind(feed)
@@ -251,24 +258,27 @@ def test_a_command_the_arm_cannot_reach_leaves_the_running_law_alone(desk):
     assert arm.modes[mark:] == [], 'the arm changed law for a command it never executed'
 
 
-def test_the_law_changes_only_where_the_target_is_published(desk):
+def test_the_law_changes_only_where_the_target_is_published(desk, world):
     """A switch with anything between it and the target can leave the arm holding its last one under it."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm)
     feed = ManualCommandReceiver()
     driver.commands._bind(feed)
+    move = _mover(world, driver)
     stop = StopFlag()
     clock = MockClock()
     loop = driver.run(stop, clock)
 
     for _ in range(3):
-        next(loop)  # init + opening reset
+        next(loop)  # init + the opening move
     mark = len(arm.calls)
     feed.push(command.JointPosition(positions=JOGGED, mode=IMPEDANCE))
     for _ in range(2):
         next(loop)
-    feed.push(command.Reset())
-    for _ in range(6):
+    answer = move(command.JointPosition(positions=PARK))  # a travel switches law too, from inside the driver
+    for _ in range(20):
+        if answer.done():
+            break
         next(loop)
 
     switches = [i for i, c in enumerate(arm.calls[mark:], start=mark) if c is Call.SET_CONTROL_MODE]
@@ -278,7 +288,7 @@ def test_the_law_changes_only_where_the_target_is_published(desk):
 
 def test_a_joint_target_the_vendor_would_refuse_leaves_the_running_law_alone(desk):
     """A joint command is passed straight through, so what the vendor rejects has to be caught here."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm)
     feed = ManualCommandReceiver()
     driver.commands._bind(feed)
@@ -298,7 +308,7 @@ def test_a_joint_target_the_vendor_would_refuse_leaves_the_running_law_alone(des
 
 
 def test_park_puts_the_arm_under_its_native_law():
-    """The home pose is far off, and only the native law shapes the reference on the way there."""
+    """The park pose is far off, and only the native law shapes the reference on the way there."""
     arm = FakeArm(JOGGED)
 
     _drive_park(_driver(arm, manage_desk=False), arm)
@@ -307,7 +317,7 @@ def test_park_puts_the_arm_under_its_native_law():
 
 
 def test_teardown_parks_the_arm_before_stopping_control(desk):
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     stop = StopFlag()
     clock = MockClock()
     loop = _driver(arm).run(stop, clock)
@@ -321,13 +331,13 @@ def test_teardown_parks_the_arm_before_stopping_control(desk):
 
     teardown = arm.calls[mark:]
     assert teardown.index(Call.SET_TARGET_JOINTS) < teardown.index(Call.STOP)
-    np.testing.assert_allclose(arm.targets[-1], HOME)
-    np.testing.assert_allclose(arm.q, HOME)
+    np.testing.assert_allclose(arm.targets[-1], PARK)
+    np.testing.assert_allclose(arm.q, PARK)
     assert desk.prepared and desk.released
 
 
 def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     stop = StopFlag()
     clock = MockClock()
     loop = _driver(arm).run(stop, clock)
@@ -346,7 +356,7 @@ def test_teardown_stops_control_and_releases_desk_when_parking_fails(desk):
 
 
 def test_a_control_fault_stops_the_arm_without_parking_it(desk):
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     stop = StopFlag()
     clock = MockClock()
     loop = _driver(arm).run(stop, clock)
@@ -364,15 +374,15 @@ def test_a_control_fault_stops_the_arm_without_parking_it(desk):
     assert desk.released
 
 
-def test_a_stop_during_the_reset_ends_the_run_without_a_fault(desk):
+def test_a_stop_during_the_opening_move_ends_the_run_without_a_fault(desk):
     """The event that ends the world also cancels the in-flight goal, so a poll taken after the stop
     reports failure. Reading it would turn a clean shutdown into a control fault — which skips the park."""
-    arm = FakeArm(JOGGED, polls_to_reach=10**9)  # the opening reset never lands on its own
+    arm = FakeArm(JOGGED, polls_to_reach=10**9)  # the opening move never lands on its own
     stop = StopFlag()
     clock = MockClock()
     loop = _driver(arm).run(stop, clock)
 
-    next(loop)  # suspended inside the reset's travel
+    next(loop)  # suspended inside the opening move's travel
     stop.stopped = True
     arm.goal_status = franka.pf.GoalStatus.ABORTED
 
@@ -381,17 +391,10 @@ def test_a_stop_during_the_reset_ends_the_run_without_a_fault(desk):
     assert arm.calls[-1] == Call.STOP
 
 
-def _mover(world: pimm.World, driver: franka.Robot) -> pimm.calls.Caller[command.CommandType, None]:
-    """A caller on ``driver.sync_move``, for a test that pumps its generator rather than running a World."""
-    caller = pimm.calls.ControlSystemCaller[command.CommandType, None](driver)
-    wire_call(world, caller, driver.sync_move)
-    return caller
-
-
-def test_an_arm_that_will_not_home_reads_error_rather_than_ending_the_run():
+def test_an_arm_that_will_not_park_reads_error_rather_than_ending_the_run():
     """The driver's own move is the one that can fail before a caller exists to hear about it, so the run
     goes on and the arm reads as it is."""
-    arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)  # the opening homing never lands
+    arm = FakeArm(JOGGED, goal_status=franka.pf.GoalStatus.ABORTED)  # the opening move never lands
     driver = _driver(arm, manage_desk=False)
     states = RecordingEmitter()
     driver.state._bind(states)
@@ -408,13 +411,13 @@ def test_an_arm_that_will_not_home_reads_error_rather_than_ending_the_run():
 
 def test_a_sync_move_answers_once_the_arm_is_there(world):
     """What a sync move adds over a command: something to wait on that means the arm is in place."""
-    arm = FakeArm(HOME, polls_to_reach=3)  # more than one poll, so an answer cannot land in the asking round
+    arm = FakeArm(PARK, polls_to_reach=3)  # more than one poll, so an answer cannot land in the asking round
     driver = _driver(arm, manage_desk=False)
     stop = StopFlag()
     clock = MockClock()
     loop = driver.run(stop, clock)
 
-    for _ in range(2):  # through the opening reset
+    for _ in range(2):  # through the opening move
         next(loop)
     answer = _mover(world, driver)(command.JointPosition(JOGGED))
     next(loop)
@@ -432,13 +435,13 @@ def test_a_sync_move_answers_once_the_arm_is_there(world):
 
 def test_a_move_the_world_stops_under_is_handed_back_to_its_asker(world):
     """A stop ends the travel with no arrival to report, and silence would hold the asker for good."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm, manage_desk=False)
     stop = StopFlag()
     clock = MockClock()
     loop = driver.run(stop, clock)
 
-    for _ in range(2):  # through the opening reset
+    for _ in range(2):  # through the opening move
         next(loop)
     arm.polls_to_reach = 1000  # the move is still travelling when the stop lands
     answer = _mover(world, driver)(command.JointPosition(JOGGED))
@@ -457,7 +460,7 @@ def test_a_move_the_world_stops_under_is_handed_back_to_its_asker(world):
 
 def test_a_sync_move_the_arm_cannot_make_fails_the_asker(world):
     """A move that stops advancing is the asker's failure to hear about."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm, manage_desk=False)
     stop = StopFlag()
     clock = MockClock()
@@ -479,7 +482,7 @@ def test_a_sync_move_the_arm_cannot_make_fails_the_asker(world):
 def test_an_arm_that_stopped_short_reads_error_until_a_move_lands(world):
     """A stall is not a fault the vendor reports, so without this the arm reads AVAILABLE at a pose nobody
     asked for."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm, manage_desk=False)
     states = RecordingEmitter()
     driver.state._bind(states)
@@ -488,7 +491,7 @@ def test_an_arm_that_stopped_short_reads_error_until_a_move_lands(world):
     clock = MockClock()
     loop = driver.run(stop, clock)
 
-    for _ in range(2):  # through the opening reset
+    for _ in range(2):  # through the opening move
         next(loop)
     arm.goal_status = franka.pf.GoalStatus.ABORTED
     answer = move(command.JointPosition(JOGGED))
@@ -501,7 +504,7 @@ def test_an_arm_that_stopped_short_reads_error_until_a_move_lands(world):
     assert states.emitted[-1][1].status == RobotStatus.ERROR
 
     arm.goal_status = None  # whatever stalled the arm is cleared
-    answer = move(command.JointPosition(HOME))
+    answer = move(command.JointPosition(PARK))
     for _ in range(20):
         if answer.done():
             break
@@ -515,7 +518,7 @@ def test_an_arm_that_stopped_short_reads_error_until_a_move_lands(world):
 def test_the_state_answering_a_sync_move_carries_the_pose_the_arm_reached(world):
     """The sample before the arriving poll was taken mid-travel, and would read AVAILABLE at the pose the
     arm set out from."""
-    arm = FakeArm(HOME, polls_to_reach=3)
+    arm = FakeArm(PARK, polls_to_reach=3)
     driver = _driver(arm, manage_desk=False)
     states = RecordingEmitter()
     driver.state._bind(states)
@@ -523,7 +526,7 @@ def test_the_state_answering_a_sync_move_carries_the_pose_the_arm_reached(world)
     clock = MockClock()
     loop = driver.run(stop, clock)
 
-    for _ in range(2):  # through the opening reset
+    for _ in range(2):  # through the opening move
         next(loop)
     answer = _mover(world, driver)(command.JointPosition(JOGGED))
     for _ in range(20):
@@ -539,7 +542,7 @@ def test_the_state_answering_a_sync_move_carries_the_pose_the_arm_reached(world)
 
 def test_a_move_that_lands_as_its_deadline_expires_is_an_arrival():
     """The deadline stops the poll loop before it asks again, so a goal that landed just then is unseen."""
-    arm = FakeArm(HOME, polls_to_reach=10**9)  # it never lands on a poll of its own
+    arm = FakeArm(PARK, polls_to_reach=10**9)  # it never lands on a poll of its own
     driver = _driver(arm, manage_desk=False)
     driver.state._bind(RecordingEmitter())
     clock = MockClock()
@@ -558,7 +561,7 @@ def test_a_move_that_lands_as_its_deadline_expires_is_an_arrival():
 
 def test_a_fault_that_lands_with_the_arrival_reads_error_rather_than_available():
     """The state answering a move reports the arm as the vendor describes it, not as the goal reported."""
-    arm = FakeArm(HOME, polls_to_reach=1)  # the first poll of the goal already reports it reached
+    arm = FakeArm(PARK, polls_to_reach=1)  # the first poll of the goal already reports it reached
     driver = _driver(arm, manage_desk=False)
     states = RecordingEmitter()
     driver.state._bind(states)
@@ -575,7 +578,7 @@ def test_a_fault_that_lands_with_the_arrival_reads_error_rather_than_available()
 def test_a_sync_move_that_never_arrives_times_out_and_holds_where_the_arm_stopped(world):
     """A goal the controller never converges on is not an error the vendor reports, so the deadline is what
     ends the move."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm, manage_desk=False)
     states = RecordingEmitter()
     driver.state._bind(states)
@@ -584,7 +587,7 @@ def test_a_sync_move_that_never_arrives_times_out_and_holds_where_the_arm_stoppe
     clock = MockClock()
     loop = driver.run(stop, clock)
 
-    for _ in range(2):  # through the opening reset, which still lands
+    for _ in range(2):  # through the opening move, which still lands
         next(loop)
     arm.polls_to_reach = 10**9  # from here the goal stays in flight
     answer = move(command.JointPosition(JOGGED))
@@ -596,7 +599,7 @@ def test_a_sync_move_that_never_arrives_times_out_and_holds_where_the_arm_stoppe
 
     with pytest.raises(TimeoutError, match='stopped short'):
         answer.result()
-    np.testing.assert_allclose(arm.targets[-1], HOME)
+    np.testing.assert_allclose(arm.targets[-1], PARK)
     np.testing.assert_allclose(arm.targets[-2], JOGGED)
     # Published before the asker heard: a caller that starts recovering must not read the arm as available
     assert states.emitted[-1][1].status == RobotStatus.ERROR
@@ -604,7 +607,7 @@ def test_a_sync_move_that_never_arrives_times_out_and_holds_where_the_arm_stoppe
 
 def test_a_commands_mode_reaches_the_arm_with_the_gains_it_named(desk):
     """Skipping a mode already running is the vendor's, so the driver hands over every command's."""
-    arm = FakeArm(HOME)
+    arm = FakeArm(PARK)
     driver = _driver(arm)
     feed = ManualCommandReceiver()
     driver.commands._bind(feed)
@@ -613,7 +616,7 @@ def test_a_commands_mode_reaches_the_arm_with_the_gains_it_named(desk):
     loop = driver.run(stop, clock)
 
     for _ in range(3):
-        next(loop)  # init + opening reset
+        next(loop)  # init + the opening move
     feed.push(command.JointPosition(positions=JOGGED, mode=IMPEDANCE))
     for _ in range(2):
         next(loop)
@@ -626,8 +629,9 @@ def test_a_commands_mode_reaches_the_arm_with_the_gains_it_named(desk):
     assert applied[-1].kq == list(IMPEDANCE.kq), 'the gains the command named did not reach the arm'
 
 
-def test_homing_returns_the_arm_to_its_native_law(desk):
-    arm = FakeArm(HOME)
+def test_a_command_pinning_no_mode_returns_the_arm_to_its_native_law(desk):
+    """A mode is pinned per command, so one that names none does not inherit what the last one ran under."""
+    arm = FakeArm(PARK)
     driver = _driver(arm)
     feed = ManualCommandReceiver()
     driver.commands._bind(feed)
@@ -641,8 +645,8 @@ def test_homing_returns_the_arm_to_its_native_law(desk):
     for _ in range(2):
         next(loop)
     mark = len(arm.modes)
-    feed.push(command.Reset())
-    for _ in range(6):
+    feed.push(command.JointPosition(positions=PARK))
+    for _ in range(2):
         next(loop)
     stop.stopped = True
     _drive(loop, clock)

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -152,7 +152,7 @@ def desk(monkeypatch) -> FakeDesk:
 
 
 def _driver(arm: FakeArm, **kwargs) -> franka.Robot:
-    robot = franka.Robot('192.0.2.1', park_joints=list(PARK), **kwargs)
+    robot = franka.Robot('192.0.2.1', **kwargs)
     robot._robot = arm  # `_vendor` hands back an already-set handle, which is how the fake arm gets in
     return robot
 

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -208,10 +208,10 @@ def test_park_gives_up_when_the_goal_stops_advancing():
 def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
     arm = FakeArm(JOGGED, polls_to_reach=10**9)
 
-    clock = _drive_park(_driver(arm, manage_desk=False, park_timeout_s=0.05), arm)
+    clock = _drive_park(_driver(arm, manage_desk=False), arm)
 
     # It waits out the timeout and gives up within one poll interval of it.
-    assert 0.05 <= clock.now() < 0.06
+    assert franka._Arm._PARK_TIMEOUT_S <= clock.now() < franka._Arm._PARK_TIMEOUT_S + franka._Arm._PARK_POLL_S
     assert arm.calls.count(Call.GOAL) > 1
     np.testing.assert_allclose(arm.q, JOGGED)
 

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -158,10 +158,11 @@ def _driver(arm: FakeArm, **kwargs) -> franka.Robot:
 
 
 def _drive(loop, clock: MockClock | None = None) -> None:
-    """Pump a driver loop to exhaustion, standing in for the world by advancing ``clock`` through each Sleep."""
+    """Pump a driver loop to exhaustion, standing in for the world by advancing ``clock`` through each wait."""
     clock = clock or MockClock()
-    for sleep in loop:
-        clock.advance(sleep.seconds)
+    for wait in loop:
+        if isinstance(wait, pimm.Sleep):
+            clock.advance(wait.seconds)
 
 
 def _drive_park(driver: franka.Robot, arm: FakeArm) -> MockClock:
@@ -188,12 +189,12 @@ def test_park_drives_the_arm_to_the_park_pose():
 
 
 def test_the_park_waits_by_yielding_rather_than_blocking():
-    """A driver's waits are the world's to honour, teardown included: the park asks for them with Sleep."""
+    """A driver's waits are the world's to honour, teardown included: the park asks for them, never sleeps."""
     arm = FakeArm(JOGGED, polls_to_reach=3)
 
     commands = list(_driver(arm, manage_desk=False)._arm(StopFlag(), MockClock()).park())
 
-    assert commands and all(isinstance(command, pimm.Sleep) for command in commands)
+    assert commands and all(isinstance(command, pimm.Sleep | pimm.Yield) for command in commands)
 
 
 def test_park_gives_up_when_the_goal_stops_advancing():
@@ -207,11 +208,14 @@ def test_park_gives_up_when_the_goal_stops_advancing():
 
 def test_park_gives_up_when_the_arm_does_not_arrive_in_time():
     arm = FakeArm(JOGGED, polls_to_reach=10**9)
+    clock = MockClock()
+    parking = _driver(arm, manage_desk=False)._arm(StopFlag(), clock)
+    budget = parking._travel_s(JOGGED, PARK)
 
-    clock = _drive_park(_driver(arm, manage_desk=False), arm)
+    _drive(parking.park(), clock)
 
-    # It waits out the timeout and gives up within one poll interval of it.
-    assert franka._Arm._PARK_TIMEOUT_S <= clock.now() < franka._Arm._PARK_TIMEOUT_S + franka._Arm._PARK_POLL_S
+    # It waits out the travel the pose is worth and gives up within a poll of it.
+    assert budget <= clock.now() < budget + 0.01
     assert arm.calls.count(Call.GOAL) > 1
     np.testing.assert_allclose(arm.q, JOGGED)
 

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -219,8 +219,11 @@ class _Chain(DriverRun[command.CommandType]):
             raise ValueError(f'{world_pose} is out of reach')
         return solution
 
-    def target_joints(self, cmd: command.CommandType, q: np.ndarray) -> np.ndarray:
+    def to_joints(self, cmd: command.CommandType, q: np.ndarray) -> np.ndarray:
         """The joints ``cmd`` asks the chain to hold; raises what the chain cannot be asked for."""
+        # TODO: accept the modes the chain can run instead of leaving them to what a command omits. Its
+        # joints are position-servoed, so `PositionControl` names the rule already running.
+        command.require_native_mode(cmd, 'YAM')
         match cmd:
             case command.JointPosition(positions):
                 return np.asarray(positions, dtype=np.float64)
@@ -287,10 +290,7 @@ class _Chain(DriverRun[command.CommandType]):
         Only an arrival earns the target: commanding it part-way is the jump the ramp exists to avoid.
         """
         try:
-            # TODO: accept the modes the chain can run instead of leaving them to what a command omits. Its
-            # joints are position-servoed, so `PositionControl` names the rule already running.
-            command.require_native_mode(call.request, 'YAM')
-            target = self.target_joints(call.request, q)
+            target = self.to_joints(call.request, q)
             if (yield from self.move_to(target, grip)) is MoveStatus.ARRIVED:
                 call.set_result(None)
                 return target, grip
@@ -375,8 +375,7 @@ class Robot(pimm.ControlSystem):
                     q_target, grip_target = yield from chain.sync_move(asked, q, grip_target)
                 elif asked is not None:
                     with log_failure(asked):
-                        command.require_native_mode(asked, 'YAM')
-                        q_target = chain.target_joints(asked, q)
+                        q_target = chain.to_joints(asked, q)
 
                 chain.vendor.command_joint_pos(np.append(q_target, 1.0 - grip_target))
 

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -44,6 +44,8 @@ _JOINT_NAMES = ('joint1', 'joint2', 'joint3', 'joint4', 'joint5', 'joint6')
 _MJCF_PATH = 'assets/mujoco/i2rt_yam/yam.xml'
 _IK_POS_TOL = 1e-3  # meters; FK-verify acceptance for an IK solution after limit clamping
 _IK_ROT_TOL = 1e-2  # radians
+# Where the driver leaves the chain when it takes control: the menagerie "home" keyframe, folded up and back.
+_PARK_JOINTS = np.array([0.0, 1.047, 1.047, 0.0, 0.0, 0.0])
 # The vendor's observation contract
 _JOINT_POS, _JOINT_VEL, _GRIPPER_POS = 'joint_pos', 'joint_vel', 'gripper_pos'
 
@@ -168,7 +170,6 @@ class _Chain(DriverRun[command.CommandType]):
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[YamState],
         grip_out: pimm.SignalEmitter[float],
-        park_joints: np.ndarray,
         base_pose: geom.Transform3D,
         should_stop: pimm.SignalReceiver,
         clock: pimm.Clock,
@@ -178,7 +179,6 @@ class _Chain(DriverRun[command.CommandType]):
         self.out = out
         self.grip_out = grip_out
         self.state = YamState()
-        self._park_joints = park_joints
         self._base_pose = base_pose
         self._kin = _Kinematics()
 
@@ -272,8 +272,8 @@ class _Chain(DriverRun[command.CommandType]):
     def park(self, grip: float) -> Generator[pimm.Command, None, tuple[np.ndarray, float]]:
         """Ramp the chain to the park pose, and return the joints and grip to hold."""
         try:
-            if (yield from self.move_to(self._park_joints, grip)) is MoveStatus.ARRIVED:
-                return self._park_joints, grip
+            if (yield from self.move_to(_PARK_JOINTS, grip)) is MoveStatus.ARRIVED:
+                return _PARK_JOINTS, grip
         # rules-allow: swallowed-error — a chain that will not park reads ERROR; it does not end the run
         except Exception as exc:
             logger.error(f'The chain did not reach the park pose, it is not where the driver put it: {exc}')
@@ -331,20 +331,17 @@ class Robot(pimm.ControlSystem):
         self,
         channel: str = 'can0',
         *,
-        park_joints: list[float],
         base_pose: geom.Transform3D | None = None,
         sim: bool = False,
         connect: Callable = _connect,
     ) -> None:
         """
         :param channel: SocketCAN interface of the chain (e.g. ``can0``). Ignored in sim mode.
-        :param park_joints: Joints the chain is put at when the driver takes control.
         :param base_pose: Arm-base mount pose in the world frame; None keeps everything in the arm-base frame.
         :param sim: Run against i2rt's own MuJoCo sim instead of hardware.
         :param connect: ``(channel, sim) -> i2rt Robot`` factory; the fake-mode smoke injects ``_FakeYam``.
         """
         self._channel = channel
-        self._park_joints = np.asarray(park_joints, dtype=np.float64)
         self._base_pose = base_pose if base_pose is not None else geom.Transform3D.identity
         self._sim = sim
         self._connect = connect
@@ -358,17 +355,7 @@ class Robot(pimm.ControlSystem):
 
     def _chain(self, vendor: Any, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> _Chain:
         """The chain this run drives, built from the driver's configuration."""
-        return _Chain(
-            vendor,
-            self.sync_move,
-            self.commands,
-            self.state,
-            self.grip,
-            self._park_joints,
-            self._base_pose,
-            should_stop,
-            clock,
-        )
+        return _Chain(vendor, self.sync_move, self.commands, self.state, self.grip, self._base_pose, should_stop, clock)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         with _opened(self._connect, self._channel, self._sim) as vendor:
@@ -446,14 +433,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     fake = _FakeYam() if args.fake else None
-    # The menagerie "home" keyframe: arm folded up and back, out of the workspace.
-    park_q = np.array([0.0, 1.047, 1.047, 0.0, 0.0, 0.0])
-    robot = Robot(
-        args.channel,
-        park_joints=list(park_q),
-        sim=args.sim,
-        connect=(lambda channel, sim: fake) if args.fake else _connect,
-    )
+    robot = Robot(args.channel, sim=args.sim, connect=(lambda channel, sim: fake) if args.fake else _connect)
 
     with pimm.World() as world:
         # `World.pair` cannot express that it returns the counterpart of the port it is given, so the four
@@ -481,8 +461,8 @@ if __name__ == '__main__':
 
         if fake is not None:
             # State round-trip: the parked chain comes back through the driver's FK.
-            assert np.allclose(state.value.q, park_q, atol=_Chain._ARRIVED_TOL), state.value.q
-            park_err = np.linalg.norm(state.value.ee_pose.translation - kin.fk(park_q).translation)
+            assert np.allclose(state.value.q, _PARK_JOINTS, atol=_Chain._ARRIVED_TOL), state.value.q
+            park_err = np.linalg.norm(state.value.ee_pose.translation - kin.fk(_PARK_JOINTS).translation)
             assert park_err < 0.02, park_err  # the chain arrives within `_Chain._ARRIVED_TOL` of it, not onto it
 
             # Grip round-trip: polarity inverted on the way out (command) and on the way back (observation).

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -279,7 +279,7 @@ class _Chain(DriverRun[command.CommandType]):
             logger.error(f'The chain did not reach the park pose, it is not where the driver put it: {exc}')
         return self.hold_where_it_stopped()
 
-    def serve_sync_move(
+    def sync_move(
         self, call: pimm.calls.Call[command.CommandType, None], q: np.ndarray, grip: float
     ) -> Generator[pimm.Command, None, tuple[np.ndarray, float]]:
         """Put the chain where ``call`` asks, hold it wherever it ends up, and answer it once that is out.
@@ -372,7 +372,7 @@ class Robot(pimm.ControlSystem):
                 q = chain.observations()[_JOINT_POS]
                 asked = chain.moves.next_request()
                 if isinstance(asked, pimm.calls.Call):
-                    q_target, grip_target = yield from chain.serve_sync_move(asked, q, grip_target)
+                    q_target, grip_target = yield from chain.sync_move(asked, q, grip_target)
                 elif asked is not None:
                     with log_failure(asked):
                         command.require_native_mode(asked, 'YAM')

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -41,9 +41,6 @@ logger = logging.getLogger(__name__)
 # The driver solves FK/IK itself, so its joint order and control frame must match the YAM sim's.
 # TODO(#517): centralise driver kinematics so driver and sim share one module.
 _JOINT_NAMES = ('joint1', 'joint2', 'joint3', 'joint4', 'joint5', 'joint6')
-# The menagerie "home" keyframe: arm folded up and back, out of the workspace.
-HOME_Q = np.array([0.0, 1.047, 1.047, 0.0, 0.0, 0.0])
-
 _MJCF_PATH = 'assets/mujoco/i2rt_yam/yam.xml'
 _IK_POS_TOL = 1e-3  # meters; FK-verify acceptance for an IK solution after limit clamping
 _IK_ROT_TOL = 1e-2  # radians
@@ -167,11 +164,11 @@ class _Chain(DriverRun[command.CommandType]):
     def __init__(
         self,
         vendor: Any,
-        sync_move: pimm.calls.ControlSystemHandler[command.CommandType | None, None],
+        sync_move: pimm.calls.ControlSystemHandler[command.CommandType, None],
         async_move: pimm.SignalReceiver[command.CommandType],
         out: pimm.SignalEmitter[YamState],
         grip_out: pimm.SignalEmitter[float],
-        home_joints: np.ndarray,
+        park_joints: np.ndarray,
         base_pose: geom.Transform3D,
         should_stop: pimm.SignalReceiver,
         clock: pimm.Clock,
@@ -181,7 +178,7 @@ class _Chain(DriverRun[command.CommandType]):
         self.out = out
         self.grip_out = grip_out
         self.state = YamState()
-        self.home_joints = home_joints
+        self._park_joints = park_joints
         self._base_pose = base_pose
         self._kin = _Kinematics()
 
@@ -272,37 +269,31 @@ class _Chain(DriverRun[command.CommandType]):
         self.publish(self.observations())
         return MoveStatus.ARRIVED
 
-    def home(self, grip: float) -> Generator[pimm.Command, None, tuple[np.ndarray, float]]:
-        """Ramp the chain home, and return the joints and grip to hold."""
-        home = np.asarray(self.home_joints, dtype=np.float64)
+    def park(self, grip: float) -> Generator[pimm.Command, None, tuple[np.ndarray, float]]:
+        """Ramp the chain to the park pose, and return the joints and grip to hold."""
         try:
-            if (yield from self.move_to(home, grip)) is MoveStatus.ARRIVED:
-                return home, grip
-        # rules-allow: swallowed-error — a chain that will not home reads ERROR; it does not end the run
+            if (yield from self.move_to(self._park_joints, grip)) is MoveStatus.ARRIVED:
+                return self._park_joints, grip
+        # rules-allow: swallowed-error — a chain that will not park reads ERROR; it does not end the run
         except Exception as exc:
-            logger.error(f'Homing failed, the chain is not where the driver put it: {exc}')
+            logger.error(f'The chain did not reach the park pose, it is not where the driver put it: {exc}')
         return self.hold_where_it_stopped()
 
     def serve_sync_move(
-        self, call: pimm.calls.Call[command.CommandType | None, None], q: np.ndarray, grip: float
+        self, call: pimm.calls.Call[command.CommandType, None], q: np.ndarray, grip: float
     ) -> Generator[pimm.Command, None, tuple[np.ndarray, float]]:
         """Put the chain where ``call`` asks, hold it wherever it ends up, and answer it once that is out.
 
-        Asking for nothing asks for home. Only an arrival earns the target: commanding it part-way is the
-        jump the ramp exists to avoid.
+        Only an arrival earns the target: commanding it part-way is the jump the ramp exists to avoid.
         """
-        request = call.request
         try:
             # TODO: accept the modes the chain can run instead of leaving them to what a command omits. Its
             # joints are position-servoed, so `PositionControl` names the rule already running.
-            command.require_native_mode(request, 'YAM')
-            if request is None or isinstance(request, command.Reset):
-                target = self.home_joints
-            else:
-                target = self.target_joints(request, q)
+            command.require_native_mode(call.request, 'YAM')
+            target = self.target_joints(call.request, q)
             if (yield from self.move_to(target, grip)) is MoveStatus.ARRIVED:
                 call.set_result(None)
-                return np.asarray(target, dtype=np.float64), grip
+                return target, grip
         except Exception as exc:
             try:
                 held = self.hold_where_it_stopped()
@@ -340,26 +331,26 @@ class Robot(pimm.ControlSystem):
         self,
         channel: str = 'can0',
         *,
-        home_joints: list[float] | None = None,
+        park_joints: list[float],
         base_pose: geom.Transform3D | None = None,
         sim: bool = False,
         connect: Callable = _connect,
     ) -> None:
         """
         :param channel: SocketCAN interface of the chain (e.g. ``can0``). Ignored in sim mode.
-        :param home_joints: Joints of the "reset" position; defaults to ``HOME_Q``.
+        :param park_joints: Joints the chain is put at when the driver takes control.
         :param base_pose: Arm-base mount pose in the world frame; None keeps everything in the arm-base frame.
         :param sim: Run against i2rt's own MuJoCo sim instead of hardware.
         :param connect: ``(channel, sim) -> i2rt Robot`` factory; the fake-mode smoke injects ``_FakeYam``.
         """
         self._channel = channel
-        self._home_joints = np.asarray(home_joints if home_joints is not None else HOME_Q, dtype=np.float64)
+        self._park_joints = np.asarray(park_joints, dtype=np.float64)
         self._base_pose = base_pose if base_pose is not None else geom.Transform3D.identity
         self._sim = sim
         self._connect = connect
 
         self.commands = pimm.ControlSystemReceiver[command.CommandType](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[command.CommandType, None](self)
         self.target_grip = pimm.ControlSystemReceiver[float](self)
         self.state = pimm.ControlSystemEmitter[YamState](self)
         self.grip = pimm.ControlSystemEmitter[float](self)
@@ -373,7 +364,7 @@ class Robot(pimm.ControlSystem):
             self.commands,
             self.state,
             self.grip,
-            self._home_joints,
+            self._park_joints,
             self._base_pose,
             should_stop,
             clock,
@@ -385,8 +376,7 @@ class Robot(pimm.ControlSystem):
             meta = {'robot': 'i2rt_yam', keys.JOINT_NAMES: list(_JOINT_NAMES), keys.CONTROL_FRAME: DEFAULT_FRAME}
             self.robot_meta.emit(meta)
 
-            grip_target = 0.0
-            q_target, grip_target = yield from chain.home(grip_target)
+            q_target, grip_target = yield from chain.park(0.0)  # nothing has asked for a grip yet
 
             while not should_stop.value:
                 if (grip := pimm.value_updated(self.target_grip)) is not None:
@@ -395,17 +385,11 @@ class Robot(pimm.ControlSystem):
                 q = chain.observations()[_JOINT_POS]
                 asked = chain.moves.next_request()
                 if isinstance(asked, pimm.calls.Call):
-                    if asked.request is None or isinstance(asked.request, command.Reset):
-                        grip_target = 0.0  # homing opens the gripper, as a ``Reset`` command does
                     q_target, grip_target = yield from chain.serve_sync_move(asked, q, grip_target)
                 elif asked is not None:
                     with log_failure(asked):
                         command.require_native_mode(asked, 'YAM')
-                        if isinstance(asked, command.Reset):
-                            grip_target = 0.0
-                            q_target, grip_target = yield from chain.home(grip_target)
-                        else:
-                            q_target = chain.target_joints(asked, q)
+                        q_target = chain.target_joints(asked, q)
 
                 chain.vendor.command_joint_pos(np.append(q_target, 1.0 - grip_target))
 
@@ -462,7 +446,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     fake = _FakeYam() if args.fake else None
-    robot = Robot(args.channel, sim=args.sim, connect=(lambda channel, sim: fake) if args.fake else _connect)
+    # The menagerie "home" keyframe: arm folded up and back, out of the workspace.
+    park_q = np.array([0.0, 1.047, 1.047, 0.0, 0.0, 0.0])
+    robot = Robot(
+        args.channel,
+        park_joints=list(park_q),
+        sim=args.sim,
+        connect=(lambda channel, sim: fake) if args.fake else _connect,
+    )
 
     with pimm.World() as world:
         # `World.pair` cannot express that it returns the counterpart of the port it is given, so the four
@@ -483,16 +474,16 @@ if __name__ == '__main__':
 
         pump(0.1)
         while state.read() is None or state.value.status == RobotStatus.BUSY:
-            pump(0.1)  # the opening move ramps the chain home over a couple of seconds
+            pump(0.1)  # the opening move ramps the chain to the park pose over a couple of seconds
         assert state.value.status == RobotStatus.AVAILABLE, state.value.status
 
         kin = _Kinematics()
 
         if fake is not None:
-            # State round-trip: the homed chain comes back through the driver's FK.
-            assert np.allclose(state.value.q, HOME_Q, atol=_Chain._ARRIVED_TOL), state.value.q
-            home_err = np.linalg.norm(state.value.ee_pose.translation - kin.fk(HOME_Q).translation)
-            assert home_err < 0.02, home_err  # the chain arrives within `_Chain._ARRIVED_TOL` of home, not onto it
+            # State round-trip: the parked chain comes back through the driver's FK.
+            assert np.allclose(state.value.q, park_q, atol=_Chain._ARRIVED_TOL), state.value.q
+            park_err = np.linalg.norm(state.value.ee_pose.translation - kin.fk(park_q).translation)
+            assert park_err < 0.02, park_err  # the chain arrives within `_Chain._ARRIVED_TOL` of it, not onto it
 
             # Grip round-trip: polarity inverted on the way out (command) and on the way back (observation).
             target_grip.emit(0.8)

--- a/positronic/drivers/tests/test_utils.py
+++ b/positronic/drivers/tests/test_utils.py
@@ -11,14 +11,13 @@ from positronic.drivers.utils import _GRIP_TIMEOUT_S, MoveAbandoned, Moves, Move
 from positronic.tests.testing_coutils import ManualCommandReceiver
 
 TOL = 0.05
-HOME_WIDTH = 0.0
 
 
 def _accepted(
     target: float | np.ndarray, tol: float = TOL, timeout_s: float = 3.0
-) -> tuple[Moves[float], FakeCall[float | None, None]]:
+) -> tuple[Moves[float], FakeCall[float, None]]:
     moves = _unasked()
-    call = FakeCall[float | None, None](0.0)
+    call = FakeCall[float, None](0.0)
     moves.accept(call, target, tol, now=0.0, timeout_s=timeout_s)
     return moves, call
 
@@ -94,14 +93,14 @@ def test_a_move_that_arrives_clears_the_error_left_by_one_that_did_not():
     moves.settle(0.4, now=3.0)
     assert moves.errored
 
-    moves.accept(FakeCall[float | None, None](0.0), 1.0, TOL, now=3.0, timeout_s=3.0)
+    moves.accept(FakeCall[float, None](0.0), 1.0, TOL, now=3.0, timeout_s=3.0)
     assert moves.settle(1.0, now=3.1) is MoveStatus.ARRIVED
     assert not moves.errored
 
 
 def _unasked() -> Moves[float]:
     """Moves driven by hand rather than asked for: nothing is bound to either way of asking."""
-    handler = pimm.calls.ControlSystemHandler[float | None, None](Passive())
+    handler = pimm.calls.ControlSystemHandler[float, None](Passive())
     return Moves[float](handler, ManualCommandReceiver())
 
 
@@ -109,8 +108,8 @@ def _unasked() -> Moves[float]:
 def asking():
     """The two ways a gripper is asked for a width: a caller wired to the moves it serves, so a test asks
     the way a client does, and the stream its setpoints arrive on."""
-    caller = pimm.calls.ControlSystemCaller[float | None, None](Passive())
-    handler = pimm.calls.ControlSystemHandler[float | None, None](Passive())
+    caller = pimm.calls.ControlSystemCaller[float, None](Passive())
+    handler = pimm.calls.ControlSystemHandler[float, None](Passive())
     stream = ManualCommandReceiver()
     with pimm.World() as world:
         wire_call(world, caller, handler)
@@ -122,7 +121,7 @@ def test_a_grip_target_that_is_no_width_is_refused_rather_than_saturated(asking)
     ask, moves, _ = asking
     answer = ask(float('nan'))
 
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.0, now=0.0) is None
+    assert grip_setpoint(moves, grip=0.0, now=0.0) is None
     assert not moves.active
     with pytest.raises(ValueError, match='not a grip width'):
         answer.result()
@@ -133,29 +132,17 @@ def test_a_streamed_grip_target_that_is_no_width_leaves_the_fingers_alone(asking
     _, moves, stream = asking
     stream.push(float('inf'))
 
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.4, now=0.0) is None
-
-
-def test_a_grip_move_that_asks_for_no_width_asks_for_home(asking):
-    """Readying a rig is this call with nothing in it, so the width it opens to is the driver's own."""
-    ask, moves, _ = asking
-    answer = ask(None)
-
-    assert grip_setpoint(moves, 0.3, grip=0.0, now=0.0) == 0.3
-    assert moves.active
-    assert grip_setpoint(moves, 0.3, grip=0.3, now=0.1) is None
-    moves.answer()
-    assert answer.result() is None
+    assert grip_setpoint(moves, grip=0.4, now=0.0) is None
 
 
 def test_a_grip_call_takes_the_fingers_until_it_arrives(asking):
     ask, moves, _ = asking
     answer = ask(0.7)
 
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.0, now=0.0) == 0.7
+    assert grip_setpoint(moves, grip=0.0, now=0.0) == 0.7
     assert moves.active
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.3, now=0.1) is None, 'commanded again mid-travel'
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.7, now=0.2) is None
+    assert grip_setpoint(moves, grip=0.3, now=0.1) is None, 'commanded again mid-travel'
+    assert grip_setpoint(moves, grip=0.7, now=0.2) is None
     assert not moves.active
     moves.answer()
     assert answer.result() is None
@@ -165,9 +152,9 @@ def test_a_grip_that_gives_up_hands_back_the_width_the_fingers_stopped_at(asking
     """The answer waits for the driver to write the width handed back here, so the fingers stop first."""
     ask, moves, _ = asking
     answer = ask(1.0)
-    grip_setpoint(moves, HOME_WIDTH, grip=0.0, now=0.0)
+    grip_setpoint(moves, grip=0.0, now=0.0)
 
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.42, now=_GRIP_TIMEOUT_S) == 0.42
+    assert grip_setpoint(moves, grip=0.42, now=_GRIP_TIMEOUT_S) == 0.42
     assert not moves.active and moves.errored
     assert not answer.done(), 'the fingers are still on the width they missed'
 
@@ -181,8 +168,8 @@ def test_a_grip_asked_for_past_the_range_is_tracked_against_a_width_the_fingers_
     ask, moves, _ = asking
     answer = ask(1.5)
 
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.0, now=0.0) == 1.0
-    assert grip_setpoint(moves, HOME_WIDTH, grip=1.0, now=0.1) is None
+    assert grip_setpoint(moves, grip=0.0, now=0.0) == 1.0
+    assert grip_setpoint(moves, grip=1.0, now=0.1) is None
     moves.answer()
     assert answer.result() is None
 
@@ -193,11 +180,11 @@ def test_a_streamed_grip_waits_for_the_call_queue_to_be_empty(asking):
     stream.push(0.25)
     ask(0.9)
 
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.0, now=0.0) == 0.9
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.9, now=0.1) is None  # the call arrives
+    assert grip_setpoint(moves, grip=0.0, now=0.0) == 0.9
+    assert grip_setpoint(moves, grip=0.9, now=0.1) is None  # the call arrives
     moves.answer()
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.9, now=0.2) == 0.25  # the stream, still waiting
-    assert grip_setpoint(moves, HOME_WIDTH, grip=0.25, now=0.3) is None
+    assert grip_setpoint(moves, grip=0.9, now=0.2) == 0.25  # the stream, still waiting
+    assert grip_setpoint(moves, grip=0.25, now=0.3) is None
 
 
 def test_how_long_a_move_gets_is_the_driver_s_to_say():
@@ -265,7 +252,7 @@ def test_a_run_that_dies_with_one_move_settled_and_another_in_flight_answers_bot
     """One outcome each: the settled move earned its answer, the travelling one is owed what killed it."""
     moves, landed = _accepted(0.0)
     moves.settle(TOL / 2, now=0.1)
-    travelling = FakeCall[float | None, None](0.0)
+    travelling = FakeCall[float, None](0.0)
     moves.accept(travelling, 1.0, TOL, now=0.1, timeout_s=3.0)
 
     moves.fail(RuntimeError('the bus went away'))

--- a/positronic/drivers/utils.py
+++ b/positronic/drivers/utils.py
@@ -40,15 +40,15 @@ class Moves(Generic[T]):
     the whole travel answers a call within the tick it takes it, and so never has one in flight.
     """
 
-    def __init__(self, sync_move: pimm.calls.ControlSystemHandler[T | None, None], async_move: pimm.SignalReceiver[T]):
+    def __init__(self, sync_move: pimm.calls.ControlSystemHandler[T, None], async_move: pimm.SignalReceiver[T]):
         self._sync_move = sync_move
         self._async_move = async_move
-        self._call: pimm.calls.Call[T | None, None] | None = None
+        self._call: pimm.calls.Call[T, None] | None = None
         self._target: np.ndarray | float = 0.0
         self._tol = 0.0
         self._deadline = 0.0
         # A move settled but not yet answered, with what to answer it with: None for an arrival
-        self._settled: tuple[pimm.calls.Call[T | None, None], TimeoutError | None] | None = None
+        self._settled: tuple[pimm.calls.Call[T, None], TimeoutError | None] | None = None
         # Set by a move that does not arrive, cleared by the next that does: the device is not where it was put
         self.errored = False
 
@@ -78,7 +78,7 @@ class Moves(Generic[T]):
         assert self._call is not None, 'no move is in flight'
         return self._target
 
-    def next_request(self) -> pimm.calls.Call[T | None, None] | T | None:
+    def next_request(self) -> pimm.calls.Call[T, None] | T | None:
         """What the device is asked for now: a call whose asker waits to hear it arrive, a streamed setpoint
         nobody waits on, or nothing.
 
@@ -92,12 +92,7 @@ class Moves(Generic[T]):
         return pimm.value_updated(self._async_move)
 
     def accept(
-        self,
-        call: pimm.calls.Call[T | None, None],
-        target: np.ndarray | float,
-        tol: float,
-        now: float,
-        timeout_s: float,
+        self, call: pimm.calls.Call[T, None], target: np.ndarray | float, tol: float, now: float, timeout_s: float
     ) -> None:
         """Take `call` as the move in flight, aiming at `target` within `tol`, with `timeout_s` to get there."""
         self._call, self._target, self._tol = call, target, tol
@@ -151,7 +146,7 @@ class DriverRun(Generic[T]):
 
     def __init__(
         self,
-        sync_move: pimm.calls.ControlSystemHandler[T | None, None],
+        sync_move: pimm.calls.ControlSystemHandler[T, None],
         async_move: pimm.SignalReceiver[T],
         should_stop: pimm.SignalReceiver,
         clock: pimm.Clock,
@@ -189,18 +184,18 @@ def _clamped(grip: float) -> float:
     return max(0.0, min(1.0, grip))
 
 
-def grip_setpoint(moves: Moves[float], home: float, grip: float, now: float) -> float | None:
+def grip_setpoint(moves: Moves[float], grip: float, now: float) -> float | None:
     """The width to command the fingers this tick, or ``None`` to leave the last one standing.
 
     A move in flight owns the fingers; one that gives up hands back the width they stopped at, which the
-    driver writes before calling ``Moves.answer``. A move that asks for no width asks for ``home``.
+    driver writes before calling ``Moves.answer``.
     """
     if moves.active:
         return grip if moves.settle(grip, now) is MoveStatus.GAVE_UP else None
     asked = moves.next_request()
     if isinstance(asked, pimm.calls.Call):
         with pimm.calls.raise_to(asked):  # a width the fingers cannot be put at is the asker's to hear about
-            target = _clamped(home if asked.request is None else asked.request)
+            target = _clamped(asked.request)
             moves.accept(asked, target, _GRIP_TOL, now, _GRIP_TIMEOUT_S)
             return target
     elif asked is not None:

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -68,7 +68,7 @@ class Task:
     instruction_source: str | Callable[[], str]
     # Time budget for a rollout; ``None`` ends on ``Eval.done`` alone.
     timeout_sec: float | None
-    # What each of the embodiment's ``prepare_handlers`` is asked with, keyed the same way
+    # What to ask for, keyed as ``Embodiment.prepare_handlers`` is; a handler this does not name goes unasked
     prepare_args: dict[str, Any] = field(default_factory=dict)
     # What the episode records as this trial's identity: its seed, its place in the sweep, its scene
     meta: dict[str, Any] = field(default_factory=dict)
@@ -92,8 +92,8 @@ class Task:
 # [✓] ``charge_inference_time`` is a ``Task`` field, not a context key.
 # [✓] Split the reset token from the policy input: the instruction is all a trial gives the policy.
 # [✓] Homing becomes a ``prepare`` call the arm and gripper answer once in place; ``Command.home`` goes with it.
-# [✓] A trial's reset is every ``prepare`` it asks for — scene, arm, gripper, human — and it opens once all answer.
-# [ ] ``command.Reset`` goes: a robot is put home by the ``prepare`` call, not by a command on its stream.
+# [✓] A trial's reset is every ``prepare`` it asks for — scene, arm, gripper — and it opens once all answer.
+# [✓] ``command.Reset`` goes: a robot is moved by a ``prepare`` call that names where to go.
 # [ ] The recorder keeps what is on the wire when it opens, and the sim publishes frame-0 with its prepare answers.
 # [ ] One runner builds the world for both.
 @dataclass

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -95,6 +95,7 @@ class Task:
 # [✓] A trial's reset is every ``prepare`` it asks for — scene, arm, gripper — and it opens once all answer.
 # [✓] ``command.Reset`` goes: a robot is moved by a ``prepare`` call that names where to go.
 # [ ] The recorder keeps what is on the wire when it opens, and the sim publishes frame-0 with its prepare answers.
+# [ ] An eval config names what its rig starts at, attended or not, so the keyboard path builds no trial of its own.
 # [ ] One runner builds the world for both.
 @dataclass
 class Eval:

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -2,8 +2,10 @@
 aliases over ``cli.eval.run``."""
 
 from collections import Counter
+from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from dataclasses import replace
+from functools import partial
 from typing import Any
 
 import configuronic as cfn
@@ -15,9 +17,11 @@ import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
 from positronic import keys, wire
 from positronic.cfg.eval.sim.positronic import stack_cubes
+from positronic.cfg.hardware.roboarm import FRANKA_JOINTS_SPREAD, FRANKA_NOMINAL_JOINTS
 from positronic.cli.eval.run import prepare_output_dir, run
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
+from positronic.drivers.roboarm import command
 from positronic.eval import Embodiment, Task
 from positronic.policy.harness import Harness
 
@@ -25,12 +29,13 @@ from positronic.policy.harness import Harness
 class KeyboardOperator(pimm.ControlSystem):
     """Turns keystrokes into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one.
 
-    It serves the trial's ``human`` prepare, and holds the pending answers because that is where an
-    episode's terminal — and any refused ask — arrives; both are printed as they land.
+    It serves the trial's ``scene`` prepare, and holds the pending answers because that is where an
+    episode's terminal — and any refused ask — arrives; both are printed as they land. ``next_task`` is
+    called per press, so what a trial draws afresh is drawn again for the one after it.
     """
 
-    def __init__(self, task: Task):
-        self._task = task
+    def __init__(self, next_task: Callable[[], Task]):
+        self._next_task = next_task
         self.keystrokes = pimm.ControlSystemReceiver[str](self)
         self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
         self.ready = pimm.calls.ControlSystemHandler[Any, None](self)
@@ -42,10 +47,11 @@ class KeyboardOperator(pimm.ControlSystem):
             if (key := pimm.value_updated(self.keystrokes)) is not None:
                 match key:
                     case 's':
-                        pending.append(self.perform_task(self._task))
+                        pending.append(self.perform_task(self._next_task()))
                     case 'p':
                         self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
             for call in self.ready.incoming():
+                print(f'Set up: {call.request}')
                 call.set_result(None)  # the operator set the rig up before asking for the trial at all
             running = []
             for answer in pending:
@@ -65,9 +71,37 @@ class KeyboardOperator(pimm.ControlSystem):
             print(f'Episode failed: {e}')
 
 
-def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
+def _attended_task(
+    instruction: str, nominal_joints: Sequence[float], joints_spread: Sequence[float], start_grip: float | None
+) -> Task:
+    """The trial one keypress asks for: the rig a person sets up, and each device this run readies put back.
+
+    An attended episode has no budget — the operator ends it, so nothing but ``done`` can. A rig this run
+    readies nothing on names nothing: no joints is no arm to place, and no ``start_grip`` no fingers to open.
+    """
+    prepare_args: dict[str, Any] = {keys.SCENE: instruction}
+    if len(nominal_joints):
+        prepare_args[keys.ARM] = command.sampled_joints(nominal_joints, joints_spread)
+    if start_grip is not None:
+        prepare_args[keys.GRIPPER] = start_grip
+    return Task(instruction_source=instruction, timeout_sec=None, prepare_args=prepare_args)
+
+
+def real(
+    policy,
+    embodiment: Embodiment,
+    task: str | None,
+    nominal_joints: Sequence[float] = (),
+    joints_spread: Sequence[float] = (),
+    start_grip: float | None = None,
+    output_dir=None,
+):
     """Run one hardware embodiment attended and headless, the keyboard deciding when an episode starts and
     finishes.
+
+    What each episode starts from belongs to the rig ``embodiment`` names: ``nominal_joints`` and
+    ``joints_spread`` are the arm's, ``start_grip`` the fingers'. A rig readies only what it is given, so an
+    arm left unnamed here holds where the last episode left it.
 
     The world is composed here rather than by the runner: an attended surface is the binary's own business,
     and the keyboard is the only one this library ships. There is no viewer — a console that shows the
@@ -82,19 +116,27 @@ def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `LocalDatasetWriter`
     # scans the one it is given.
     try:
-        _run_attended(policy, embodiment, task, output_dir)
+        _run_attended(policy, embodiment, task, nominal_joints, joints_spread, start_grip, output_dir)
     finally:
         policy.close()
 
 
-def _run_attended(policy, embodiment: Embodiment, task: str | None, output_dir) -> None:
+def _run_attended(
+    policy,
+    embodiment: Embodiment,
+    task: str | None,
+    nominal_joints: Sequence[float],
+    joints_spread: Sequence[float],
+    start_grip: float | None,
+    output_dir,
+) -> None:
     """Record from a warmed policy until the keyboard returns. The caller owns the policy."""
     output_dir = prepare_output_dir(output_dir)
     keyboard = KeyboardControl(quit_key='q')
-    # An attended episode has no budget: the operator ends it, so nothing but ``done`` can.
-    operator = KeyboardOperator(Task(instruction_source=task or '', timeout_sec=None))
-    # The rig a human sets up by hand readies like any device: it is the operator who answers for it.
-    embodiment = replace(embodiment, prepare_handlers={**embodiment.prepare_handlers, keys.HUMAN: operator.ready})
+    instruction = task or ''
+    operator = KeyboardOperator(partial(_attended_task, instruction, nominal_joints, joints_spread, start_grip))
+    # A world a person sets up by hand readies like any device: it is the operator who answers for it.
+    embodiment = replace(embodiment, prepare_handlers={**embodiment.prepare_handlers, keys.SCENE: operator.ready})
     harness = Harness(policy, embodiment)
     print('Keyboard controls: [s]tart, sto[p], [q]uit')
 
@@ -109,7 +151,14 @@ def _run_attended(policy, embodiment: Embodiment, task: str | None, output_dir) 
         world.run([harness, keyboard, operator], [*producers, ds_agent])
 
 
-real_cfg = cfn.Config(real, embodiment=positronic.cfg.embodiment.droid, policy=policy_cfg.placeholder)
+real_cfg = cfn.Config(
+    real,
+    embodiment=positronic.cfg.embodiment.droid,
+    policy=policy_cfg.placeholder,
+    nominal_joints=FRANKA_NOMINAL_JOINTS,
+    joints_spread=FRANKA_JOINTS_SPREAD,
+    start_grip=0.0,
+)
 
 
 # Console entry point for [project.scripts].

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -4,7 +4,6 @@ aliases over ``cli.eval.run``."""
 from collections import Counter
 from collections.abc import Callable
 from contextlib import nullcontext
-from dataclasses import replace
 from functools import partial
 from typing import Any
 
@@ -29,16 +28,15 @@ from positronic.policy.harness import Harness
 class KeyboardOperator(pimm.ControlSystem):
     """Turns keystrokes into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one.
 
-    It serves the trial's ``scene`` prepare, and holds the pending answers because that is where an
-    episode's terminal — and any refused ask — arrives; both are printed as they land. ``next_task`` is
-    called per press, so each trial draws its own start pose.
+    It holds the pending answers because that is where an episode's terminal — and any refused ask —
+    arrives; both are printed as they land. ``next_task`` is called per press, so each trial draws its own
+    start pose.
     """
 
     def __init__(self, next_task: Callable[[], Task]):
         self._next_task = next_task
         self.keystrokes = pimm.ControlSystemReceiver[str](self)
         self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
-        self.ready = pimm.calls.ControlSystemHandler[Any, None](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
@@ -50,9 +48,6 @@ class KeyboardOperator(pimm.ControlSystem):
                         pending.append(self.perform_task(self._next_task()))
                     case 'p':
                         self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
-            for call in self.ready.incoming():
-                print(f'Set up: {call.request}')
-                call.set_result(None)  # the operator set the rig up before asking for the trial at all
             running = []
             for answer in pending:
                 if answer.done():
@@ -72,15 +67,15 @@ class KeyboardOperator(pimm.ControlSystem):
 
 
 def _attended_task(instruction: str) -> Task:
-    """The trial one keypress asks for. An attended episode has no time budget: the operator is what ends it."""
+    """The trial one keypress asks for.
+
+    Nothing asks for the scene: pressing for the trial is the operator saying it is set up. Nothing holds
+    the episode to a budget either — the operator is what ends it.
+    """
     return Task(
         instruction_source=instruction,
         timeout_sec=None,
-        prepare_args={
-            keys.SCENE: instruction,
-            keys.ARM: command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD),
-            keys.GRIPPER: 0.0,
-        },
+        prepare_args={keys.ARM: command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD), keys.GRIPPER: 0.0},
     )
 
 
@@ -98,10 +93,8 @@ def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
     """
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
-    # The operator answers for the scene whatever the rig declares; the arm and the fingers the rig must have
-    # of its own, and a run pointed at an embodiment that readies neither is caught here rather than at the
-    # first press.
-    unknown = sorted(set(_attended_task('').prepare_args) - set(embodiment.prepare_handlers) - {keys.SCENE})
+    # A rig that cannot be put at a start pose fails the run at startup rather than at the first press.
+    unknown = sorted(set(_attended_task('').prepare_args) - set(embodiment.prepare_handlers))
     if unknown:
         raise ValueError(f'{unknown} is not something {embodiment.descriptor or "this rig"} readies')
 
@@ -119,7 +112,6 @@ def _run_attended(policy, embodiment: Embodiment, task: str | None, output_dir) 
     output_dir = prepare_output_dir(output_dir)
     keyboard = KeyboardControl(quit_key='q')
     operator = KeyboardOperator(partial(_attended_task, task or ''))
-    embodiment = replace(embodiment, prepare_handlers={**embodiment.prepare_handlers, keys.SCENE: operator.ready})
     harness = Harness(policy, embodiment)
     print('Keyboard controls: [s]tart, sto[p], [q]uit')
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -16,7 +16,7 @@ import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
 from positronic import keys, wire
 from positronic.cfg.eval.sim.positronic import stack_cubes
-from positronic.cfg.hardware.roboarm import franka_start_pose
+from positronic.cfg.hardware.roboarm import droid_start_pose
 from positronic.cli.eval.run import prepare_output_dir, run
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
@@ -72,9 +72,7 @@ def _attended_task(instruction: str) -> Task:
     the episode to a budget either — the operator is what ends it.
     """
     return Task(
-        instruction_source=instruction,
-        timeout_sec=None,
-        prepare_args={keys.ARM: franka_start_pose(), keys.GRIPPER: 0.0},
+        instruction_source=instruction, timeout_sec=None, prepare_args={keys.ARM: droid_start_pose(), keys.GRIPPER: 0.0}
     )
 
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -2,7 +2,7 @@
 aliases over ``cli.eval.run``."""
 
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import replace
 from functools import partial
@@ -71,34 +71,24 @@ class KeyboardOperator(pimm.ControlSystem):
             print(f'Episode failed: {e}')
 
 
-def _attended_task(
-    instruction: str, nominal_joints: Sequence[float], joints_spread: Sequence[float], start_grip: float | None
-) -> Task:
+def _attended_task(instruction: str) -> Task:
     """The trial one keypress asks for. An attended episode has no time budget: the operator is what ends it."""
-    prepare_args: dict[str, Any] = {keys.SCENE: instruction}
-    if len(nominal_joints):
-        prepare_args[keys.ARM] = command.sampled_joints(nominal_joints, joints_spread)
-    if start_grip is not None:
-        prepare_args[keys.GRIPPER] = start_grip
-    return Task(instruction_source=instruction, timeout_sec=None, prepare_args=prepare_args)
+    return Task(
+        instruction_source=instruction,
+        timeout_sec=None,
+        prepare_args={
+            keys.SCENE: instruction,
+            keys.ARM: command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD),
+            keys.GRIPPER: 0.0,
+        },
+    )
 
 
-def real(
-    policy,
-    embodiment: Embodiment,
-    task: str | None,
-    nominal_joints: Sequence[float] = (),
-    joints_spread: Sequence[float] = (),
-    start_grip: float | None = None,
-    output_dir=None,
-):
+def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
     """Run one hardware embodiment attended and headless, the keyboard deciding when an episode starts and
     finishes.
 
-    What each episode starts from belongs to the rig ``embodiment`` names: ``nominal_joints`` and
-    ``joints_spread`` are the arm's, ``start_grip`` the fingers'. A rig readies only what it is given, so an
-    arm left unnamed here holds where the last episode left it, and fingers with no ``start_grip`` stay as
-    they are.
+    Every episode starts the arm at a pose drawn around the Franka's nominal joints, with the fingers open.
 
     The world is composed here rather than by the runner: an attended surface is the binary's own business,
     and the keyboard is the only one this library ships. There is no viewer — a console that shows the
@@ -108,11 +98,10 @@ def real(
     """
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
-    # The operator answers for the scene whatever the rig declares; everything else the rig must have of its
-    # own. Swapping the embodiment on the command line and keeping the start pose is caught here rather than
-    # at the first press.
-    asks = set(_attended_task(task or '', nominal_joints, joints_spread, start_grip).prepare_args)
-    unknown = sorted(asks - set(embodiment.prepare_handlers) - {keys.SCENE})
+    # The operator answers for the scene whatever the rig declares; the arm and the fingers the rig must have
+    # of its own, and a run pointed at an embodiment that readies neither is caught here rather than at the
+    # first press.
+    unknown = sorted(set(_attended_task('').prepare_args) - set(embodiment.prepare_handlers) - {keys.SCENE})
     if unknown:
         raise ValueError(f'{unknown} is not something {embodiment.descriptor or "this rig"} readies')
 
@@ -120,25 +109,16 @@ def real(
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `LocalDatasetWriter`
     # scans the one it is given.
     try:
-        _run_attended(policy, embodiment, task, nominal_joints, joints_spread, start_grip, output_dir)
+        _run_attended(policy, embodiment, task, output_dir)
     finally:
         policy.close()
 
 
-def _run_attended(
-    policy,
-    embodiment: Embodiment,
-    task: str | None,
-    nominal_joints: Sequence[float],
-    joints_spread: Sequence[float],
-    start_grip: float | None,
-    output_dir,
-) -> None:
+def _run_attended(policy, embodiment: Embodiment, task: str | None, output_dir) -> None:
     """Record from a warmed policy until the keyboard returns. The caller owns the policy."""
     output_dir = prepare_output_dir(output_dir)
     keyboard = KeyboardControl(quit_key='q')
-    instruction = task or ''
-    operator = KeyboardOperator(partial(_attended_task, instruction, nominal_joints, joints_spread, start_grip))
+    operator = KeyboardOperator(partial(_attended_task, task or ''))
     embodiment = replace(embodiment, prepare_handlers={**embodiment.prepare_handlers, keys.SCENE: operator.ready})
     harness = Harness(policy, embodiment)
     print('Keyboard controls: [s]tart, sto[p], [q]uit')
@@ -154,14 +134,7 @@ def _run_attended(
         world.run([harness, keyboard, operator], [*producers, ds_agent])
 
 
-real_cfg = cfn.Config(
-    real,
-    embodiment=positronic.cfg.embodiment.droid,
-    policy=policy_cfg.placeholder,
-    nominal_joints=FRANKA_NOMINAL_JOINTS,
-    joints_spread=FRANKA_JOINTS_SPREAD,
-    start_grip=0.0,
-)
+real_cfg = cfn.Config(real, embodiment=positronic.cfg.embodiment.droid, policy=policy_cfg.placeholder)
 
 
 # Console entry point for [project.scripts].

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -16,11 +16,10 @@ import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
 from positronic import keys, wire
 from positronic.cfg.eval.sim.positronic import stack_cubes
-from positronic.cfg.hardware.roboarm import FRANKA_JOINTS_SPREAD, FRANKA_NOMINAL_JOINTS
+from positronic.cfg.hardware.roboarm import franka_start_pose
 from positronic.cli.eval.run import prepare_output_dir, run
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
-from positronic.drivers.roboarm import command
 from positronic.eval import Embodiment, Task
 from positronic.policy.harness import Harness
 
@@ -75,7 +74,7 @@ def _attended_task(instruction: str) -> Task:
     return Task(
         instruction_source=instruction,
         timeout_sec=None,
-        prepare_args={keys.ARM: command.sampled_joints(FRANKA_NOMINAL_JOINTS, FRANKA_JOINTS_SPREAD), keys.GRIPPER: 0.0},
+        prepare_args={keys.ARM: franka_start_pose(), keys.GRIPPER: 0.0},
     )
 
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -111,6 +111,12 @@ def real(
     """
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
+    # The operator answers for the scene whatever the rig declares; everything else the rig must have of its
+    # own, and a run configured against one embodiment names what another has not got.
+    asks = set(_attended_task(task or '', nominal_joints, joints_spread, start_grip).prepare_args)
+    unknown = sorted(asks - set(embodiment.prepare_handlers) - {keys.SCENE})
+    if unknown:
+        raise ValueError(f'{unknown} is not something {embodiment.descriptor or "this rig"} readies')
 
     # The policy is this function's to close from here on, and everything below can raise:
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `LocalDatasetWriter`

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -31,7 +31,7 @@ class KeyboardOperator(pimm.ControlSystem):
 
     It serves the trial's ``scene`` prepare, and holds the pending answers because that is where an
     episode's terminal — and any refused ask — arrives; both are printed as they land. ``next_task`` is
-    called per press, so what a trial draws afresh is drawn again for the one after it.
+    called per press, so each trial draws its own start pose.
     """
 
     def __init__(self, next_task: Callable[[], Task]):
@@ -74,11 +74,7 @@ class KeyboardOperator(pimm.ControlSystem):
 def _attended_task(
     instruction: str, nominal_joints: Sequence[float], joints_spread: Sequence[float], start_grip: float | None
 ) -> Task:
-    """The trial one keypress asks for: the rig a person sets up, and each device this run readies put back.
-
-    An attended episode has no budget — the operator ends it, so nothing but ``done`` can. A rig this run
-    readies nothing on names nothing: no joints is no arm to place, and no ``start_grip`` no fingers to open.
-    """
+    """The trial one keypress asks for. An attended episode has no time budget: the operator is what ends it."""
     prepare_args: dict[str, Any] = {keys.SCENE: instruction}
     if len(nominal_joints):
         prepare_args[keys.ARM] = command.sampled_joints(nominal_joints, joints_spread)
@@ -101,7 +97,8 @@ def real(
 
     What each episode starts from belongs to the rig ``embodiment`` names: ``nominal_joints`` and
     ``joints_spread`` are the arm's, ``start_grip`` the fingers'. A rig readies only what it is given, so an
-    arm left unnamed here holds where the last episode left it.
+    arm left unnamed here holds where the last episode left it, and fingers with no ``start_grip`` stay as
+    they are.
 
     The world is composed here rather than by the runner: an attended surface is the binary's own business,
     and the keyboard is the only one this library ships. There is no viewer — a console that shows the
@@ -112,7 +109,8 @@ def real(
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
     # The operator answers for the scene whatever the rig declares; everything else the rig must have of its
-    # own, and a run configured against one embodiment names what another has not got.
+    # own. Swapping the embodiment on the command line and keeping the start pose is caught here rather than
+    # at the first press.
     asks = set(_attended_task(task or '', nominal_joints, joints_spread, start_grip).prepare_args)
     unknown = sorted(asks - set(embodiment.prepare_handlers) - {keys.SCENE})
     if unknown:
@@ -141,7 +139,6 @@ def _run_attended(
     keyboard = KeyboardControl(quit_key='q')
     instruction = task or ''
     operator = KeyboardOperator(partial(_attended_task, instruction, nominal_joints, joints_spread, start_grip))
-    # A world a person sets up by hand readies like any device: it is the operator who answers for it.
     embodiment = replace(embodiment, prepare_handlers={**embodiment.prepare_handlers, keys.SCENE: operator.ready})
     harness = Harness(policy, embodiment)
     print('Keyboard controls: [s]tart, sto[p], [q]uit')

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -19,7 +19,7 @@ TARGET_GRIP = 'target_grip'
 
 # The names of what a trial readies before it opens. ``Embodiment.prepare_handlers`` is keyed by them, and so
 # is what a ``Task`` asks for. A rig with two arms names its arms ``arm.{side}``. ``SCENE`` means the world
-# this trial runs in is ready, drawn by a sim or set up by a person — whichever handler is bound says which.
+# this trial runs in is ready, drawn by whichever handler the embodiment binds.
 ARM = 'arm'
 GRIPPER = 'gripper'
 SCENE = 'scene'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -18,12 +18,11 @@ TARGET_JOINTS = f'{ROBOT_COMMAND}.joints'
 TARGET_GRIP = 'target_grip'
 
 # The names of what a trial readies before it opens. ``Embodiment.prepare_handlers`` is keyed by them, and so
-# is whatever a ``Task`` asks each of them for. A rig with two arms names its arms ``arm.{side}``. ``SCENE``
-# names the env that draws the world a trial runs in, ``HUMAN`` the operator who sets a real rig up by hand.
+# is what a ``Task`` asks for. A rig with two arms names its arms ``arm.{side}``. ``SCENE`` means the world
+# this trial runs in is ready, drawn by a sim or set up by a person — whichever handler is bound says which.
 ARM = 'arm'
 GRIPPER = 'gripper'
 SCENE = 'scene'
-HUMAN = 'human'
 
 
 def is_robot_command(name: str) -> bool:

--- a/positronic/offboard/README.md
+++ b/positronic/offboard/README.md
@@ -166,9 +166,9 @@ Keys are flat strings — the dots are literal, not nesting. Arrays travel as nu
 }
 ```
 
-A command's `type` selects the fields beside it: `cartesian_pos` (`pose`), `joint_pos` (`positions`), `joint_delta` (`velocities`), `cartesian_delta` (`delta`, `frame`), and `reset` (no fields). A pose is translation followed by a row-major 3x3 rotation.
+A command's `type` selects the fields beside it: `cartesian_pos` (`pose`), `joint_pos` (`positions`), `joint_delta` (`velocities`), and `cartesian_delta` (`delta`, `frame`). A pose is translation followed by a row-major 3x3 rotation.
 
-Every command but `reset` may carry a `mode`, itself a tagged mapping naming the control law to execute under: `{"type": "position_control", "stiffness": [...]}` or `{"type": "impedance", "kq": [...], "kqd": [...], "kx": [...], "kxd": [...]}`. Omit `stiffness` to take the arm's own gains — an empty list is refused. Omit `mode` entirely and the arm runs its native law. `positronic.offboard.protocol` reads that mapping into the typed command the drivers dispatch on, so a server written against another stack sends it as plain data; one built on positronic may instead put a `positronic.drivers.roboarm.command` instance here and let `serialise` encode it.
+Every command may carry a `mode`, itself a tagged mapping naming the control law to execute under: `{"type": "position_control", "stiffness": [...]}` or `{"type": "impedance", "kq": [...], "kqd": [...], "kx": [...], "kxd": [...]}`. Omit `stiffness` to take the arm's own gains — an empty list is refused. Omit `mode` entirely and the arm runs its native law. `positronic.offboard.protocol` reads that mapping into the typed command the drivers dispatch on, so a server written against another stack sends it as plain data; one built on positronic may instead put a `positronic.drivers.roboarm.command` instance here and let `serialise` encode it.
 
 **Server → Client (Error):**
 ```json

--- a/positronic/offboard/tests/test_offboard.py
+++ b/positronic/offboard/tests/test_offboard.py
@@ -10,7 +10,6 @@ from positronic.drivers.roboarm.command import (
     JointDelta,
     JointPosition,
     PositionControl,
-    Reset,
     to_wire,
 )
 from positronic.geom import Rotation, Transform3D
@@ -119,9 +118,6 @@ class TestCommandEnvelope:
     """A ``CommandType`` sitting anywhere in the payload crosses as the ``__cmd__`` envelope and comes back
     typed, without the receiver having to know which channel carries it."""
 
-    def test_reset(self):
-        assert isinstance(deserialise(serialise(Reset())), Reset)
-
     def test_cartesian_position(self):
         pose = Transform3D(translation=np.array([0.1, 0.2, 0.3], dtype=np.float32), rotation=Rotation.identity)
         cmd = CartesianPosition(pose=pose)
@@ -182,17 +178,16 @@ class TestCommandEnvelope:
         joints = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7], dtype=np.float32)
         actions = [
             {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), 'target_grip': 0.5, 'timestamp': 0.0},
-            {keys.ROBOT_COMMAND: Reset(), 'timestamp': 0.1},
-            {keys.ROBOT_COMMAND: JointPosition(positions=joints), 'target_grip': 0.8, 'timestamp': 0.2},
+            # An action need not carry every channel: this one moves the arm and leaves the gripper be.
+            {keys.ROBOT_COMMAND: JointPosition(positions=joints), 'timestamp': 0.1},
         ]
         result = deserialise(serialise({'result': actions}))['result']
-        assert len(result) == 3
+        assert len(result) == 2
         assert isinstance(result[0][keys.ROBOT_COMMAND], CartesianPosition)
-        assert isinstance(result[1][keys.ROBOT_COMMAND], Reset)
-        assert isinstance(result[2][keys.ROBOT_COMMAND], JointPosition)
+        assert isinstance(result[1][keys.ROBOT_COMMAND], JointPosition)
         assert result[0]['target_grip'] == 0.5
         assert result[1]['timestamp'] == 0.1
-        np.testing.assert_allclose(result[2][keys.ROBOT_COMMAND].positions, joints)
+        np.testing.assert_allclose(result[1][keys.ROBOT_COMMAND].positions, joints)
 
     def test_plain_dict_passthrough(self):
         """Dicts without Commands round-trip unchanged."""
@@ -256,7 +251,8 @@ class TestServedCommandDecode:
     def test_a_typed_command_and_a_sentinel_are_left_alone(self):
         """A command the ``__cmd__`` envelope already typed, and a result carrying no command channel at
         all, both come back unchanged."""
-        assert isinstance(typed_commands({keys.ROBOT_COMMAND: Reset()})[keys.ROBOT_COMMAND], Reset)
+        typed = CartesianPosition(pose=Transform3D(translation=np.zeros(3), rotation=Rotation.identity))
+        assert typed_commands({keys.ROBOT_COMMAND: typed})[keys.ROBOT_COMMAND] is typed
         assert typed_commands({'timestamp': 1.6}) == {'timestamp': 1.6}
         assert typed_commands(None) is None
 

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -514,7 +514,7 @@ class ChangeEEFrame(Codec):
                 return command.CartesianPosition(pose=pose * transform, mode=mode)
             case command.CartesianDelta(delta, frame, mode):
                 return command.CartesianDelta(delta=delta, frame=transform.inv * frame, mode=mode)
-            case command.Reset() | command.JointPosition() | command.JointDelta():
+            case command.JointPosition() | command.JointDelta():
                 return value
             case _:
                 return change_frame(value, transform)
@@ -589,8 +589,7 @@ class SetControlMode(Codec):
     """Sets the control mode a chunk executes under on every robot command it carries (inference only).
 
     Composes left of an action decoder (``SetControlMode(mode) | action``). Every command of every arm
-    carries the mode, not only the first of the unsuffixed channel; a ``Reset`` pins none and passes
-    through untouched.
+    carries the mode, not only the first of the unsuffixed channel.
     """
 
     def __init__(self, mode: command.ControlModeType):
@@ -605,8 +604,6 @@ class SetControlMode(Codec):
         stamped = {
             key: replace(cmd, mode=self._mode)
             for key, cmd in data.items()
-            if obs_keys.is_robot_command(key)
-            and isinstance(cmd, command.CommandType)
-            and not isinstance(cmd, command.Reset)
+            if obs_keys.is_robot_command(key) and isinstance(cmd, command.CommandType)
         }
         return {**data, **stamped} if stamped else data

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -282,10 +282,10 @@ class Harness(pimm.ControlSystem):
             self.commands[name].emit(value)
 
     def _prepare(self, should_stop: pimm.SignalReceiver, task: Task) -> Generator[pimm.Command, None, None]:
-        """Ask everything the trial readies — scene, devices, operator — and come back once all have."""
+        """Ask everything the task names, and come back once every one of them has answered."""
         unknown = sorted(set(task.prepare_args) - set(self.prepare))
         assert not unknown, f'{unknown} is not something this embodiment readies, so nothing would be asked'
-        ready = pimm.calls.all_of([ask(task.prepare_args.get(name)) for name, ask in self.prepare.items()])
+        ready = pimm.calls.all_of([self.prepare[name](arg) for name, arg in task.prepare_args.items()])
         while not ready.done() and not should_stop.value:
             yield pimm.Yield() if self._embodiment.simulated else pimm.Sleep(POLL_PERIOD_SEC)
         # An episode must not open on a rig that never got ready, and its asker must hear that rather than wait
@@ -308,7 +308,8 @@ class Harness(pimm.ControlSystem):
         """Drop everything the episode has going: the schedule being played, and the call on the worker.
 
         The call is let go of rather than waited for, so a model that hangs cannot hold up the recording's
-        stop or the home. Devices hold their last commanded position; nothing downstream is buffered.
+        stop or the next trial's prepare. Devices hold their last commanded position; nothing downstream is
+        buffered.
         """
         for schedule in self._schedules.values():
             schedule.clear()
@@ -338,7 +339,8 @@ class Harness(pimm.ControlSystem):
         self.ds_command.emit(stop)
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
         # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
-        # last-value-wins would drop one) and before the home command, so homing stays out of the recording.
+        # last-value-wins would drop one) and before the next trial's prepare, so the moves it asks for stay
+        # out of the recording.
         yield self._pace(clock)
         # After that round, so the recorder's STOP-time record.io span still parents to the episode. Skew: a
         # producer stepping in that shared round charges ≤ one control period to the closing episode.

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -384,13 +384,12 @@ class Harness(pimm.ControlSystem):
         still using it.
         """
         yield from self._finalize_recording(clock, payload)
-        if not self._embodiment.simulated:
-            # A powered arm holds the policy's last setpoint until the next trial, so each device the trial
-            # placed goes back where it put it — the trial's own args, not a fresh draw. The scene is a
-            # person's to set up, and is not asked again.
-            for name, arg in self._task.prepare_args.items():
-                if name != keys.SCENE:
-                    self.prepare[name](arg)
+        # A powered arm holds the policy's last setpoint until the next trial, so each device the trial placed
+        # goes back where it put it — the trial's own args, not a fresh draw. The scene is a person's to set
+        # up, and is not asked again.
+        for name, arg in self._task.prepare_args.items():
+            if name != keys.SCENE:
+                self.prepare[name](arg)
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -14,7 +14,6 @@ import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
-from positronic.drivers.roboarm.command import Reset
 from positronic.drivers.roboarm.ik import assert_default_frame
 from positronic.eval import Embodiment, Task
 from positronic.policy.base import Policy
@@ -385,8 +384,13 @@ class Harness(pimm.ControlSystem):
         still using it.
         """
         yield from self._finalize_recording(clock, payload)
-        if not self._embodiment.simulated:  # a powered arm holds the policy's last setpoint until the next trial
-            self._emit({name: Reset() for name in self.commands if keys.is_robot_command(name)})
+        if not self._embodiment.simulated:
+            # A powered arm holds the policy's last setpoint until the next trial, so each device the trial
+            # placed goes back where it put it — the trial's own args, not a fresh draw. The scene is a
+            # person's to set up, and is not asked again.
+            for name, arg in self._task.prepare_args.items():
+                if name != keys.SCENE:
+                    self.prepare[name](arg)
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -280,11 +280,11 @@ class Harness(pimm.ControlSystem):
         for name, value in action.items():
             self.commands[name].emit(value)
 
-    def _prepare(self, should_stop: pimm.SignalReceiver, task: Task) -> Generator[pimm.Command, None, None]:
-        """Ask everything the task names, and come back once every one of them has answered."""
-        unknown = sorted(set(task.prepare_args) - set(self.prepare))
+    def _ready(self, should_stop: pimm.SignalReceiver, args: dict[str, Any]) -> Generator[pimm.Command, None, None]:
+        """Ask each device in ``args`` for the value it names, and come back once every one has answered."""
+        unknown = sorted(set(args) - set(self.prepare))
         assert not unknown, f'{unknown} is not something this embodiment readies, so nothing would be asked'
-        ready = pimm.calls.all_of([self.prepare[name](arg) for name, arg in task.prepare_args.items()])
+        ready = pimm.calls.all_of([self.prepare[name](arg) for name, arg in args.items()])
         while not ready.done() and not should_stop.value:
             yield pimm.Yield() if self._embodiment.simulated else pimm.Sleep(POLL_PERIOD_SEC)
         # An episode must not open on a rig that never got ready, and its asker must hear that rather than wait
@@ -362,7 +362,7 @@ class Harness(pimm.ControlSystem):
         # The episode span opens first, so the prepare and the rollout's other phase spans parent to it.
         self._telemetry.begin(self._task.meta)
         with telemetry.span(telemetry_keys.SPAN_RESET):
-            yield from self._prepare(should_stop, self._task)
+            yield from self._ready(should_stop, self._task.prepare_args)
         # The join waits on the call the last episode abandoned, so the rig is readied before it: a model
         # that hangs must not leave the devices standing at the setpoint the policy left them. It runs
         # before the session below, which is what makes closing the abandoned one safe.
@@ -376,9 +376,11 @@ class Harness(pimm.ControlSystem):
         self._deadline = clock.now() + budget if budget is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
-    def _end_episode(self, clock: pimm.Clock, payload: dict[str, Any]) -> Generator[pimm.Command, None, None]:
-        """Close the live episode: finalize the recording, retire the session, hand the terminal back to
-        whoever asked for the episode.
+    def _end_episode(
+        self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]
+    ) -> Generator[pimm.Command, None, None]:
+        """Close the live episode: finalize the recording, put the rig back, retire the session, hand the
+        terminal back to whoever asked for the episode.
 
         The worker is retired rather than joined here, so a ``RemoteSession``'s websocket outlives the call
         still using it.
@@ -386,10 +388,9 @@ class Harness(pimm.ControlSystem):
         yield from self._finalize_recording(clock, payload)
         # A powered arm holds the policy's last setpoint until the next trial, so each device the trial placed
         # goes back where it put it — the trial's own args, not a fresh draw. The scene is a person's to set
-        # up, and is not asked again.
-        for name, arg in self._task.prepare_args.items():
-            if name != keys.SCENE:
-                self.prepare[name](arg)
+        # up, and is not asked again. The terminal waits on the move: a scene the next trial draws rebuilds
+        # the model an unfinished one is still travelling under, which nothing but its timeout would end.
+        yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != keys.SCENE})
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None
@@ -401,11 +402,15 @@ class Harness(pimm.ControlSystem):
             self._call = None
 
     def _advance_episode(
-        self, worker: _InferenceWorker, done: pimm.Message[dict] | None, clock: pimm.Clock
+        self,
+        worker: _InferenceWorker,
+        done: pimm.Message[dict] | None,
+        clock: pimm.Clock,
+        should_stop: pimm.SignalReceiver,
     ) -> Generator[pimm.Command, None, None]:
         """One round of the live episode: end it if it is out of budget or done, else step the policy."""
         if (terminal := self._trial_terminal(done, clock)) is not None:
-            yield from self._end_episode(clock, terminal)
+            yield from self._end_episode(clock, should_stop, terminal)
         else:
             try:
                 self._step(worker, clock)
@@ -550,7 +555,7 @@ class Harness(pimm.ControlSystem):
             if self._worker is not None:
                 if call is not None:  # the live episode is the one that finishes; a second ask is refused
                     call.set_exception(RuntimeError('An episode is already running'))
-                yield from self._advance_episode(self._worker, done, clock)
+                yield from self._advance_episode(self._worker, done, clock, should_stop)
             elif call is not None:
                 yield from self._begin_episode(clock, should_stop, call)
             elif manual is not None:

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -37,7 +37,7 @@ from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus
-from positronic.drivers.roboarm.command import CartesianPosition, CommandType, Reset
+from positronic.drivers.roboarm.command import CartesianPosition, CommandType
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation, Task
 from positronic.geom import Rotation, Transform3D
@@ -156,10 +156,6 @@ class FakeRobot(pimm.ControlSystem):
                 self._pos = np.asarray(pose.translation, dtype=np.float32)
                 self._q = self._q.copy()
                 self._q[:3] = self._pos
-            case Reset():
-                self._pos = INITIAL_POS.copy()
-                self._q = INITIAL_Q.copy()
-                self._status = RobotStatus.AVAILABLE
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
         self.robot_meta.emit({})

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -15,7 +15,7 @@ from positronic.dataset.ds_writer_agent import DsWriterCommand, DsWriterCommandT
 from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import RobotStatus
-from positronic.drivers.roboarm.command import CartesianDelta, CartesianPosition, Reset, from_wire, to_wire
+from positronic.drivers.roboarm.command import CartesianDelta, CartesianPosition, JointPosition, from_wire, to_wire
 from positronic.drivers.roboarm.models import DEFAULT_FRAME, EE_LINK, bundled_franka_model
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
 from positronic.eval import Command, Embodiment, Observation, Task
@@ -489,9 +489,8 @@ def test_harness_waits_for_complete_inputs(world):
     robot_state = make_robot_state([0.2, 0.0, -0.1], [0.7, 0.1, -0.2])
 
     def assert_no_inference():
-        # The startup home may have emitted (Reset / grip 0.0); the policy must not have run on partial inputs.
         assert policy.last_obs is None
-        assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))
+        assert not _emitted_commands(cmd_recorder)
 
     driver = ManualDriver([
         (partial(perform_task, Task(instruction_source='dummy-task', timeout_sec=None)), 0.01),
@@ -641,8 +640,7 @@ def test_the_world_stopping_under_a_live_episode_fails_the_call(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_ends_at_its_timeout(world):
-    """Nothing ever lands on ``done``, yet the trial still ends at ``task.timeout_sec``: terminated=False,
-    robot homed."""
+    """Nothing ever lands on ``done``, yet the trial still ends at ``task.timeout_sec``: terminated=False."""
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment())
     p = _pair_all(world, harness)
@@ -697,7 +695,7 @@ def test_trial_budget_starts_at_the_first_usable_observation(world):
 
 @pytest.mark.timeout(3.0)
 def test_trial_stop_signal_terminates(world):
-    """Delivering the privileged ``done`` ends a trial early: terminated=True, payload recorded, homed."""
+    """Delivering the privileged ``done`` ends a trial early: terminated=True, payload recorded."""
     policy = StubPolicy()
     harness = Harness(policy, make_embodiment())
     p = _pair_all(world, harness)
@@ -806,7 +804,7 @@ def test_policy_first_obs_is_frame0(world):
     wire.wire_embodiment(world, harness, embodiment, None)
 
     scheduler = world.start([harness, device])
-    perform_task(Task(instruction_source='t', timeout_sec=100.0))
+    perform_task(Task(instruction_source='t', timeout_sec=100.0, prepare_args={keys.SCENE: {}}))
     drive_scheduler(scheduler, steps=20)
 
     assert policy.observations, 'policy was never called'
@@ -887,16 +885,37 @@ def test_done_after_deadline_is_a_timeout(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_a_handler_the_trial_does_not_name_is_left_alone(world):
+    """A rig readies more than any one trial wants, so what a trial leaves unnamed it leaves as it stands."""
+    drawn, moved = [], []
+    scene, arm = _Scene(drawn.append), _Scene(moved.append)
+    handlers = {keys.SCENE: scene.env_reset, keys.ARM: arm.env_reset}
+    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers=handlers))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, scene, arm])
+    p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.SCENE: {}}))
+    drive_scheduler(scheduler, steps=50)
+
+    assert drawn == [{}]
+    assert moved == []
+
+
+@pytest.mark.timeout(3.0)
 def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
-    """The args are read per handler, so a name matching none of them would be dropped and the device would
-    silently get its own default instead of what the trial asked for."""
+    """Only the handlers a task names are asked, so a name matching none of them would go unasked and the
+    trial would open on a rig nothing readied."""
     scene = _Scene(lambda _params: None)
     harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
     p = _pair_all(world, harness)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
-    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: None}))
+    answer = p['perform_task'](
+        Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: JointPosition(np.zeros(7))})
+    )
 
     with pytest.raises(AssertionError, match='not something this embodiment readies'):
         drive_scheduler(scheduler, steps=50)
@@ -1152,7 +1171,7 @@ def test_task_instruction_reaches_session_context_after_reset(world):
     wire_call(world, harness.prepare[keys.SCENE], drawing.env_reset)
 
     scheduler = world.start([harness, drawing])
-    p['perform_task'](Task(instruction_source=lambda: scene['task'], timeout_sec=0.05))
+    p['perform_task'](Task(instruction_source=lambda: scene['task'], timeout_sec=0.05, prepare_args={keys.SCENE: {}}))
     drive_scheduler(scheduler, steps=200)
 
     assert policy.last_reset_context is not None
@@ -1173,7 +1192,7 @@ class _LabeledRecorder(pimm.SignalEmitter):
 @pytest.mark.timeout(3.0)
 def test_finish_stops_playing_the_live_chunk(world):
     """Finishing drops the schedule the harness is playing: the chunk's remaining waypoints never reach the
-    devices, and the only command after the recorder's STOP is the home the close emits."""
+    devices, so nothing is emitted past the recorder's STOP."""
     policy = ChunkPolicy()
     wrapped = ActionTimestamp(fps=5.0).wrap(policy)  # 1.8 s chunk — won't drain before the episode ends
     harness = Harness(wrapped, make_embodiment())
@@ -1554,7 +1573,10 @@ def test_failed_pass_seals_open_episode_span(world, tmp_path):
     harness = Harness(policy, make_embodiment(prepare_handlers={keys.SCENE: scene}))
     wire_call(world, harness.prepare[keys.SCENE], scene)
     harness.ds_command._bind(RecordingEmitter())
-    _ask(world, harness, Task(instruction_source='stack', timeout_sec=10.0, meta={keys.EVAL_TRIAL_INDEX: 0}))
+    task = Task(
+        instruction_source='stack', timeout_sec=10.0, prepare_args={keys.SCENE: {}}, meta={keys.EVAL_TRIAL_INDEX: 0}
+    )
+    _ask(world, harness, task)
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
 
@@ -1783,7 +1805,7 @@ def _run_episode(
     ])
     systems = [harness, driver, _Pacer()] if simulated else [harness, driver]
     drive_scheduler(world.start(systems), steps=steps)
-    return grip_recorder.emitted[1:]  # drop the startup home
+    return grip_recorder.emitted
 
 
 @pytest.mark.timeout(20.0)
@@ -1969,7 +1991,7 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
     ])
     drive_scheduler(world.start([harness, driver, _Pacer(period)]), steps=4000)
 
-    played = [t for t, _ in grip_recorder.emitted[1:]]  # drop the startup home
+    played = [t for t, _ in grip_recorder.emitted]
     assert [t for t in played if t < fault_at], 'the chunk was not playing when the arm faulted'
     late = [t for t in played if t > fault_at + 3 * period]
     assert not late, f'the faulted arm was still being driven at {late}'
@@ -1977,8 +1999,8 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
 
 @pytest.mark.timeout(20.0)
 def test_finish_does_not_wait_for_the_call_in_flight():
-    """Finishing ends the episode where it lands: the recording stops and the arm homes while the model is
-    still inside its call, and the failure that call ends in reaches nobody.
+    """Finishing ends the episode where it lands: the recording stops while the model is still inside its
+    call, and the failure that call ends in reaches nobody.
 
     Real time, real rig: a wall-charged call is the only one the harness leaves in flight across rounds.
     """
@@ -2207,4 +2229,4 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
     ])
     drive_scheduler(world.start([harness, driver, _Pacer()]), steps=2000)
 
-    assert all(isinstance(c, Reset) for c in _emitted_commands(cmd_recorder))
+    assert not _emitted_commands(cmd_recorder)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -905,10 +905,10 @@ def test_a_handler_the_trial_does_not_name_is_left_alone(world):
 
 @pytest.mark.timeout(3.0)
 @pytest.mark.parametrize('simulated', [False, True], ids=['real', 'sim'])
-def test_only_a_real_rig_is_put_back_where_the_trial_placed_it(world, simulated):
-    """A powered arm holds the policy's last setpoint through the gap to the next trial, so a real rig is
-    asked for the trial's start pose again once the recording stops. A sim's arm is placed by the next
-    trial's prepare, so nothing is asked between episodes."""
+def test_every_rig_is_put_back_where_the_trial_placed_it(world, simulated):
+    """A powered arm holds the policy's last setpoint through the gap to the next trial, so what the trial
+    placed is placed again once the recording stops — the same joints it opened on, never a fresh draw. A
+    sim rig is asked no differently."""
     placed = []
     arm = _Scene(placed.append)
     handlers = {keys.ARM: arm.env_reset}
@@ -922,7 +922,7 @@ def test_only_a_real_rig_is_put_back_where_the_trial_placed_it(world, simulated)
     drive_scheduler(scheduler, steps=2000)
 
     assert answer.done(), 'the episode never ended, so there was no close to be put back by'
-    assert len(placed) == (1 if simulated else 2)
+    assert len(placed) == 2, 'the trial opened on its start pose and closes back at it'
     # The same object every time: a trial closes on the joints it opened on, never a fresh draw.
     assert all(asked is start for asked in placed)
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -904,6 +904,30 @@ def test_a_handler_the_trial_does_not_name_is_left_alone(world):
 
 
 @pytest.mark.timeout(3.0)
+@pytest.mark.parametrize('simulated', [False, True], ids=['real', 'sim'])
+def test_only_a_real_rig_is_put_back_where_the_trial_placed_it(world, simulated):
+    """A powered arm holds the policy's last setpoint through the gap to the next trial, so a real rig is
+    asked for the trial's start pose again once the recording stops. A sim's arm is placed by the next
+    trial's prepare, so nothing is asked between episodes."""
+    placed = []
+    arm = _Scene(placed.append)
+    handlers = {keys.ARM: arm.env_reset}
+    harness = Harness(StubPolicy(), make_embodiment(simulated=simulated, prepare_handlers=handlers))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+
+    start = JointPosition(np.arange(7, dtype=np.float64))
+    scheduler = world.start([harness, arm, _Pacer()])
+    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: start}))
+    drive_scheduler(scheduler, steps=2000)
+
+    assert answer.done(), 'the episode never ended, so there was no close to be put back by'
+    assert len(placed) == (1 if simulated else 2)
+    # The same object every time: a trial closes on the joints it opened on, never a fresh draw.
+    assert all(asked is start for asked in placed)
+
+
+@pytest.mark.timeout(3.0)
 def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     """Only the handlers a task names are asked, so a name matching none of them would go unasked and the
     trial would open on a rig nothing readied."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -927,6 +927,40 @@ def test_every_rig_is_put_back_where_the_trial_placed_it(world, simulated):
     assert all(asked is start for asked in placed)
 
 
+class _PlacesOnce(pimm.ControlSystem):
+    """A device that answers the first ask and keeps every one after it in hand."""
+
+    def __init__(self):
+        self.env_reset = pimm.calls.ControlSystemHandler[Any, None](self)
+        self.asks = 0
+
+    def run(self, should_stop, clock):
+        while not should_stop.value:
+            for call in self.env_reset.incoming():
+                self.asks += 1
+                if self.asks == 1:
+                    call.set_result(None)
+            yield pimm.Sleep(0.001)
+
+
+@pytest.mark.timeout(3.0)
+def test_a_trial_does_not_end_until_the_rig_is_back_where_it_started(world):
+    """The terminal waits on the return move. Handed back sooner, the next trial's scene draw goes ahead of a
+    move still travelling and rebuilds the model under it, leaving nothing but its timeout to end it."""
+    arm = _PlacesOnce()
+    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, arm, _Pacer()])
+    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: JointPosition(np.zeros(7))})
+    answer = p['perform_task'](task)
+    drive_scheduler(scheduler, steps=2000)
+
+    assert arm.asks == 2, 'the rig was never asked to go back'
+    assert not answer.done(), 'the terminal landed while the return move was still in hand'
+
+
 @pytest.mark.timeout(3.0)
 def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     """Only the handlers a task names are asked, so a name matching none of them would go unasked and the

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -7,7 +7,7 @@ import pytest
 
 from positronic import keys
 from positronic.drivers.roboarm import RobotStatus
-from positronic.drivers.roboarm.command import Impedance, JointDelta, Reset
+from positronic.drivers.roboarm.command import Impedance, JointDelta
 from positronic.geom import Rotation, Transform3D
 from positronic.policy import spec
 from positronic.policy.action import (
@@ -352,12 +352,6 @@ class TestSetControlMode:
         assert decoded[f'{keys.ROBOT_COMMAND}.left'].mode == IMPEDANCE
         assert decoded[f'{keys.ROBOT_COMMAND}.right'].mode == IMPEDANCE
         np.testing.assert_array_equal(decoded[keys.TARGET_JOINTS], np.zeros(7))
-
-    def test_a_reset_passes_through_unchanged(self):
-        """A reset names no mode: how the arm travels home is the driver's."""
-        decoded = SetControlMode(IMPEDANCE).decode({keys.ROBOT_COMMAND: Reset()})
-        assert isinstance(decoded, dict)
-        assert decoded[keys.ROBOT_COMMAND] == Reset()
 
 
 class TestTemporalStack:

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -132,16 +132,12 @@ class WireCommandAdapter(EnvAdapter):
         for name, msg in commands.items():
             if msg.updated:
                 self._held[name] = msg.data
-        # The server maps the held command into its controller's action. Reset has no env-side action, so it
-        # forwards as a hold; a delta — Cartesian or joint — is a one-shot relative motion, forwarded once then
-        # dropped. Re-sending a stale delta would re-compose it against the moving arm every tick (the eef
-        # drifts, or the joints walk toward their limits), so after one step the arm holds its measured pose.
+        # The server maps the held command into its controller's action. A delta — Cartesian or joint — is a
+        # one-shot relative motion, forwarded once then dropped: re-sending a stale delta would re-compose it
+        # against the moving arm every tick (the eef drifts, or the joints walk toward their limits), so after
+        # one step the arm holds its measured pose.
         cmd = self._held.get(keys.ROBOT_COMMAND)
-        match cmd:
-            case roboarm_command.Reset():
-                self._held.pop(keys.ROBOT_COMMAND)
-                cmd = None
-            case roboarm_command.CartesianDelta() | roboarm_command.JointDelta():
-                self._held.pop(keys.ROBOT_COMMAND)
+        if isinstance(cmd, roboarm_command.CartesianDelta | roboarm_command.JointDelta):
+            self._held.pop(keys.ROBOT_COMMAND)
         grip = float(self._held.get(keys.TARGET_GRIP, 0.0))
         return {'command': _wire_command(_in_env_control_frame(cmd, self.env_control_frame)), 'grip': grip}

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -402,13 +402,13 @@ def test_full_chunk_executes_between_replans(env_server, tmp_path):
 
     grip = LocalDataset(tmp_path)[0].signals['target_grip']
     executed = [(float(v), int(ts)) for v, ts in (grip[i] for i in range(len(grip)))]
-    values = [v for v, _ in executed if v >= 100.0]  # the inter-episode home command emits 0.0
+    values = [v for v, _ in executed]  # every sample is a chunk action: nothing else commands this channel
     complete_chunks = raw.chunks - 1  # the deadline cuts the last chunk short
     assert complete_chunks >= 2
     expected = [c * 100.0 + i for c in range(1, complete_chunks + 1) for i in range(chunk_len)]
     assert values[: len(expected)] == expected
 
-    starts = [ts for v, ts in executed if v >= 100.0 and v % 100 == 0]
+    starts = [ts for v, ts in executed if v % 100 == 0]
     period_ns = chunk_len * control_dt * 1e9
     for earlier, later in zip(starts, starts[1:], strict=False):
         assert later - earlier == pytest.approx(period_ns, abs=period_ns / (2 * chunk_len))

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -202,7 +202,7 @@ class MujocoSim(pimm.ControlSystem):
     def _accept_move(self, call: pimm.calls.Call[roboarm_command.CommandType, None], now: float) -> None:
         """Aim the actuators at what ``call`` asks for; the arm is that move's until it reads back there."""
         with pimm.calls.raise_to(call):
-            target = self._target_joints(call.request)
+            target = self._to_joints(call.request)
             self._set_actuator_values(target)
             self._moves.accept(call, target, self._MOVE_TOL, now, self._MOVE_TIMEOUT_S)
             # Already there: answered on the spot, after its state and without a step, so the scene a
@@ -369,7 +369,7 @@ class MujocoSim(pimm.ControlSystem):
         while self.data.time < target_time:
             mj.mj_step(self.model, self.data)
 
-    def _target_joints(self, cmd: roboarm_command.CommandType) -> np.ndarray:
+    def _to_joints(self, cmd: roboarm_command.CommandType) -> np.ndarray:
         """The joints ``cmd`` asks the arm to hold. A control mode it pins is not honored: the sim runs its
         own law."""
         match cmd:
@@ -394,7 +394,7 @@ class MujocoSim(pimm.ControlSystem):
     def _apply_command(self, cmd: roboarm_command.CommandType) -> None:
         """Aim the actuators at what ``cmd`` asks for, leaving the arm where it is if it cannot be met."""
         try:
-            self._set_actuator_values(self._target_joints(cmd))
+            self._set_actuator_values(self._to_joints(cmd))
         # rules-allow: swallowed-error — a command stream cannot end the run; the arm reads ERROR instead
         except ValueError as exc:
             logger.warning(f'{cmd} not applied: {exc}')

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -141,7 +141,7 @@ class MujocoSim(pimm.ControlSystem):
         self._ik_data: mj.MjData | None = None
 
         self._load_scene()
-        self._home()
+        self._apply_initial_ctrl()
         self._error = False
         self._adapters: dict[str, pimm.shared_memory.NumpySMAdapter] | None = None
         self._last_grip = 0.0
@@ -149,7 +149,7 @@ class MujocoSim(pimm.ControlSystem):
         self._reset_pending = False
 
         self.commands = pimm.ControlSystemReceiver[roboarm_command.CommandType](self)
-        self.sync_move = pimm.calls.ControlSystemHandler[roboarm_command.CommandType | None, None](self)
+        self.sync_move = pimm.calls.ControlSystemHandler[roboarm_command.CommandType, None](self)
         self.env_reset = pimm.calls.ControlSystemHandler[Any, None](self)
         self.state = pimm.ControlSystemEmitter[MujocoFrankaState](self)
         self.robot_meta = pimm.ControlSystemEmitter(self)
@@ -199,7 +199,7 @@ class MujocoSim(pimm.ControlSystem):
             self._renderer.close()
             self._renderer = None
 
-    def _accept_move(self, call: pimm.calls.Call[roboarm_command.CommandType | None, None], now: float) -> None:
+    def _accept_move(self, call: pimm.calls.Call[roboarm_command.CommandType, None], now: float) -> None:
         """Aim the actuators at what ``call`` asks for; the arm is that move's until it reads back there."""
         with pimm.calls.raise_to(call):
             target = self._target_joints(call.request)
@@ -266,7 +266,7 @@ class MujocoSim(pimm.ControlSystem):
         queued command on the freshly reset scene.
         """
         self._load_scene(seed)
-        self._home()
+        self._apply_initial_ctrl()
         self._error = False
         self.commands.read()
         self.target_grip.read()
@@ -319,7 +319,7 @@ class MujocoSim(pimm.ControlSystem):
         """Derive everything that hangs off ``self.model``; runs at construction and on every rebuild."""
         self.data = mj.MjData(self.model)
         self.initial_ctrl = [float(x) for x in self.metadata.get('initial_ctrl').split(',')]
-        self._home_joints = np.array([self.initial_ctrl[self.model.actuator(n).id] for n in self._actuator_names])
+        self.initial_joints = np.array([self.initial_ctrl[self.model.actuator(n).id] for n in self._actuator_names])
         self._joint_qpos_ids = [self.model.joint(name).qposadr.item() for name in self._joint_names]
         min_grip, max_grip = self.model.actuator(self._gripper_actuator).ctrlrange
         self._grip_range = (float(min_grip), float(max_grip))
@@ -328,9 +328,9 @@ class MujocoSim(pimm.ControlSystem):
             self._renderer = None
         self._ik_data = None
 
-    def _home(self):
+    def _apply_initial_ctrl(self):
         """Drive the actuators to their default controls (``initial_ctrl``) and step through the settling
-        transient — the arm's default pose, whether after a scene build or on a ``Reset`` command."""
+        transient, leaving the arm in the pose the scene draws it in."""
         self.data.ctrl = self.initial_ctrl
         mj.mj_step(self.model, self.data, self.warmup_steps)
 
@@ -369,12 +369,10 @@ class MujocoSim(pimm.ControlSystem):
         while self.data.time < target_time:
             mj.mj_step(self.model, self.data)
 
-    def _target_joints(self, cmd: roboarm_command.CommandType | None) -> np.ndarray:
-        """The joints ``cmd`` asks the arm to hold; asking for nothing asks for home. A control mode it
-        pins is not honored: the sim runs its own law."""
+    def _target_joints(self, cmd: roboarm_command.CommandType) -> np.ndarray:
+        """The joints ``cmd`` asks the arm to hold. A control mode it pins is not honored: the sim runs its
+        own law."""
         match cmd:
-            case None | roboarm_command.Reset():
-                return self._home_joints
             case roboarm_command.CartesianPosition(pose=pose):
                 return self._ik(pose)
             case roboarm_command.CartesianDelta() as delta_cmd:
@@ -395,15 +393,12 @@ class MujocoSim(pimm.ControlSystem):
 
     def _apply_command(self, cmd: roboarm_command.CommandType) -> None:
         """Aim the actuators at what ``cmd`` asks for, leaving the arm where it is if it cannot be met."""
-        if isinstance(cmd, roboarm_command.Reset):
-            self._home()  # the Reset command homes the arm; re-randomizing the scene is ``reset``'s job
-        else:
-            try:
-                self._set_actuator_values(self._target_joints(cmd))
-            # rules-allow: swallowed-error — a command stream cannot end the run; the arm reads ERROR instead
-            except ValueError as exc:
-                logger.warning(f'{cmd} not applied: {exc}')
-                self._error = True
+        try:
+            self._set_actuator_values(self._target_joints(cmd))
+        # rules-allow: swallowed-error — a command stream cannot end the run; the arm reads ERROR instead
+        except ValueError as exc:
+            logger.warning(f'{cmd} not applied: {exc}')
+            self._error = True
 
     def _ik(self, target: geom.Transform3D) -> np.ndarray:
         """The joints that put the end effector at ``target``; raises what the arm cannot reach."""

--- a/positronic/simulator/mujoco/tests/test_sim.py
+++ b/positronic/simulator/mujoco/tests/test_sim.py
@@ -48,8 +48,8 @@ def test_a_sync_move_travels_the_arm_to_the_joints_it_asks_for():
         np.testing.assert_allclose(state.value.q, target, atol=sim._MOVE_TOL)
 
 
-def test_a_sync_move_that_asks_for_nothing_puts_the_arm_home():
-    """Readying a rig is this call with nothing in it, so where it goes is the sim's own home pose."""
+def test_a_sync_move_takes_the_arm_over_from_the_command_stream():
+    """Between moves the stream owns the arm, so a move has to retarget what the stream last set."""
     sim = MujocoSim(MODEL, loaders=())
 
     with pimm.World(virtual_time=True) as world:
@@ -61,9 +61,9 @@ def test_a_sync_move_that_asks_for_nothing_puts_the_arm_home():
 
         commands.emit(roboarm_command.JointPosition(home + 0.3))
         drive_scheduler(scheduler, steps=_turns(sim, 2.0))
-        assert np.max(np.abs(state.value.q - home)) > sim._MOVE_TOL, 'the arm never left home'
+        assert np.max(np.abs(state.value.q - home)) > sim._MOVE_TOL, 'the streamed command never moved the arm'
 
-        _answered(scheduler, move(None), _turns(sim, 5.0)).result()
+        _answered(scheduler, move(roboarm_command.JointPosition(home)), _turns(sim, 5.0)).result()
         np.testing.assert_allclose(state.value.q, home, atol=sim._MOVE_TOL)
 
 

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -223,6 +223,21 @@ def test_the_right_stick_holds_the_session_until_the_arm_is_at_its_start_pose(wo
     assert marks['arrived'] > marks['waited']
 
 
+def test_a_start_pose_naming_something_that_is_not_an_angle_is_refused():
+    """A draw between non-finite bounds raises where the operator hears nothing but a failed move, so the
+    station is refused before any hardware starts."""
+    with pytest.raises(ValueError, match='finite'):
+        data_collection.main(
+            robot_arm=DummyRobot(),
+            gripper=None,
+            webxr=WebXR(port=0),
+            sound=None,
+            cameras=None,
+            nominal_joints=NOMINAL_JOINTS.tolist(),
+            joints_spread=[*JOINTS_SPREAD[:-1].tolist(), float('nan')],
+        )
+
+
 def test_the_right_stick_redraws_the_scene_the_arm_is_put_back_into(world):
     """One press readies every device the station has: a sim's scene is drawn again alongside the arm's
     start pose, and the session stays held until both have answered."""

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import numpy as np
@@ -154,9 +154,9 @@ NOMINAL_JOINTS = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
 JOINTS_SPREAD = np.array([0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10])
 
 
-def build_teleop_arm(world):
+def build_teleop_arm(world, spread: Sequence[float] | np.ndarray = JOINTS_SPREAD):
     """The controller with the arm side of its ``sync_move`` paired, and recorders on what it emits."""
-    dc = DataCollectionController(OperatorPosition.FRONT.value, NOMINAL_JOINTS, JOINTS_SPREAD)
+    dc = DataCollectionController(OperatorPosition.FRONT.value, NOMINAL_JOINTS, spread)
     grips, sounds = RecordingEmitter(), RecordingEmitter()
     dc.target_grip._bind(grips)
     dc.sound._bind(sounds)
@@ -218,10 +218,20 @@ def test_a_start_pose_the_arm_refuses_is_sounded_to_the_operator(world):
     assert marks['after'] > marks['refused']
 
 
-@pytest.mark.parametrize('spread', [np.zeros(7), ()], ids=['zeros', 'unspecified'])
-def test_a_start_pose_without_spread_is_the_nominal(spread):
-    joints = roboarm_command.sampled_joints(NOMINAL_JOINTS, spread).positions
-    np.testing.assert_array_equal(joints, NOMINAL_JOINTS)
+def test_a_station_that_measured_no_spread_puts_the_arm_at_its_nominal(world):
+    """Jitter is a station's to measure, and the arms that have none named are the ones asked for their
+    nominal joints themselves."""
+    dc, arm, buttons, _, _ = build_teleop_arm(world, spread=())
+    asked = []
+
+    driver = ManualDriver([
+        (lambda: buttons.emit(make_buttons(stick=0.0)), 0.01),
+        (lambda: buttons.emit(make_buttons(stick=1.0)), 0.01),
+        (lambda: asked.extend(arm.incoming()), 0.0),
+    ])
+    drive_scheduler(world.start([dc, driver]), steps=400)
+
+    np.testing.assert_array_equal(asked[0].request.positions, NOMINAL_JOINTS)
 
 
 def test_every_start_pose_is_a_fresh_per_joint_draw_around_the_nominal():

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -14,7 +14,7 @@ from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.geom import Rotation, Transform3D
 from positronic.simulator.mujoco.sim import MujocoSim
-from positronic.tests.testing_coutils import ManualDriver, drive_scheduler
+from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
 
 
 # TODO: Move these fixtures into a common module so that others can reuse them.
@@ -48,7 +48,7 @@ class DummyRobot(pimm.ControlSystem):
 
 
 def build_collection(world, out_dir: Path, *, metadata_getter: Callable[[], dict[str, object]] | None = None):
-    dc = DataCollectionController(operator_position=None, metadata_getter=metadata_getter)
+    dc = DataCollectionController(operator_position=None, nominal_joints=(), metadata_getter=metadata_getter)
     robot = DummyRobot()
 
     writer_cm = LocalDatasetWriter(out_dir)
@@ -149,12 +149,87 @@ def test_data_collection_basic_recording(tmp_path, world):
     np.testing.assert_allclose(right_pose_sig[0][0][3:], right_pose.rotation.as_quat)
 
 
+NOMINAL_JOINTS = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
+JOINTS_SPREAD = np.array([0.03, 0.05, 0.08, 0.08, 0.10, 0.10, 0.10])
+
+
+def build_teleop_arm(world):
+    """The controller with the arm side of its ``sync_move`` paired, and recorders on what it emits."""
+    dc = DataCollectionController(OperatorPosition.FRONT.value, NOMINAL_JOINTS, JOINTS_SPREAD)
+    grips, sounds = RecordingEmitter(), RecordingEmitter()
+    dc.target_grip._bind(grips)
+    dc.sound._bind(sounds)
+    return dc, world.pair(dc.sync_move), world.pair(dc.buttons_receiver), grips, sounds
+
+
+def test_the_right_stick_holds_the_session_until_the_arm_is_at_its_start_pose(world):
+    """The right stick asks for a start pose drawn around the nominal joints, and the controller does
+    nothing further until the arm answers that it is there."""
+    dc, arm, buttons, grips, _ = build_teleop_arm(world)
+    asked, marks = [], {}
+
+    driver = ManualDriver([
+        (lambda: buttons.emit(make_buttons(stick=0.0)), 0.01),
+        (lambda: buttons.emit(make_buttons(stick=1.0)), 0.01),
+        (lambda: asked.extend(arm.incoming()), 0.01),
+        (lambda: marks.update(asked=len(grips.emitted)), 0.01),
+        (lambda: marks.update(waited=len(grips.emitted)), 0.01),
+        (lambda: asked[0].set_result(None), 0.01),
+        (lambda: marks.update(arrived=len(grips.emitted)), 0.0),
+    ])
+    drive_scheduler(world.start([dc, driver]), steps=400)
+
+    assert len(asked) == 1
+    move = asked[0].request
+    assert isinstance(move, roboarm_command.JointPosition)
+    np.testing.assert_array_less(np.abs(np.asarray(move.positions) - NOMINAL_JOINTS), JOINTS_SPREAD)
+    assert marks['asked'] > 0  # the loop was running before the press
+    assert marks['waited'] == marks['asked']  # ... and stood still for the whole move
+    assert marks['arrived'] > marks['waited']
+
+
+def test_a_start_pose_the_arm_refuses_is_sounded_to_the_operator(world):
+    """A move the arm fails is the operator's to hear about and ask for again; the session goes on."""
+    dc, arm, buttons, grips, sounds = build_teleop_arm(world)
+    asked, marks = [], {}
+
+    def refuse_the_move():
+        marks['refused'] = len(grips.emitted)
+        asked[0].set_exception(RuntimeError('joint limit'))
+
+    driver = ManualDriver([
+        (lambda: buttons.emit(make_buttons(stick=0.0)), 0.01),
+        (lambda: buttons.emit(make_buttons(stick=1.0)), 0.01),
+        (lambda: asked.extend(arm.incoming()), 0.01),
+        (refuse_the_move, 0.01),
+        (lambda: marks.update(after=len(grips.emitted)), 0.0),
+    ])
+    drive_scheduler(world.start([dc, driver]), steps=400)
+
+    assert [path.name for _, path in sounds.emitted] == ['error-occurred.wav']
+    assert marks['after'] > marks['refused']
+
+
+@pytest.mark.parametrize('spread', [np.zeros(7), ()], ids=['zeros', 'unspecified'])
+def test_a_start_pose_without_spread_is_the_nominal(spread):
+    joints = roboarm_command.sampled_joints(NOMINAL_JOINTS, spread).positions
+    np.testing.assert_array_equal(joints, NOMINAL_JOINTS)
+
+
+def test_every_start_pose_is_a_fresh_per_joint_draw_around_the_nominal():
+    draws = [roboarm_command.sampled_joints(NOMINAL_JOINTS, JOINTS_SPREAD).positions for _ in range(64)]
+    offsets = (np.array(draws) - NOMINAL_JOINTS) / JOINTS_SPREAD
+    assert np.all(np.abs(offsets) < 1)  # inside the spread the nominal allows each joint
+    assert np.all(offsets.std(axis=0) > 0)  # a draw of its own each time
+    assert np.all(offsets.std(axis=1) > 0)  # each joint drawn on its own, not one offset for the whole vector
+
+
 def test_data_collection_with_mujoco_robot_gripper(tmp_path):
     sim = MujocoSim('positronic/assets/mujoco/franka_table.xml', loaders=())
 
     # Virtual time: the sim advances the world clock as physics steps
     with pimm.World(virtual_time=True) as world:
-        dc = DataCollectionController(operator_position=OperatorPosition.FRONT.value)
+        dc = DataCollectionController(operator_position=OperatorPosition.FRONT.value, nominal_joints=sim.initial_joints)
 
         writer_cm = LocalDatasetWriter(tmp_path)
         agent = DsWriterAgent(writer_cm.__enter__())
@@ -269,7 +344,7 @@ def test_mujoco_grip_one_is_closed():
         """Physical finger travel: 0 = fingers together (closed), 0.04 m = fully apart (open)."""
         return sim.data.joint('finger_joint1_ph').qpos.item()
 
-    # The home pose leaves the gripper open.
+    # The pose the scene is built in leaves the gripper open.
     assert finger_qpos() > 0.03
 
     snapshots = {}

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -5,13 +5,14 @@ import numpy as np
 import pytest
 
 import pimm
-from positronic import keys, wire
+from positronic import data_collection, keys, wire
 from positronic.data_collection import DataCollectionController, OperatorPosition, controller_positions_serializer
 from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType
 from positronic.dataset.episode import Episode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
+from positronic.drivers.webxr import WebXR
 from positronic.geom import Rotation, Transform3D
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
@@ -160,6 +161,13 @@ def build_teleop_arm(world):
     dc.target_grip._bind(grips)
     dc.sound._bind(sounds)
     return dc, world.pair(dc.sync_move), world.pair(dc.buttons_receiver), grips, sounds
+
+
+def test_a_station_that_names_an_arm_but_no_start_pose_is_refused():
+    """A start pose belongs to the arm it was measured on, so the two are named together or not at all: a
+    station that swaps its arm and keeps the pose would drive the new one to the old one's joints."""
+    with pytest.raises(ValueError, match='nominal_joints'):
+        data_collection.main(robot_arm=DummyRobot(), gripper=None, webxr=WebXR(port=0), sound=None, cameras=None)
 
 
 def test_the_right_stick_holds_the_session_until_the_arm_is_at_its_start_pose(world):

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -223,6 +223,30 @@ def test_the_right_stick_holds_the_session_until_the_arm_is_at_its_start_pose(wo
     assert marks['arrived'] > marks['waited']
 
 
+def test_the_right_stick_redraws_the_scene_the_arm_is_put_back_into(world):
+    """One press readies every device the station has: a sim's scene is drawn again alongside the arm's
+    start pose, and the session stays held until both have answered."""
+    dc, arm, buttons, grips, _ = build_teleop_arm(world)
+    scene = world.pair(dc.redraw_scene)
+    asked, marks = [], {}
+
+    driver = ManualDriver([
+        (lambda: buttons.emit(make_buttons(stick=0.0)), 0.01),
+        (lambda: buttons.emit(make_buttons(stick=1.0)), 0.01),
+        (lambda: asked.extend([*scene.incoming(), *arm.incoming()]), 0.01),
+        (lambda: marks.update(asked=len(grips.emitted)), 0.01),
+        (lambda: asked[0].set_result(None), 0.01),
+        (lambda: marks.update(drawn=len(grips.emitted)), 0.01),
+        (lambda: asked[1].set_result(None), 0.01),
+        (lambda: marks.update(placed=len(grips.emitted)), 0.0),
+    ])
+    drive_scheduler(world.start([dc, driver]), steps=400)
+
+    assert len(asked) == 2, 'the press reached only one of the scene and the arm'
+    assert marks['drawn'] == marks['asked'], 'the session went on with the arm still travelling'
+    assert marks['placed'] > marks['drawn']
+
+
 def test_a_start_pose_the_arm_refuses_is_sounded_to_the_operator(world):
     """A move the arm fails is the operator's to hear about and ask for again; the session goes on."""
     dc, arm, buttons, grips, sounds = build_teleop_arm(world)

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -6,7 +6,6 @@ import pytest
 
 import pimm
 from positronic import data_collection, keys, wire
-from positronic.cfg.hardware.roboarm import DROID_IMPEDANCE, franka_start_pose
 from positronic.data_collection import DataCollectionController, OperatorPosition, controller_positions_serializer
 from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType
 from positronic.dataset.episode import Episode
@@ -299,11 +298,6 @@ def test_a_station_that_measured_no_spread_puts_the_arm_at_its_nominal(world):
     drive_scheduler(world.start([dc, driver]), steps=400)
 
     np.testing.assert_array_equal(asked[0].request.positions, NOMINAL_JOINTS)
-
-
-def test_a_franka_start_pose_travels_under_the_gains_the_rollout_runs():
-    """The arm is no stiffer being put at the pose a trial starts from than it is once the policy has it."""
-    assert franka_start_pose().mode is DROID_IMPEDANCE
 
 
 def test_every_start_pose_is_a_fresh_per_joint_draw_around_the_nominal():

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -6,6 +6,7 @@ import pytest
 
 import pimm
 from positronic import data_collection, keys, wire
+from positronic.cfg.hardware.roboarm import DROID_IMPEDANCE, franka_start_pose
 from positronic.data_collection import DataCollectionController, OperatorPosition, controller_positions_serializer
 from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType
 from positronic.dataset.episode import Episode
@@ -298,6 +299,11 @@ def test_a_station_that_measured_no_spread_puts_the_arm_at_its_nominal(world):
     drive_scheduler(world.start([dc, driver]), steps=400)
 
     np.testing.assert_array_equal(asked[0].request.positions, NOMINAL_JOINTS)
+
+
+def test_a_franka_start_pose_travels_under_the_gains_the_rollout_runs():
+    """The arm is no stiffer being put at the pose a trial starts from than it is once the policy has it."""
+    assert franka_start_pose().mode is DROID_IMPEDANCE
 
 
 def test_every_start_pose_is_a_fresh_per_joint_draw_around_the_nominal():

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -163,11 +163,23 @@ def build_teleop_arm(world, spread: Sequence[float] | np.ndarray = JOINTS_SPREAD
     return dc, world.pair(dc.sync_move), world.pair(dc.buttons_receiver), grips, sounds
 
 
-def test_a_station_that_names_an_arm_but_no_start_pose_is_refused():
-    """A start pose belongs to the arm it was measured on, so the two are named together or not at all: a
-    station that swaps its arm and keeps the pose would drive the new one to the old one's joints."""
+@pytest.mark.parametrize(
+    ('robot_arm', 'nominal_joints'),
+    [(DummyRobot(), ()), (None, NOMINAL_JOINTS)],
+    ids=['an arm with no pose to put it at', 'a pose with no arm to put there'],
+)
+def test_a_station_naming_an_arm_or_a_start_pose_without_the_other_is_refused(robot_arm, nominal_joints):
+    """A start pose belongs to the arm it was measured on: a station that swaps its arm and keeps the pose
+    would drive the new one to the old one's joints, and one that drops the arm has nothing to move."""
     with pytest.raises(ValueError, match='nominal_joints'):
-        data_collection.main(robot_arm=DummyRobot(), gripper=None, webxr=WebXR(port=0), sound=None, cameras=None)
+        data_collection.main(
+            robot_arm=robot_arm,
+            gripper=None,
+            webxr=WebXR(port=0),
+            sound=None,
+            cameras=None,
+            nominal_joints=nominal_joints,
+        )
 
 
 def test_the_right_stick_holds_the_session_until_the_arm_is_at_its_start_pose(world):

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -182,6 +182,21 @@ def test_a_station_naming_an_arm_or_a_start_pose_without_the_other_is_refused(ro
         )
 
 
+def test_a_spread_that_does_not_cover_every_nominal_joint_is_refused():
+    """A spread holds one measurement per joint. Widths that disagree reach numpy on the first right-stick
+    press, where a misconfigured station is indistinguishable from an arm that refused the move."""
+    with pytest.raises(ValueError, match='joints_spread'):
+        data_collection.main(
+            robot_arm=DummyRobot(),
+            gripper=None,
+            webxr=WebXR(port=0),
+            sound=None,
+            cameras=None,
+            nominal_joints=NOMINAL_JOINTS.tolist(),
+            joints_spread=JOINTS_SPREAD[:-1].tolist(),
+        )
+
+
 def test_the_right_stick_holds_the_session_until_the_arm_is_at_its_start_pose(world):
     """The right stick asks for a start pose drawn around the nominal joints, and the controller does
     nothing further until the arm answers that it is there."""

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -4,12 +4,10 @@ from dataclasses import replace
 from functools import partial
 from typing import Any
 
-import numpy as np
 import pytest
 
 import pimm
 from positronic import inference, keys
-from positronic.cfg.hardware.roboarm import FRANKA_JOINTS_SPREAD, FRANKA_NOMINAL_JOINTS
 from positronic.eval import Embodiment, Task
 from positronic.inference import KeyboardOperator, real
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler, scripted_driver
@@ -131,17 +129,6 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
     assert policy.observations[0][keys.TASK] == 'pick up the cube'
     assert keys.ENDED_BY_OPERATOR in capsys.readouterr().out
     assert policy.closed
-
-
-def test_every_attended_trial_draws_its_own_start_pose():
-    """A press readies the arm and the fingers, and the pose the arm is put at is drawn afresh each time."""
-    first, second = inference._attended_task('pick'), inference._attended_task('pick')
-
-    assert set(first.prepare_args) == {keys.ARM, keys.GRIPPER}
-    assert first.prepare_args[keys.GRIPPER] == 0.0
-    arms = [t.prepare_args[keys.ARM].positions for t in (first, second)]
-    np.testing.assert_array_less(np.abs(arms[0] - np.array(FRANKA_NOMINAL_JOINTS)), FRANKA_JOINTS_SPREAD)
-    assert not (arms[0] == arms[1]).all(), 'every trial draws its own start pose'
 
 
 def test_the_operator_reports_an_ask_the_harness_refuses(capsys):

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -1,26 +1,47 @@
 import io
 import sys
 from functools import partial
-from types import SimpleNamespace
 
 import pytest
 
 import pimm
+from positronic import inference, keys
 from positronic.eval import Embodiment, Task
 from positronic.inference import KeyboardOperator, real
 from positronic.tests.testing_coutils import drive_scheduler, scripted_driver
 
 
+class _IdleSession:
+    def __init__(self, policy):
+        self._policy = policy
+
+    def __call__(self, obs):
+        self._policy.observations.append(obs)
+        return []  # nothing to place: an attended episode ends when the operator says so, not on a chunk
+
+    @property
+    def meta(self):
+        return {}
+
+    def close(self):
+        pass
+
+
 class _IdlePolicy:
-    """Enough policy for the attended path to warm up and close; it is never asked for an action."""
+    """Enough policy for the attended path to run an episode and close; it commands nothing."""
 
     def __init__(self):
         self.warmed = False
         self.closed = False
+        self.observations: list[dict] = []
 
     def new_session(self, *_args, **_kwargs):
         self.warmed = True
-        return SimpleNamespace(close=lambda: None)
+        return _IdleSession(self)
+
+    @property
+    def meta(self):
+        return {}
 
     def close(self):
         self.closed = True
@@ -62,11 +83,65 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
         real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), task='stub')
 
 
+class _ScriptedKeyboard(pimm.ControlSystem):
+    """Stands in for ``KeyboardControl``: types each key a beat apart, then returns as ``q`` would.
+
+    The beat is wide enough that the episode a key asks for has opened before the next one lands.
+    """
+
+    def __init__(self, *keystrokes: str):
+        self._keystrokes = keystrokes
+        self.keyboard_inputs = pimm.ControlSystemEmitter[str](self)
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        for key in self._keystrokes:
+            yield pimm.Sleep(0.3)
+            if should_stop.value:
+                return
+            self.keyboard_inputs.emit(key)
+        yield pimm.Sleep(0.3)
+
+
+@pytest.mark.timeout(30.0)
+def test_the_operator_readies_the_scene_an_attended_trial_runs_in(monkeypatch, capsys):
+    """The rig a person sets up by hand readies like any device: the trial asks for the scene, the operator
+    answers for it, and the episode runs from there until they stop it."""
+    monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard('s', 'p'))
+    policy = _IdlePolicy()
+
+    real(policy=policy, embodiment=_embodiment(), task='pick up the cube')
+
+    assert policy.observations, 'the episode never opened'
+    assert policy.observations[0][keys.TASK] == 'pick up the cube'
+    assert keys.ENDED_BY_OPERATOR in capsys.readouterr().out
+    assert policy.closed
+
+
+def test_each_attended_trial_readies_the_devices_its_rig_was_given():
+    """Only what a trial names is readied, so the arm and fingers of a rig that has them are named per press."""
+    nominal, spread = [0.0] * 7, [0.1] * 7
+    first = inference._attended_task('pick', nominal, spread, start_grip=0.0)
+    second = inference._attended_task('pick', nominal, spread, start_grip=0.0)
+
+    assert set(first.prepare_args) == {keys.ARM, keys.GRIPPER, keys.SCENE}
+    assert first.prepare_args[keys.GRIPPER] == 0.0
+    arms = [t.prepare_args[keys.ARM].positions for t in (first, second)]
+    assert all(abs(q) <= 0.1 for q in arms[0]), arms[0]
+    assert not (arms[0] == arms[1]).all(), 'every trial draws its own start pose'
+
+
+def test_an_attended_trial_names_no_device_its_rig_has_not_got():
+    """A rig with no arm to place holds where the last episode left it rather than being asked for a pose."""
+    task = inference._attended_task('pick', nominal_joints=(), joints_spread=(), start_grip=None)
+
+    assert set(task.prepare_args) == {keys.SCENE}
+
+
 def test_the_operator_reports_an_ask_the_harness_refuses(capsys):
     """The operator does not police who may start an episode: every press is asked for, and what comes back
     is printed as it lands."""
     task = Task(instruction_source='pick', timeout_sec=None)
-    operator = KeyboardOperator(task)
+    operator = KeyboardOperator(lambda: task)
     with pimm.World(virtual_time=True) as world:
         keystrokes = world.pair(operator.keystrokes)
         harness = world.pair(operator.perform_task)

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -119,9 +119,9 @@ class _ScriptedKeyboard(pimm.ControlSystem):
 
 
 @pytest.mark.timeout(30.0)
-def test_the_operator_readies_the_scene_an_attended_trial_runs_in(monkeypatch, capsys):
-    """The rig a person sets up by hand readies like any device: the trial asks for the scene, the operator
-    answers for it, and the episode runs from there until they stop it."""
+def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
+    """The press is the whole start signal: the rig's devices ready, the episode opens on the instruction it
+    was given, and it runs until the operator stops it."""
     policy = _IdlePolicy()
     monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard(policy))
 
@@ -134,10 +134,10 @@ def test_the_operator_readies_the_scene_an_attended_trial_runs_in(monkeypatch, c
 
 
 def test_every_attended_trial_draws_its_own_start_pose():
-    """A press readies the scene, the arm and the fingers, and the pose the arm is put at is drawn afresh."""
+    """A press readies the arm and the fingers, and the pose the arm is put at is drawn afresh each time."""
     first, second = inference._attended_task('pick'), inference._attended_task('pick')
 
-    assert set(first.prepare_args) == {keys.ARM, keys.GRIPPER, keys.SCENE}
+    assert set(first.prepare_args) == {keys.ARM, keys.GRIPPER}
     assert first.prepare_args[keys.GRIPPER] == 0.0
     arms = [t.prepare_args[keys.ARM].positions for t in (first, second)]
     np.testing.assert_array_less(np.abs(arms[0] - np.array(FRANKA_NOMINAL_JOINTS)), FRANKA_JOINTS_SPREAD)

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -109,7 +109,7 @@ def test_the_operator_readies_the_scene_an_attended_trial_runs_in(monkeypatch, c
 
 
 def test_each_attended_trial_readies_the_devices_its_rig_was_given():
-    """Only what a trial names is readied, so the arm and fingers of a rig that has them are named per press."""
+    """A rig with an arm and fingers names both every press, and the arm's start pose is drawn afresh each time."""
     nominal, spread = [0.0] * 7, [0.1] * 7
     first = inference._attended_task('pick', nominal, spread, start_grip=0.0)
     second = inference._attended_task('pick', nominal, spread, start_grip=0.0)

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -1,11 +1,15 @@
 import io
 import sys
+from dataclasses import replace
 from functools import partial
+from typing import Any
 
+import numpy as np
 import pytest
 
 import pimm
 from positronic import inference, keys
+from positronic.cfg.hardware.roboarm import FRANKA_JOINTS_SPREAD, FRANKA_NOMINAL_JOINTS
 from positronic.eval import Embodiment, Task
 from positronic.inference import KeyboardOperator, real
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler, scripted_driver
@@ -31,14 +35,31 @@ class _IdlePolicy:
         self.closed = True
 
 
+class _ReadyDevices(pimm.ControlSystem):
+    """The arm and fingers of a rig that is already wherever it is asked to go."""
+
+    def __init__(self):
+        self.arm = pimm.calls.ControlSystemHandler[Any, None](self)
+        self.gripper = pimm.calls.ControlSystemHandler[Any, None](self)
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        while not should_stop.value:
+            for handler in (self.arm, self.gripper):
+                for call in handler.incoming():
+                    call.set_result(None)
+            yield pimm.Sleep(0.01)
+
+
 def _embodiment(simulated: bool = False) -> Embodiment:
+    devices = _ReadyDevices()
     return Embodiment(
         descriptor='stub',
         observations={},
         commands={},
-        prepare_handlers={},
+        prepare_handlers={keys.ARM: devices.arm, keys.GRIPPER: devices.gripper},
         static_meta={},
         meta_source=None,
+        control_systems=(devices,),
         simulated=simulated,
     )
 
@@ -67,29 +88,33 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
         real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), task='stub')
 
 
-def test_the_keyboard_path_refuses_a_start_the_rig_cannot_be_put_at():
-    """What an episode starts from belongs to the rig, so swapping the embodiment and keeping the start pose
-    is caught before a run begins rather than at the first press."""
+def test_the_keyboard_path_refuses_a_rig_it_cannot_put_at_a_start_pose():
+    """Every attended episode places the arm and opens the fingers, so a rig that readies neither is caught
+    before a run begins rather than at the first press."""
+    bare = replace(_embodiment(), prepare_handlers={}, control_systems=())
     with pytest.raises(ValueError, match="'gripper'"):
-        real(policy=_IdlePolicy(), embodiment=_embodiment(), task='stub', start_grip=0.0)
+        real(policy=_IdlePolicy(), embodiment=bare, task='stub')
 
 
 class _ScriptedKeyboard(pimm.ControlSystem):
-    """Stands in for ``KeyboardControl``: types each key a beat apart, then returns as ``q`` would.
+    """Stands in for ``KeyboardControl``: starts an episode, stops it once it is running, returns as ``q`` would.
 
-    The beat is wide enough that the episode a key asks for has opened before the next one lands.
+    ``policy`` is what says the episode is running. The rig's devices are spawned, so how long they take to
+    answer the trial's prepare is nothing a beat between keystrokes could name.
     """
 
-    def __init__(self, *keystrokes: str):
-        self._keystrokes = keystrokes
+    def __init__(self, policy):
+        self._policy = policy
         self.keyboard_inputs = pimm.ControlSystemEmitter[str](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        for key in self._keystrokes:
-            yield pimm.Sleep(0.3)
+        yield pimm.Sleep(0.1)
+        self.keyboard_inputs.emit('s')
+        while not self._policy.observations:
             if should_stop.value:
                 return
-            self.keyboard_inputs.emit(key)
+            yield pimm.Sleep(0.01)
+        self.keyboard_inputs.emit('p')
         yield pimm.Sleep(0.3)
 
 
@@ -97,8 +122,8 @@ class _ScriptedKeyboard(pimm.ControlSystem):
 def test_the_operator_readies_the_scene_an_attended_trial_runs_in(monkeypatch, capsys):
     """The rig a person sets up by hand readies like any device: the trial asks for the scene, the operator
     answers for it, and the episode runs from there until they stop it."""
-    monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard('s', 'p'))
     policy = _IdlePolicy()
+    monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard(policy))
 
     real(policy=policy, embodiment=_embodiment(), task='pick up the cube')
 
@@ -108,24 +133,15 @@ def test_the_operator_readies_the_scene_an_attended_trial_runs_in(monkeypatch, c
     assert policy.closed
 
 
-def test_each_attended_trial_readies_the_devices_its_rig_was_given():
-    """A rig with an arm and fingers names both every press, and the arm's start pose is drawn afresh each time."""
-    nominal, spread = [0.0] * 7, [0.1] * 7
-    first = inference._attended_task('pick', nominal, spread, start_grip=0.0)
-    second = inference._attended_task('pick', nominal, spread, start_grip=0.0)
+def test_every_attended_trial_draws_its_own_start_pose():
+    """A press readies the scene, the arm and the fingers, and the pose the arm is put at is drawn afresh."""
+    first, second = inference._attended_task('pick'), inference._attended_task('pick')
 
     assert set(first.prepare_args) == {keys.ARM, keys.GRIPPER, keys.SCENE}
     assert first.prepare_args[keys.GRIPPER] == 0.0
     arms = [t.prepare_args[keys.ARM].positions for t in (first, second)]
-    assert all(abs(q) <= 0.1 for q in arms[0]), arms[0]
+    np.testing.assert_array_less(np.abs(arms[0] - np.array(FRANKA_NOMINAL_JOINTS)), FRANKA_JOINTS_SPREAD)
     assert not (arms[0] == arms[1]).all(), 'every trial draws its own start pose'
-
-
-def test_an_attended_trial_names_no_device_its_rig_has_not_got():
-    """A rig with no arm to place holds where the last episode left it rather than being asked for a pose."""
-    task = inference._attended_task('pick', nominal_joints=(), joints_spread=(), start_grip=None)
-
-    assert set(task.prepare_args) == {keys.SCENE}
 
 
 def test_the_operator_reports_an_ask_the_harness_refuses(capsys):

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -8,23 +8,7 @@ import pimm
 from positronic import inference, keys
 from positronic.eval import Embodiment, Task
 from positronic.inference import KeyboardOperator, real
-from positronic.tests.testing_coutils import drive_scheduler, scripted_driver
-
-
-class _IdleSession:
-    def __init__(self, policy):
-        self._policy = policy
-
-    def __call__(self, obs):
-        self._policy.observations.append(obs)
-        return []  # nothing to place: an attended episode ends when the operator says so, not on a chunk
-
-    @property
-    def meta(self):
-        return {}
-
-    def close(self):
-        pass
+from positronic.tests.testing_coutils import IdleSession, drive_scheduler, scripted_driver
 
 
 class _IdlePolicy:
@@ -37,7 +21,7 @@ class _IdlePolicy:
 
     def new_session(self, *_args, **_kwargs):
         self.warmed = True
-        return _IdleSession(self)
+        return IdleSession(self)
 
     @property
     def meta(self):
@@ -81,6 +65,13 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
     neither of."""
     with pytest.raises(ValueError, match='sim'):
         real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), task='stub')
+
+
+def test_the_keyboard_path_refuses_a_start_the_rig_cannot_be_put_at():
+    """What an episode starts from belongs to the rig, so swapping the embodiment and keeping the start pose
+    is caught before a run begins rather than at the first press."""
+    with pytest.raises(ValueError, match="'gripper'"):
+        real(policy=_IdlePolicy(), embodiment=_embodiment(), task='stub', start_grip=0.0)
 
 
 class _ScriptedKeyboard(pimm.ControlSystem):

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -134,8 +134,8 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     grip_samples = list(grip_signal)
     assert grip_samples, 'target_grip signal is empty'
     grip_values = [value for value, _ts in grip_samples]
-    # The inter-episode home grip is drained by ``reset``, so the command stream starts with the policy's
-    # first commanded grip (0.33) — consistent with ``robot_command.pose`` above.
+    # Nothing but the policy commands this channel, so the stream starts with its first commanded grip
+    # (0.33) — consistent with ``robot_command.pose`` above.
     assert grip_values[0] == pytest.approx(0.33, rel=1e-2, abs=1e-2)
     assert np.all(np.diff([ts for _, ts in grip_samples]) > 0) or len(grip_samples) == 1
 
@@ -217,7 +217,7 @@ def test_countdown_records_frame0_every_trial(tmp_path):
     trials = number_trials(ev.tasks[0], [{keys.EVAL_SEED: i} for i in range(2)])
     with pos3.mirror():
         main(
-            policy=StubPolicy(command=roboarm_command.Reset(), target_grip=0.0),
+            policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
             evals=[replace(ev, tasks=trials)],
             # the degenerate obs is not Franka-shaped, so run the policy unwrapped
             output_dir=str(tmp_path),
@@ -240,7 +240,9 @@ def test_timing_writes_telemetry_sidecars(tmp_path):
     trials = number_trials(ev.tasks[0], [{}, {}])
     with pos3.mirror():
         main(
-            policy=ChunkedSchedule().wrap(RemoteStubPolicy(command=roboarm_command.Reset(), target_grip=0.0)),
+            policy=ChunkedSchedule().wrap(
+                RemoteStubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0)
+            ),
             evals=[replace(ev, tasks=trials)],
             output_dir=str(tmp_path),
             timing=True,
@@ -286,7 +288,7 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     trial = number_trials(ev.tasks[0], [{keys.EVAL_SEED: 100}])[0]
     with pos3.mirror():
         main(
-            policy=StubPolicy(command=roboarm_command.Reset(), target_grip=0.0),
+            policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
             evals=[replace(ev, tasks=[trial])],
             output_dir=str(tmp_path),
         )

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -117,9 +117,9 @@ def run_scripted_agent(
 
 
 class IdleSession:
-    """A policy session that records what it is shown and places nothing.
+    """A policy session that records what it is shown and commands nothing.
 
-    Its policy owns an ``observations`` list, which is where each one lands.
+    The recording lands on its policy's ``observations`` list.
     """
 
     def __init__(self, policy):

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -114,3 +114,24 @@ def run_scripted_agent(
     driver = ManualDriver(script=script)
     scheduler = world.start([agent, driver])
     drive_scheduler(scheduler, steps=steps)
+
+
+class IdleSession:
+    """A policy session that records what it is shown and places nothing.
+
+    Its policy owns an ``observations`` list, which is where each one lands.
+    """
+
+    def __init__(self, policy):
+        self._policy = policy
+
+    def __call__(self, obs):
+        self._policy.observations.append(obs)
+        return []
+
+    @property
+    def meta(self):
+        return {}
+
+    def close(self):
+        pass


### PR DESCRIPTION
## Summary

An arm driver no longer knows what "reset" or "home" means. `command.Reset` is deleted, and `sync_move` takes a command — `None` is not one.

- **Drivers keep one pose, `park_joints`**: where the driver puts the arm when it takes control and when it hands it back. It is required, so the config that names it is its only owner. SO-101 and Kinova had one solely to serve the `None` case and lose it entirely; Robotiq and DH lose `home_grip`.
- **The start pose and its jitter move to the callers.** `command.sampled_joints(nominal, spread)` draws it. Teleop draws one per right-stick press and waits for the arm to arrive before tracking can resume; the droid eval draws one per trial into `prepare_args`.
- **`Harness._prepare` asks only the handlers a task names**, instead of asking every bound handler with `prepare_args.get(name)`.
- **`keys.HUMAN` goes.** `keys.SCENE` already means "the world this trial runs in is ready"; which handler is bound says whether a sim draws it or a person sets it up. The eval CLI answers it with a logged stand-in on real rigs, and refuses to stand in for a simulated one.
- `MujocoSim._home_joints` becomes the public `initial_joints` its callers now read.

Two defects fixed along the way: `cfg/eval/real/droid.py` built its trials through the sim path's `number_trials`, which writes a `keys.SCENE` arg the droid embodiment has no handler for — it tripped the Harness assert on the first trial. And `test_harness.py` carried `grip_recorder.emitted[1:]  # drop the startup home` in two places, silently discarding a real first waypoint since the startup home was removed in #655.

## Test plan

- `uv run --locked pytest` — 1625 passed, 8 skipped
- `ruff check` / `ruff format` clean; `basedpyright` 0 errors, baseline untouched
- Sim teleop by hand: `uv run positronic-data-collection sim --webxr=...`, right stick moves the arm to a fresh start pose