### PR TITLE
Rename `PolicyWrapper` to `Layer` and `wrap_session` to `make_session`

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5388,7 +5388,7 @@
                 }
             }
         ],
-        "./positronic/policy/tests/test_wrappers.py": [
+        "./positronic/policy/tests/test_layers.py": [
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,20 +116,20 @@ control system its clock, and no component reads time at point of use. Trajector
 the same time frame the observations carry, so a virtual clock, a slowed sim, or a replayed episode
 changes nothing downstream.
 
-**The wrapper owns the plan, the harness plays it, the driver executes.** A policy speaks in
+**The layer owns the plan, the harness plays it, the driver executes.** A policy speaks in
 trajectories — waypoints with absolute timestamps — because a model predicts a horizon, not an
 instant. But a trajectory on the wire makes every driver buffer the future, and makes the recording
 guess which prefix of that buffer actually ran. So the plan stops at the harness: a command channel
 carries the single command due at the moment it is emitted, the driver executes the latest one and
 holds otherwise, and emission time *is* execution time. Continuous-update schemes (RTC, temporal
-ensembling) therefore need no special mechanism: they are wrappers that hand back a new trajectory
+ensembling) therefore need no special mechanism: they are layers that hand back a new trajectory
 more often, and the harness keeps playing the old one until they do.
 
 **The harness stays thin.** It is the one layer standing between any policy and any embodiment, so
 anything it encodes about either side breaks the any-to-any goal. It assembles the observation
 dict, calls the session, plays the returned trajectory one command per channel per round, and runs
 episode lifecycle — nothing else. Scheduling, blending, history stacking and error recovery live in
-the wrapper stack around the policy; a session returning `None` means "keep executing the current
+the layer stack around the policy; a session returning `None` means "keep executing the current
 trajectory".
 
 **Inference cost is a fact of the trial, owned by the harness.** A call costs the trial either the
@@ -138,7 +138,7 @@ and a real rig pays it regardless. Only the harness reads the flag. Paying nothi
 world for the call, which holds a virtual clock still; paying wall time means letting the world run,
 though no further ahead of the call's start than wall time has. The clock the harness hands the
 policy stack (`now`) reads the instant the in-flight call's output takes effect, so a scheduling
-wrapper stamps its chunk at `now()` and never learns the mode.
+layer stamps its chunk at `now()` and never learns the mode.
 
 **Recordings are canonical; codecs bind the dialect late.** The dataset records every run in the
 canonical conventions (frames, key names, absolute time) — never in a model's dialect. Every

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -86,7 +86,7 @@ Four small concepts make up the API. You meet them whether you use a built-in se
 
 **Codec.** Different models want different inputs: end-effector pose vs joint angles, absolute targets vs deltas, 224×224 vs 512×512 images. A `Codec` translates between the robot's raw data (what is on the wire) and your model's format — `encode` on the way in, `decode` on the way out. The same codec prepares the training data, so a model is served exactly the way it was trained. The full catalog is in the [Codecs Guide](codecs.md).
 
-**Wrapper.** A `PolicyWrapper` is the swappable client-side logic from the previous section — scheduling, error recovery, recording. Wrappers compose with `|` and wrap a policy, so you can change *how* latency is handled without touching the model. A policy pipeline names the wrappers together with the codec as one chain split by the `remote` marker and closed by a *model source* — the server-side terminal that loads the model (`local | remote | codec | source`, see `positronic.policy.spec`). The server declares the local half in its handshake and the client builds it, so both halves ship as one pipeline.
+**Layer.** A `Layer` is the swappable client-side logic from the previous section — scheduling, error recovery, recording. Layers compose with `|` and wrap a policy, so you can change *how* latency is handled without touching the model. A policy pipeline names the layers together with the codec as one chain split by the `remote` marker and closed by a *model source* — the server-side terminal that loads the model (`local | remote | codec | source`, see `positronic.policy.spec`). The server declares the local half in its handshake and the client builds it, so both halves ship as one pipeline.
 
 ## The wire format
 
@@ -113,7 +113,7 @@ Your server receives every key each step. An arm that is faulted or busy still r
 
 ### Actions (server → client)
 
-The normal response is a list of action dicts — a short trajectory. (A single action dict is also valid; what matters is that the client-side wrappers and the server, taken together, produce actions carrying the fields below.)
+The normal response is a list of action dicts — a short trajectory. (A single action dict is also valid; what matters is that the client-side layers and the server, taken together, produce actions carrying the fields below.)
 
 ```python
 {"result": [
@@ -153,7 +153,7 @@ A rig with more than one arm names every channel after the arm that owns it: obs
 
 ## Debugging with recordings
 
-When a run doesn't produce the result you expected, it helps to record exactly what crossed the boundaries between the robot, the codec, and the model. Recording is itself a policy wrapper — `Recorder` in [`positronic/policy/recording.py`](../positronic/policy/recording.py) — that taps into any client pipeline; the built-in servers expose it via `--recording_dir`. It writes one [rerun](https://rerun.io) file per episode with two layers:
+When a run doesn't produce the result you expected, it helps to record exactly what crossed the boundaries between the robot, the codec, and the model. Recording is itself a policy layer — `Recorder` in [`positronic/policy/recording.py`](../positronic/policy/recording.py) — that taps into any client pipeline; the built-in servers expose it via `--recording_dir`. It writes one [rerun](https://rerun.io) file per episode with two layers:
 
 - **`raw`** — the observation and the action as they cross the wire.
 - **`inference`** — the same episode *after* the codec: the encoded observation the model received and the raw actions it produced.
@@ -175,7 +175,7 @@ from positronic.drivers.roboarm import command
 from positronic.offboard import PolicyServer
 from positronic.policy import Policy, Session
 from positronic.policy.spec import PolicySource, remote
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 
 
 class MySession(Session):
@@ -212,9 +212,9 @@ PolicyServer(pipeline, host='0.0.0.0', port=8000).serve()
 
 The pipeline reads left to right: everything left of the `remote` marker is the client-side stack the server declares in its handshake (here the standard `StopOnFault` and `ChunkedSchedule`); everything right of it runs on the server. `PolicySource` is the pipeline's terminal — a model source that serves one already-built policy.
 
-The left side is not optional: a pipeline with nothing there is refused when the server starts, and a rig refuses a handshake that declares nothing. It needs a scheduler in particular, and `StopOnFault` outside that scheduler — an arm that is faulted or busy is not taking the plan it was given, so the wrapper answers the empty trajectory and the rig stops rather than resuming a chunk stamped before. Actions come back timestamped relative to their chunk, and `ChunkedSchedule` is what turns those into times on the rig's clock; a stack that leaves them relative — or anchors them twice — makes the harness reject the chunk at the first inference, since it schedules nothing more than `MAX_ACTION_SKEW_SEC` from now.
+The left side is not optional: a pipeline with nothing there is refused when the server starts, and a rig refuses a handshake that declares nothing. It needs a scheduler in particular, and `StopOnFault` outside that scheduler — an arm that is faulted or busy is not taking the plan it was given, so the layer answers the empty trajectory and the rig stops rather than resuming a chunk stamped before. Actions come back timestamped relative to their chunk, and `ChunkedSchedule` is what turns those into times on the rig's clock; a stack that leaves them relative — or anchors them twice — makes the harness reject the chunk at the first inference, since it schedules nothing more than `MAX_ACTION_SKEW_SEC` from now.
 
-`new_session`'s `now` argument is the runtime clock that wrappers scheduling against live time read; a policy that does no scheduling of its own just accepts and ignores it (server-side it is `None`).
+`new_session`'s `now` argument is the runtime clock that layers scheduling against live time read; a policy that does no scheduling of its own just accepts and ignores it (server-side it is `None`).
 
 If you put a `Codec` right of the marker (`ChunkedSchedule() | remote | codec | PolicySource(...)`), your session works entirely in *model space* — it receives encoded observations and returns model-native actions, and the codec handles the wire format. A codec that encodes images should also bound them on the rig, so full-resolution frames never cross the wire — that is what the built-in vendor pipelines do:
 

--- a/positronic/cfg/layers.py
+++ b/positronic/cfg/layers.py
@@ -1,7 +1,7 @@
 import configuronic as cfn
 
 from positronic import keys as obs_keys
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault, TemporalStack
+from positronic.policy.layers import ChunkedSchedule, StopOnFault, TemporalStack
 
 chunked_schedule = cfn.Config(ChunkedSchedule)
 temporal_stack = cfn.Config(TemporalStack)
@@ -28,7 +28,7 @@ def _frame_offsets_sec(history_frames: int, stride: int, fps: float) -> tuple[fl
 @cfn.config(
     keys=(obs_keys.WRIST_IMAGE, obs_keys.EXTERIOR_IMAGE, obs_keys.EE_POSE, obs_keys.GRIP), fps=15.0, pad_start=True
 )
-def video_context_wrappers(history_frames: int, stride: int, keys: tuple[str, ...], fps: float, pad_start: bool):
+def video_context_layers(history_frames: int, stride: int, keys: tuple[str, ...], fps: float, pad_start: bool):
     """The pipeline's local half for video-conditioned policies: strided temporal context, scheduling.
 
     The temporal stack sits outside the scheduler so it records the named ``keys`` every control tick and

--- a/positronic/offboard/README.md
+++ b/positronic/offboard/README.md
@@ -110,7 +110,7 @@ This metadata tells the client:
 - `local_stack` — the declared local half of the policy pipeline: a spec tree of `{"name", "args"}`
   leaves composed by `"seq"` (the `|` operator) and `"par"` (the `&` operator). `RemotePolicy` builds
   this stack in front of the connection, resolving names only against the closed vocabulary in
-  `positronic.policy.spec.WIRE_WRAPPERS` — an unknown entry fails at connect, before the robot moves.
+  `positronic.policy.spec.WIRE_LAYERS` — an unknown entry fails at connect, before the robot moves.
   Never empty and never absent: a pipeline with nothing left of the marker is refused when the server
   starts, and a handshake declaring nothing is refused by the client. In practice it names at least a
   `chunked_schedule`, which turns the chunk-relative timestamps a codec stamps into times on the rig's
@@ -209,12 +209,12 @@ uv run positronic-inference sim \
 ## Classes
 
 ### `server.PolicyServer`
-The one server implementation behind every vendor. It serves a **policy pipeline** (see `positronic.policy.spec`): a wrapper chain with a `remote` marker, closed by a `ModelSource` terminal. The half right of the marker wraps the model on the server; the half left of it is declared as `local_stack` in the ready handshake for the client to build. The source is the only model loader: `get_models()` backs `/api/v1/models`, `resolve()` maps a requested id (or the default), and `load(model_id, on_progress)` produces the `Policy` — with `on_progress` messages streamed to the connecting client as `loading` status messages.
+The one server implementation behind every vendor. It serves a **policy pipeline** (see `positronic.policy.spec`): a layer chain with a `remote` marker, closed by a `ModelSource` terminal. The half right of the marker wraps the model on the server; the half left of it is declared as `local_stack` in the ready handshake for the client to build. The source is the only model loader: `get_models()` backs `/api/v1/models`, `resolve()` maps a requested id (or the default), and `load(model_id, on_progress)` produces the `Policy` — with `on_progress` messages streamed to the connecting client as `loading` status messages.
 
 ```python
 from positronic.offboard import PolicyServer
 from positronic.policy.spec import PolicySource, remote
-from positronic.policy.wrappers import ChunkedSchedule
+from positronic.policy.layers import ChunkedSchedule
 
 pipeline = ChunkedSchedule() | remote | PolicySource(my_policy)
 PolicyServer(pipeline, host='0.0.0.0', port=8000).serve()

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -19,7 +19,7 @@ from starlette.datastructures import QueryParams
 
 from positronic import keys
 from positronic.policy import Policy, Recorder
-from positronic.policy.base import PolicyWrapper
+from positronic.policy.base import Layer
 from positronic.policy.spec import ModelSource, Pipeline, split
 
 from . import protocol
@@ -168,18 +168,18 @@ def _session_params(query_params: QueryParams) -> dict[str, Any]:
     return {key: _literal_value(raw) for key, raw in items}
 
 
-def _declared_stack(local: PolicyWrapper | None) -> dict[str, Any]:
+def _declared_stack(local: Layer | None) -> dict[str, Any]:
     """The rig-side spec a served pipeline must publish."""
     if local is None:
         raise ValueError(
             'Nothing sits left of the `remote` marker, so the pipeline declares no rig-side stack. Put the '
-            'wrappers the rig runs there, starting with a scheduler such as ChunkedSchedule'
+            'layers the rig runs there, starting with a scheduler such as ChunkedSchedule'
         )
     return local.to_spec()
 
 
 class PolicyServer:
-    """Serves a policy pipeline: one wrapper chain with a ``remote`` marker, closed by a ``ModelSource``
+    """Serves a policy pipeline: one layer chain with a ``remote`` marker, closed by a ``ModelSource``
     (see ``positronic.policy.spec``).
 
     The half right of the marker wraps the model here; the half left of it is published as the

--- a/positronic/offboard/tests/conftest.py
+++ b/positronic/offboard/tests/conftest.py
@@ -10,8 +10,8 @@ import uvicorn
 
 from positronic.offboard.server import PolicyServer
 from positronic.policy import Policy
+from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.spec import ModelSource, PolicySource, remote
-from positronic.policy.wrappers import ChunkedSchedule
 
 
 def _find_free_port() -> int:

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -13,9 +13,9 @@ from positronic.drivers.roboarm import command
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _ConnectRetries
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
+from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.remote import RemoteSession
 from positronic.policy.spec import PolicySource, remote
-from positronic.policy.wrappers import ChunkedSchedule
 
 # These fixtures stand in for a server, so they spell the handshake fields rather than importing the
 # ``keys`` constants the client reads: sharing a constant makes the two agree whatever its value, which
@@ -318,8 +318,8 @@ def test_remote_session_passes_through_none():
     assert session({}) is None
 
 
-def test_records_infer_span_without_scheduling_wrapper(tmp_path):
-    """The ``policy.infer`` span is recorded at the remote inference boundary itself, not by a wrapper in
+def test_records_infer_span_without_scheduling_layer(tmp_path):
+    """The ``policy.infer`` span is recorded at the remote inference boundary itself, not by a layer in
     front of it."""
     endpoint, _ = _mock_endpoint(infer_return=[{'a': 1, 'timestamp': 0.0}])
     session = endpoint.new_session()

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -19,8 +19,8 @@ from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer
 from positronic.offboard.server_utils import warmup
 from positronic.policy import Codec, Policy, RemotePolicy, Session
 from positronic.policy.codec import ActionTimestamp
+from positronic.policy.layers import ChunkedSchedule, TemporalStack
 from positronic.policy.spec import ModelSource, PolicySource, inline, remote
-from positronic.policy.wrappers import ChunkedSchedule, TemporalStack
 
 
 class _StubSource(ModelSource):

--- a/positronic/policy/__init__.py
+++ b/positronic/policy/__init__.py
@@ -1,4 +1,4 @@
-from .base import DelegatingPolicy, DelegatingSession, Policy, PolicyWrapper, Session
+from .base import DelegatingPolicy, DelegatingSession, Layer, Policy, Session
 from .codec import ActionHorizon, ActionTimestamp, ActionTiming, Codec, is_action
 from .recording import Recorder
 from .remote import RemotePolicy
@@ -8,7 +8,7 @@ __all__ = [
     'Session',
     'DelegatingPolicy',
     'DelegatingSession',
-    'PolicyWrapper',
+    'Layer',
     'RemotePolicy',
     'Codec',
     'ActionTimestamp',

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -26,7 +26,7 @@ class Session(ABC):
     (dicts, lists, numpy arrays, scalars). No tensors or custom objects.
 
     **Return contract**: ``list[dict] | None``. ``None`` means "no new
-    trajectory, keep executing the current one" (used by scheduling wrappers).
+    trajectory, keep executing the current one" (used by scheduling layers).
     An empty list means "stop whatever is executing now". A non-empty list is
     a new trajectory. Single-action returns must be wrapped into a 1-element
     list by the producer.
@@ -42,7 +42,7 @@ class Session(ABC):
         return {}
 
     def cancel(self):
-        """Drop any in-flight trajectory state. Wrappers that buffer/schedule a
+        """Drop any in-flight trajectory state. Layers that buffer/schedule a
         trajectory (e.g. ``ChunkedSchedule``) should reset so the next call
         triggers a fresh inference. Override and propagate via ``super().cancel()``.
         """
@@ -117,85 +117,85 @@ class DelegatingPolicy(Policy):
         self._inner.close()
 
 
-class PolicyWrapper:
-    """Composable wrapper recipe — created without an inner policy, applied via ``wrap()``.
+class Layer:
+    """Composable recipe — created without an inner policy, applied via ``wrap()``.
 
-    PolicyWrappers may be stateful, may control flow (skip the inner call),
-    and have no training-time dual. They compose with ``|`` (sequential, left
-    is outermost). Unlike Codecs, they do NOT support ``&`` (parallel).
+    Layers may be stateful, may control flow (skip the inner call), and have no
+    training-time dual. They compose with ``|`` (sequential, left is outermost).
+    Unlike Codecs, they do NOT support ``&`` (parallel).
 
-    ``|`` works across types: ``wrapper | wrapper``, ``wrapper | codec``,
-    and ``codec | wrapper`` all produce a PolicyWrapper pipeline that
-    ``wrap(policy)`` applies right-to-left::
+    ``|`` works across types: ``layer | layer``, ``layer | codec``, and
+    ``codec | layer`` all produce a Layer pipeline that ``wrap(policy)``
+    applies right-to-left::
 
         pipeline = TemporalStack(...) | ChunkedSchedule() | codec
         wrapped = pipeline.wrap(RemotePolicy(...))
 
-    **Extension points**: subclasses override *one* of ``wrap_session`` (the
+    **Extension points**: subclasses override *one* of ``make_session`` (the
     common case — transform one session's ``__call__``) or ``wrap`` (for
     policy-level state across sessions, like composition).
     """
 
     def wrap(self, policy: Policy) -> Policy:
-        """Apply this wrapper to a policy. Default: wrap every session it creates via ``wrap_session``.
+        """Apply this layer to a policy. Default: wrap every session it creates via ``make_session``.
 
         Composition happens at config time; the runtime clock reaches the wrapped
         sessions through ``new_session``.
         """
-        return _WrapperPolicy(policy, self)
+        return _LayerPolicy(policy, self)
 
-    def wrap_session(self, inner: Session, context: dict[str, Any] | None, now: Now | None) -> Session:
-        """Wrap a single session. Subclasses override this for per-session wrapping."""
-        raise NotImplementedError('Override wrap_session or wrap')
+    def make_session(self, inner: Session, context: dict[str, Any] | None, now: Now | None) -> Session:
+        """Make this layer's session around ``inner``. Subclasses override this for per-session wrapping."""
+        raise NotImplementedError('Override make_session or wrap')
 
-    # The name this wrapper travels under, set by every deliverable subclass. ``WIRE_WRAPPERS`` is keyed by
+    # The name this layer travels under, set by every deliverable subclass. ``WIRE_LAYERS`` is keyed by
     # it, so the name is written once and both sides of the wire read the same attribute.
     WIRE_NAME: ClassVar[str]
 
     def to_spec(self) -> dict[str, Any]:
-        """Plain-data wire spec of this wrapper, for a server's local-stack declaration.
+        """Plain-data wire spec of this layer, for a server's local-stack declaration.
 
-        Only wrappers registered in ``positronic.policy.spec.WIRE_WRAPPERS`` are deliverable to a rig.
-        The spec is ``{'name': WIRE_NAME}`` plus ``{'args': {...}}`` when the wrapper takes any;
+        Only layers registered in ``positronic.policy.spec.WIRE_LAYERS`` are deliverable to a rig.
+        The spec is ``{'name': WIRE_NAME}`` plus ``{'args': {...}}`` when the layer takes any;
         ``args`` are constructor keywords, since the rig rebuilds by calling the constructor with them.
         """
         raise NotImplementedError(f'{type(self).__name__} is not deliverable to a rig (no wire spec)')
 
     @property
     def meta(self) -> dict[str, Any]:
-        """Metadata contributed by this wrapper (merged into the wrapped policy's meta)."""
+        """Metadata contributed by this layer (merged into the wrapped policy's meta)."""
         return {}
 
-    def __or__(self, other: PolicyWrapper) -> PolicyWrapper:
-        if isinstance(other, PolicyWrapper):
-            return _ComposedWrapper((*self._wrappers(), *other._wrappers()))
+    def __or__(self, other: Layer) -> Layer:
+        if isinstance(other, Layer):
+            return _ComposedLayer((*self._layers(), *other._layers()))
         return NotImplemented
 
-    # Used for flattening nested | compositions into a single _ComposedWrapper
-    def _wrappers(self) -> tuple:
+    # Used for flattening nested | compositions into a single _ComposedLayer
+    def _layers(self) -> tuple:
         return (self,)
 
 
-class _WrapperPolicy(DelegatingPolicy):
-    """Generic policy wrapper produced by ``PolicyWrapper.wrap()``.
+class _LayerPolicy(DelegatingPolicy):
+    """Policy produced by ``Layer.wrap()``.
 
-    Delegates session creation to the wrapper's ``wrap_session`` and merges meta.
+    Delegates session creation to the layer's ``make_session`` and merges meta.
     """
 
-    def __init__(self, inner: Policy, wrapper: PolicyWrapper):
+    def __init__(self, inner: Policy, layer: Layer):
         super().__init__(inner)
-        self._wrapper = wrapper
+        self._layer = layer
 
     def new_session(self, context=None, now=None):
-        return self._wrapper.wrap_session(self._inner.new_session(context, now), context, now)
+        return self._layer.make_session(self._inner.new_session(context, now), context, now)
 
     @property
     def meta(self):
-        return self._inner.meta | self._wrapper.meta
+        return self._inner.meta | self._layer.meta
 
 
-class _ComposedWrapper(PolicyWrapper):
-    """Composed pipeline of wrappers and codecs. Applies right-to-left."""
+class _ComposedLayer(Layer):
+    """Composed pipeline of layers and codecs. Applies right-to-left."""
 
     def __init__(self, components: tuple):
         self._components = components
@@ -208,5 +208,5 @@ class _ComposedWrapper(PolicyWrapper):
     def to_spec(self) -> dict[str, Any]:
         return {SEQ: [component.to_spec() for component in self._components]}
 
-    def _wrappers(self) -> tuple:
+    def _layers(self) -> tuple:
         return self._components

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -118,7 +118,7 @@ class DelegatingPolicy(Policy):
 
 
 class Layer:
-    """Composable recipe — created without an inner policy, applied via ``wrap()``.
+    """Recipe for wrapping a session, fixed at configuration time and applied to a policy via ``wrap()``.
 
     Layers may be stateful, may control flow (skip the inner call), and have no
     training-time dual. They compose with ``|`` (sequential, left is outermost).
@@ -145,7 +145,7 @@ class Layer:
         return _LayerPolicy(policy, self)
 
     def make_session(self, inner: Session, context: dict[str, Any] | None, now: Now | None) -> Session:
-        """Make this layer's session around ``inner``. Subclasses override this for per-session wrapping."""
+        """Make this layer's session around ``inner``."""
         raise NotImplementedError('Override make_session or wrap')
 
     # The name this layer travels under, set by every deliverable subclass. ``WIRE_LAYERS`` is keyed by
@@ -195,7 +195,7 @@ class _LayerPolicy(DelegatingPolicy):
 
 
 class _ComposedLayer(Layer):
-    """Composed pipeline of layers and codecs. Applies right-to-left."""
+    """Composed pipeline of layers. Applies right-to-left."""
 
     def __init__(self, components: tuple):
         self._components = components

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -24,7 +24,7 @@ from positronic.dataset.transforms.episode import Derive, EpisodeTransform, From
 from positronic.drivers.roboarm import command
 from positronic.drivers.roboarm.ik import assert_default_frame, change_frame, ee_frame
 from positronic.drivers.roboarm.models import DEFAULT_FRAME
-from positronic.policy.base import PAR, SEQ, DelegatingSession, PolicyWrapper, Session, _ComposedWrapper
+from positronic.policy.base import PAR, SEQ, DelegatingSession, Layer, Session, _ComposedLayer
 from positronic.utils import merge_dicts
 
 _QUAT = geom.Rotation.Representation.QUAT
@@ -48,7 +48,7 @@ def lerobot_action(dim: int) -> dict[str, Any]:
     return {'shape': (dim,), 'names': ['actions'], 'dtype': 'float32'}
 
 
-class Codec(PolicyWrapper):
+class Codec(Layer):
     """Base class for observation/action codecs.
 
     Subclasses override ``encode`` (observation encoding) and/or ``_decode_single``
@@ -81,16 +81,16 @@ class Codec(PolicyWrapper):
     def meta(self) -> dict:
         return {}
 
-    def wrap_session(self, inner: Session, context, now):
+    def make_session(self, inner: Session, context, now):
         return _CodecSession(inner, self)
 
     @final
     def __or__(self, other):
         if isinstance(other, Codec):
             return _ComposedCodec(self, other)
-        if isinstance(other, PolicyWrapper):
-            # Mixed Codec | non-Codec-wrapper → generic pipeline, not a Codec.
-            return _ComposedWrapper((self, *other._wrappers()))
+        if isinstance(other, Layer):
+            # Mixed Codec | non-Codec layer → generic pipeline, not a Codec.
+            return _ComposedLayer((self, *other._layers()))
         return NotImplemented
 
     @final

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -28,7 +28,7 @@ MAX_ACTION_SKEW_SEC = 60.0
 # and with it the granularity every command timestamp is quantized to.
 POLL_PERIOD_SEC = 0.01
 
-# How long a submitted call may take and still resolve within its round: a wrapper that skips inference
+# How long a submitted call may take and still resolve within its round: a layer that skips inference
 # answers in microseconds, a real model call runs far past this and is throttled across rounds.
 SKIP_REPLY_SEC = 0.001
 
@@ -81,7 +81,7 @@ class _InferenceWorker:
         return {name: value.copy() if isinstance(value, np.ndarray) else value for name, value in obs.items()}
 
     def submit(self, obs: dict[str, Any]) -> None:
-        """Start a call on ``obs``. The moment's wait lets a wrapper that skips inference resolve in the round
+        """Start a call on ``obs``. The moment's wait lets a layer that skips inference resolve in the round
         it was asked."""
         self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
         # The call runs under a copy of the loop's context, so the telemetry it records anchors to the episode
@@ -197,10 +197,10 @@ class _EpisodeTelemetry:
 class Harness(pimm.ControlSystem):
     """Control system that runs the episode lifecycle and plays the policy's trajectory to the drivers.
 
-    The wrapper owns the trajectory, the harness plays it, one command per channel per round. The session call
+    The layer owns the trajectory, the harness plays it, one command per channel per round. The session call
     runs on a worker so playing continues while the model does. A call costs the trial either the wall time
     it took or nothing — the world held still for it — and the ``now`` handed to ``new_session`` reads the
-    instant the call's output takes effect, so wrappers stamp for it without knowing the mode.
+    instant the call's output takes effect, so layers stamp for it without knowing the mode.
 
     An episode runs one ``Task``, asked for by a ``perform_task`` call and answered with the terminal
     payload it ended on. The task's ``timeout_sec`` bounds it and a truthy ``done`` within budget ends it
@@ -472,7 +472,7 @@ class Harness(pimm.ControlSystem):
     def _reschedule(self, trajectory: list[dict[str, Any]], clock: pimm.Clock) -> None:
         """Replace the schedule being played with the session's trajectory. Every channel it names gets that
         channel's waypoints; one it omits is cleared and holds. The timestamps are already absolute, stamped
-        by the scheduling wrapper for the instant the call's output takes effect.
+        by the scheduling layer for the instant the call's output takes effect.
         """
         if self._deadline is not None and clock.now() >= self._deadline:
             # The world reached the deadline while the call was in flight, so its chunk is dropped rather than
@@ -480,7 +480,7 @@ class Harness(pimm.ControlSystem):
             return
         self._assert_anchored(trajectory, clock.now())
         self._telemetry.step()
-        # The single explicit seconds->ns seam: wrappers time actions in float seconds, the schedules and
+        # The single explicit seconds->ns seam: layers time actions in float seconds, the schedules and
         # every pimm channel are in ns.
         for name, schedule in self._schedules.items():
             schedule.clear()

--- a/positronic/policy/layers.py
+++ b/positronic/policy/layers.py
@@ -1,10 +1,9 @@
 """Composable policy layers — scheduling, fault handling and temporal frame stacking.
 
-Layers are composable serving-time concerns wrapped around a policy with ``|`` (left is
-outermost), exactly like codecs. Most read time from the observation (``obs_time_ns``); only
-``ChunkedSchedule`` needs the live clock — it anchors a chunk to inference *completion*, which the
-pre-inference observation stamp cannot give — so the harness passes ``now`` (a ``Callable[[], float]``
-in seconds) to ``new_session`` and it reaches that one session.
+Layers are serving-time concerns wrapped around a policy with ``|`` (left is outermost). Most read time
+from the observation (``obs_time_ns``); only ``ChunkedSchedule`` needs the live clock — it anchors a chunk
+to inference *completion*, which the pre-inference observation stamp cannot give — so the harness passes
+``now`` (a ``Callable[[], float]`` in seconds) to ``new_session`` and it reaches that one session.
 """
 
 from collections import deque
@@ -64,7 +63,7 @@ class StopOnFault(Layer):
 class ChunkedSchedule(Layer):
     """Wait for the current trajectory to finish before calling the inner policy again.
 
-    Owns relative→absolute time conversion: inner layers (codecs, models) emit relative timestamps;
+    Owns relative→absolute time conversion: the sessions below (codecs, models) emit relative timestamps;
     this layer anchors them to ``now()`` *after* inner inference returns, so execution aligns to
     inference-finish (not inference-start). Returns ``None`` ("keep executing the current trajectory")
     until the last action's timestamp is reached, then calls the inner policy.

--- a/positronic/policy/layers.py
+++ b/positronic/policy/layers.py
@@ -1,6 +1,6 @@
-"""Composable policy wrappers — scheduling, fault handling and temporal frame stacking.
+"""Composable policy layers — scheduling, fault handling and temporal frame stacking.
 
-Wrappers are composable serving-time concerns layered around a policy with ``|`` (left is
+Layers are composable serving-time concerns wrapped around a policy with ``|`` (left is
 outermost), exactly like codecs. Most read time from the observation (``obs_time_ns``); only
 ``ChunkedSchedule`` needs the live clock — it anchors a chunk to inference *completion*, which the
 pre-inference observation stamp cannot give — so the harness passes ``now`` (a ``Callable[[], float]``
@@ -13,7 +13,7 @@ import numpy as np
 
 from positronic import keys
 from positronic.drivers.roboarm import RobotStatus
-from positronic.policy.base import DelegatingSession, Now, PolicyWrapper, Session
+from positronic.policy.base import DelegatingSession, Layer, Now, Session
 
 
 def _obs_time(obs) -> float:
@@ -36,11 +36,11 @@ def _arms_available(obs) -> bool:
     return all(RobotStatus(v) is RobotStatus.AVAILABLE for name, v in obs.items() if _is_robot_status(name))
 
 
-class StopOnFault(PolicyWrapper):
+class StopOnFault(Layer):
     """Stop the arm while it will not take a command, and plan afresh once it will.
 
     An arm the driver has taken, or that is faulted, is not tracking the plan it was given: this answers the
-    empty trajectory and resets the sessions below. It goes outside the scheduling wrapper, which would
+    empty trajectory and resets the sessions below. It goes outside the scheduling layer, which would
     otherwise answer "keep playing" without seeing the status. Every arm is checked, so a bimanual rig stops
     on either.
     """
@@ -54,18 +54,18 @@ class StopOnFault(PolicyWrapper):
             self.cancel()
             return []
 
-    def wrap_session(self, inner: Session, context, now: Now | None):
+    def make_session(self, inner: Session, context, now: Now | None):
         return StopOnFault._Session(inner)
 
     def to_spec(self):
         return {'name': self.WIRE_NAME}
 
 
-class ChunkedSchedule(PolicyWrapper):
+class ChunkedSchedule(Layer):
     """Wait for the current trajectory to finish before calling the inner policy again.
 
     Owns relative→absolute time conversion: inner layers (codecs, models) emit relative timestamps;
-    this wrapper anchors them to ``now()`` *after* inner inference returns, so execution aligns to
+    this layer anchors them to ``now()`` *after* inner inference returns, so execution aligns to
     inference-finish (not inference-start). Returns ``None`` ("keep executing the current trajectory")
     until the last action's timestamp is reached, then calls the inner policy.
     """
@@ -107,7 +107,7 @@ class ChunkedSchedule(PolicyWrapper):
             self._trajectory_end = None
             super().cancel()
 
-    def wrap_session(self, inner: Session, context, now: Now | None):
+    def make_session(self, inner: Session, context, now: Now | None):
         return ChunkedSchedule._Session(inner, now)
 
     def to_spec(self):
@@ -157,13 +157,13 @@ class _StackBuffer:
         return max(int(np.searchsorted(times, target, side='right')) - 1, 0)
 
 
-class TemporalStack(PolicyWrapper):
+class TemporalStack(Layer):
     """Replaces each named observation entry with a temporal stack of recent samples.
 
     A model that conditions on a short window of history (e.g. DreamZero's video context) needs several
     samples spanning the just-executed chunk at the cadence seen in training, but the harness only
-    forwards an observation to the policy at re-query boundaries. This wrapper sits outside the
-    scheduling wrapper so it sees every control tick: it records the named ``keys`` and substitutes, for
+    forwards an observation to the policy at re-query boundaries. This layer sits outside the
+    scheduling layer so it sees every control tick: it records the named ``keys`` and substitutes, for
     each, a ``(len(offsets_sec), ...)`` stack sampled at ``offsets_sec`` (ascending negative seconds
     relative to now), so every stacked step carries its own value at that time rather than the current
     one repeated across history.
@@ -203,7 +203,7 @@ class TemporalStack(PolicyWrapper):
             'in-range targets and the stack would be empty'
         )
 
-    def wrap_session(self, inner: Session, context, now: Now | None):
+    def make_session(self, inner: Session, context, now: Now | None):
         return TemporalStack._Session(inner, self._keys, self._offsets_sec, self._pad_start)
 
     def to_spec(self):

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -4,7 +4,7 @@ Recordings are written with `rerun <https://rerun.io>`_, a logging/visualization
 tool. Each episode becomes one ``.rrd`` file in the recording directory; open it in
 the rerun viewer to inspect what flowed through the policy.
 
-A :class:`Recorder` hands out lightweight ``tap(name)`` wrappers. A tap inserted
+A :class:`Recorder` hands out lightweight ``tap(name)`` layers. A tap inserted
 into a policy pipeline logs the observation passing *down* through it and the action
 chunk coming back *up*, under entity paths prefixed by its ``name``. Placing two
 taps at different points captures both ends of a remote inference round-trip in one
@@ -56,7 +56,7 @@ import rerun.blueprint as rrb
 from positronic import geom
 from positronic import keys as obs_keys
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.policy.base import DelegatingSession, PolicyWrapper, Session
+from positronic.policy.base import DelegatingSession, Layer, Session
 from positronic.policy.codec import is_action
 from positronic.utils.rerun_compat import log_numeric_series, set_timeline_sequence, set_timeline_time
 
@@ -297,7 +297,7 @@ def _log_ee_pose_chunk(
 
 
 class Recorder:
-    """Writes one rerun ``.rrd`` file per episode and hands out ``tap(name)`` wrappers.
+    """Writes one rerun ``.rrd`` file per episode and hands out ``tap(name)`` layers.
 
     Taps share the recorder's current episode stream, so taps placed at different
     points in one pipeline write to the same recording. The episode boundary is
@@ -352,14 +352,14 @@ class Recorder:
         self._live -= 1
 
 
-class _RecordingTap(PolicyWrapper):
+class _RecordingTap(Layer):
     """A named tap. Wraps a single session to log its observations and actions."""
 
     def __init__(self, rec: Recorder, name: str):
         self._rec = rec
         self._name = name
 
-    def wrap_session(self, inner: Session, context, now) -> Session:
+    def make_session(self, inner: Session, context, now) -> Session:
         stream = self._rec._open_stream()
         return _RecordingTapSession(inner, self._rec, self._name, stream)
 

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -10,7 +10,7 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, I
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 
-from .base import Policy, PolicyWrapper, Session
+from .base import Layer, Policy, Session
 from .recording import Recorder
 from .spec import from_spec
 
@@ -109,7 +109,7 @@ class RemotePolicy(Policy):
 
     The server's ``ready`` handshake declares the local half of its policy pipeline (the
     ``local_stack`` spec — see ``positronic.policy.spec``) along with the wire settings of the
-    ``remote`` marker. The declared wrappers are built here, once, and every session runs through
+    ``remote`` marker. The declared layers are built here, once, and every session runs through
     them; a handshake that declares no stack is an error.
 
     ``recording_dir`` taps the raw and wire boundaries around the stack.
@@ -127,7 +127,7 @@ class RemotePolicy(Policy):
         self._recording_dir = pos3.sync(recording_dir) if recording_dir else None
         self._stacked: Policy | None = None
 
-    def _resolve_stack(self) -> PolicyWrapper:
+    def _resolve_stack(self) -> Layer:
         meta = self._endpoint.server_meta()
         version = meta.get(keys.POSITRONIC_VERSION, 'unknown')
         declared = meta.get(keys.LOCAL_STACK)

--- a/positronic/policy/spec.py
+++ b/positronic/policy/spec.py
@@ -1,6 +1,6 @@
 """The policy-pipeline algebra: the split marker, the model-source terminal, and the rig-side wire format.
 
-A policy pipeline is one wrapper chain with a ``remote`` marker naming the client/server border,
+A policy pipeline is one layer chain with a ``remote`` marker naming the client/server border,
 closed by a ``ModelSource`` terminal::
 
     pipeline = TemporalStack(...) | ChunkedSchedule() | remote | codec | source
@@ -15,7 +15,7 @@ The server publishes the local half in its ``ready`` handshake as a plain-data s
 ``{'name': ..., 'args': {...}}`` leaves composed by ``{SEQ: [...]}`` (the ``|`` operator) and
 ``{PAR: [...]}`` (the ``&`` operator). ``RemotePolicy`` rebuilds the stack via ``from_spec``.
 
-``WIRE_WRAPPERS`` is the closed vocabulary and the security boundary: names resolve only against
+``WIRE_LAYERS`` is the closed vocabulary and the security boundary: names resolve only against
 this table, so a server can select which components the rig runs but can never make it execute
 foreign code. Model sources are never wire-deliverable — they exist only server-side. Names are
 stable and decoupled from import paths: new constructor arguments need defaults, and changing an
@@ -35,7 +35,7 @@ from positronic.policy.action import (
     JointDeltaAction,
     RelativePositionAction,
 )
-from positronic.policy.base import PAR, SEQ, Policy, PolicyWrapper
+from positronic.policy.base import PAR, SEQ, Layer, Policy
 from positronic.policy.codec import (
     ActionHorizon,
     ActionTimestamp,
@@ -45,11 +45,11 @@ from positronic.policy.codec import (
     FlipGrip,
     RestrictImageSize,
 )
+from positronic.policy.layers import ChunkedSchedule, StopOnFault, TemporalStack
 from positronic.policy.observation import ObservationCodec
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault, TemporalStack
 
 
-class RemoteMarker(PolicyWrapper):
+class RemoteMarker(Layer):
     """The client/server border in a policy pipeline. Only ever split on, never applied.
 
     Its arguments describe the wire rather than the policy, so they belong to the border itself:
@@ -107,15 +107,15 @@ class ModelSource(abc.ABC):
         return type(self) is type(other) and self.__dict__ == other.__dict__
 
     def __ror__(self, left):
-        if isinstance(left, PolicyWrapper):
-            return Pipeline(left._wrappers(), self)
+        if isinstance(left, Layer):
+            return Pipeline(left._layers(), self)
         return NotImplemented
 
 
 class Pipeline:
     """A policy pipeline closed by a model source: the full description of a policy server."""
 
-    def __init__(self, components: tuple[PolicyWrapper, ...], source: ModelSource):
+    def __init__(self, components: tuple[Layer, ...], source: ModelSource):
         self.components = tuple(components)
         self.source = source
         # Which side of ``remote`` the conversion sits on is a choice; doing it on both sides is not. Two
@@ -142,9 +142,9 @@ class PolicySource(ModelSource):
         return self._policy
 
 
-WIRE_WRAPPERS: dict[str, type[PolicyWrapper]] = {
-    wrapper.WIRE_NAME: wrapper
-    for wrapper in (
+WIRE_LAYERS: dict[str, type[Layer]] = {
+    layer.WIRE_NAME: layer
+    for layer in (
         ChunkedSchedule,
         StopOnFault,
         TemporalStack,
@@ -164,17 +164,17 @@ WIRE_WRAPPERS: dict[str, type[PolicyWrapper]] = {
 }
 
 
-def _join(components: tuple) -> PolicyWrapper | None:
+def _join(components: tuple) -> Layer | None:
     return functools.reduce(operator.or_, components) if components else None
 
 
-def split(pipeline: Pipeline | PolicyWrapper) -> tuple[PolicyWrapper | None, RemoteMarker, PolicyWrapper | None]:
-    """Split a pipeline's wrapper chain at the ``remote`` marker into ``(local, border, remote)``.
+def split(pipeline: Pipeline | Layer) -> tuple[Layer | None, RemoteMarker, Layer | None]:
+    """Split a pipeline's layer chain at the ``remote`` marker into ``(local, border, remote)``.
 
     An empty half is ``None``; a chain of just the marker means "no glue on either side". The border
     carries the wire's own settings for the server to declare.
     """
-    components = pipeline.components if isinstance(pipeline, Pipeline) else pipeline._wrappers()
+    components = pipeline.components if isinstance(pipeline, Pipeline) else pipeline._layers()
     markers = [(i, c) for i, c in enumerate(components) if isinstance(c, RemoteMarker)]
     if len(markers) != 1:
         raise ValueError(f'A policy pipeline needs exactly one `remote` marker, found {len(markers)}')
@@ -190,7 +190,7 @@ def inline(pipeline: Pipeline) -> Policy:
     return joined.wrap(policy) if joined is not None else policy
 
 
-def from_spec(node: dict[str, Any]) -> PolicyWrapper | None:
+def from_spec(node: dict[str, Any]) -> Layer | None:
     """Rebuild a declared local stack from its wire spec; ``None`` for an empty declaration.
 
     Unknown entry names raise ``ValueError`` and unknown arguments ``TypeError`` — a declaration
@@ -202,6 +202,6 @@ def from_spec(node: dict[str, Any]) -> PolicyWrapper | None:
     if PAR in node:
         return functools.reduce(operator.and_, (from_spec(child) for child in node[PAR]))
     name = node.get('name')
-    if name not in WIRE_WRAPPERS:
-        raise ValueError(f'Unknown local-stack entry {name!r}; this build knows {sorted(WIRE_WRAPPERS)}')
-    return WIRE_WRAPPERS[name](**node.get('args', {}))
+    if name not in WIRE_LAYERS:
+        raise ValueError(f'Unknown local-stack entry {name!r}; this build knows {sorted(WIRE_LAYERS)}')
+    return WIRE_LAYERS[name](**node.get('args', {}))

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -44,7 +44,7 @@ from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import DelegatingPolicy, DelegatingSession, Now, Policy, Session
 from positronic.policy.codec import ActionTiming
 from positronic.policy.harness import Harness
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.tests.testing_coutils import ManualDriver, drive_scheduler
 
 GOLDEN_FILE = Path(__file__).parent / 'golden_pipeline.json.gz'

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -21,11 +21,11 @@ from positronic.drivers.roboarm.tests.fakes import make_robot_state
 from positronic.eval import Command, Embodiment, Observation, Task
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
-from positronic.policy.base import DelegatingSession, Policy, PolicyWrapper, Session
+from positronic.policy.base import DelegatingSession, Layer, Policy, Session
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.harness import Harness, _InferenceWorker
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.remote import RemoteSession
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
 
 
@@ -201,7 +201,7 @@ class _FakeInferenceSession(InferenceSession):
 
 class RemoteStubPolicy(Policy):
     """A stub policy served through a real ``RemoteSession`` over a fake inference session, so its inference
-    round-trips ``RemoteSession.__call__`` and records the ``policy.infer`` span independent of any wrapper."""
+    round-trips ``RemoteSession.__call__`` and records the ``policy.infer`` span independent of any layer."""
 
     def __init__(
         self, command: roboarm.command.CommandType | None = None, target_grip: float = 0.33, wall_sec: float = 0.0
@@ -843,7 +843,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
         static_meta={},
         meta_source=None,
     )
-    # Termination is independent of the policy wrappers; the minimal embodiment has no
+    # Termination is independent of the policy layers; the minimal embodiment has no
     # ``robot_state``, so run the stub policy bare.
     harness = Harness(StubPolicy(), embodiment)
     ds_recorder = RecordingEmitter()
@@ -1713,7 +1713,7 @@ class SlowPolicy(Policy):
         return _SlowSession(self._wall_sec, self._span_sec, self._steps)
 
 
-class _ReplanEarly(PolicyWrapper):
+class _ReplanEarly(Layer):
     """Infers on the first observation and again halfway through the chunk it returned.
 
     The re-query-before-exhaustion shape (RTC, temporal ensembling) that the substrate exists for: unlike
@@ -1731,13 +1731,13 @@ class _ReplanEarly(PolicyWrapper):
             if self._replan_at is not None and t0 < self._replan_at:
                 return None
             result = self._inner(obs)
-            assert result is not None, 'the inner policy of this test wrapper always returns a chunk'
+            assert result is not None, 'the inner policy of this test layer always returns a chunk'
             anchor = self._now()
             result = [{**action, keys.ACTION_TIMESTAMP: anchor + action[keys.ACTION_TIMESTAMP]} for action in result]
             self._replan_at = t0 + (result[-1][keys.ACTION_TIMESTAMP] - t0) / 2
             return result
 
-    def wrap_session(self, inner: Session, context, now):
+    def make_session(self, inner: Session, context, now):
         assert now is not None  # the harness always passes its clock
         return _ReplanEarly._Session(inner, now)
 
@@ -1754,11 +1754,11 @@ class _TimedRecorder(pimm.SignalEmitter):
 
 
 def _run_episode(
-    world, policy, wrapper, *, charge_inference_time, simulated=True, steps=4000, run_sec=1.5
+    world, policy, layer, *, charge_inference_time, simulated=True, steps=4000, run_sec=1.5
 ) -> list[tuple[float, Any]]:
     """One trial run with ``charge_inference_time``; returns the grip commands with the world time each went
     out at. A sim trial runs against a pacer, the sole time-master a real rig doesn't need."""
-    harness = Harness(wrapper.wrap(policy), make_embodiment(simulated=simulated))
+    harness = Harness(layer.wrap(policy), make_embodiment(simulated=simulated))
     grip_recorder = _TimedRecorder(world.clock)
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
@@ -1818,7 +1818,7 @@ def test_a_real_rig_pays_wall_time_whatever_the_trial_asks_for(world):
     assert played[0][0] >= 0.2, f'first command at {played[0][0]}s, under the 0.2s the call took'
 
 
-class _ObservedTicks(PolicyWrapper):
+class _ObservedTicks(Layer):
     """Records the observation instant of every call that reaches it."""
 
     def __init__(self):
@@ -1833,13 +1833,13 @@ class _ObservedTicks(PolicyWrapper):
             self._seen.append(obs[keys.OBS_TIME_NS] / 1e9)
             return self._inner(obs)
 
-    def wrap_session(self, inner: Session, context, now):
+    def make_session(self, inner: Session, context, now):
         return _ObservedTicks._Session(inner, self.seen)
 
 
 @pytest.mark.timeout(30.0)
-def test_the_wrappers_see_every_tick(world):
-    """What a temporal stack records: nothing keeps an observation from the wrappers above the scheduler —
+def test_the_layers_see_every_tick(world):
+    """What a temporal stack records: nothing keeps an observation from the layers above the scheduler —
     not the machine inside the model call, and not the rounds in between."""
     ticks = _ObservedTicks()
     _run_episode(
@@ -1857,7 +1857,7 @@ def test_the_wrappers_see_every_tick(world):
 
 @pytest.mark.timeout(20.0)
 def test_harness_keeps_playing_while_a_call_is_in_flight(world):
-    """A wrapper that replans before its chunk is exhausted leaves waypoints due during inference, and the
+    """A layer that replans before its chunk is exhausted leaves waypoints due during inference, and the
     harness emits them on time instead of standing still until the model answers."""
     played = _run_episode(
         world, SlowPolicy(wall_sec=0.15, span_sec=0.4, steps=20), _ReplanEarly(), charge_inference_time=True

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -1,4 +1,4 @@
-"""Unit tests for PolicyWrapper composition, ChunkedSchedule, TemporalStack, and the policy-pipeline algebra."""
+"""Unit tests for Layer composition, ChunkedSchedule, TemporalStack, and the policy-pipeline algebra."""
 
 from typing import Any
 
@@ -17,7 +17,7 @@ from positronic.policy.action import (
     JointDeltaAction,
     RelativePositionAction,
 )
-from positronic.policy.base import Policy, PolicyWrapper, Session
+from positronic.policy.base import Layer, Policy, Session
 from positronic.policy.codec import (
     ActionHorizon,
     ActionTimestamp,
@@ -29,8 +29,8 @@ from positronic.policy.codec import (
     RestrictImageSize,
     SetControlMode,
 )
+from positronic.policy.layers import ChunkedSchedule, StopOnFault, TemporalStack
 from positronic.policy.observation import ObservationCodec
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault, TemporalStack
 
 
 class _FakeClock:
@@ -74,14 +74,14 @@ class TestStopOnFault:
     @pytest.mark.parametrize('unavailable', [RobotStatus.ERROR, RobotStatus.BUSY])
     def test_an_unavailable_arm_stops_what_is_executing(self, unavailable):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().wrap_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None, None)
 
         assert session(_obs(0.0, unavailable)) == []
         assert inner.call_count == 0, 'the model was asked about an arm that is not tracking it'
 
     def test_an_available_arm_reaches_the_model(self):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().wrap_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None, None)
 
         assert session(_obs(0.0, RobotStatus.AVAILABLE)) is not None
         assert inner.call_count == 1
@@ -89,7 +89,7 @@ class TestStopOnFault:
     def test_an_observation_with_no_arm_status_reaches_the_model(self):
         """A probe replaying a recording has no arm to stop for."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().wrap_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None, None)
 
         assert session({keys.OBS_TIME_NS: 0}) is not None
         assert inner.call_count == 1
@@ -98,7 +98,7 @@ class TestStopOnFault:
         """Whichever arm is unavailable stops the pair, and the status counts as its number: a server-side stack
         reads it off a wire with no enum to carry."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().wrap_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None, None)
         obs = {
             keys.OBS_TIME_NS: 0,
             f'{keys.ROBOT_STATE}.left.status': int(RobotStatus.AVAILABLE),
@@ -111,7 +111,7 @@ class TestStopOnFault:
     def test_the_status_a_recording_carries_for_a_taken_arm_stops_the_policy(self):
         """The numbers are the contract between a rig and a server: 1 is an arm its driver has taken."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().wrap_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None, None)
 
         assert (RobotStatus.AVAILABLE, RobotStatus.BUSY, RobotStatus.ERROR) == (0, 1, 3)
         assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 1}) == []
@@ -120,7 +120,7 @@ class TestStopOnFault:
     def test_the_status_published_for_a_travelling_arm_reaches_the_model(self):
         """The wire protocol publishes 2 for an arm on its way to a setpoint, which is one taking commands."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().wrap_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None, None)
 
         assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 2}) is not None
         assert inner.call_count == 1
@@ -128,7 +128,7 @@ class TestStopOnFault:
     def test_a_status_no_arm_answers_to_raises(self):
         """A number outside ``RobotStatus`` is the rig and the server disagreeing about the protocol, which
         is not something to drive an arm through."""
-        session = StopOnFault().wrap_session(_ConstSession([]), None, None)
+        session = StopOnFault().make_session(_ConstSession([]), None, None)
 
         with pytest.raises(ValueError):
             session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 99})
@@ -201,23 +201,23 @@ class TestChunkedSchedule:
 
 
 class TestPipelineComposition:
-    """Test | operator across PolicyWrapper and Codec types."""
+    """Test | operator across Layer and Codec types."""
 
-    def test_wrapper_pipe_wrapper(self):
+    def test_layer_pipe_layer(self):
         clock = _FakeClock(t=1.0)
         pipeline = TemporalStack(keys=('v',), offsets_sec=(0.0,)) | ChunkedSchedule()
-        assert isinstance(pipeline, PolicyWrapper)
+        assert isinstance(pipeline, Layer)
         policy = pipeline.wrap(_ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]))
         session = policy.new_session(now=clock.now)
         result = session({keys.OBS_TIME_NS: int(1e9), 'v': np.array([5.0])})
         assert result is not None
         assert result[0]['v'] == 1
 
-    def test_codec_pipe_wrapper(self):
+    def test_codec_pipe_layer(self):
         clock = _FakeClock(t=1.0)
         codec = ActionTimestamp(fps=10.0)
         pipeline = codec | ChunkedSchedule()
-        assert isinstance(pipeline, PolicyWrapper)
+        assert isinstance(pipeline, Layer)
         policy = pipeline.wrap(_ConstPolicy([{'action': 'test', keys.ACTION_TIMESTAMP: 0.0}]))
         session = policy.new_session(now=clock.now)
         result = session(_obs())
@@ -227,7 +227,7 @@ class TestPipelineComposition:
         clock = _FakeClock(t=1.0)
         codec = ActionTimestamp(fps=10.0)
         pipeline = ChunkedSchedule() | codec
-        assert isinstance(pipeline, PolicyWrapper)
+        assert isinstance(pipeline, Layer)
         # 5 raw actions → codec stamps relative 0.0, 0.1, 0.2, 0.3, 0.4
         # → ChunkedSchedule shifts to 1.0, 1.1, 1.2, 1.3, 1.4 (clock=1.0).
         policy = pipeline.wrap(_ConstPolicy([{'action': f'a{i}'} for i in range(5)]))
@@ -240,7 +240,7 @@ class TestPipelineComposition:
         assert session(_obs()) is None
 
     def test_codec_and_stays_codec_only(self):
-        """& only works between codecs, not wrappers."""
+        """& only works between codecs, not layers."""
         c1 = ActionTimestamp(fps=10.0)
         c2 = ActionTimestamp(fps=5.0)
         composed = c1 & c2
@@ -375,8 +375,8 @@ class TestTemporalStack:
     def test_no_pad_start_grows_from_one(self):
         clock = _FakeClock(t=0.0)
         inner = _CapturePolicy()
-        wrapper = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS, pad_start=False)
-        session = wrapper.wrap(inner).new_session(now=clock.now)
+        layer = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS, pad_start=False)
+        session = layer.wrap(inner).new_session(now=clock.now)
 
         session(_stack_obs(0.0, 1.0))
         assert inner.session.seen[0]['v'].shape == (1, 1)
