### PR TITLE
Let a refused move back log instead of ending the run

### DIFF
--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -14,7 +14,6 @@ import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
-from positronic.drivers.roboarm.command import Reset
 from positronic.drivers.roboarm.ik import assert_default_frame
 from positronic.eval import Embodiment, Task
 from positronic.policy.base import Policy
@@ -31,6 +30,16 @@ POLL_PERIOD_SEC = 0.01
 # How long a submitted call may take and still resolve within its round: a wrapper that skips inference
 # answers in microseconds, a real model call runs far past this and is throttled across rounds.
 SKIP_REPLY_SEC = 0.001
+
+
+def _releases_at_close(name: str) -> bool:
+    """Whether the thing ``name`` readies is one an ending episode lets go of.
+
+    Everything but the scene and the operator: those two SET UP the next trial, and asking them as one
+    ends would redraw the world the operator is about to score and send her to stage a tote she has not
+    scored yet. Written as an exclusion so a device kind nobody has added yet is released by default.
+    """
+    return name.split('.', 1)[0] not in (keys.SCENE, keys.HUMAN)
 
 
 class _InferenceWorker:
@@ -375,16 +384,38 @@ class Harness(pimm.ControlSystem):
         self._deadline = clock.now() + budget if budget is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
-    def _end_episode(self, clock: pimm.Clock, payload: dict[str, Any]) -> Generator[pimm.Command, None, None]:
-        """Close the live episode: finalize the recording, retire the session, hand the terminal back to
-        whoever asked for the episode.
+    def _release(self, should_stop: pimm.SignalReceiver) -> Generator[pimm.Command, None, None]:
+        """Put a real rig's devices back where a trial starts them, and wait for them to get there.
+
+        The same ask an episode opens on, so an arm that holds the policy's last setpoint and a hand that
+        holds what it gripped are both released the moment the episode is over rather than at the next
+        Start. Asked rather than emitted: a driver serves one move at a time, so a command left on the
+        stream races the next trial's ask for the same device.
+        """
+        args = self._task.prepare_args
+        ready = pimm.calls.all_of([
+            ask(args.get(name)) for name, ask in self.prepare.items() if _releases_at_close(name)
+        ])
+        while not ready.done() and not should_stop.value:
+            yield pimm.Sleep(POLL_PERIOD_SEC)
+        # Nothing to raise to at teardown: the World is coming down and each driver parks what it owns.
+        if ready.done():
+            ready.result()
+
+    def _end_episode(
+        self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]
+    ) -> Generator[pimm.Command, None, None]:
+        """Close the live episode: finalize the recording, release the rig, retire the session, hand the
+        terminal back to whoever asked for the episode.
 
         The worker is retired rather than joined here, so a ``RemoteSession``'s websocket outlives the call
         still using it.
         """
         yield from self._finalize_recording(clock, payload)
-        if not self._embodiment.simulated:  # a powered arm holds the policy's last setpoint until the next trial
-            self._emit({name: Reset() for name in self.commands if keys.is_robot_command(name)})
+        # A sim redraws its scene for the next trial, and its `prepare` is what does the redrawing — asking
+        # here would wipe the end state the operator is about to score.
+        if not self._embodiment.simulated:
+            yield from self._release(should_stop)
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None
@@ -396,11 +427,15 @@ class Harness(pimm.ControlSystem):
             self._call = None
 
     def _advance_episode(
-        self, worker: _InferenceWorker, done: pimm.Message[dict] | None, clock: pimm.Clock
+        self,
+        worker: _InferenceWorker,
+        done: pimm.Message[dict] | None,
+        clock: pimm.Clock,
+        should_stop: pimm.SignalReceiver,
     ) -> Generator[pimm.Command, None, None]:
         """One round of the live episode: end it if it is out of budget or done, else step the policy."""
         if (terminal := self._trial_terminal(done, clock)) is not None:
-            yield from self._end_episode(clock, terminal)
+            yield from self._end_episode(clock, should_stop, terminal)
         else:
             try:
                 self._step(worker, clock)
@@ -545,7 +580,7 @@ class Harness(pimm.ControlSystem):
             if self._worker is not None:
                 if call is not None:  # the live episode is the one that finishes; a second ask is refused
                     call.set_exception(RuntimeError('An episode is already running'))
-                yield from self._advance_episode(self._worker, done, clock)
+                yield from self._advance_episode(self._worker, done, clock, should_stop)
             elif call is not None:
                 yield from self._begin_episode(clock, should_stop, call)
             elif manual is not None:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -32,16 +32,6 @@ POLL_PERIOD_SEC = 0.01
 SKIP_REPLY_SEC = 0.001
 
 
-def _releases_at_close(name: str) -> bool:
-    """Whether the thing ``name`` readies is one an ending episode lets go of.
-
-    Everything but the scene and the operator: those two SET UP the next trial, and asking them as one
-    ends would redraw the world the operator is about to score and send her to stage a tote she has not
-    scored yet. Written as an exclusion so a device kind nobody has added yet is released by default.
-    """
-    return name.split('.', 1)[0] not in (keys.SCENE, keys.HUMAN)
-
-
 class _InferenceWorker:
     """One episode's policy session, called one at a time on a thread of its own so the harness keeps
     playing while the model runs.
