### PR TITLE
Read the certificate in its tests, not `openssl`'s printout

### DIFF
--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -584,7 +584,13 @@ def _access_url(scheme: str, host: str, port: int) -> str:
     return f'{scheme}://{literal}:{port}'
 
 
-def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
+@dataclass(frozen=True)
+class _SelfSignedCert:
+    keyfile: Path
+    certfile: Path
+
+
+def _generate_self_signed_cert(hosts: list[str]) -> _SelfSignedCert:
     """A self-signed certificate naming every host the server answers on.
 
     The subject is a fixed name: a client matches `subjectAltName` (RFC 6125), and X.509 caps the
@@ -593,9 +599,8 @@ def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
     """
     entries = [f'IP:{host.split("%")[0]}' if _as_ip(host) is not None else f'DNS:{host}' for host in hosts]
 
-    ssl_dir = tempfile.mkdtemp(prefix='positronic-ssl-')
-    keyfile = os.path.join(ssl_dir, 'key.pem')
-    certfile = os.path.join(ssl_dir, 'cert.pem')
+    ssl_dir = Path(tempfile.mkdtemp(prefix='positronic-ssl-'))
+    keyfile, certfile = ssl_dir / 'key.pem', ssl_dir / 'cert.pem'
     subprocess.run(
         [
             'openssl',
@@ -619,7 +624,7 @@ def _generate_self_signed_cert(hosts: list[str]) -> dict[str, str]:
         capture_output=True,
     )
     atexit.register(shutil.rmtree, ssl_dir, True)
-    return {'ssl_keyfile': keyfile, 'ssl_certfile': certfile}
+    return _SelfSignedCert(keyfile, certfile)
 
 
 @cfn.config(dataset=positronic.cfg.ds.local_all, ep_table_cfg=default_table, max_resolution=640, group_tables=None)
@@ -718,7 +723,8 @@ def main(
     t.start()
 
     served = _served_addresses(host)
-    ssl_kwargs = _generate_self_signed_cert(served) if https else {}
+    cert = _generate_self_signed_cert(served) if https else None
+    ssl_kwargs = {'ssl_keyfile': str(cert.keyfile), 'ssl_certfile': str(cert.certfile)} if cert else {}
     scheme = 'https' if https else 'http'
 
     exposed = [] if https else [address for address in served if not _is_loopback(address)]

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,7 +1,6 @@
 import ipaddress
 import socket
 from collections import namedtuple
-from pathlib import Path
 
 import psutil
 import pytest
@@ -29,8 +28,7 @@ def multi_homed(monkeypatch):
 
 
 def _certificate(hosts: list[str]) -> x509.Certificate:
-    files = _generate_self_signed_cert(hosts)
-    return x509.load_pem_x509_certificate(Path(files['ssl_certfile']).read_bytes())
+    return x509.load_pem_x509_certificate(_generate_self_signed_cert(hosts).certfile.read_bytes())
 
 
 def _alt_names(cert: x509.Certificate) -> x509.SubjectAlternativeName:

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,11 +1,12 @@
 import ipaddress
-import re
 import socket
-import subprocess
 from collections import namedtuple
+from pathlib import Path
 
 import psutil
 import pytest
+from cryptography import x509
+from cryptography.x509.oid import NameOID
 
 from positronic.server.positronic_server import _access_url, _generate_self_signed_cert, _is_loopback, _served_addresses
 
@@ -27,15 +28,13 @@ def multi_homed(monkeypatch):
     monkeypatch.setattr(psutil, 'net_if_addrs', lambda: _INTERFACES)
 
 
-def _certified_ips(extension: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    return {ipaddress.ip_address(address) for address in re.findall(r'IP Address:([0-9A-Fa-f.:]+)', extension)}
-
-
-def _certificate_text(hosts: list[str], *fields: str) -> str:
+def _certificate(hosts: list[str]) -> x509.Certificate:
     files = _generate_self_signed_cert(hosts)
-    return subprocess.run(
-        ['openssl', 'x509', '-in', files['ssl_certfile'], '-noout', *fields], check=True, capture_output=True, text=True
-    ).stdout
+    return x509.load_pem_x509_certificate(Path(files['ssl_certfile']).read_bytes())
+
+
+def _alt_names(cert: x509.Certificate) -> x509.SubjectAlternativeName:
+    return cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
 
 
 def test_wildcard_bind_serves_every_routable_local_address(multi_homed):
@@ -70,38 +69,41 @@ def test_a_name_the_resolver_would_take_stays_a_name(multi_homed):
 
 
 def test_certificate_names_every_served_address():
-    extension = _certificate_text(['198.51.100.7', '2001:db8::7'], '-ext', 'subjectAltName')
+    names = _alt_names(_certificate(['198.51.100.7', '2001:db8::7']))
 
-    assert _certified_ips(extension) == {ipaddress.ip_address('198.51.100.7'), ipaddress.ip_address('2001:db8::7')}
+    assert set(names.get_values_for_type(x509.IPAddress)) == {
+        ipaddress.ip_address('198.51.100.7'),
+        ipaddress.ip_address('2001:db8::7'),
+    }
 
 
 def test_certificate_names_a_host_name_as_a_dns_entry():
-    extension = _certificate_text(['rig.local'], '-ext', 'subjectAltName')
+    names = _alt_names(_certificate(['rig.local']))
 
-    assert 'DNS:rig.local' in extension
-    assert not _certified_ips(extension)
+    assert 'rig.local' in names.get_values_for_type(x509.DNSName)
+    assert not names.get_values_for_type(x509.IPAddress)
 
 
 def test_certificate_drops_a_zone_from_an_ip_it_names():
-    extension = _certificate_text(['fe80::1%eth0'], '-ext', 'subjectAltName')
+    names = _alt_names(_certificate(['fe80::1%eth0']))
 
-    assert _certified_ips(extension) == {ipaddress.ip_address('fe80::1')}
+    assert names.get_values_for_type(x509.IPAddress) == [ipaddress.ip_address('fe80::1')]
 
 
 def test_certificate_carries_a_subject_a_long_host_name_would_overflow():
     host = 'a' * 60 + '.example.com'
     assert len(host.encode()) > 64
-    text = _certificate_text([host], '-subject', '-ext', 'subjectAltName')
+    cert = _certificate([host])
 
-    assert 'CN = positronic-server' in text
-    assert f'DNS:{host}' in text
+    assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == 'positronic-server'
+    assert host in _alt_names(cert).get_values_for_type(x509.DNSName)
 
 
 def test_a_bind_naming_no_address_still_certifies():
-    extension = _certificate_text([], '-ext', 'subjectAltName')
+    names = _alt_names(_certificate([]))
 
-    assert 'DNS:localhost' in extension
-    assert not _certified_ips(extension)
+    assert 'localhost' in names.get_values_for_type(x509.DNSName)
+    assert not names.get_values_for_type(x509.IPAddress)
 
 
 def test_advertised_url_follows_the_bind_address():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ dev = [
     "pytest-xdist",
     "pytest",
     "rerun-sdk[notebook]",
+    "cryptography",  # the server's certificate tests read the certificate itself
     "positronic[telemetry]",  # the telemetry tests exercise the SDK and the samplers
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1342,6 +1342,49 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-lerobot-0-3-3') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot' and extra == 'extra-10-positronic-yam') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-molmoact2') or (extra == 'extra-10-positronic-lerobot-0-3-3' and extra == 'extra-10-positronic-yam') or (extra == 'extra-10-positronic-molmoact2' and extra == 'extra-10-positronic-yam')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
+]
+
+[[package]]
 name = "cvxopt"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4939,6 +4982,7 @@ yam = [
 dev = [
     { name = "basedpyright" },
     { name = "coverage" },
+    { name = "cryptography" },
     { name = "ipython" },
     { name = "jupyter" },
     { name = "opencv-python" },
@@ -5023,6 +5067,7 @@ provides-extras = ["openpi", "hardware", "lerobot-0-3-3", "lerobot", "molmoact2"
 dev = [
     { name = "basedpyright" },
     { name = "coverage" },
+    { name = "cryptography" },
     { name = "ipython" },
     { name = "jupyter" },
     { name = "opencv-python" },


### PR DESCRIPTION
## What

The server's certificate tests read the certificate itself. `cryptography` joins the `dev` dependency group to let them.

## Why

The tests asserted on the text that `openssl x509` prints, so they pinned the printer and not the certificate. Every build spaces that text its own way:

| build | printed subject |
|---|---|
| OpenSSL 3.0 — the ubuntu runners | `subject=CN = positronic-server` |
| OpenSSL 3.6.1 — homebrew, the macOS runner | `subject=CN=positronic-server` |
| LibreSSL 3.3.6 — `/usr/bin/openssl` | `subject= /CN=positronic-server` |

`test_certificate_carries_a_subject_a_long_host_name_would_overflow` was written against the first form, so `core (macos-latest, 3.13)` fails and main has been red since #654. Every branch cut from main inherits it.

The alternative-name tests carry the same defect. `_certified_ips` scraped addresses out of the extension text with a regular expression, so all five certificate tests read a printout.

## How

`_certificate(hosts)` loads the PEM, and `_alt_names(cert)` returns the extension. Each test then reads what it means to test:

```python
assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == 'positronic-server'
assert names.get_values_for_type(x509.IPAddress) == [ipaddress.ip_address('fe80::1')]
```

No text, no spacing, and no `openssl` in the test path. `_certificate_text` and `_certified_ips` are gone.

`cryptography` goes in the `dev` group and not in an extra: it serves the tests, not a product feature, so `uv sync --no-dev` leaves it out of a lean image. The server still generates the certificate by calling `openssl req`, which this PR does not change.

#667 fixes the same failure by relaxing the assertion to a pattern. That keeps the test reading a printout, so close it if this lands.

## Test plan

- `uv run --locked pytest positronic/server/tests/test_positronic_server.py` on macOS with OpenSSL 3.6.1: 14 passed.
- CI covers the ubuntu and macOS runners.