### PR TITLE
Match the certificate subject however `openssl` spaces it

### DIFF
--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -93,7 +93,8 @@ def test_certificate_carries_a_subject_a_long_host_name_would_overflow():
     assert len(host.encode()) > 64
     text = _certificate_text([host], '-subject', '-ext', 'subjectAltName')
 
-    # OpenSSL prints the subject as `CN = value`, LibreSSL as `CN=value`.
+    # Every implementation spaces the subject its own way: `CN = value` on OpenSSL 3.0, `CN=value` on
+    # OpenSSL 3.6, `/CN=value` on LibreSSL.
     assert re.search(r'CN\s*=\s*positronic-server', text)
     assert f'DNS:{host}' in text
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -93,7 +93,8 @@ def test_certificate_carries_a_subject_a_long_host_name_would_overflow():
     assert len(host.encode()) > 64
     text = _certificate_text([host], '-subject', '-ext', 'subjectAltName')
 
-    assert 'CN = positronic-server' in text
+    # OpenSSL prints the subject as `CN = value`, LibreSSL as `CN=value`.
+    assert re.search(r'CN\s*=\s*positronic-server', text)
     assert f'DNS:{host}' in text
 
 


### PR DESCRIPTION
## What

`test_certificate_carries_a_subject_a_long_host_name_would_overflow` asserted the substring `CN = positronic-server`. Assert the common name with a pattern that tolerates either spacing.

## Why

That spacing is OpenSSL's `oneline` name format. LibreSSL, which macOS ships, prints the same subject as `CN=positronic-server`, so the assertion pinned the printer rather than the certificate. `core (macos-latest, 3.13)` failed on 5da7d2db6 while every Linux job passed; main has been red since.

The two forms, both now matched:

| Runner | `openssl x509 -noout -subject` |
|---|---|
| ubuntu-latest (OpenSSL 3.0.13) | `subject=CN = positronic-server` |
| macos-latest (LibreSSL) | `subject=CN=positronic-server` |

Reading the subject through `-nameopt` would also fix it, but that flag's option set is not identical across the two implementations, and a pattern needs no support from either.

## Test

`uv run --locked pytest --no-cov` — 1643 passed, 8 skipped, on Linux/OpenSSL 3.0.13. The pattern was also checked against the macOS output captured from the failing run.

<!-- opened-by: posi-agent -->