@@ -395,8 +395,8 @@ class TestTemporalStack:
         for pad_start in (True, False):
             clock = _FakeClock(t=0.0)
             inner = _CapturePolicy()
-            wrapper = TemporalStack(keys=('v',), offsets_sec=offsets, pad_start=pad_start)
-            session = wrapper.wrap(inner).new_session(now=clock.now)
+            layer = TemporalStack(keys=('v',), offsets_sec=offsets, pad_start=pad_start)
+            session = layer.wrap(inner).new_session(now=clock.now)
             for i in range(4):
                 session(_stack_obs(0.1 * i, float(i)))
             stacks[pad_start] = inner.session.seen[-1]['v']
@@ -412,7 +412,7 @@ class TestPipelineSpec:
         sched = ChunkedSchedule()
         codec = ActionTimestamp(fps=10.0)
         local, border, rem = spec.split(stack | sched | spec.remote | codec)
-        assert local is not None and local._wrappers() == (stack, sched)
+        assert local is not None and local._layers() == (stack, sched)
         assert border is spec.remote
         assert rem is codec
 
@@ -465,7 +465,7 @@ class TestPipelineSpec:
             def to_spec(self):
                 return {'name': 'wire_codec', 'args': {'tag': self._tag}}
 
-        monkeypatch.setitem(spec.WIRE_WRAPPERS, 'wire_codec', _WireCodec)
+        monkeypatch.setitem(spec.WIRE_LAYERS, 'wire_codec', _WireCodec)
         composed = _WireCodec('t') | (_WireCodec('a') & _WireCodec('b'))
         rebuilt = spec.from_spec(composed.to_spec())
         assert rebuilt is not None and rebuilt.to_spec() == composed.to_spec()