@@ -384,6 +374,16 @@ class Harness(pimm.ControlSystem):
         self._deadline = clock.now() + budget if budget is not None else None
         self.ds_command.emit(DsWriterCommand.START())
 
+    @staticmethod
+    def _releases_at_close(name: str) -> bool:
+        """Whether the thing ``name`` readies is one an ending episode lets go of.
+
+        Everything but the scene and the operator: those two SET UP the next trial, and asking them as one
+        ends would redraw the world the operator is about to score and send her to stage a tote she has not
+        scored yet. Written as an exclusion so a device kind nobody has added yet is released by default.
+        """
+        return name.split('.', 1)[0] not in (keys.SCENE, keys.HUMAN)
+
     def _release(self, should_stop: pimm.SignalReceiver) -> Generator[pimm.Command, None, None]:
         """Put a real rig's devices back where a trial starts them, and wait for them to get there.
 
@@ -394,7 +394,7 @@ class Harness(pimm.ControlSystem):
         """
         args = self._task.prepare_args
         ready = pimm.calls.all_of([
-            ask(args.get(name)) for name, ask in self.prepare.items() if _releases_at_close(name)
+            ask(args.get(name)) for name, ask in self.prepare.items() if self._releases_at_close(name)
         ])
         while not ready.done() and not should_stop.value:
             yield pimm.Sleep(POLL_PERIOD_SEC)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -393,14 +393,17 @@ class Harness(pimm.ControlSystem):
         stream races the next trial's ask for the same device.
         """
         args = self._task.prepare_args
-        ready = pimm.calls.all_of([
-            ask(args.get(name)) for name, ask in self.prepare.items() if self._releases_at_close(name)
-        ])
+        asked = {name: ask(args.get(name)) for name, ask in self.prepare.items() if self._releases_at_close(name)}
+        ready = pimm.calls.all_of(asked.values())
         while not ready.done() and not should_stop.value:
             yield pimm.Sleep(POLL_PERIOD_SEC)
-        # Nothing to raise to at teardown: the World is coming down and each driver parks what it owns.
+        # rules-allow: swallowed-error — the World is coming down and each driver parks what it owns, so
+        # there is no caller left to raise to; the log is the only place a release cut short can go.
         if ready.done():
             ready.result()
+        else:
+            outstanding = sorted(name for name, answer in asked.items() if not answer.done())
+            logging.error(f'The world stopped before every device was released: {outstanding} did not answer')
 
     def _end_episode(
         self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -397,13 +397,18 @@ class Harness(pimm.ControlSystem):
         ready = pimm.calls.all_of(asked.values())
         while not ready.done() and not should_stop.value:
             yield pimm.Sleep(POLL_PERIOD_SEC)
-        # rules-allow: swallowed-error — the World is coming down and each driver parks what it owns, so
-        # there is no caller left to raise to; the log is the only place a release cut short can go.
-        if ready.done():
-            ready.result()
-        else:
+        # rules-allow: swallowed-error — a close clears the rig while the operator scores; it is a courtesy,
+        # not a correctness gate. The gate is the next episode's `prepare`, which raises on a rig still stuck
+        # and does so before anything is recorded, so a release that fails costs the run nothing. Raising
+        # here would let one reflex on the way home end a run with episodes left to play.
+        if not ready.done():
             outstanding = sorted(name for name, answer in asked.items() if not answer.done())
             logging.error(f'The world stopped before every device was released: {outstanding} did not answer')
+            return
+        try:
+            ready.result()
+        except Exception as exc:
+            logging.error(f'Releasing the rig after the episode ended failed: {exc}')
 
     def _end_episode(
         self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from collections import deque
 from collections.abc import Generator, Iterator
@@ -309,9 +310,13 @@ class Harness(pimm.ControlSystem):
     ) -> Generator[pimm.Command, None, None]:
         """Close the live episode: finalize the recording, put the rig back, return the terminal to the caller"""
         yield from self._finalize_recording(clock, payload)
-        yield from self._ready(  # Move robot back to ready state
-            should_stop, clock, {k: v for k, v in self._task.prepare_args.items() if k != eval_keys.SCENE}
-        )
+        back_args = {k: v for k, v in self._task.prepare_args.items() if k != eval_keys.SCENE}
+        # rules-allow: swallowed-error — the move back is cleanup, and the recording is already complete.
+        # A raise here costs the recorded episode its answer, and the run every episode it has left.
+        try:
+            yield from self._ready(should_stop, clock, back_args)  # Move robot back to ready state
+        except Exception as exc:
+            logging.error(f'The rig failed to go back after the episode: {exc}')
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -640,8 +640,8 @@ def test_a_closing_episode_releases_a_real_rig(world):
 
 @pytest.mark.timeout(3.0)
 def test_a_closing_episode_leaves_a_simulated_rig_where_it_stands(world):
-    """The boundary the case above rests on. A sim's readying is what DRAWS its next scene, so asking for
-    it at the close would wipe the end state the operator is about to score."""
+    """A sim's readying is what DRAWS its next scene, so asking for it at the close would wipe the end
+    state the operator is about to score."""
     asked: list[str] = []
     arm, hand = _devices(asked)
     handlers = {keys.ARM: arm.env_reset, keys.GRIPPER: hand.env_reset}
@@ -692,8 +692,8 @@ def test_a_release_that_fails_is_logged_and_leaves_the_run_playing(world, caplog
 
 @pytest.mark.timeout(3.0)
 def test_a_readying_that_fails_at_the_open_still_ends_the_run(world):
-    """The boundary the case above rests on. Tolerating a failed release must not tolerate a failed OPEN:
-    that one gates a rig too stuck to run, and it raises before the episode records anything."""
+    """Tolerating a failed release must not tolerate a failed OPEN: that one gates a rig too stuck to run,
+    and it raises before the episode has recorded anything."""
     arm = _Scene(_fails_from(1))
     harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
     p = _pair_all(world, harness)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -316,7 +316,7 @@ def test_harness_emits_cartesian_move(world):
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
-    harness.commands['target_grip']._bind(grip_recorder)
+    harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
     harness.ds_command._bind(RecordingEmitter())
 
     frame_em = world.pair(harness.observations[CAM])
@@ -476,7 +476,7 @@ def test_harness_waits_for_complete_inputs(world):
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
-    harness.commands['target_grip']._bind(grip_recorder)
+    harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
     harness.ds_command._bind(RecordingEmitter())
 
     frame_em = world.pair(harness.observations[CAM])
@@ -606,6 +606,55 @@ def test_finish_emits_ds_stop_with_data(world):
     assert len(stops) == 1
     assert stops[0].static_data['outcome'] == 'Success'
     assert stops[0].static_data['notes'] == 'good'
+
+
+def _devices(asked: list[str]) -> tuple[_Scene, _Scene]:
+    """An arm and a hand that answer a readying ask, each recording that it was asked."""
+    return _Scene(lambda _r: asked.append(keys.ARM)), _Scene(lambda _r: asked.append(keys.GRIPPER))
+
+
+@pytest.mark.timeout(3.0)
+def test_a_closing_episode_releases_a_real_rig(world):
+    """A powered rig holds the policy's last setpoint until something else says otherwise: an arm left in
+    the tote stays there, and a hand stays shut on what it gripped. The close asks for the same readying
+    the open does, so the rig is clear while the operator scores rather than at the next Start."""
+    asked: list[str] = []
+    arm, hand = _devices(asked)
+    handlers = {keys.ARM: arm.env_reset, keys.GRIPPER: hand.env_reset}
+    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers=handlers))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+    wire_call(world, harness.prepare[keys.GRIPPER], hand.env_reset)
+
+    scheduler = world.start([harness, arm, hand])
+    p['perform_task'](Task(instruction_source='test', timeout_sec=None))
+    drive_scheduler(scheduler, steps=40)
+    assert sorted(asked) == [keys.ARM, keys.GRIPPER], 'the open readies both devices'
+
+    p['done_em'].emit({keys.EVAL_SUCCESS: True})
+    drive_scheduler(scheduler, steps=40)
+    assert sorted(asked[2:]) == [keys.ARM, keys.GRIPPER], 'and so does the close'
+
+
+@pytest.mark.timeout(3.0)
+def test_a_closing_episode_leaves_a_simulated_rig_where_it_stands(world):
+    """The boundary the case above rests on. A sim's readying is what DRAWS its next scene, so asking for
+    it at the close would wipe the end state the operator is about to score."""
+    asked: list[str] = []
+    arm, hand = _devices(asked)
+    handlers = {keys.ARM: arm.env_reset, keys.GRIPPER: hand.env_reset}
+    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers=handlers, simulated=True))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+    wire_call(world, harness.prepare[keys.GRIPPER], hand.env_reset)
+
+    scheduler = world.start([harness, arm, hand])
+    p['perform_task'](Task(instruction_source='test', timeout_sec=None))
+    drive_scheduler(scheduler, steps=40)
+    p['done_em'].emit({keys.EVAL_SUCCESS: True})
+    drive_scheduler(scheduler, steps=40)
+
+    assert sorted(asked) == [keys.ARM, keys.GRIPPER], 'the open readied them once, and the close not again'
 
 
 @pytest.mark.timeout(3.0)
@@ -953,7 +1002,7 @@ def test_timeout_during_inference_drops_the_chunk(world):
     grip_recorder = RecordingEmitter()
     ds_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
-    harness.commands['target_grip']._bind(grip_recorder)
+    harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
     harness.ds_command._bind(ds_recorder)
 
     frame_em = world.pair(harness.observations[CAM])
@@ -1222,7 +1271,7 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
-    harness.commands['target_grip']._bind(grip_recorder)
+    harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
     harness.ds_command._bind(RecordingEmitter())
 
     frame_em = world.pair(harness.observations[CAM])

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1,3 +1,5 @@
+import itertools
+import logging
 import threading
 import time
 from contextlib import contextmanager
@@ -655,6 +657,53 @@ def test_a_closing_episode_leaves_a_simulated_rig_where_it_stands(world):
     drive_scheduler(scheduler, steps=40)
 
     assert sorted(asked) == [keys.ARM, keys.GRIPPER], 'the open readied them once, and the close not again'
+
+
+def _fails_from(nth: int):
+    """A readying that answers normally until the ``nth`` ask, then fails the way an aborted move does."""
+    asks = itertools.count(1)
+
+    def ready(_request):
+        if next(asks) >= nth:
+            raise RuntimeError('motion aborted by reflex!')
+
+    return ready
+
+
+@pytest.mark.timeout(3.0)
+def test_a_release_that_fails_is_logged_and_leaves_the_run_playing(world, caplog):
+    """A reflex on the way home aborts the move and fails the release. The episode is still answered and the
+    run plays on: a close clears the rig for the operator, and the next open is what gates a stuck rig."""
+    arm = _Scene(_fails_from(2))  # the open readies it, the close is the ask that trips
+    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, arm])
+    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
+    drive_scheduler(scheduler, steps=40)
+    with caplog.at_level(logging.ERROR):
+        p['done_em'].emit({keys.EVAL_SUCCESS: True})
+        drive_scheduler(scheduler, steps=40)
+
+    assert answer.done() and answer.result()[keys.EVAL_SUCCESS] is True, 'the episode was answered'
+    assert 'motion aborted by reflex!' in caplog.text, 'and the failure reached the log'
+
+
+@pytest.mark.timeout(3.0)
+def test_a_readying_that_fails_at_the_open_still_ends_the_run(world):
+    """The boundary the case above rests on. Tolerating a failed release must not tolerate a failed OPEN:
+    that one gates a rig too stuck to run, and it raises before the episode records anything."""
+    arm = _Scene(_fails_from(1))
+    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
+    p = _pair_all(world, harness)
+    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, arm])
+    p['perform_task'](Task(instruction_source='test', timeout_sec=None))
+
+    with pytest.raises(RuntimeError, match='motion aborted by reflex!'):
+        drive_scheduler(scheduler, steps=40)
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import re
 import threading
 import time
 from contextlib import contextmanager
@@ -659,13 +660,18 @@ def test_a_closing_episode_leaves_a_simulated_rig_where_it_stands(world):
     assert sorted(asked) == [keys.ARM, keys.GRIPPER], 'the open readied them once, and the close not again'
 
 
+# What a reflex trip reads like when it aborts a move: raised by the readying below, asserted by both
+# tests that drive it.
+ABORTED_BY_REFLEX = 'motion aborted by reflex!'
+
+
 def _fails_from(nth: int):
     """A readying that answers normally until the ``nth`` ask, then fails the way an aborted move does."""
     asks = itertools.count(1)
 
     def ready(_request):
         if next(asks) >= nth:
-            raise RuntimeError('motion aborted by reflex!')
+            raise RuntimeError(ABORTED_BY_REFLEX)
 
     return ready
 
@@ -687,7 +693,7 @@ def test_a_release_that_fails_is_logged_and_leaves_the_run_playing(world, caplog
         drive_scheduler(scheduler, steps=40)
 
     assert answer.done() and answer.result()[keys.EVAL_SUCCESS] is True, 'the episode was answered'
-    assert 'motion aborted by reflex!' in caplog.text, 'and the failure reached the log'
+    assert ABORTED_BY_REFLEX in caplog.text, 'and the failure reached the log'
 
 
 @pytest.mark.timeout(3.0)
@@ -702,7 +708,7 @@ def test_a_readying_that_fails_at_the_open_still_ends_the_run(world):
     scheduler = world.start([harness, arm])
     p['perform_task'](Task(instruction_source='test', timeout_sec=None))
 
-    with pytest.raises(RuntimeError, match='motion aborted by reflex!'):
+    with pytest.raises(RuntimeError, match=re.escape(ABORTED_BY_REFLEX)):
         drive_scheduler(scheduler, steps=40)
 
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1052,6 +1052,69 @@ def test_a_trial_does_not_end_until_the_rig_is_back_where_it_started(world):
     assert not answer.done(), 'the terminal landed while the return move was still in hand'
 
 
+# libfranka's message when a reflex aborts a move.
+REFUSED_ASK_DIAGNOSTIC = 'motion aborted by reflex'
+
+
+class _FailsNthAsk(pimm.ControlSystem):
+    """A device that answers every ask except the ``nth``, which it fails the way an aborted move does."""
+
+    def __init__(self, nth: int):
+        self.env_reset = pimm.calls.ControlSystemHandler[Any, None](self)
+        self._nth = nth
+        self.asks = 0
+
+    def run(self, should_stop, clock):
+        while not should_stop.value:
+            for call in self.env_reset.incoming():
+                self.asks += 1
+                if self.asks == self._nth:
+                    call.set_exception(RuntimeError(REFUSED_ASK_DIAGNOSTIC))
+                else:
+                    call.set_result(None)
+            yield pimm.Sleep(0.001)
+
+
+@pytest.mark.timeout(3.0)
+def test_a_refused_move_back_leaves_the_run_playing(world):
+    """The episode is already recorded, so a move back the rig refuses is logged and not raised. The run
+    answers the episode and plays the episodes it has left."""
+    arm = _FailsNthAsk(2)  # the second ask is the close; the first opened the episode
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.ARM: arm.env_reset}))
+    p = _pair_all(world, harness, policy)
+    wire_call(world, harness.prepare[eval_keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, arm, _Pacer()])
+    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.ARM: JointPosition(np.zeros(7))})
+    answer = p['perform_task'](task)
+    drive_scheduler(scheduler, steps=2000)
+
+    assert arm.asks == 2, 'the rig was never asked to go back, so nothing was under test'
+    assert answer.done(), 'the refused move back ended the run instead of being logged'
+    answer.result()  # whoever asked reads a clean episode
+
+
+@pytest.mark.timeout(3.0)
+def test_a_rig_that_refuses_to_open_still_ends_the_run(world):
+    """An episode must not record on a rig that never got ready. A refused opening ask ends the run, and
+    whoever asked hears the failure."""
+    arm = _FailsNthAsk(1)  # the first ask is the open
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.ARM: arm.env_reset}))
+    p = _pair_all(world, harness, policy)
+    wire_call(world, harness.prepare[eval_keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, arm, _Pacer()])
+    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.ARM: JointPosition(np.zeros(7))})
+    answer = p['perform_task'](task)
+
+    with pytest.raises(RuntimeError, match=REFUSED_ASK_DIAGNOSTIC):
+        drive_scheduler(scheduler, steps=2000)
+    with pytest.raises(RuntimeError):
+        answer.result()
+
+
 def test_the_deadline_is_published_once_the_rig_is_ready(world):
     """An idle harness publishes nothing: ``deadline_ns`` states the instant the harness will stop at, and
     between episodes there is none to state. The first one goes out when the episode's prepare has


