### PR TITLE
Send a real rig's arms home when an episode closes

### DIFF
--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -14,6 +14,7 @@ import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
+from positronic.drivers.roboarm.command import Reset
 from positronic.drivers.roboarm.ik import assert_default_frame
 from positronic.eval import Embodiment, Task
 from positronic.policy.base import Policy
@@ -337,7 +338,7 @@ class Harness(pimm.ControlSystem):
         self.ds_command.emit(stop)
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
         # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
-        # last-value-wins would drop one) and before the home command, so homing stays out of the recording.
+        # last-value-wins would drop one) and before the reset below, so homing stays out of the recording.
         yield self._pace(clock)
         # After that round, so the recorder's STOP-time record.io span still parents to the episode. Skew: a
         # producer stepping in that shared round charges ≤ one control period to the closing episode.
@@ -374,14 +375,28 @@ class Harness(pimm.ControlSystem):
         self._deadline = clock.now() + budget if budget is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
+    def _reset_arms(self) -> None:
+        """Send every arm home, on a real rig only.
+
+        A powered arm holds the setpoint the policy left it at until the next trial readies it, a gap of
+        human length with the arm standing in the scene. A sim's arm is placed by the trial's prepare and
+        costs nothing in between.
+        """
+        if self._embodiment.simulated:
+            return
+        for name, emitter in self.commands.items():
+            if keys.is_robot_command(name):
+                emitter.emit(Reset())
+
     def _end_episode(self, clock: pimm.Clock, payload: dict[str, Any]) -> Generator[pimm.Command, None, None]:
-        """Close the live episode: finalize the recording, retire the session, hand the terminal back to
-        whoever asked for the episode.
+        """Close the live episode: finalize the recording, send the arms home, retire the session, hand the
+        terminal back to whoever asked for the episode.
 
         The worker is retired rather than joined here, so a ``RemoteSession``'s websocket outlives the call
         still using it.
         """
         yield from self._finalize_recording(clock, payload)
+        self._reset_arms()
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -338,7 +338,7 @@ class Harness(pimm.ControlSystem):
         self.ds_command.emit(stop)
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
         # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
-        # last-value-wins would drop one) and before the reset below, so homing stays out of the recording.
+        # last-value-wins would drop one) and before the home command, so homing stays out of the recording.
         yield self._pace(clock)
         # After that round, so the recorder's STOP-time record.io span still parents to the episode. Skew: a
         # producer stepping in that shared round charges ≤ one control period to the closing episode.
@@ -375,28 +375,16 @@ class Harness(pimm.ControlSystem):
         self._deadline = clock.now() + budget if budget is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
-    def _reset_arms(self) -> None:
-        """Send every arm home, on a real rig only.
-
-        A powered arm holds the setpoint the policy left it at until the next trial readies it, a gap of
-        human length with the arm standing in the scene. A sim's arm is placed by the trial's prepare and
-        costs nothing in between.
-        """
-        if self._embodiment.simulated:
-            return
-        for name, emitter in self.commands.items():
-            if keys.is_robot_command(name):
-                emitter.emit(Reset())
-
     def _end_episode(self, clock: pimm.Clock, payload: dict[str, Any]) -> Generator[pimm.Command, None, None]:
-        """Close the live episode: finalize the recording, send the arms home, retire the session, hand the
-        terminal back to whoever asked for the episode.
+        """Close the live episode: finalize the recording, retire the session, hand the terminal back to
+        whoever asked for the episode.
 
         The worker is retired rather than joined here, so a ``RemoteSession``'s websocket outlives the call
         still using it.
         """
         yield from self._finalize_recording(clock, payload)
-        self._reset_arms()
+        if not self._embodiment.simulated:  # a powered arm holds the policy's last setpoint until the next trial
+            self._emit({name: Reset() for name in self.commands if keys.is_robot_command(name)})
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1173,7 +1173,7 @@ class _LabeledRecorder(pimm.SignalEmitter):
 @pytest.mark.timeout(3.0)
 def test_finish_stops_playing_the_live_chunk(world):
     """Finishing drops the schedule the harness is playing: the chunk's remaining waypoints never reach the
-    devices, and the only command after the recorder's STOP is the reset the close emits."""
+    devices, and the only command after the recorder's STOP is the home the close emits."""
     policy = ChunkPolicy()
     wrapped = ActionTimestamp(fps=5.0).wrap(policy)  # 1.8 s chunk — won't drain before the episode ends
     harness = Harness(wrapped, make_embodiment())
@@ -1203,44 +1203,6 @@ def test_finish_stops_playing_the_live_chunk(world):
     assert stops, 'finishing did not emit STOP_EPISODE'
     grips_after = [data for lbl, data in events[stops[0] :] if lbl == keys.TARGET_GRIP]
     assert not grips_after, f'the cancelled chunk kept playing past the finish: {grips_after}'