@@ -485,13 +485,13 @@ class TestPipelineSpec:
 
     def test_unknown_name_lists_vocabulary(self):
         with pytest.raises(ValueError, match='chunked_schedule'):
-            spec.from_spec({'name': 'not_a_wrapper'})
+            spec.from_spec({'name': 'not_a_layer'})
 
     def test_unknown_arg_fails(self):
         with pytest.raises(TypeError):
             spec.from_spec({'name': 'temporal_stack', 'args': {'keys': ['v'], 'offsets_sec': [0.0], 'bogus': 1}})
 
-    def test_non_deliverable_wrapper_fails_loudly(self):
+    def test_non_deliverable_layer_fails_loudly(self):
         with pytest.raises(NotImplementedError, match='not deliverable'):
             IKJointsAction(solver_cls=None).to_spec()
 
@@ -515,10 +515,10 @@ class TestPipelineSpec:
             'joint_delta_action': JointDeltaAction(),
             'change_ee_frame': ChangeEEFrame(Transform3D.identity),
         }
-        assert set(instances) == set(spec.WIRE_WRAPPERS)
+        assert set(instances) == set(spec.WIRE_LAYERS)
         for name, instance in instances.items():
             assert instance.to_spec()['name'] == name
-            assert type(instance) is spec.WIRE_WRAPPERS[name]
+            assert type(instance) is spec.WIRE_LAYERS[name]
 
 
 class _ListSource(spec.ModelSource):