### PR DESCRIPTION
A `cartesian_reflex` in the move that closes an episode ends the whole run. `blind_20260824-122151` died at episode 8's close on `libfranka: Move command aborted: motion aborted by reflex!`, with episodes left to play.

## What

The move that puts the rig back after an episode logs a failure instead of raising it. The episode is already recorded, so the harness answers it and plays the episodes it has left. A refused *opening* ask still ends the run, because an episode must not record on a rig that never got ready.

## Why

The close is a courtesy that clears the rig while the operator scores. The gate on a rig too stuck to run is the next episode's opening `prepare`, which refuses before anything is recorded. Raising in the close costs the run for a fault that later ask already catches.

## Verification

`positronic/policy`: 248 pass on main at `5fc7e22e`. The pair pins the asymmetry. `test_a_refused_move_back_leaves_the_run_playing` fails without the change, with the reflex propagating exactly as it did on the rig. `test_a_rig_that_refuses_to_open_still_ends_the_run` passes either way, which makes it the boundary rather than a copy.

## Refs

Positronic-Robotics/internal#620. positronic#653 was the upstream retry that would have stopped a reflex ending a home at all. It was closed in favour of homing in impedance mode, and this guard stops a reflex costing a run meanwhile.

<!-- opened-by: posi-agent -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ENGhJnNtBiNhgMYfS79t1
