### PR TITLE
Set Simplified Technical English as the standard for human-read text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@
   together
 - Write not more than 20 words in an instruction. Write not more than 25 words in a description. Write one
   instruction in one sentence
-- Use the active voice and the present tense. Start an instruction with its verb
+- Use the active voice. Use the present tense for a fact or a state, and the past tense for an event that
+  happened. Start an instruction with its verb
 - Write no idiom, no metaphor, no joke and no rhetorical question
 - Code, identifiers, configuration values and log lines are out of scope. Quote text from a source as written
 - The standard is at asd-ste100.org, free for non-commercial use. Part 2 is a dictionary of approved words.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,8 @@
   use a synonym for variety
 - Choose the shortest common word that carries the meaning. Write the articles. Put not more than three nouns
   together
-- Write not more than 20 words in an instruction and not more than 25 in a description. Write one instruction
-  in one sentence
+- Write not more than 20 words in an instruction. Write not more than 25 words in a description. Write one
+  instruction in one sentence
 - Use the active voice and the present tense. Start an instruction with its verb
 - Write no idiom, no metaphor, no joke and no rhetorical question
 - Code, identifiers, configuration values and log lines are out of scope. Quote text from a source as written

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@
 # Writing
 - Write every text that a person reads in **Simplified Technical English** (ASD-STE100). This covers
   comments, docstrings, commit messages, pull requests, review replies, issues and documents
-- Give each word one meaning and one part of speech. Use the same word for the same thing every time; do not
+- Give each word one meaning and one part of speech. Use the same word for the same thing every time. Do not
   use a synonym for variety
 - Choose the shortest common word that carries the meaning. Write the articles. Put not more than three nouns
   together
@@ -72,9 +72,9 @@
 - Use the active voice and the present tense. Start an instruction with its verb
 - Write no idiom, no metaphor, no joke and no rhetorical question
 - Code, identifiers, configuration values and log lines are out of scope. Quote text from a source as written
-- The standard is at asd-ste100.org, free for non-commercial use. Part 2 is a dictionary of approved words;
-  where you cannot check it, apply the shortest-common-word rule
-- A caveat, a correction and a mark on an unverified claim all stay. Write each one in short sentences; do not
+- The standard is at asd-ste100.org, free for non-commercial use. Part 2 is a dictionary of approved words.
+  Where you cannot check it, apply the shortest-common-word rule
+- A caveat, a correction and a mark on an unverified claim all stay. Write each one in short sentences. Do not
   drop one to meet a word count
 
 # Comments & docstrings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,8 @@
   suppress an error that actually fires — no blanket or speculative suppressions
 
 # Writing
-- Write every text that a person reads in **Simplified Technical English** (ASD-STE100): a code comment, a
-  docstring, a commit message, a pull request title and body, a review reply, an issue, and every document
+- Write every text that a person reads in **Simplified Technical English** (ASD-STE100). This covers
+  comments, docstrings, commit messages, pull requests, review replies, issues and documents
 - Give each word one meaning and one part of speech. Use the same word for the same thing every time; do not
   use a synonym for variety
 - Choose the shortest common word that carries the meaning. Write the articles. Put not more than three nouns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,23 @@
 - Linter suppressions (`noqa`, `type: ignore`, `pyright: ignore`) must be narrowly scoped to a specific rule and
   suppress an error that actually fires — no blanket or speculative suppressions
 
+# Writing
+- Write every text that a person reads in **Simplified Technical English** (ASD-STE100): a code comment, a
+  docstring, a commit message, a pull request title and body, a review reply, an issue, and every document
+- Give each word one meaning and one part of speech. Use the same word for the same thing every time; do not
+  use a synonym for variety
+- Choose the shortest common word that carries the meaning. Write the articles. Put not more than three nouns
+  together
+- Write not more than 20 words in an instruction and not more than 25 in a description. Write one instruction
+  in one sentence
+- Use the active voice and the present tense. Start an instruction with its verb
+- Write no idiom, no metaphor, no joke and no rhetorical question
+- Code, identifiers, configuration values and log lines are out of scope. Quote text from a source as written
+- The standard is at asd-ste100.org, free for non-commercial use. Part 2 is a dictionary of approved words;
+  where you cannot check it, apply the shortest-common-word rule
+- A caveat, a correction and a mark on an unverified claim all stay. Write each one in short sentences; do not
+  drop one to meet a word count
+
 # Comments & docstrings
 - Write for a colleague who knows this codebase but not the thing you are documenting: don't explain the domain,
   the neighbouring modules, or vocabulary the repo already uses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@
 - Write no idiom, no metaphor, no joke and no rhetorical question
 - Code, identifiers, configuration values and log lines are out of scope. Quote text from a source as written
 - The standard is at asd-ste100.org, free for non-commercial use. Part 2 is a dictionary of approved words.
-  Where you cannot check it, apply the shortest-common-word rule
+  Apply the shortest-common-word rule where you cannot check it
 - A caveat, a correction and a mark on an unverified claim all stay. Write each one in short sentences. Do not
   drop one to meet a word count
 


### PR DESCRIPTION
`CLAUDE.md` gains a `# Writing` section. It sets ASD-STE100, Simplified Technical English, for every text a person reads in this repo: a code comment, a docstring, a commit message, a pull request title and body, a review reply, an issue, and every document. Code, identifiers, configuration values and log lines stay out of scope, and quoted text keeps the words of its source.

The repo already tells a contributor to be dry and to cut decoration. It does not say which English to write, so two contributors can both follow every rule in it and still produce text that reads nothing alike. ASD-STE100 fixes the vocabulary, the sentence length and the voice. AECMA published it in 1986 for aircraft maintenance manuals and ASD owns it now: Part 1 gives about 65 writing rules, Part 2 a dictionary of approved words. It exists because a manual must read the same way to every reader, including a reader whose first language is not English.

The viable alternative is to say the same thing as more prose in the sections that already exist — shorter sentences, plainer words. Those sections ask for exactly that today, and the text in this repo still varies widely. A named external standard gives a reviewer something to cite and a contributor something to check against, which prose advice does not.

A caveat, a correction and a mark on an unverified claim all stay, written in short sentences. Short sentences do not make an unverified claim true.

`CODE_RULES.md` gets no entry here. A rule there is what a review agent reads, so the standard rests on contributors alone until one exists. Such a rule fires thirteen agents on every change in every repo of the org, so it needs the calibration the `add-rule` skill gives it. That is a change of its own.

Documentation only: no code path moves, and the pre-commit framework passed.

Requested by Sergey Arkhangelskiy.

<!-- opened-by: posi-agent -->