@@ -533,9 +533,9 @@ class _ListSource(spec.ModelSource):
 
 
 class TestPipe:
-    """The source terminal: ``... | source`` closes a wrapper chain into a Pipeline."""
+    """The source terminal: ``... | source`` closes a layer chain into a Pipeline."""
 
-    def test_wrapper_chain_terminates_into_pipe(self):
+    def test_layer_chain_terminates_into_pipe(self):
         stack = TemporalStack(keys=('v',), offsets_sec=(0.0,))
         sched = ChunkedSchedule()
         codec = ActionTimestamp(fps=10.0)

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -21,8 +21,8 @@ from positronic.drivers.roboarm import command as roboarm_command
 from positronic.eval import Task
 from positronic.policy import Policy, Session
 from positronic.policy.codec import ActionTimestamp
+from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.tests.test_harness import StubPolicy
-from positronic.policy.wrappers import ChunkedSchedule
 from positronic.simulator.env_server.adapter import EnvAdapter, _in_env_control_frame, _wire_command
 from positronic.simulator.env_server.client import _CLOSE_ACK_TIMEOUT, EnvConnection
 from positronic.simulator.env_server.launcher import free_port

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -20,8 +20,8 @@ from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Task
+from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.tests.test_harness import RemoteStubPolicy, StubPolicy
-from positronic.policy.wrappers import ChunkedSchedule
 from positronic.simulator.env_server import telemetry as env_telemetry
 from positronic.simulator.mujoco.sim import MujocoSim
 from positronic.simulator.mujoco.transforms import AddBox, SetBodyPosition

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -52,7 +52,7 @@ The server owns the whole policy pipeline: it runs the codec (raw observations i
 commands out) and declares the rig-side half — the model's autoregressive video context
 (`TemporalStack`, which must run every control tick to record frames) plus chunk scheduling — in its
 handshake. The client builds that declared stack automatically.