-
-
-@pytest.mark.timeout(3.0)
-@pytest.mark.parametrize('simulated', [False, True])
-def test_a_closing_episode_sends_a_real_arm_home(world, simulated):
-    """A real episode ends on a ``Reset``, emitted after the recorder's STOP so the homing stays out of the
-    recording. A sim's arm is placed by the trial's prepare, so nothing is sent between episodes."""
-    harness = Harness(ChunkPolicy(), make_embodiment(simulated=simulated))
-    events: list[tuple[str, object]] = []
-    harness.commands[keys.ROBOT_COMMAND]._bind(_LabeledRecorder(keys.ROBOT_COMMAND, events))
-    harness.commands['target_grip']._bind(_LabeledRecorder('target_grip', events))
-    harness.ds_command._bind(_LabeledRecorder('ds_command', events))
-
-    frame_em = world.pair(harness.observations[CAM])
-    robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
-    grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
-    done_em = world.pair(harness.done)
-
-    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
-    script = [
-        (partial(perform_task, Task(instruction_source='t', timeout_sec=None)), 0.0),
-        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
-        (None, 0.1),
-        (partial(done_em.emit, OPERATOR_DONE), 0.0),
-        (None, 0.5),
-    ]
-    scheduler = world.start([harness, ManualDriver(script), _Pacer()])
-    drive_scheduler(scheduler, steps=400)
-
-    stops = [i for i, (_, data) in enumerate(events) if getattr(data, 'type', None) is DsWriterCommandType.STOP_EPISODE]
-    assert stops, 'the episode never ended'
-    resets = [i for i, (_, data) in enumerate(events) if isinstance(data, Reset)]
-    if simulated:
-        assert not resets, 'a sim arm is placed by the trial it opens, not by a command between episodes'
-    else:
-        assert resets == [len(events) - 1], 'the arm was not sent home as the last thing the episode did'
-        assert resets[0] > stops[0], 'the homing landed inside the recording'
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1173,7 +1173,7 @@ class _LabeledRecorder(pimm.SignalEmitter):
 @pytest.mark.timeout(3.0)
 def test_finish_stops_playing_the_live_chunk(world):
     """Finishing drops the schedule the harness is playing: the chunk's remaining waypoints never reach the
-    devices, and the only command after the recorder's STOP is the home the close emits."""
+    devices, and the only command after the recorder's STOP is the reset the close emits."""
     policy = ChunkPolicy()
     wrapped = ActionTimestamp(fps=5.0).wrap(policy)  # 1.8 s chunk — won't drain before the episode ends
     harness = Harness(wrapped, make_embodiment())
@@ -1203,6 +1203,44 @@ def test_finish_stops_playing_the_live_chunk(world):
     assert stops, 'finishing did not emit STOP_EPISODE'
     grips_after = [data for lbl, data in events[stops[0] :] if lbl == keys.TARGET_GRIP]
     assert not grips_after, f'the cancelled chunk kept playing past the finish: {grips_after}'
+
+
+@pytest.mark.timeout(3.0)
+@pytest.mark.parametrize('simulated', [False, True])
+def test_a_closing_episode_sends_a_real_arm_home(world, simulated):
+    """A real episode ends on a ``Reset``, emitted after the recorder's STOP so the homing stays out of the
+    recording. A sim's arm is placed by the trial's prepare, so nothing is sent between episodes."""
+    harness = Harness(ChunkPolicy(), make_embodiment(simulated=simulated))
+    events: list[tuple[str, object]] = []
+    harness.commands[keys.ROBOT_COMMAND]._bind(_LabeledRecorder(keys.ROBOT_COMMAND, events))
+    harness.commands['target_grip']._bind(_LabeledRecorder('target_grip', events))
+    harness.ds_command._bind(_LabeledRecorder('ds_command', events))
+
+    frame_em = world.pair(harness.observations[CAM])
+    robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
+    grip_em = world.pair(harness.observations[keys.GRIP])
+    perform_task = world.pair(harness.perform_task)
+    done_em = world.pair(harness.done)
+
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    script = [
+        (partial(perform_task, Task(instruction_source='t', timeout_sec=None)), 0.0),
+        (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.01),
+        (None, 0.1),
+        (partial(done_em.emit, OPERATOR_DONE), 0.0),
+        (None, 0.5),
+    ]
+    scheduler = world.start([harness, ManualDriver(script), _Pacer()])
+    drive_scheduler(scheduler, steps=400)
+
+    stops = [i for i, (_, data) in enumerate(events) if getattr(data, 'type', None) is DsWriterCommandType.STOP_EPISODE]
+    assert stops, 'the episode never ended'
+    resets = [i for i, (_, data) in enumerate(events) if isinstance(data, Reset)]
+    if simulated:
+        assert not resets, 'a sim arm is placed by the trial it opens, not by a command between episodes'
+    else:
+        assert resets == [len(events) - 1], 'the arm was not sent home as the last thing the episode did'
+        assert resets[0] > stops[0], 'the homing landed inside the recording'
 
 
 @pytest.mark.timeout(3.0)


### PR DESCRIPTION
The harness emits `roboarm.command.Reset` on every `robot_command` channel once an episode's
recording is stopped, so a powered arm does not hold the policy's last setpoint through the gap
to the next trial. A sim's arm is placed by that trial's prepare, so nothing is sent there.

The emit sits after `_finalize_recording`, which has already cleared the schedules and given the
recorder its round to commit the STOP: the homing stays out of the recording, and no leftover
waypoint overrides it. Channels are picked by `keys.is_robot_command`, so a bimanual rig homes
both arms. Gripper channels are untouched — YAM's driver opens its fingers on `Reset` itself.

Reviewer notes:

- This re-adds a pathway the roadmap in `positronic/eval.py` says should go (`command.Reset` goes:
  a robot is put home by the `prepare` call, not by a command on its stream). The roadmap line is
  left as it stands.
- Only the normal episode end homes. A trial that dies on an exception, or the world coming down
  mid-episode, leaves the arm where the policy left it; the drivers' own shutdown parks it.
- No test: the change was deliberately kept to the emit itself.