### PR TITLE
Guard `main` against the GitHub MCP, not only the shell

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|mcp__github__.*",
         "hooks": [
           {
             "type": "command",

--- a/utilities/claude_hooks/guard_main_merge.py
+++ b/utilities/claude_hooks/guard_main_merge.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Claude Code PreToolUse hook guarding this repo's `main` from the agent's Bash tool.
+"""Claude Code PreToolUse hook guarding this repo's `main` from the agent's Bash tool and from
+the GitHub MCP.
 
 Blocks history-rewriting `git commit --amend`, merges / integrating pulls / direct pushes to
 `main`, and `gh pr merge`. Amend rewrites history — create a new commit instead. Integrating
 into main requires an explicit human/operator command run outside the agent's Bash tool, or a
 receipt a human wrote from chat authorizing one named pull request (see `consume_merge_allow`).
+
+The GitHub MCP reaches the same branch without a shell, so it is read too and answers to the same
+receipt — see `analyze_mcp`. Everything above analyzes a COMMAND; that half is untouched.
 
 Scope: the git-command guards apply only to invocations that operate on THIS repo — same
 `origin` as the session's project repo, which covers clones and worktrees. A `git -C <dir> …`
@@ -13,9 +17,9 @@ is exempt, unless the push destination itself names the guarded repo. Anything u
 an unexpanded `$dir`, `cd -`, a `cd` inside `( … )` / `{ … }` / a substitution, a dir with no
 origin — stays guarded: fail toward blocking.
 
-Wired in `.claude/settings.json` (PreToolUse, matcher Bash): reads the hook payload on stdin,
-exits 2 with a message on stderr to block, 0 to allow. Stdlib-only so it runs without the
-project venv.
+Wired in `.claude/settings.json` (PreToolUse, matcher `Bash|mcp__github__.*`): reads the hook
+payload on stdin, exits 2 with a message on stderr to block, 0 to allow. Stdlib-only so it runs
+without the project venv.
 """
 
 from __future__ import annotations
@@ -56,6 +60,20 @@ MERGE_EXPANSION_MSG = (
     ' into further arguments, which can select a repository the authorization never named.'
 )
 AMEND_MSG = 'BLOCKED: Never amend commits, create new ones instead.'
+MCP_MERGE_MSG = 'BLOCKED: {tool} is not allowed.' + DENY_TAIL + MERGE_ESCAPE
+MCP_UNNUMBERED_MSG = (
+    'BLOCKED: {tool} names no pull request — an authorization names one pull request, so a merge'
+    ' that names none can never match it.'
+)
+MCP_BRANCH_WRITE_MSG = (
+    'BLOCKED: {tool} commits straight onto `{branch}` of this repository. Put the change on a'
+    ' branch of its own and open a pull request.'
+)
+MCP_UNREADABLE_MSG = (
+    'BLOCKED: this GitHub MCP call could not be read, so the guard cannot tell whether it merges.'
+    ' Run the merge as `gh pr merge <number>` in Bash instead, where the command is read and a'
+    ' `!allow_merge <pr>` receipt applies.'
+)
 
 # git global options that consume the following argument in their space-separated form
 GIT_ARG_OPTS = {'-C', '-c', '--namespace', '--git-dir', '--work-tree', '--super-prefix', '--exec-path'}
@@ -69,6 +87,10 @@ GIT_DIR_REDIRECT_OPTS = ('--git-dir', '--work-tree', '--namespace')
 # Sentinel for a command-substitution word (`` `…` ``): its runtime value is unknown, so it
 # poisons whatever it appears in — a cd's target, a push's refspec.
 SUBST = '\x00subst'
+
+# The branch this repository lands work on, which is the branch both halves of the guard
+# protect. `MAIN_REF_RE` and `switches_to_main` spell it inside a pattern rather than reading it.
+GUARDED_BRANCH = 'main'
 
 # A word that names `main` as a push target or checkout target: `main`, `+main`, `HEAD:main`,
 # `origin/main`, `main:other` — but not `mainline` or `feature/main2`.
@@ -429,6 +451,77 @@ def consume_merge_allow(
     return True
 
 
+# The GitHub MCP puts this repository's `main` one tool call away, with no command for anything
+# above to read: `mcp__github__merge_pull_request` lands a pull request through the API, and
+# `push_files` and its siblings commit straight onto a named branch. Naming those tools would leave
+# the class open — the tool list is the MCP's to change, not ours — so membership is a SHAPE read
+# off the call rather than a list someone has to keep current:
+#
+#   * a call naming `branch` writes to that branch, so naming the guarded branch of the guarded
+#     repository is a direct commit onto `main` (`create_or_update_file`, `push_files` and
+#     `delete_file` today, and anything later spelling its target the same way);
+#   * a call whose tool name carries `merge` lands one branch on another, so it answers to the
+#     receipt `gh pr merge` answers to, spent through the same `consume_merge_allow`
+#     (`merge_pull_request` today).
+#
+# The shape errs toward refusing: a later READ tool with `merge` in its name is refused too, which
+# costs a message telling the caller to use the shell rather than a merge nobody authorized.
+#
+# Considered and left out, each because it cannot itself put a commit on `main`: `update_pull_request`
+# (its `base` decides where a merge WOULD land, and that merge is still gated), `update_pull_request_branch`
+# (writes the pull request's head, which is never its own base), `create_branch` (GitHub refuses to
+# create a branch that exists), and every read tool.
+GITHUB_MCP_PREFIX = 'mcp__github__'
+MERGE_VERB = 'merge'
+# The MCP's own argument names, which is how a call says what it acts on.
+MCP_OWNER = 'owner'
+MCP_REPO = 'repo'
+MCP_BRANCH = 'branch'
+MCP_PULL_NUMBER = 'pullNumber'
+
+
+def _mcp_slug(arguments: dict) -> str:
+    """`owner/repo` the call names, casefolded; '' when it names neither."""
+    owner, repo = str(arguments.get(MCP_OWNER) or ''), str(arguments.get(MCP_REPO) or '')
+    return f'{owner}/{repo}'.casefold() if owner and repo else ''
+
+
+def _mcp_pull_number(arguments: dict) -> int | None:
+    """The pull request the call names, or None when nothing it carries is one.
+
+    JSON has one number type, so an integral float is the same number written differently; a bool
+    is an int to Python and names no pull request.
+    """
+    number = arguments.get(MCP_PULL_NUMBER)
+    if isinstance(number, bool):
+        return None
+    if isinstance(number, int):
+        return number
+    if isinstance(number, float) and number.is_integer():
+        return int(number)
+    return int(number) if isinstance(number, str) and number.isdigit() else None
+
+
+def analyze_mcp(tool: str, arguments: dict, guarded_slug: str, allow_merge=consume_merge_allow) -> str | None:
+    """The deny message for a GitHub MCP call, or None to allow it."""
+    if not tool.startswith(GITHUB_MCP_PREFIX):
+        return None
+    guarded_slug, slug = guarded_slug.casefold(), _mcp_slug(arguments)
+    if MERGE_VERB in tool.removeprefix(GITHUB_MCP_PREFIX):
+        # Refused wherever it points, exactly as `gh pr merge` is: an authorization names one pull
+        # request of one repository, so a merge of anything else has nothing that could permit it.
+        # The authorization is consulted last, so a refusal on any other ground spends nothing.
+        number = _mcp_pull_number(arguments)
+        if number is None:
+            return MCP_UNNUMBERED_MSG.format(tool=tool)
+        if not guarded_slug or slug != guarded_slug or not allow_merge(number, guarded_slug):
+            return MCP_MERGE_MSG.format(tool=tool)
+        return None
+    if slug and slug == guarded_slug and str(arguments.get(MCP_BRANCH) or '') == GUARDED_BRANCH:
+        return MCP_BRANCH_WRITE_MSG.format(tool=tool, branch=GUARDED_BRANCH)
+    return None
+
+
 def _carries_substitution(cmd: str) -> bool:
     """Whether `cmd` carries a substitution, or quoting that cannot be read.
 
@@ -742,7 +835,7 @@ def analyze(  # noqa: C901
         return bool(slug) and slug != guarded_slug
 
     def on_main(inv_dir: str | None) -> bool:
-        return True if inv_dir is None else git.branch(inv_dir) == 'main'
+        return True if inv_dir is None else git.branch(inv_dir) == GUARDED_BRANCH
 
     def switches_to_main() -> bool:
         return any(
@@ -845,22 +938,45 @@ def _check_push_refspecs(rest: list[str], to_main: bool) -> str | None:
     return None
 
 
+def _refuse(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 2
+
+
 def main() -> int:
+    """The hook protocol: exit 2 with a message on stderr to refuse the call, 0 to allow it.
+
+    The two halves fail in opposite directions, deliberately. The command half is a LINT over text
+    a human still has to have typed, and it has always allowed what it could not read. The MCP half
+    is an AUTHORIZATION gate: nothing else stands between that call and `main`, so an answer it
+    cannot compute is a refusal, not a shrug. There is no environment kill switch for either — one
+    the agent can set is not a gate — so a guard that refuses wrongly is fixed here, in the file the
+    refusal names.
+    """
+    raw = sys.stdin.read()
     try:
-        payload = json.load(sys.stdin)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return 0
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        payload = None
+    if not isinstance(payload, dict):
+        # Which half this belonged to is exactly what cannot be read. A payload whose text names the
+        # GitHub MCP might carry a merge, so it is refused; anything else keeps the historical allow.
+        return _refuse(MCP_UNREADABLE_MSG) if GITHUB_MCP_PREFIX in raw else 0
+    git = GitInfo()
+    guarded_slug = repo_slug(git.origin_url(os.environ.get('CLAUDE_PROJECT_DIR') or os.getcwd()))
+    tool = hook_payload.tool_name(payload)
+    if tool.startswith(GITHUB_MCP_PREFIX):
+        try:
+            deny = analyze_mcp(tool, hook_payload.tool_input(payload), guarded_slug)
+        except Exception:  # noqa: BLE001 — a gate that crashes open is worse than one that refuses
+            deny = MCP_UNREADABLE_MSG
+        return _refuse(deny) if deny else 0
     cmd = hook_payload.command(payload)
     if not cmd:
         return 0
     cwd = payload.get(hook_payload.CWD) or os.getcwd()
-    git = GitInfo()
-    guarded_slug = repo_slug(git.origin_url(os.environ.get('CLAUDE_PROJECT_DIR') or os.getcwd()))
     deny = analyze(cmd, cwd, guarded_slug, git, gh_repo_env=os.environ.get(GH_REPO_ENV, ''))
-    if deny:
-        print(deny, file=sys.stderr)
-        return 2
-    return 0
+    return _refuse(deny) if deny else 0
 
 
 if __name__ == '__main__':

--- a/utilities/claude_hooks/hook_payload.py
+++ b/utilities/claude_hooks/hook_payload.py
@@ -7,6 +7,7 @@ project venv; the harness runs a hook by path, which puts this directory on `sys
 
 from __future__ import annotations
 
+TOOL_NAME = 'tool_name'
 TOOL_INPUT = 'tool_input'
 COMMAND = 'command'
 FILE_PATH = 'file_path'
@@ -19,6 +20,17 @@ PRE_TOOL_USE = 'PreToolUse'
 SESSION_START = 'SessionStart'
 
 
+def tool_name(payload: dict) -> str:
+    """The tool a call names, or '' when the payload names none."""
+    return str(payload.get(TOOL_NAME) or '')
+
+
+def tool_input(payload: dict) -> dict:
+    """The arguments a tool call carries, or {} when it carries none readable as arguments."""
+    arguments = payload.get(TOOL_INPUT)
+    return arguments if isinstance(arguments, dict) else {}
+
+
 def command(payload: dict) -> str:
     """The shell command a Bash tool call runs, or '' when the payload carries none."""
     return str((payload.get(TOOL_INPUT) or {}).get(COMMAND) or '')
@@ -26,8 +38,8 @@ def command(payload: dict) -> str:
 
 def target_path(payload: dict) -> str:
     """The file a write-shaped tool call targets, or '' when it names none."""
-    tool_input = payload.get(TOOL_INPUT) or {}
-    return str(tool_input.get(FILE_PATH) or tool_input.get(NOTEBOOK_PATH) or '')
+    arguments = payload.get(TOOL_INPUT) or {}
+    return str(arguments.get(FILE_PATH) or arguments.get(NOTEBOOK_PATH) or '')
 
 
 def additional_context(text: str, event: str) -> dict:

--- a/utilities/claude_hooks/tests/test_guard_main_merge.py
+++ b/utilities/claude_hooks/tests/test_guard_main_merge.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import subprocess
@@ -572,3 +573,164 @@ def test_end_to_end_subprocess(tmp_path):
     assert r.returncode == 2 and 'BLOCKED' in r.stderr
     assert run(f'cd {infra} && git push', clone).returncode == 0
     assert run('ls', clone).returncode == 0
+
+
+MERGE_TOOL = 'mcp__github__merge_pull_request'
+# The tools that reach a branch of this repository today. The guard reads a SHAPE rather than this
+# list — `test_a_later_tool_of_the_same_shape_is_caught_without_being_named` is what keeps the
+# enumeration exhaustive — but every one of them is pinned here as well, so a shape that stopped
+# covering one of them fails rather than going quiet.
+BRANCH_WRITE_TOOLS = ['mcp__github__create_or_update_file', 'mcp__github__push_files', 'mcp__github__delete_file']
+GUARDED_REPO_ARGS = {'owner': 'Positronic-Robotics', 'repo': 'positronic'}
+OTHER_REPO_ARGS = {'owner': 'someone', 'repo': 'agent_infra'}
+
+
+def mcp_verdict(tool, arguments, guarded=GUARDED, allow_merge=no_allow):
+    return gmm.analyze_mcp(tool, arguments, guarded, allow_merge=allow_merge)
+
+
+def merge_args(number=566, **overrides):
+    return {**GUARDED_REPO_ARGS, 'pullNumber': number, 'merge_method': 'squash', **overrides}
+
+
+def test_an_mcp_merge_without_an_authorization_is_refused():
+    assert mcp_verdict(MERGE_TOOL, merge_args()) is not None
+
+
+def test_an_authorized_mcp_merge_goes_through():
+    assert mcp_verdict(MERGE_TOOL, merge_args(), allow_merge=lambda number, slug: True) is None
+
+
+def test_the_mcp_asks_about_the_pull_request_being_merged():
+    asked = []
+    mcp_verdict(MERGE_TOOL, merge_args(571), allow_merge=lambda number, slug: asked.append((number, slug)) or True)
+    assert asked == [(571, GUARDED.casefold())]
+
+
+def test_both_halves_spend_one_authorization(tmp_path, as_root, git):
+    """The two paths do not each carry their own idea of what is authorized."""
+    write_allow(tmp_path, 566)
+
+    def allow(number, slug):
+        return gmm.consume_merge_allow(number, slug, tmp_path, tmp_path / 'spent', now=1_000_060)
+
+    assert mcp_verdict(MERGE_TOOL, merge_args(), allow_merge=allow) is None
+    assert verdict(git, 'gh pr merge 566', allow_merge=allow) is not None
+
+
+def test_an_mcp_merge_of_another_repository_is_refused_without_consulting_any_authorization():
+    def allow(number, slug):
+        raise AssertionError('the authorization must not be spent on a merge refused anyway')
+
+    assert mcp_verdict(MERGE_TOOL, {**OTHER_REPO_ARGS, 'pullNumber': 566}, allow_merge=allow) is not None
+
+
+@pytest.mark.parametrize('number', [None, 'abc', '', True, 1.5, {'n': 1}])
+def test_an_mcp_merge_naming_no_pull_request_says_to_name_one(number):
+    assert 'names no pull request' in mcp_verdict(MERGE_TOOL, merge_args(number))
+
+
+def test_a_pull_request_number_json_wrote_as_a_float_is_the_same_number():
+    assert mcp_verdict(MERGE_TOOL, merge_args(566.0), allow_merge=lambda number, slug: number == 566) is None
+
+
+def test_an_mcp_merge_whose_repository_cannot_be_established_is_refused():
+    assert mcp_verdict(MERGE_TOOL, {'pullNumber': 566}) is not None
+    assert mcp_verdict(MERGE_TOOL, merge_args(), guarded='') is not None
+
+
+@pytest.mark.parametrize('tool', BRANCH_WRITE_TOOLS)
+def test_an_mcp_commit_onto_main_is_refused(tool):
+    assert mcp_verdict(tool, {**GUARDED_REPO_ARGS, 'branch': 'main', 'message': 'm'}) is not None
+
+
+@pytest.mark.parametrize('tool', BRANCH_WRITE_TOOLS)
+def test_an_mcp_commit_onto_another_branch_is_untouched(tool):
+    assert mcp_verdict(tool, {**GUARDED_REPO_ARGS, 'branch': 'feature-x', 'message': 'm'}) is None
+
+
+@pytest.mark.parametrize('tool', BRANCH_WRITE_TOOLS)
+def test_another_repository_runs_its_own_branch_contract(tool):
+    assert mcp_verdict(tool, {**OTHER_REPO_ARGS, 'branch': 'main', 'message': 'm'}) is None
+
+
+def test_a_later_tool_of_the_same_shape_is_caught_without_being_named():
+    """The enumeration is a shape, so a tool the MCP grows tomorrow is guarded the day it appears."""
+    assert mcp_verdict('mcp__github__replace_branch_contents', {**GUARDED_REPO_ARGS, 'branch': 'main'}) is not None
+    assert mcp_verdict('mcp__github__merge_branch', {**GUARDED_REPO_ARGS, 'base': 'main'}) is not None
+
+
+@pytest.mark.parametrize(
+    'tool,arguments',
+    [
+        ('mcp__github__get_file_contents', {**GUARDED_REPO_ARGS, 'path': 'x'}),
+        ('mcp__github__list_pull_requests', GUARDED_REPO_ARGS),
+        ('mcp__github__create_pull_request', {**GUARDED_REPO_ARGS, 'base': 'main', 'head': 'feature-x'}),
+        ('mcp__github__update_pull_request_branch', {**GUARDED_REPO_ARGS, 'pullNumber': 566}),
+        ('mcp__tracker__create_ticket', {'title': 'merge the branch onto main'}),
+        ('Bash', {'command': 'gh pr merge 566'}),
+    ],
+)
+def test_a_call_that_cannot_land_a_commit_on_main_is_untouched(tool, arguments):
+    assert mcp_verdict(tool, arguments) is None
+
+
+def run_hook(payload, cwd, project_dir, script=None):
+    script = script or Path(__file__).resolve().parents[1] / 'guard_main_merge.py'
+    env = {**os.environ, 'CLAUDE_PROJECT_DIR': str(project_dir)}
+    body = payload if isinstance(payload, str) else json.dumps({**payload, 'cwd': str(cwd)})
+    return subprocess.run([sys.executable, str(script)], input=body, env=env, capture_output=True, text=True)
+
+
+@pytest.fixture
+def guarded_clone(tmp_path):
+    clone = tmp_path / 'positronic'
+    _init_repo(clone, POSITRONIC_URL)
+    return clone
+
+
+def test_the_mcp_merge_is_refused_end_to_end(guarded_clone):
+    """The hole this closes: the same merge the shell path refuses, arriving as a tool call."""
+    r = run_hook({'tool_name': MERGE_TOOL, 'tool_input': merge_args()}, guarded_clone, guarded_clone)
+    assert r.returncode == 2 and 'BLOCKED' in r.stderr and '!allow_merge' in r.stderr
+
+
+def test_an_mcp_commit_onto_main_is_refused_end_to_end(guarded_clone):
+    arguments = {**GUARDED_REPO_ARGS, 'branch': 'main', 'files': [{'path': 'x', 'content': 'y'}], 'message': 'm'}
+    r = run_hook({'tool_name': 'mcp__github__push_files', 'tool_input': arguments}, guarded_clone, guarded_clone)
+    assert r.returncode == 2 and 'BLOCKED' in r.stderr
+
+
+def test_an_mcp_read_is_allowed_end_to_end(guarded_clone):
+    arguments = {**GUARDED_REPO_ARGS, 'path': 'README.md'}
+    payload = {'tool_name': 'mcp__github__get_file_contents', 'tool_input': arguments}
+    assert run_hook(payload, guarded_clone, guarded_clone).returncode == 0
+
+
+@pytest.mark.parametrize('arguments,expected', [({'command': 'git push'}, 2), ({'command': 'ls'}, 0), ({}, 0)])
+def test_the_command_half_is_unchanged_end_to_end(arguments, expected, guarded_clone):
+    """A Bash payload decides exactly what it decided before the MCP half existed."""
+    payload = {'tool_name': 'Bash', 'tool_input': arguments}
+    assert run_hook(payload, guarded_clone, guarded_clone).returncode == expected
+
+
+@pytest.mark.parametrize(
+    'body,expected',
+    [
+        ('{not json', 0),
+        ('[]', 0),
+        ('{"tool_name": "mcp__github__merge_pull_request", "tool_input": {', 2),
+        ('null mcp__github__push_files', 2),
+    ],
+)
+def test_a_payload_the_guard_cannot_read_refuses_only_where_a_merge_could_hide(body, expected, guarded_clone):
+    assert run_hook(body, guarded_clone, guarded_clone).returncode == expected
+
+
+def test_a_gate_that_cannot_answer_refuses(monkeypatch, capsys, guarded_clone):
+    """An authorization gate fails CLOSED: a crash in it must not become an allow."""
+    monkeypatch.setattr(gmm, 'analyze_mcp', lambda *a, **k: 1 / 0)
+    monkeypatch.setenv('CLAUDE_PROJECT_DIR', str(guarded_clone))
+    monkeypatch.setattr('sys.stdin', io.StringIO(json.dumps({'tool_name': MERGE_TOOL, 'tool_input': merge_args()})))
+    assert gmm.main() == 2
+    assert 'BLOCKED' in capsys.readouterr().err


### PR DESCRIPTION
The merge guard reads a shell command. `gh pr merge 566` is refused unless a named human wrote a receipt from chat, and the same merge as `mcp__github__merge_pull_request` lands on `main` through the API with nothing in front of it — no receipt read, no spend mark, no record that it was unauthorized. The guard now reads GitHub MCP calls as well as commands, against the same `consume_merge_allow`, and `.claude/settings.json` matches `Bash|mcp__github__.*` so those calls reach it.

Membership is a shape read off the call rather than a list of tool names, because the tool list belongs to the MCP and not to us. A call naming `branch` writes to that branch, so naming `main` of this repository is a direct commit onto it; a tool whose name carries `merge` lands one branch on another, so it answers to the receipt. That covers `merge_pull_request`, `create_or_update_file`, `push_files` and `delete_file` today, and a tool the MCP grows tomorrow on the day it appears — `test_a_later_tool_of_the_same_shape_is_caught_without_being_named` is what keeps that true. Left out, each because it cannot itself put a commit on `main`: `update_pull_request` (its `base` decides where a merge would land, and that merge is still gated), `update_pull_request_branch` (writes the pull request's head, which is never its own base), `create_branch` (GitHub refuses to create a branch that exists), and every read tool.

The two halves fail in opposite directions, deliberately. The command half is a lint over text a human still has to type, and it has always allowed a payload it could not read; it is untouched. The MCP half is an authorization gate — nothing else stands between that call and `main` — so an answer it cannot compute is a refusal whose message names what to do instead. That covers a crash inside the analysis and a payload that is not readable JSON, which the guard previously answered by exiting 1 on an unhandled `AttributeError`. There is no environment kill switch, because one the agent can set is not a gate; a guard that refuses wrongly is fixed in the file its refusal names.

The scope of the two halves matches. A merge is refused wherever it points, exactly as `gh pr merge` is, since an authorization names one pull request of one repository; a branch write to another repository's `main` is that repository's own contract, exactly as `git push` from a different clone is.

Verification: `utilities/claude_hooks/tests/` passes, 171 tests. 19 new test functions add 40 cases, and every one was run against `main`'s guard first — 35 fail there, and the remaining 5 are must-not-change assertions correctly green on both sides. The two end-to-end merge cases fail on `main` with `assert (0 == 2)`, which is the hole itself. Six mutations of the new clauses were then applied to the fixed guard and each was caught: always-allow (17 failures), a merge that never consults the receipt (4), the branch-write clause removed (5), fail-open on an internal error (1), an unreadable payload allowed (2), and a merge ignoring which repository it targets (1). Wiring checked with the fleet's `test_hook_wiring.py` against this repo's settings (no swallowed exit status), the matcher checked to accept `Bash` and every `mcp__github__*` and nothing else, and the script driven through its wired command string against a real clone: MCP merge and MCP write-to-`main` exit 2, MCP write to a feature branch and MCP reads exit 0, `gh pr merge` and `ls` unchanged.

Not run: `/check-rules`, which needs a session in this repo — this change was authored from another checkout.

Refs: internal tracker 3b462b8d409f81689eaef13af662e017.