-(Server config and defaults: [`server.py`](./server.py); wrappers: [`codecs.py`](./codecs.py);
+(Server config and defaults: [`server.py`](./server.py); layers: [`codecs.py`](./codecs.py);
 remote-policy protocol: [Inference Guide](../../../docs/inference.md).)
 
 ## Full pipeline (fine-tune your own checkpoint)
@@ -209,7 +209,7 @@ protocol details in the [Inference Guide](../../../docs/inference.md).
 - **Observation**: 3 cameras (2 exterior + 1 wrist) + joint state + language prompt. The wan2.2 fine-tunes
   use the `(320, 176)` codec and the trainer resizes to 160 at load; the pretrained DROID model (wan2.1)
   asserts exactly `(320, 180)`, so the `droid` codec (`codecs.droid`) feeds that resolution.
-- **Action horizon**: 24 timesteps per inference; the server-declared `dreamzero_wrappers` re-query
+- **Action horizon**: 24 timesteps per inference; the server-declared `dreamzero_layers` re-query
   aligns the chunk schedule with the AR frame-stack window
 - **Wire protocol**: Positronic's standard WebSocket protocol — see [Connect Your Model](../../../docs/connect-your-model.md)
 - **No Positronic fork**: upstream DreamZero is used unmodified (pinned SHA in [`Dockerfile`](./Dockerfile));

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -8,7 +8,7 @@ import numpy as np
 from PIL import Image as PilImage
 
 from positronic import keys
-from positronic.cfg import codecs, wrappers
+from positronic.cfg import codecs, layers
 from positronic.dataset import Signal, transforms
 from positronic.dataset.episode import Episode
 from positronic.dataset.transforms import image
@@ -247,6 +247,6 @@ joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 # DreamZero AR eval schedule: 24-step action horizon → 23-frame look-back (ACTION_HORIZON - 1), sampled
 # at stride 8 from the current frame with the oldest pinned to the window start → trained offsets
 # -23, -16, -8, 0 (test_client_AR.py RELATIVE_OFFSETS; -23 not -24 keeps the oldest inside the window).
-dreamzero_wrappers = wrappers.video_context_wrappers.override(
+dreamzero_layers = layers.video_context_layers.override(
     history_frames=23, stride=8, keys=(keys.WRIST_IMAGE, keys.EXTERIOR_IMAGE)
 )

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -20,7 +20,7 @@ from pimm.logging import init_logging
 from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
-from positronic.policy import Codec, Policy, PolicyWrapper, Session
+from positronic.policy import Codec, Layer, Policy, Session
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.spec import ModelSource, remote
 from positronic.utils.checkpoints import list_checkpoints
@@ -370,8 +370,8 @@ class DreamZeroSource(ModelSource):
 dreamzero_source = cfn.Config(DreamZeroSource)
 
 
-@cfn.config(local=codecs.dreamzero_wrappers, codec=codecs.joints, source=dreamzero_source, width=320, height=176)
-def pipeline(local: PolicyWrapper, codec: Codec, source: ModelSource, width: int, height: int):
+@cfn.config(local=codecs.dreamzero_layers, codec=codecs.joints, source=dreamzero_source, width=320, height=176)
+def pipeline(local: Layer, codec: Codec, source: ModelSource, width: int, height: int):
     """One DreamZero serving pipeline: the rig-side AR video context, the codec, the subprocess-backed source.
 
     ``width``/``height`` bound frames on the rig and follow the codec's own geometry.

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -19,8 +19,8 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready, warmup
 from positronic.policy import Policy, Session
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.utils.checkpoints import list_checkpoints
 from positronic.vendors import gr00t
 from positronic.vendors.gr00t import codecs

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -12,8 +12,8 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, warmup
 from positronic.policy import Codec, Policy
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, Pipeline, remote
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.utils.checkpoints import list_checkpoints, resolve_checkpoint
 from positronic.vendors.lerobot import codecs as lerobot_codecs
 from positronic.vendors.lerobot.policy import LerobotPolicy, _detect_device, warm_observation

--- a/positronic/vendors/lerobot/tests/test_server.py
+++ b/positronic/vendors/lerobot/tests/test_server.py
@@ -6,8 +6,8 @@ from starlette.datastructures import QueryParams
 
 from positronic.offboard.protocol import deserialise
 from positronic.offboard.server import PolicyServer
+from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.spec import remote
-from positronic.policy.wrappers import ChunkedSchedule
 
 pytest.importorskip('lerobot', minversion='0.4')
 

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -13,9 +13,9 @@ from lerobot.policies.pretrained import PreTrainedPolicy
 from positronic import keys
 from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.observation import TASK_FIELD
 from positronic.policy.spec import PolicySource, inline
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.utils.checkpoints import resolve_checkpoint
 from positronic.vendors.lerobot_0_3_3.backbone import register_all
 

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -15,8 +15,8 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, warmup
 from positronic.policy import Codec, Policy
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.utils.checkpoints import list_checkpoints, resolve_checkpoint
 from positronic.vendors.lerobot_0_3_3 import codecs as lerobot_codecs
 from positronic.vendors.lerobot_0_3_3.backbone import register_all

--- a/positronic/vendors/lerobot_0_3_3/tests/test_server.py
+++ b/positronic/vendors/lerobot_0_3_3/tests/test_server.py
@@ -5,8 +5,8 @@ from fastapi import WebSocketDisconnect
 from starlette.datastructures import QueryParams
 
 from positronic.offboard.protocol import deserialise
+from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.spec import remote
-from positronic.policy.wrappers import ChunkedSchedule
 
 pytest.importorskip('torch')
 

--- a/positronic/vendors/molmoact2/server.py
+++ b/positronic/vendors/molmoact2/server.py
@@ -9,8 +9,8 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import warmup
 from positronic.policy import Codec, Policy
 from positronic.policy.codec import RestrictImageSize
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.vendors.molmoact2 import codecs as molmoact2_codecs
 from positronic.vendors.molmoact2.policy import MolmoAct2Policy, warm_observation
 

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -16,8 +16,8 @@ from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready, warmup
 from positronic.policy import Codec, Policy, Session
 from positronic.policy.codec import ChangeEEFrame, RestrictImageSize
+from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
-from positronic.policy.wrappers import ChunkedSchedule, StopOnFault
 from positronic.utils.checkpoints import get_latest_checkpoint, list_checkpoints
 from positronic.vendors import openpi
 from positronic.vendors.openpi import codecs, ensure_paligemma_tokenizer


### PR DESCRIPTION
Rung 1 of #661. The policy API design calls the composable recipe around a session a *layer*, so the code says layer.

## Summary

- `PolicyWrapper` → `Layer`, `wrap_session` → `make_session`
- `_ComposedWrapper` → `_ComposedLayer`, `_WrapperPolicy` → `_LayerPolicy`, `_wrappers()` → `_layers()`, `WIRE_WRAPPERS` → `WIRE_LAYERS`
- `positronic/policy/wrappers.py` → `layers.py`, `positronic/cfg/wrappers.py` → `layers.py`, `tests/test_wrappers.py` → `test_layers.py`
- `video_context_wrappers` → `video_context_layers`, `dreamzero_wrappers` → `dreamzero_layers`
- Docstrings, comments and docs (`ARCHITECTURE.md`, `docs/connect-your-model.md`, the offboard and dreamzero READMEs) speak the same vocabulary

`wrap()` survives: the design keeps `chain.wrap(policy)`.

The wire is untouched. `WIRE_NAME` values and the spec strings a served pipeline declares stay what a deployed server already publishes — only the table's Python name changed.

## Test plan

- `uv run --locked pytest` — 1618 passed, 8 skipped
- `basedpyright` — 0 errors
- `ruff check` / `ruff format` — clean