### PR TITLE
Serve a policy's functions on a pool, each call answering an `Answer`

### DIFF
--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -1,50 +1,67 @@
-"""Served functions: a call starts the work off the caller's thread and hands back a pimm ``Answer``."""
+"""Served functions: a call starts the work off the caller's thread and hands back an ``Answer``.
+
+``Answer`` is the policy API's own, not pimm's: the two are alike but not interchangeable.
+"""
 
 import contextvars
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from typing import Any
 
-import pimm
+
+class NotAnswered(RuntimeError):
+    """The call has not answered yet, and reading it never waits for one."""
+
+
+class Answer(ABC):
+    """The caller's handle on one call: ``done()`` once the function has answered, then ``result()``."""
+
+    @abstractmethod
+    def done(self) -> bool: ...
+
+    @abstractmethod
+    def result(self) -> Any:
+        """What the function returned, re-raising what it raised. ``NotAnswered`` before it has answered."""
+
 
 # Calling one starts the work and returns its ``Answer`` at once, never waiting.
-Fn = Callable[..., pimm.calls.Answer[Any]]
-
-
-class _PoolAnswer(pimm.calls.Answer[Any]):
-    def __init__(self, call: Future[Any]):
-        self._call = call
-
-    def done(self) -> bool:
-        return self._call.done()
-
-    def result(self) -> Any:
-        if not self._call.done():
-            raise pimm.NoValueException('The call is not answered yet')
-        return self._call.result()
+Fn = Callable[..., Answer]
 
 
 class Executor:
-    """Serves a set of functions on a worker thread of its own, one call at a time.
+    """Serves a set of functions on worker threads of its own, ``max_workers`` calls at a time.
 
     A call runs under a copy of the context it was made in, so telemetry recorded inside it anchors where
     it was asked for.
     """
 
-    def __init__(self, functions: Mapping[str, Callable[..., Any]]):
-        self._pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix='policy-fn')
+    class _Answer(Answer):
+        def __init__(self, call: Future[Any]):
+            self._call = call
+
+        def done(self) -> bool:
+            return self._call.done()
+
+        def result(self) -> Any:
+            if not self._call.done():
+                raise NotAnswered('The call is not answered yet')
+            return self._call.result()
+
+    def __init__(self, functions: Mapping[str, Callable[..., Any]], *, max_workers: int = 1):
+        self._pool = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix='policy-fn')
         self._fns: Mapping[str, Fn] = {name: partial(self._start, fn) for name, fn in functions.items()}
 
     @property
     def fns(self) -> Mapping[str, Fn]:
         return self._fns
 
-    def _start(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> pimm.calls.Answer[Any]:
+    def _start(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Answer:
         context = contextvars.copy_context()
-        return _PoolAnswer(self._pool.submit(context.run, fn, *args, **kwargs))
+        return self._Answer(self._pool.submit(context.run, fn, *args, **kwargs))
 
     def close(self) -> None:
-        """Drop the queued calls and wait out the one in flight, which may still hold its caller's resources.
+        """Drop the queued calls and wait out those in flight, which may still hold their caller's resources.
         A call made after close raises."""
         self._pool.shutdown(wait=True, cancel_futures=True)

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -1,0 +1,50 @@
+"""Served functions: a call starts the work off the caller's thread and hands back a pimm ``Answer``."""
+
+import contextvars
+from collections.abc import Callable, Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
+from functools import partial
+from typing import Any
+
+import pimm
+
+# Calling one starts the work and returns its ``Answer`` at once, never waiting.
+Fn = Callable[..., pimm.calls.Answer[Any]]
+
+
+class _PoolAnswer(pimm.calls.Answer[Any]):
+    def __init__(self, call: Future[Any]):
+        self._call = call
+
+    def done(self) -> bool:
+        return self._call.done()
+
+    def result(self) -> Any:
+        if not self._call.done():
+            raise pimm.NoValueException('The call is not answered yet')
+        return self._call.result()
+
+
+class Executor:
+    """Serves a set of functions on a worker thread of its own, one call at a time.
+
+    A call runs under a copy of the context it was made in, so telemetry recorded inside it anchors where
+    it was asked for.
+    """
+
+    def __init__(self, functions: Mapping[str, Callable[..., Any]]):
+        self._pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix='policy-fn')
+        self._fns: Mapping[str, Fn] = {name: partial(self._start, fn) for name, fn in functions.items()}
+
+    @property
+    def fns(self) -> Mapping[str, Fn]:
+        return self._fns
+
+    def _start(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> pimm.calls.Answer[Any]:
+        context = contextvars.copy_context()
+        return _PoolAnswer(self._pool.submit(context.run, fn, *args, **kwargs))
+
+    def close(self) -> None:
+        """Drop the queued calls and wait out the one in flight, which may still hold its caller's resources.
+        A call made after close raises."""
+        self._pool.shutdown(wait=True, cancel_futures=True)

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -57,7 +57,7 @@ class Executor:
     def fns(self) -> Mapping[str, Fn]:
         return self._fns
 
-    def _start(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Answer:
+    def _start(self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Answer:
         context = contextvars.copy_context()
         return self._Answer(self._pool.submit(context.run, fn, *args, **kwargs))
 

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -12,8 +12,6 @@ from positronic.policy.executor import Answer, Executor, NotAnswered
 # How long a test waits for the worker threads before calling the call lost.
 TIMEOUT_SEC = 5.0
 
-_marker: ContextVar[str] = ContextVar('test_executor_marker', default='unset')
-
 
 def settled(answer: Answer) -> Answer:
     """The answer once the worker has run its call; fails the test if it never lands."""
@@ -53,6 +51,12 @@ def test_keyword_arguments_reach_the_function(serve):
     fns = serve(pose=lambda arm, gripper=0.0: (arm, gripper)).fns
 
     assert settled(fns['pose']('left', gripper=0.5)).result() == ('left', 0.5)
+
+
+def test_no_keyword_name_is_reserved(serve):
+    fns = serve(apply=lambda fn, self: (fn, self)).fns
+
+    assert settled(fns['apply'](fn='a', self='b')).result() == ('a', 'b')
 
 
 def test_answer_is_pending_until_the_function_returns(serve):
@@ -97,6 +101,11 @@ def test_max_workers_calls_run_side_by_side(serve):
     first, second = fns['gate'](), fns['gate']()
 
     assert sorted([settled(first).result(), settled(second).result()]) == [0, 1]
+
+
+# A ContextVar belongs at module level: every context that sets it holds a strong reference, so one made
+# inside a function is never collected.
+_marker: ContextVar[str] = ContextVar('test_executor_marker', default='unset')
 
 
 def test_call_runs_under_a_copy_of_the_context_it_was_made_in(serve):

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -1,0 +1,121 @@
+"""Unit tests for the executor serving functions off the caller's thread."""
+
+import operator
+import threading
+import time
+from contextvars import ContextVar
+
+import pytest
+
+import pimm
+from positronic.policy.executor import Executor
+
+# How long a test waits for the worker thread before calling the call lost.
+TIMEOUT_SEC = 5.0
+
+_marker: ContextVar[str] = ContextVar('test_executor_marker', default='unset')
+
+
+def settled(answer: pimm.calls.Answer) -> pimm.calls.Answer:
+    """The answer once the worker has run its call; fails the test if it never lands."""
+    deadline = time.monotonic() + TIMEOUT_SEC
+    while not answer.done():
+        assert time.monotonic() < deadline, 'the call was never answered'
+        time.sleep(0.001)
+    return answer
+
+
+@pytest.fixture
+def serve():
+    """Serves the functions it is called with, and closes every executor it made when the test ends."""
+    executors = []
+
+    def make(**functions):
+        executors.append(Executor(functions))
+        return executors[-1]
+
+    yield make
+    for executor in executors:
+        executor.close()
+
+
+def test_fns_are_the_declared_names(serve):
+    assert sorted(serve(add=operator.add, mul=operator.mul).fns) == ['add', 'mul']
+
+
+def test_call_answers_with_the_functions_result(serve):
+    answer = serve(add=operator.add).fns['add'](2, 3)
+
+    assert isinstance(answer, pimm.calls.Answer)
+    assert settled(answer).result() == 5
+
+
+def test_keyword_arguments_reach_the_function(serve):
+    fns = serve(pose=lambda arm, gripper=0.0: (arm, gripper)).fns
+
+    assert settled(fns['pose']('left', gripper=0.5)).result() == ('left', 0.5)
+
+
+def test_answer_is_pending_until_the_function_returns(serve):
+    release = threading.Event()
+    answer = serve(gate=lambda: release.wait(TIMEOUT_SEC)).fns['gate']()
+
+    assert not answer.done()
+    with pytest.raises(pimm.NoValueException):
+        answer.result()
+
+    release.set()
+    assert settled(answer).result() is True
+
+
+def test_result_raises_what_the_function_raised(serve):
+    def fail():
+        raise ValueError('inference blew up')
+
+    answer = serve(fail=fail).fns['fail']()
+
+    with pytest.raises(ValueError, match='inference blew up'):
+        settled(answer).result()
+
+
+def test_calls_run_one_at_a_time(serve):
+    release = threading.Event()
+    fns = serve(gate=lambda: release.wait(TIMEOUT_SEC), add=operator.add).fns
+
+    gated, queued = fns['gate'](), fns['add'](2, 3)
+    assert not queued.done()
+
+    release.set()
+    assert settled(gated).result() is True
+    assert settled(queued).result() == 5
+
+
+def test_call_runs_under_a_copy_of_the_context_it_was_made_in(serve):
+    fns = serve(marker=_marker.get).fns
+    _marker.set('episode-7')
+
+    assert settled(fns['marker']()).result() == 'episode-7'
+
+
+def test_close_waits_out_the_call_in_flight(serve):
+    started, finished = threading.Event(), []
+
+    def slow():
+        started.set()
+        time.sleep(0.05)
+        finished.append(True)
+
+    executor = serve(slow=slow)
+    executor.fns['slow']()
+    assert started.wait(TIMEOUT_SEC)
+    executor.close()
+
+    assert finished == [True]
+
+
+def test_calling_a_closed_executor_raises(serve):
+    executor = serve(add=operator.add)
+    executor.close()
+
+    with pytest.raises(RuntimeError):
+        executor.fns['add'](2, 3)

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -7,16 +7,15 @@ from contextvars import ContextVar
 
 import pytest
 
-import pimm
-from positronic.policy.executor import Executor
+from positronic.policy.executor import Answer, Executor, NotAnswered
 
-# How long a test waits for the worker thread before calling the call lost.
+# How long a test waits for the worker threads before calling the call lost.
 TIMEOUT_SEC = 5.0
 
 _marker: ContextVar[str] = ContextVar('test_executor_marker', default='unset')
 
 
-def settled(answer: pimm.calls.Answer) -> pimm.calls.Answer:
+def settled(answer: Answer) -> Answer:
     """The answer once the worker has run its call; fails the test if it never lands."""
     deadline = time.monotonic() + TIMEOUT_SEC
     while not answer.done():
@@ -30,8 +29,8 @@ def serve():
     """Serves the functions it is called with, and closes every executor it made when the test ends."""
     executors = []
 
-    def make(**functions):
-        executors.append(Executor(functions))
+    def make(*, max_workers: int = 1, **functions):
+        executors.append(Executor(functions, max_workers=max_workers))
         return executors[-1]
 
     yield make
@@ -46,7 +45,7 @@ def test_fns_are_the_declared_names(serve):
 def test_call_answers_with_the_functions_result(serve):
     answer = serve(add=operator.add).fns['add'](2, 3)
 
-    assert isinstance(answer, pimm.calls.Answer)
+    assert isinstance(answer, Answer)
     assert settled(answer).result() == 5
 
 
@@ -61,7 +60,7 @@ def test_answer_is_pending_until_the_function_returns(serve):
     answer = serve(gate=lambda: release.wait(TIMEOUT_SEC)).fns['gate']()
 
     assert not answer.done()
-    with pytest.raises(pimm.NoValueException):
+    with pytest.raises(NotAnswered):
         answer.result()
 
     release.set()
@@ -88,6 +87,16 @@ def test_calls_run_one_at_a_time(serve):
     release.set()
     assert settled(gated).result() is True
     assert settled(queued).result() == 5
+
+
+def test_max_workers_calls_run_side_by_side(serve):
+    # Neither call passes the barrier unless the other is running too, so a single worker breaks it.
+    paired = threading.Barrier(2)
+    fns = serve(max_workers=2, gate=lambda: paired.wait(TIMEOUT_SEC)).fns
+
+    first, second = fns['gate'](), fns['gate']()
+
+    assert sorted([settled(first).result(), settled(second).result()]) == [0, 1]
 
 
 def test_call_runs_under_a_copy_of_the_context_it_was_made_in(serve):


### PR DESCRIPTION
Rung 2 of #661: the function executor, with no consumer yet.

## Summary

- `positronic/policy/executor.py` — `Executor` takes the functions a policy declares and hands them back as `Fn`s (`Fn = Callable[..., Answer]`). Calling one starts it on a worker thread and returns its `Answer` at once, so the caller keeps running while it computes.
- `Answer` is the policy API's own, not pimm's — the module depends on nothing outside the standard library. `done()` and `result()` never wait, `result()` before the call answers raises `NotAnswered`, and what the function raised is what `result()` raises.
- A call runs under a copy of the context it was made in, so telemetry recorded inside it anchors to the episode that asked for it — the property `_InferenceWorker.submit` has today and the executor takes over in rung 3.
- `max_workers` sets how many calls run at once, one by default. `close()` drops the queued calls and waits out those in flight, which may still hold their caller's resources.

## Test plan

`positronic/policy/tests/test_executor.py` covers the answer's pending/settled states, argument passing, exception propagation, one-at-a-time and side-by-side execution, context propagation, and close semantics.

`uv run --locked pytest` — 1628 passed, 8 skipped.