### PR TITLE
Run a local model as a served function, answered while control keeps going

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -19,7 +19,7 @@ from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.eval import Embodiment, Eval, Task
-from positronic.policy.executor import Executor
+from positronic.policy.executor import blocking
 from positronic.policy.harness import Harness
 from positronic.simulator.env_server.telemetry import ATTR_RUN_ID, ENV_RUN_ID, ENV_TELEMETRY_DIR
 
@@ -193,9 +193,7 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     # empty .rrd plus a bump to the recorder's episode counter — but warmup is not a real episode.
     logger.info('Warming up policy endpoints')
     # The session runs no inference, but a session that serves its model on a runtime needs one to open.
-    warmup_runtime = Executor(policy.functions)
-    policy.new_session(rt=warmup_runtime).close()
-    warmup_runtime.close()
+    blocking(policy).new_session().close()
     output_dir = prepare_output_dir(output_dir)
 
     try:

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -8,7 +8,6 @@ import os
 import time
 from collections import Counter
 from collections.abc import Callable
-from functools import partial
 from importlib.metadata import version as _pkg_version
 from typing import Any
 
@@ -331,7 +330,7 @@ class PolicyServer:
             await _acquire_with_keepalives(self._infer_lock, websocket, 'Waiting for inference slot')
             try:
                 rt = Executor(served.functions)
-                session = await asyncio.to_thread(partial(served.new_session, rt=rt))
+                session = await asyncio.to_thread(served.new_session, rt=rt)
             finally:
                 self._infer_lock.release()
             assert session is not None and rt is not None
@@ -385,11 +384,7 @@ class PolicyServer:
                     await self._manager.release_session()
 
     async def _close_session(self, rt: Executor | None, session: Session | None) -> None:
-        """Release what one served session held, in the order that keeps it usable to the end.
-
-        The runtime closes first: a call in flight is still using what the session holds. A ``new_session``
-        that raised leaves the runtime to close on its own.
-        """
+        """Release what one served session held. A ``new_session`` that raised leaves only the runtime."""
         if rt is None:
             return
         # Both ends of a session's life touch the backend — close does a reset round-trip — so it takes

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -18,9 +18,9 @@ from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocke
 from starlette.datastructures import QueryParams
 
 from positronic import keys
-from positronic.policy import Policy, Recorder, Session
+from positronic.policy import Policy, Recorder
 from positronic.policy.base import Layer
-from positronic.policy.executor import Executor, call_until_answered
+from positronic.policy.executor import blocking
 from positronic.policy.spec import ModelSource, Pipeline, split
 
 from . import protocol
@@ -307,7 +307,6 @@ class PolicyServer:
         self._last_activity = time.monotonic()
         policy: Policy | None = None
         session = None
-        rt: Executor | None = None
         try:
             pipeline = self._session_pipeline(_session_params(websocket.query_params))
             local, border, remote_half = split(pipeline)
@@ -316,24 +315,26 @@ class PolicyServer:
             rid = self._source.resolve(model_id) if model_id is not None else self._default_id
             assert rid is not None
             policy = await self._manager.get_policy(rid, websocket)
+            # Wrapped in ``blocking`` before anything else: a request has no control loop to answer
+            # ``None`` to, and every layer above it must see one call per answer.
+            answered = blocking(policy)
             if self._recording_dir is not None:
                 # Tap both sides: 'raw' is the wire boundary, 'inference' the encoded obs and model output.
                 rec = Recorder(self._recording_dir)
                 if remote_half is not None:
-                    served = (rec.tap('raw') | remote_half | rec.tap('inference')).wrap(policy)
+                    served = (rec.tap('raw') | remote_half | rec.tap('inference')).wrap(answered)
                 else:
-                    served = rec.tap('inference').wrap(policy)
+                    served = rec.tap('inference').wrap(answered)
             else:
-                served = remote_half.wrap(policy) if remote_half is not None else policy
+                served = remote_half.wrap(answered) if remote_half is not None else answered
             # ``new_session`` resets the shared backend client, so it must not interleave with an in-flight
             # inference. Keepalives here: queuing behind a peer would otherwise trip the handshake timeout.
             await _acquire_with_keepalives(self._infer_lock, websocket, 'Waiting for inference slot')
             try:
-                rt = Executor(served.functions)
-                session = await asyncio.to_thread(served.new_session, rt=rt)
+                session = await asyncio.to_thread(served.new_session)
             finally:
                 self._infer_lock.release()
-            assert session is not None and rt is not None
+            assert session is not None
             # Later entries win: per-episode session facts over static ones, the server's own last.
             meta = {
                 **self.metadata,
@@ -356,7 +357,7 @@ class PolicyServer:
                         # Plain acquire, not the keepalive helper: the client is awaiting a ``result`` and
                         # would mis-parse a ``waiting`` message. Its ``infer_timeout`` bounds the wait.
                         async with self._infer_lock:
-                            actions = await asyncio.to_thread(call_until_answered, session, rt, raw_obs)
+                            actions = await asyncio.to_thread(session, raw_obs)
                         await websocket.send_bytes(serialise({protocol.RESULT: actions}))
                     except Exception as e:
                         logger.error(f'Error processing message: {e}', exc_info=True)
@@ -377,22 +378,15 @@ class PolicyServer:
             self._active_sessions = max(0, self._active_sessions - 1)
             self._last_activity = time.monotonic()
             try:
-                # The nesting keeps a failure here from swallowing the manager release.
-                await self._close_session(rt, session)
+                if session is not None:
+                    # Both ends of a session's life touch the backend — close does a reset round-trip — so
+                    # it takes the inference lock like ``new_session`` and runs off the event loop. The
+                    # nesting keeps a failure here from swallowing the manager release.
+                    async with self._infer_lock:
+                        await asyncio.to_thread(session.close)
             finally:
                 if policy is not None:
                     await self._manager.release_session()
-
-    async def _close_session(self, rt: Executor | None, session: Session | None) -> None:
-        """Release what one served session held. A ``new_session`` that raised leaves only the runtime."""
-        if rt is None:
-            return
-        # Both ends of a session's life touch the backend — close does a reset round-trip — so it takes
-        # the inference lock like ``new_session`` and runs off the event loop.
-        async with self._infer_lock:
-            await asyncio.to_thread(rt.close)
-            if session is not None:
-                await asyncio.to_thread(session.close)
 
     async def _startup(self):
         self._default_id = self._source.resolve(None)

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -8,6 +8,7 @@ import os
 import time
 from collections import Counter
 from collections.abc import Callable
+from functools import partial
 from importlib.metadata import version as _pkg_version
 from typing import Any
 
@@ -18,8 +19,9 @@ from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocke
 from starlette.datastructures import QueryParams
 
 from positronic import keys
-from positronic.policy import Policy, Recorder
+from positronic.policy import Policy, Recorder, Session
 from positronic.policy.base import Layer
+from positronic.policy.executor import Executor, call_until_answered
 from positronic.policy.spec import ModelSource, Pipeline, split
 
 from . import protocol
@@ -306,6 +308,7 @@ class PolicyServer:
         self._last_activity = time.monotonic()
         policy: Policy | None = None
         session = None
+        rt: Executor | None = None
         try:
             pipeline = self._session_pipeline(_session_params(websocket.query_params))
             local, border, remote_half = split(pipeline)
@@ -327,10 +330,11 @@ class PolicyServer:
             # inference. Keepalives here: queuing behind a peer would otherwise trip the handshake timeout.
             await _acquire_with_keepalives(self._infer_lock, websocket, 'Waiting for inference slot')
             try:
-                session = await asyncio.to_thread(served.new_session)
+                rt = Executor(served.functions)
+                session = await asyncio.to_thread(partial(served.new_session, rt=rt))
             finally:
                 self._infer_lock.release()
-            assert session is not None
+            assert session is not None and rt is not None
             # Later entries win: per-episode session facts over static ones, the server's own last.
             meta = {
                 **self.metadata,
@@ -353,7 +357,7 @@ class PolicyServer:
                         # Plain acquire, not the keepalive helper: the client is awaiting a ``result`` and
                         # would mis-parse a ``waiting`` message. Its ``infer_timeout`` bounds the wait.
                         async with self._infer_lock:
-                            actions = await asyncio.to_thread(session, raw_obs)
+                            actions = await asyncio.to_thread(call_until_answered, session, rt, raw_obs)
                         await websocket.send_bytes(serialise({protocol.RESULT: actions}))
                     except Exception as e:
                         logger.error(f'Error processing message: {e}', exc_info=True)
@@ -374,15 +378,26 @@ class PolicyServer:
             self._active_sessions = max(0, self._active_sessions - 1)
             self._last_activity = time.monotonic()
             try:
-                if session is not None:
-                    # Both ends of a session's life touch the backend — close does a reset round-trip — so
-                    # it takes the inference lock like ``new_session`` and runs off the event loop. The
-                    # nesting keeps a failure here from swallowing the manager release.
-                    async with self._infer_lock:
-                        await asyncio.to_thread(session.close)
+                # The nesting keeps a failure here from swallowing the manager release.
+                await self._close_session(rt, session)
             finally:
                 if policy is not None:
                     await self._manager.release_session()
+
+    async def _close_session(self, rt: Executor | None, session: Session | None) -> None:
+        """Release what one served session held, in the order that keeps it usable to the end.
+
+        The runtime closes first: a call in flight is still using what the session holds. A ``new_session``
+        that raised leaves the runtime to close on its own.
+        """
+        if rt is None:
+            return
+        # Both ends of a session's life touch the backend — close does a reset round-trip — so it takes
+        # the inference lock like ``new_session`` and runs off the event loop.
+        async with self._infer_lock:
+            await asyncio.to_thread(rt.close)
+            if session is not None:
+                await asyncio.to_thread(session.close)
 
     async def _startup(self):
         self._default_id = self._source.resolve(None)

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -315,8 +315,8 @@ class PolicyServer:
             rid = self._source.resolve(model_id) if model_id is not None else self._default_id
             assert rid is not None
             policy = await self._manager.get_policy(rid, websocket)
-            # Wrapped in ``blocking`` before anything else: a request has no control loop to answer
-            # ``None`` to, and every layer above it must see one call per answer.
+            # A request has no control loop to answer ``None`` to. This goes innermost, so every layer
+            # above it sees one call per answer rather than one per call the answer took.
             answered = blocking(policy)
             if self._recording_dir is not None:
                 # Tap both sides: 'raw' is the wire boundary, 'inference' the encoded obs and model output.

--- a/positronic/offboard/server_utils.py
+++ b/positronic/offboard/server_utils.py
@@ -43,12 +43,15 @@ def warmup(policy: Policy, obs: dict[str, Any], on_progress: Callable[[str], Non
     ``obs`` has to be an observation the loaded backend accepts.
     """
     rt = Executor(policy.functions)
-    session = policy.new_session(rt=rt)
+    session = None
     try:
+        session = policy.new_session(rt=rt)
         run_with_progress(lambda: call_until_answered(session, rt, obs), 'Running warmup inference', on_progress)
     finally:
+        # The runtime closes first: a call in flight is still using what the session holds.
         rt.close()
-        session.close()
+        if session is not None:
+            session.close()
 
 
 def wait_for_subprocess_ready(

--- a/positronic/offboard/server_utils.py
+++ b/positronic/offboard/server_utils.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import Any
 
 from positronic.policy import Policy
+from positronic.policy.executor import Executor, call_until_answered
 
 logger = logging.getLogger(__name__)
 
@@ -41,10 +42,12 @@ def warmup(policy: Policy, obs: dict[str, Any], on_progress: Callable[[str], Non
 
     ``obs`` has to be an observation the loaded backend accepts.
     """
-    session = policy.new_session()
+    rt = Executor(policy.functions)
+    session = policy.new_session(rt=rt)
     try:
-        run_with_progress(lambda: session(obs), 'Running warmup inference', on_progress)
+        run_with_progress(lambda: call_until_answered(session, rt, obs), 'Running warmup inference', on_progress)
     finally:
+        rt.close()
         session.close()
 
 

--- a/positronic/offboard/server_utils.py
+++ b/positronic/offboard/server_utils.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from typing import Any
 
 from positronic.policy import Policy
-from positronic.policy.executor import Executor, call_until_answered
+from positronic.policy.executor import blocking
 
 logger = logging.getLogger(__name__)
 
@@ -42,16 +42,11 @@ def warmup(policy: Policy, obs: dict[str, Any], on_progress: Callable[[str], Non
 
     ``obs`` has to be an observation the loaded backend accepts.
     """
-    rt = Executor(policy.functions)
-    session = None
+    session = blocking(policy).new_session()
     try:
-        session = policy.new_session(rt=rt)
-        run_with_progress(lambda: call_until_answered(session, rt, obs), 'Running warmup inference', on_progress)
+        run_with_progress(lambda: session(obs), 'Running warmup inference', on_progress)
     finally:
-        # The runtime closes first: a call in flight is still using what the session holds.
-        rt.close()
-        if session is not None:
-            session.close()
+        session.close()
 
 
 def wait_for_subprocess_ready(

--- a/positronic/offboard/tests/conftest.py
+++ b/positronic/offboard/tests/conftest.py
@@ -92,7 +92,7 @@ def _make_mock_policy(action, meta):
     policy = MagicMock()
     policy.new_session.return_value = session
     policy.meta = meta
-    policy.functions = {}  # a real mapping: the runtime serving this policy iterates it
+    policy.functions = {}  # `Policy.functions` is a mapping, and MagicMock's stand-in is not
     policy._mock_session = session  # expose for assertions
     return policy
 

--- a/positronic/offboard/tests/conftest.py
+++ b/positronic/offboard/tests/conftest.py
@@ -92,6 +92,7 @@ def _make_mock_policy(action, meta):
     policy = MagicMock()
     policy.new_session.return_value = session
     policy.meta = meta
+    policy.functions = {}  # a real mapping: the runtime serving this policy iterates it
     policy._mock_session = session  # expose for assertions
     return policy
 

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -15,10 +15,7 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _
 from positronic.offboard.tests.conftest import ANSWER_SEC, round_trip
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
-from positronic.policy.executor import Executor
 from positronic.policy.layers import ChunkedSchedule
-from positronic.policy.remote import INFER, RemoteSession
-from positronic.policy.remote import round_trip as wire_round_trip
 from positronic.policy.spec import PolicySource, remote
 
 # These fixtures stand in for a server, so they spell the handshake fields rather than importing the
@@ -55,23 +52,20 @@ def _make_image(h, w):
     return np.zeros((h, w, 3), dtype=np.uint8)
 
 
-def _served_wire() -> Executor:
-    """A runtime serving the round trip a ``RemoteSession`` declares. These tests never start one."""
-    return Executor({INFER: wire_round_trip})
-
-
 class TestPrepareObs:
     """The border's own settings. Image geometry is the declared stack's business (see RestrictImageSize)."""
 
-    def test_images_pass_through_untouched_by_default(self):
-        session = RemoteSession(_mock_ws_session(), _served_wire())
+    def test_images_pass_through_untouched_by_default(self, open_session):
+        endpoint, _ = _mock_endpoint()
+        session, _ = open_session(endpoint)
         obs = {'cam': _make_image(480, 640), 'state': np.array([1.0])}
         prepared = session._prepare_obs(obs)
         assert prepared.keys() == obs.keys()
         assert all(prepared[key] is value for key, value in obs.items())
 
-    def test_compression_reaches_nested_images(self):
-        session = RemoteSession(_mock_ws_session(), _served_wire(), compress_images=True)
+    def test_compression_reaches_nested_images(self, open_session):
+        endpoint, _ = _mock_endpoint({keys.COMPRESS_IMAGES: True})
+        session, _ = open_session(endpoint)
         result = session._prepare_obs({
             'cam': _make_image(48, 64),
             'video': {'wrist': _make_image(48, 64)},

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -17,7 +17,8 @@ from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.executor import Executor
 from positronic.policy.layers import ChunkedSchedule
-from positronic.policy.remote import RemoteSession
+from positronic.policy.remote import INFER, RemoteSession
+from positronic.policy.remote import round_trip as wire_round_trip
 from positronic.policy.spec import PolicySource, remote
 
 # These fixtures stand in for a server, so they spell the handshake fields rather than importing the
@@ -54,18 +55,23 @@ def _make_image(h, w):
     return np.zeros((h, w, 3), dtype=np.uint8)
 
 
+def _served_wire() -> Executor:
+    """A runtime serving the round trip a ``RemoteSession`` declares. These tests never start one."""
+    return Executor({INFER: wire_round_trip})
+
+
 class TestPrepareObs:
     """The border's own settings. Image geometry is the declared stack's business (see RestrictImageSize)."""
 
     def test_images_pass_through_untouched_by_default(self):
-        session = RemoteSession(_mock_ws_session(), Executor({}))
+        session = RemoteSession(_mock_ws_session(), _served_wire())
         obs = {'cam': _make_image(480, 640), 'state': np.array([1.0])}
         prepared = session._prepare_obs(obs)
         assert prepared.keys() == obs.keys()
         assert all(prepared[key] is value for key, value in obs.items())
 
     def test_compression_reaches_nested_images(self):
-        session = RemoteSession(_mock_ws_session(), Executor({}), compress_images=True)
+        session = RemoteSession(_mock_ws_session(), _served_wire(), compress_images=True)
         result = session._prepare_obs({
             'cam': _make_image(48, 64),
             'video': {'wrist': _make_image(48, 64)},

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -19,7 +19,7 @@ from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer
 from positronic.offboard.server_utils import warmup
 from positronic.offboard.tests.conftest import round_trip
 from positronic.policy import Codec, Policy, RemotePolicy, Session
-from positronic.policy.base import Caller, Runtime
+from positronic.policy.base import Runtime
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.layers import ChunkedSchedule, TemporalStack
 from positronic.policy.spec import ModelSource, PolicySource, inline, remote
@@ -244,13 +244,17 @@ _INFER = 'infer'
 
 class _ScriptedSession(Session):
     def __init__(self, rt: Runtime):
-        self._infer = Caller(rt, _INFER)
+        self._rt = rt
+        self._answer = None
 
     def __call__(self, obs):
-        if self._infer.idle:
-            self._infer.start(obs)
+        if self._answer is None:
+            self._answer = self._rt.fns[_INFER](obs)
             return None
-        return self._infer.take()
+        if not self._answer.done():
+            return None
+        answer, self._answer = self._answer, None
+        return answer.result()
 
 
 class _ScriptedPolicy(Policy):

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -242,10 +242,6 @@ def test_pipeline_with_no_rig_side_half_refused_at_startup(make_mock_policy):
 _INFER = 'infer'
 
 
-def _scripted_chunk(obs) -> list[dict[str, Any]]:
-    return [{'a': 1.0}, {'a': 2.0}, {'a': 3.0}]
-
-
 class _ScriptedSession(Session):
     def __init__(self, rt: Runtime):
         self._infer = Caller(rt, _INFER)
@@ -266,7 +262,7 @@ class _ScriptedPolicy(Policy):
 
     @property
     def functions(self):
-        return {_INFER: _scripted_chunk}
+        return {_INFER: lambda obs: [{'a': 1.0}, {'a': 2.0}, {'a': 3.0}]}
 
 
 def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -238,7 +238,6 @@ def test_pipeline_with_no_rig_side_half_refused_at_startup(make_mock_policy):
         PolicyServer(remote | _StubSource(stub))
 
 
-# The name the scripted model is served under.
 _INFER = 'infer'
 
 

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -19,7 +19,9 @@ from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer
 from positronic.offboard.server_utils import warmup
 from positronic.offboard.tests.conftest import round_trip
 from positronic.policy import Codec, Policy, RemotePolicy, Session
+from positronic.policy.base import Runtime
 from positronic.policy.codec import ActionTimestamp
+from positronic.policy.executor import Caller
 from positronic.policy.layers import ChunkedSchedule, TemporalStack
 from positronic.policy.spec import ModelSource, PolicySource, inline, remote
 
@@ -237,16 +239,35 @@ def test_pipeline_with_no_rig_side_half_refused_at_startup(make_mock_policy):
         PolicyServer(remote | _StubSource(stub))
 
 
+# The name the scripted model is served under.
+_INFER = 'infer'
+
+
+def _scripted_chunk(obs) -> list[dict[str, Any]]:
+    return [{'a': 1.0}, {'a': 2.0}, {'a': 3.0}]
+
+
 class _ScriptedSession(Session):
+    def __init__(self, rt: Runtime):
+        self._infer = Caller(rt, _INFER)
+
     def __call__(self, obs):
-        return [{'a': 1.0}, {'a': 2.0}, {'a': 3.0}]
+        if self._infer.idle:
+            self._infer.start(obs)
+            return None
+        return self._infer.take()
 
 
 class _ScriptedPolicy(Policy):
-    """Deterministic base policy: every session returns the same untimestamped chunk."""
+    """Deterministic base policy: every session serves the same untimestamped chunk from its runtime."""
 
     def new_session(self, context=None, now=None, rt=None) -> Session:
-        return _ScriptedSession()
+        assert rt is not None
+        return _ScriptedSession(rt)
+
+    @property
+    def functions(self):
+        return {_INFER: _scripted_chunk}
 
 
 def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):
@@ -260,11 +281,10 @@ def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):
     host, port, _server = start_server(pipeline())
     remote_session, rt = open_session(RemotePolicy(f'{host}:{port}'), now=lambda: clock[0])
 
-    local_session, _ = open_session(inline(pipeline()), now=lambda: clock[0])
+    local_session, local_rt = open_session(inline(pipeline()), now=lambda: clock[0])
 
-    # The wire half answers on the call after the one that asked. The in-process half answers that call.
     remote_actions = round_trip(remote_session, rt, {keys.OBS_TIME_NS: 0})
-    local_actions = local_session({keys.OBS_TIME_NS: 0})
+    local_actions = round_trip(local_session, local_rt, {keys.OBS_TIME_NS: 0})
     assert remote_actions == local_actions
     # Three scripted actions plus the chunk-closing validity sentinel ActionTimestamp appends.
     assert local_actions == [

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -19,9 +19,8 @@ from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer
 from positronic.offboard.server_utils import warmup
 from positronic.offboard.tests.conftest import round_trip
 from positronic.policy import Codec, Policy, RemotePolicy, Session
-from positronic.policy.base import Runtime
+from positronic.policy.base import Caller, Runtime
 from positronic.policy.codec import ActionTimestamp
-from positronic.policy.executor import Caller
 from positronic.policy.layers import ChunkedSchedule, TemporalStack
 from positronic.policy.spec import ModelSource, PolicySource, inline, remote
 

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -46,53 +46,6 @@ class Runtime(ABC):
         """The policy's functions, under the names it declared them by."""
 
 
-class Caller:
-    """One session's use of one served function, with one call in flight at a time.
-
-    A session starts a call and gives control back. It reads the answer on a later call, through ``take``.
-
-    pimm has a ``Caller`` of another shape. The two are not interchangeable.
-    """
-
-    def __init__(self, rt: Runtime, name: str):
-        # Looked up per call, so a runtime that closes drops the function and what it was declared with.
-        assert name in rt.fns, f'the runtime serves no function named {name!r}'
-        self._rt = rt
-        self._name = name
-        self._answer: Answer | None = None
-        self._cancelled = False
-
-    @property
-    def idle(self) -> bool:
-        """Whether no call is held, so a new one can start."""
-        return self._answer is None
-
-    @property
-    def in_flight(self) -> bool:
-        """Whether the call that is held has still to answer."""
-        return self._answer is not None and not self._answer.done()
-
-    def start(self, *args: Any, **kwargs: Any) -> None:
-        assert self._answer is None, 'a call is already in flight'
-        self._answer = self._rt.fns[self._name](*args, **kwargs)
-
-    def take(self) -> Any:
-        """What the call returned, and ``None`` while it is out or after a cancel."""
-        assert self._answer is not None, 'no call is held, so there is no answer to take'
-        if not self._answer.done():
-            return None
-        answer, cancelled = self._answer, self._cancelled
-        # Both are cleared before the read, because ``result`` raises what the call raised. A cancel then
-        # ends with the answer it was made against, and does not drop the next one.
-        self._answer, self._cancelled = None, False
-        result = answer.result()
-        return None if cancelled else result
-
-    def cancel(self) -> None:
-        """Drop the result of the call that is held. ``take`` still raises what that call raised."""
-        self._cancelled = self._answer is not None
-
-
 class Session(ABC):
     """Per-episode inference session. Created by ``Policy.new_session()``.
 

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -46,6 +46,48 @@ class Runtime(ABC):
         """The policy's functions, under the names it declared them by."""
 
 
+class Caller:
+    """One session's use of one served function, with one call in flight at a time.
+
+    A session starts a call and gives control back. It reads the answer on a later call, through ``take``.
+    """
+
+    def __init__(self, rt: Runtime, name: str):
+        self._fn = rt.fns[name]
+        self._answer: Answer | None = None
+        self._cancelled = False
+
+    @property
+    def idle(self) -> bool:
+        """Whether no call is held, so a new one can start."""
+        return self._answer is None
+
+    @property
+    def in_flight(self) -> bool:
+        """Whether the call that is held has still to answer."""
+        return self._answer is not None and not self._answer.done()
+
+    def start(self, *args: Any, **kwargs: Any) -> None:
+        assert self._answer is None, 'a call is already in flight'
+        self._answer = self._fn(*args, **kwargs)
+
+    def take(self) -> Any:
+        """What the call returned, and ``None`` while it is out or after a cancel."""
+        assert self._answer is not None, 'no call is held, so there is no answer to take'
+        if not self._answer.done():
+            return None
+        answer, cancelled = self._answer, self._cancelled
+        # Both are cleared before the read, because ``result`` raises what the call raised. A cancel then
+        # ends with the answer it was made against, and does not drop the next one.
+        self._answer, self._cancelled = None, False
+        result = answer.result()
+        return None if cancelled else result
+
+    def cancel(self) -> None:
+        """Drop the result of the call that is held. ``take`` still raises what that call raised."""
+        self._cancelled = self._answer is not None
+
+
 class Session(ABC):
     """Per-episode inference session. Created by ``Policy.new_session()``.
 
@@ -127,8 +169,8 @@ class Policy(ABC):
             context: The episode's task description.
             now: The runtime clock (current time in seconds), supplied by the harness and passed down
                 to every wrapped session. ``None`` where no runtime clock exists (server-side, warmup).
-            rt: This session's runtime, serving ``functions``. ``None`` where nothing runs them, as in a
-                server's own session. A session that needs one refuses to open without it.
+            rt: This session's runtime, serving ``functions``. ``None`` only where no caller supplied one.
+                A session that needs one refuses to open without it.
         """
 
     @property

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -50,10 +50,15 @@ class Caller:
     """One session's use of one served function, with one call in flight at a time.
 
     A session starts a call and gives control back. It reads the answer on a later call, through ``take``.
+
+    pimm has a ``Caller`` of another shape. The two are not interchangeable.
     """
 
     def __init__(self, rt: Runtime, name: str):
-        self._fn = rt.fns[name]
+        # Looked up per call, so a runtime that closes drops the function and what it was declared with.
+        assert name in rt.fns, f'the runtime serves no function named {name!r}'
+        self._rt = rt
+        self._name = name
         self._answer: Answer | None = None
         self._cancelled = False
 
@@ -69,7 +74,7 @@ class Caller:
 
     def start(self, *args: Any, **kwargs: Any) -> None:
         assert self._answer is None, 'a call is already in flight'
-        self._answer = self._fn(*args, **kwargs)
+        self._answer = self._rt.fns[self._name](*args, **kwargs)
 
     def take(self) -> Any:
         """What the call returned, and ``None`` while it is out or after a cancel."""

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -1,4 +1,8 @@
-"""The in-process runtime: a call starts the work on a worker thread and returns an ``Answer``."""
+"""The in-process runtime, and the two ways code calls a served function.
+
+A session holds one call at a time through a ``Caller``. A caller with no control loop of its own —
+a server request, a warmup, a probe — runs a session call to its answer with ``call_until_answered``.
+"""
 
 import concurrent.futures
 import contextvars
@@ -9,7 +13,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from typing import Any
 
-from positronic.policy.base import Answer, Fn, NotAnswered, Runtime
+from positronic.policy.base import Answer, Fn, NotAnswered, Runtime, Session
 
 
 class Executor(Runtime):
@@ -58,6 +62,12 @@ class Executor(Runtime):
         with self._lock:
             return bool(self._pending)
 
+    @property
+    def owes_an_answer(self) -> bool:
+        """Whether any call's answer has still to be read, whether or not that call has landed."""
+        with self._lock:
+            return bool(self._unread)
+
     def wait(self, timeout: float | None = None) -> None:
         """Block until every call made so far has answered, or until ``timeout`` seconds pass."""
         with self._lock:
@@ -96,3 +106,59 @@ class Executor(Runtime):
             # and the log is the only place the failure can go.
             if (exc := answer.failure()) is not None:
                 logging.error(f'The function {answer.name} failed and no caller read its answer: {exc}')
+
+
+class Caller:
+    """One session's use of one served function, with one call in flight at a time.
+
+    A session starts a call and gives control back. It reads the answer on a later call, through ``take``.
+    """
+
+    def __init__(self, rt: Runtime, name: str):
+        self._fn = rt.fns[name]
+        self._answer: Answer | None = None
+        self._cancelled = False
+
+    @property
+    def idle(self) -> bool:
+        """Whether no call is held, so a new one can start."""
+        return self._answer is None
+
+    @property
+    def in_flight(self) -> bool:
+        """Whether the call that is held has still to answer."""
+        return self._answer is not None and not self._answer.done()
+
+    def start(self, *args: Any, **kwargs: Any) -> None:
+        assert self._answer is None, 'a call is already in flight'
+        self._answer = self._fn(*args, **kwargs)
+
+    def take(self) -> Any:
+        """What the call returned, and ``None`` while it is out or after a cancel."""
+        assert self._answer is not None, 'no call is held, so there is no answer to take'
+        if not self._answer.done():
+            return None
+        answer, cancelled = self._answer, self._cancelled
+        # Both are cleared before the read, because ``result`` raises what the call raised. A cancel then
+        # ends with the answer it was made against, and does not drop the next one.
+        self._answer, self._cancelled = None, False
+        result = answer.result()
+        return None if cancelled else result
+
+    def cancel(self) -> None:
+        """Drop the result of the call that is held. ``take`` still raises what that call raised."""
+        self._cancelled = self._answer is not None
+
+
+def call_until_answered(session: Session, rt: Executor, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+    """What ``session`` answers for ``obs``, over as many calls as the functions it starts take.
+
+    For a caller that has no control loop to give the time back to.
+    """
+    actions = session(obs)
+    # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the session
+    # reads an answer only on a later call.
+    while actions is None and rt.owes_an_answer:
+        rt.wait()
+        actions = session(obs)
+    return actions

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -54,9 +54,8 @@ class Executor(Runtime):
     def __init__(self, functions: Mapping[str, Callable[..., Any]], *, max_workers: int = 1):
         self._pool = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix='policy-fn')
         self._fns: Mapping[str, Fn] = {name: partial(self._start, name, fn) for name, fn in functions.items()}
-        # Every answer that no caller has read, written from the caller's thread while the workers answer.
-        # A call that has still to answer is one of these; what is left at close failed with nobody to
-        # raise to.
+        # Every answer that no caller has read. A call that has still to answer is one of these, so
+        # ``in_flight`` and ``owes_an_answer`` read this one set.
         self._unread: set[Executor._Answer] = set()
         self._lock = threading.Lock()
 
@@ -104,8 +103,8 @@ class Executor(Runtime):
         """
         self._pool.shutdown(wait=True, cancel_futures=True)
         with self._lock:
-            # A function holds what it was declared with — model weights, a socket — so the close that ends
-            # its last call drops it. Otherwise the policy that closes next frees nothing.
+            # A function holds what it was declared with — model weights, a socket. Dropping the functions
+            # here is what lets the policy that closes next free them.
             unread, self._unread = self._unread, set()
             self._fns = dict.fromkeys(self._fns, _closed)
         for answer in unread:
@@ -122,8 +121,8 @@ class _BlockingPolicy(DelegatingPolicy):
             self._rt = rt
 
         def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
-            # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the
-            # inner session reads an answer only on a later call.
+            # The inner session reads an answer only on a later call. A test of ``in_flight`` would exit
+            # on a call that lands while the session call runs, leaving its answer unread.
             while (actions := self._inner(obs)) is None and self._rt.owes_an_answer:
                 self._rt.wait()
             return actions

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -1,8 +1,4 @@
-"""The in-process runtime, and the two ways code calls a served function.
-
-A session holds one call at a time through a ``Caller``. A caller with no control loop of its own —
-a server request, a warmup, a probe — runs a session call to its answer with ``call_until_answered``.
-"""
+"""The in-process runtime: a call starts the work on a worker thread and returns an ``Answer``."""
 
 import concurrent.futures
 import contextvars
@@ -14,6 +10,10 @@ from functools import partial
 from typing import Any
 
 from positronic.policy.base import Answer, Fn, NotAnswered, Runtime, Session
+
+
+def _closed(*args: Any, **kwargs: Any) -> Answer:
+    raise RuntimeError('The runtime is closed and serves nothing')
 
 
 class Executor(Runtime):
@@ -65,6 +65,8 @@ class Executor(Runtime):
     @property
     def owes_an_answer(self) -> bool:
         """Whether any call's answer has still to be read, whether or not that call has landed."""
+        # TODO(#661): a caller polls this because a session cannot say when it wants the next call. Rung 7
+        # gives the session ``resume_at``, and the poll goes with it.
         with self._lock:
             return bool(self._unread)
 
@@ -100,7 +102,10 @@ class Executor(Runtime):
         """
         self._pool.shutdown(wait=True, cancel_futures=True)
         with self._lock:
+            # A function holds what it was declared with — model weights, a socket — so the close that ends
+            # its last call drops it. Otherwise the policy that closes next frees nothing.
             unread, self._unread = self._unread, set()
+            self._fns = dict.fromkeys(self._fns, _closed)
         for answer in unread:
             # rules-allow: swallowed-error — the caller dropped the answer, so there is nobody to raise to,
             # and the log is the only place the failure can go.
@@ -108,57 +113,13 @@ class Executor(Runtime):
                 logging.error(f'The function {answer.name} failed and no caller read its answer: {exc}')
 
 
-class Caller:
-    """One session's use of one served function, with one call in flight at a time.
-
-    A session starts a call and gives control back. It reads the answer on a later call, through ``take``.
-    """
-
-    def __init__(self, rt: Runtime, name: str):
-        self._fn = rt.fns[name]
-        self._answer: Answer | None = None
-        self._cancelled = False
-
-    @property
-    def idle(self) -> bool:
-        """Whether no call is held, so a new one can start."""
-        return self._answer is None
-
-    @property
-    def in_flight(self) -> bool:
-        """Whether the call that is held has still to answer."""
-        return self._answer is not None and not self._answer.done()
-
-    def start(self, *args: Any, **kwargs: Any) -> None:
-        assert self._answer is None, 'a call is already in flight'
-        self._answer = self._fn(*args, **kwargs)
-
-    def take(self) -> Any:
-        """What the call returned, and ``None`` while it is out or after a cancel."""
-        assert self._answer is not None, 'no call is held, so there is no answer to take'
-        if not self._answer.done():
-            return None
-        answer, cancelled = self._answer, self._cancelled
-        # Both are cleared before the read, because ``result`` raises what the call raised. A cancel then
-        # ends with the answer it was made against, and does not drop the next one.
-        self._answer, self._cancelled = None, False
-        result = answer.result()
-        return None if cancelled else result
-
-    def cancel(self) -> None:
-        """Drop the result of the call that is held. ``take`` still raises what that call raised."""
-        self._cancelled = self._answer is not None
-
-
 def call_until_answered(session: Session, rt: Executor, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
     """What ``session`` answers for ``obs``, over as many calls as the functions it starts take.
 
     For a caller that has no control loop to give the time back to.
     """
-    actions = session(obs)
     # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the session
     # reads an answer only on a later call.
-    while actions is None and rt.owes_an_answer:
+    while (actions := session(obs)) is None and rt.owes_an_answer:
         rt.wait()
-        actions = session(obs)
     return actions

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -35,31 +35,30 @@ class Executor(Runtime):
     class _Answer(Answer):
         def __init__(self, name: str, call: Future[Any], read: Callable[['Executor._Answer'], None]):
             self.name = name
-            self._call = call
+            self.call = call
             self._read = read
 
         def done(self) -> bool:
-            return self._call.done()
+            return self.call.done()
 
         def result(self) -> Any:
-            if not self._call.done():
+            if not self.call.done():
                 raise NotAnswered('The call is not answered yet')
             self._read(self)
-            return self._call.result()
+            return self.call.result()
 
         def failure(self) -> BaseException | None:
             """What the call raised, once it has answered. ``None`` when it returned a value or was cancelled."""
-            return None if self._call.cancelled() else self._call.exception()
+            return None if self.call.cancelled() else self.call.exception()
 
     def __init__(self, functions: Mapping[str, Callable[..., Any]], *, max_workers: int = 1):
         self._pool = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix='policy-fn')
         self._fns: Mapping[str, Fn] = {name: partial(self._start, name, fn) for name, fn in functions.items()}
-        # Every call made and not answered yet, read from the caller's thread while the workers answer. The
-        # lock is reentrant because a call that answers before it is registered runs ``_answered`` inline.
-        self._pending: set[Future[Any]] = set()
-        # Every answer that no caller has read. What is left at close failed with nobody to raise to.
+        # Every answer that no caller has read, written from the caller's thread while the workers answer.
+        # A call that has still to answer is one of these; what is left at close failed with nobody to
+        # raise to.
         self._unread: set[Executor._Answer] = set()
-        self._lock = threading.RLock()
+        self._lock = threading.Lock()
 
     @property
     def fns(self) -> Mapping[str, Fn]:
@@ -69,7 +68,7 @@ class Executor(Runtime):
     def in_flight(self) -> bool:
         """Whether any call is still to answer."""
         with self._lock:
-            return bool(self._pending)
+            return any(not answer.done() for answer in self._unread)
 
     @property
     def owes_an_answer(self) -> bool:
@@ -82,7 +81,7 @@ class Executor(Runtime):
     def wait(self, timeout: float | None = None) -> None:
         """Block until every call made so far has answered, or until ``timeout`` seconds pass."""
         with self._lock:
-            pending = set(self._pending)
+            pending = [answer.call for answer in self._unread]
         concurrent.futures.wait(pending, timeout=timeout)
 
     def _start(self, name: str, fn: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Answer:
@@ -90,14 +89,8 @@ class Executor(Runtime):
         call = self._pool.submit(context.run, fn, *args, **kwargs)
         answer = self._Answer(name, call, self._read)
         with self._lock:
-            self._pending.add(call)
             self._unread.add(answer)
-            call.add_done_callback(self._answered)
         return answer
-
-    def _answered(self, call: Future[Any]) -> None:
-        with self._lock:
-            self._pending.discard(call)
 
     def _read(self, answer: '_Answer') -> None:
         with self._lock:
@@ -143,8 +136,12 @@ class _BlockingSession(DelegatingSession):
 class _BlockingPolicy(DelegatingPolicy):
     def new_session(self, context=None, now=None, rt=None) -> Session:
         assert rt is None, 'a blocking policy serves its own functions; nothing above it runs them'
-        rt = Executor(self._inner.functions)
-        return _BlockingSession(self._inner.new_session(context, now, rt), rt)
+        own = Executor(self._inner.functions)
+        try:
+            return _BlockingSession(self._inner.new_session(context, now, own), own)
+        except BaseException:
+            own.close()
+            raise
 
     @property
     def functions(self) -> Mapping[str, Callable[..., Any]]:
@@ -155,6 +152,7 @@ def blocking(policy: Policy) -> Policy:
     """``policy`` with its heavy work waited out: a session answers in the call that asked.
 
     For a caller with no control loop to give the time back to — a server request, a warmup, a probe.
-    Layers wrap the result rather than the other way round, so each sees one call per answer.
+    Layers wrap the result rather than the other way round, so each sees one call per answer. Layers that
+    ``policy`` composes itself are inside, so those still run once per call.
     """
     return _BlockingPolicy(policy)

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -9,7 +9,16 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from typing import Any
 
-from positronic.policy.base import Answer, Fn, NotAnswered, Runtime, Session
+from positronic.policy.base import (
+    Answer,
+    DelegatingPolicy,
+    DelegatingSession,
+    Fn,
+    NotAnswered,
+    Policy,
+    Runtime,
+    Session,
+)
 
 
 def _closed(*args: Any, **kwargs: Any) -> Answer:
@@ -113,13 +122,39 @@ class Executor(Runtime):
                 logging.error(f'The function {answer.name} failed and no caller read its answer: {exc}')
 
 
-def call_until_answered(session: Session, rt: Executor, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
-    """What ``session`` answers for ``obs``, over as many calls as the functions it starts take.
+class _BlockingSession(DelegatingSession):
+    def __init__(self, inner: Session, rt: Executor):
+        super().__init__(inner)
+        self._rt = rt
 
-    For a caller that has no control loop to give the time back to.
+    def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+        # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the
+        # inner session reads an answer only on a later call.
+        while (actions := self._inner(obs)) is None and self._rt.owes_an_answer:
+            self._rt.wait()
+        return actions
+
+    def close(self):
+        # The runtime closes first: a call in flight is still using what the session holds.
+        self._rt.close()
+        self._inner.close()
+
+
+class _BlockingPolicy(DelegatingPolicy):
+    def new_session(self, context=None, now=None, rt=None) -> Session:
+        assert rt is None, 'a blocking policy serves its own functions; nothing above it runs them'
+        rt = Executor(self._inner.functions)
+        return _BlockingSession(self._inner.new_session(context, now, rt), rt)
+
+    @property
+    def functions(self) -> Mapping[str, Callable[..., Any]]:
+        return {}
+
+
+def blocking(policy: Policy) -> Policy:
+    """``policy`` with its heavy work waited out: a session answers in the call that asked.
+
+    For a caller with no control loop to give the time back to — a server request, a warmup, a probe.
+    Layers wrap the result rather than the other way round, so each sees one call per answer.
     """
-    # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the session
-    # reads an answer only on a later call.
-    while (actions := session(obs)) is None and rt.owes_an_answer:
-        rt.wait()
-    return actions
+    return _BlockingPolicy(policy)

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -21,10 +21,6 @@ from positronic.policy.base import (
 )
 
 
-def _closed(*args: Any, **kwargs: Any) -> Answer:
-    raise RuntimeError('The runtime is closed and serves nothing')
-
-
 class Executor(Runtime):
     """Serves a set of functions on worker threads of its own, ``max_workers`` calls at a time.
 
@@ -95,6 +91,10 @@ class Executor(Runtime):
         with self._lock:
             self._unread.discard(answer)
 
+    @staticmethod
+    def _closed(*args: Any, **kwargs: Any) -> Answer:
+        raise RuntimeError('The runtime is closed and serves nothing')
+
     def close(self) -> None:
         """Drop the queued calls and wait out those in flight, which may still hold their caller's resources.
         A call made after close raises.
@@ -103,10 +103,10 @@ class Executor(Runtime):
         """
         self._pool.shutdown(wait=True, cancel_futures=True)
         with self._lock:
-            # A function holds what it was declared with — model weights, a socket. Dropping the functions
-            # here is what lets the policy that closes next free them.
+            # A function holds what it was declared with — model weights, a socket. Nothing reaches them
+            # through this runtime after it closes.
             unread, self._unread = self._unread, set()
-            self._fns = dict.fromkeys(self._fns, _closed)
+            self._fns = dict.fromkeys(self._fns, self._closed)
         for answer in unread:
             # rules-allow: swallowed-error — the caller dropped the answer, so there is nobody to raise to,
             # and the log is the only place the failure can go.

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -115,30 +115,29 @@ class Executor(Runtime):
                 logging.error(f'The function {answer.name} failed and no caller read its answer: {exc}')
 
 
-class _BlockingSession(DelegatingSession):
-    def __init__(self, inner: Session, rt: Executor):
-        super().__init__(inner)
-        self._rt = rt
-
-    def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
-        # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the
-        # inner session reads an answer only on a later call.
-        while (actions := self._inner(obs)) is None and self._rt.owes_an_answer:
-            self._rt.wait()
-        return actions
-
-    def close(self):
-        # The runtime closes first: a call in flight is still using what the session holds.
-        self._rt.close()
-        self._inner.close()
-
-
 class _BlockingPolicy(DelegatingPolicy):
+    class _Session(DelegatingSession):
+        def __init__(self, inner: Session, rt: Executor):
+            super().__init__(inner)
+            self._rt = rt
+
+        def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+            # Not ``in_flight``: a call that lands before this test would leave its answer unread, and the
+            # inner session reads an answer only on a later call.
+            while (actions := self._inner(obs)) is None and self._rt.owes_an_answer:
+                self._rt.wait()
+            return actions
+
+        def close(self):
+            # The runtime closes first: a call in flight is still using what the session holds.
+            self._rt.close()
+            self._inner.close()
+
     def new_session(self, context=None, now=None, rt=None) -> Session:
         assert rt is None, 'a blocking policy serves its own functions; nothing above it runs them'
         own = Executor(self._inner.functions)
         try:
-            return _BlockingSession(self._inner.new_session(context, now, own), own)
+            return _BlockingPolicy._Session(self._inner.new_session(context, now, own), own)
         except BaseException:
             own.close()
             raise

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -74,8 +74,9 @@ class RemoteSession(Session):
         if not self._answer.done():
             return None
         answer, cancelled = self._answer, self._cancelled
-        # Both are cleared before the read, because ``result`` raises what the round trip raised. A cancel
-        # then ends with the answer it was made against, and does not drop the next chunk.
+        # The answer and the flag are cleared before the read, because ``result`` raises what the round
+        # trip raised. A cancel then ends with the answer it was made against, and never drops the next
+        # chunk.
         self._answer, self._cancelled = None, False
         result = answer.result()
         if cancelled:

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -10,7 +10,7 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, I
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 
-from .base import Caller, Layer, Policy, Runtime, Session
+from .base import Answer, Layer, Policy, Runtime, Session
 from .recording import Recorder
 from .spec import from_spec
 
@@ -39,8 +39,10 @@ class RemoteSession(Session):
 
     def __init__(self, ws_session: InferenceSession, rt: Runtime, compress_images: bool = False):
         self._session = ws_session
-        self._infer = Caller(rt, INFER)
+        self._rt = rt
         self._compress_images = compress_images
+        self._answer: Answer | None = None
+        self._cancelled = False
 
     def _prepare_obs(self, obs: cabc.Mapping[str, Any]) -> dict[str, Any]:
         if not self._compress_images:
@@ -64,23 +66,33 @@ class RemoteSession(Session):
         A server answer of one action becomes a 1-element list, which is the form ``Session.__call__``
         returns.
         """
-        if self._infer.idle:
+        if self._answer is None:
             # The session prepares the observation, and the function only sends it. The ``policy.infer`` span
             # times the function, and a JPEG encode of an HD frame stack is not inference.
-            self._infer.start(self._session, self._prepare_obs(obs))
+            self._answer = self._rt.fns[INFER](self._session, self._prepare_obs(obs))
             return None
-        result = self._infer.take()
+        if not self._answer.done():
+            return None
+        answer, cancelled = self._answer, self._cancelled
+        # Both are cleared before the read, because ``result`` raises what the round trip raised. A cancel
+        # then ends with the answer it was made against, and does not drop the next chunk.
+        self._answer, self._cancelled = None, False
+        result = answer.result()
+        if cancelled:
+            return None
         return [result] if isinstance(result, dict) else result
 
     def cancel(self):
-        self._infer.cancel()
+        # The cancel says the world the chunk applies to has gone. The session still reads the round trip
+        # for its failure, and drops the chunk that comes with it.
+        self._cancelled = self._answer is not None
 
     @property
     def meta(self) -> dict[str, Any]:
         return flatten_dict({keys.TYPE: 'remote', keys.SERVER: self._session.metadata})
 
     def close(self):
-        assert not self._infer.in_flight, (
+        assert self._answer is None or self._answer.done(), (
             'close the runtime serving this session first: the round trip in flight uses the websocket that this closes'
         )
         self._session.close()

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -10,8 +10,7 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, I
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 
-from .base import Layer, Policy, Runtime, Session
-from .executor import Caller
+from .base import Caller, Layer, Policy, Runtime, Session
 from .recording import Recorder
 from .spec import from_spec
 
@@ -109,10 +108,7 @@ class _Endpoint(Policy):
 
     def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
         if rt is None:
-            raise ValueError(
-                'A remote session runs its inference on a runtime: pass rt to new_session. The harness '
-                'passes one, and a caller that opens a session outside the harness must pass one too.'
-            )
+            raise ValueError('A remote session runs its inference on a runtime: pass rt to new_session.')
         compress = bool(self.server_meta().get(keys.COMPRESS_IMAGES))
         ws_session = self._client.new_session()
         return RemoteSession(ws_session, rt, compress_images=compress)

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -10,7 +10,8 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, I
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 
-from .base import Answer, Layer, Policy, Runtime, Session
+from .base import Layer, Policy, Runtime, Session
+from .executor import Caller
 from .recording import Recorder
 from .spec import from_spec
 
@@ -39,10 +40,8 @@ class RemoteSession(Session):
 
     def __init__(self, ws_session: InferenceSession, rt: Runtime, compress_images: bool = False):
         self._session = ws_session
-        self._rt = rt
+        self._infer = Caller(rt, INFER)
         self._compress_images = compress_images
-        self._answer: Answer | None = None
-        self._cancelled = False
 
     def _prepare_obs(self, obs: cabc.Mapping[str, Any]) -> dict[str, Any]:
         if not self._compress_images:
@@ -66,33 +65,23 @@ class RemoteSession(Session):
         A server answer of one action becomes a 1-element list, which is the form ``Session.__call__``
         returns.
         """
-        if self._answer is None:
+        if self._infer.idle:
             # The session prepares the observation, and the function only sends it. The ``policy.infer`` span
             # times the function, and a JPEG encode of an HD frame stack is not inference.
-            self._answer = self._rt.fns[INFER](self._session, self._prepare_obs(obs))
+            self._infer.start(self._session, self._prepare_obs(obs))
             return None
-        if not self._answer.done():
-            return None
-        answer, cancelled = self._answer, self._cancelled
-        # Both are cleared before the read, because ``result`` raises what the round trip raised. A cancel
-        # then ends with the answer it was made against, and does not drop the next chunk.
-        self._answer, self._cancelled = None, False
-        result = answer.result()
-        if cancelled:
-            return None
+        result = self._infer.take()
         return [result] if isinstance(result, dict) else result
 
     def cancel(self):
-        # The cancel says the world the chunk applies to has gone. The session still reads the round trip
-        # for its failure, and drops the chunk that comes with it.
-        self._cancelled = self._answer is not None
+        self._infer.cancel()
 
     @property
     def meta(self) -> dict[str, Any]:
         return flatten_dict({keys.TYPE: 'remote', keys.SERVER: self._session.metadata})
 
     def close(self):
-        assert self._answer is None or self._answer.done(), (
+        assert not self._infer.in_flight, (
             'close the runtime serving this session first: the round trip in flight uses the websocket that this closes'
         )
         self._session.close()

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -234,61 +234,55 @@ def test_close_stays_quiet_about_a_call_that_answered(serve, caplog):
     assert caplog.text == ''
 
 
-class _PlainSession(Session):
-    """A session that does its work inside its own call."""
-
-    def __init__(self):
-        self.calls = 0
-
-    def __call__(self, obs):
-        self.calls += 1
-        return [{'action': obs}]
-
-
-_ECHO = 'echo'
-
-
-class _RoundsSession(Session):
-    """A session that starts one served call per round, and answers the last round's result."""
-
-    def __init__(self, rt, rounds: int):
-        self._rt = rt
-        self._answer = None
-        self._left = rounds
-        self.calls = 0
-
-    def __call__(self, obs):
-        self.calls += 1
-        result = None
-        if self._answer is not None:
-            result, self._answer = self._answer.result(), None
-        if self._left > 0:
-            self._left -= 1
-            self._answer = self._rt.fns[_ECHO](obs)
-            return None
-        return result
-
-
 class _PlainPolicy(Policy):
     """Serves nothing: its session answers inside the call that asked."""
 
+    class _Session(Session):
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, obs):
+            self.calls += 1
+            return [{'action': obs}]
+
     def __init__(self):
-        self.session = _PlainSession()
+        self.session = _PlainPolicy._Session()
 
     def new_session(self, context=None, now=None, rt=None) -> Session:
         return self.session
 
 
+_ECHO = 'echo'
+
+
 class _EchoPolicy(Policy):
     """Serves ``echo``, and makes sessions that take ``rounds`` calls of it to answer."""
 
+    class _Session(Session):
+        def __init__(self, rt, rounds: int):
+            self._rt = rt
+            self._answer = None
+            self._left = rounds
+            self.calls = 0
+
+        def __call__(self, obs):
+            self.calls += 1
+            result = None
+            if self._answer is not None:
+                result, self._answer = self._answer.result(), None
+            if self._left > 0:
+                self._left -= 1
+                self._answer = self._rt.fns[_ECHO](obs)
+                return None
+            return result
+
     def __init__(self, rounds: int):
         self._rounds = rounds
-        self.session: _RoundsSession
+        self.session: _EchoPolicy._Session
 
     def new_session(self, context=None, now=None, rt=None) -> Session:
         assert rt is not None
-        self.session = _RoundsSession(rt, self._rounds)
+        self.session = _EchoPolicy._Session(rt, self._rounds)
         return self.session
 
     @property

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -242,7 +242,7 @@ class TestCaller:
     """One session's use of one served function."""
 
     def test_a_caller_of_an_unserved_function_fails_where_it_is_built(self, serve):
-        with pytest.raises(KeyError):
+        with pytest.raises(AssertionError, match='infer'):
             Caller(serve(add=operator.add), 'infer')
 
     def test_a_fresh_caller_is_idle(self, serve):
@@ -360,19 +360,26 @@ class _RoundsSession(Session):
         return result
 
 
+class _PlainPolicy(Policy):
+    """Serves nothing: its session answers inside the call that asked."""
+
+    def __init__(self):
+        self.session = _PlainSession()
+
+    def new_session(self, context=None, now=None, rt=None) -> Session:
+        return self.session
+
+
 class _EchoPolicy(Policy):
     """Serves ``echo``, and makes sessions that take ``rounds`` calls of it to answer."""
 
-    def __init__(self, rounds: int | None = None):
+    def __init__(self, rounds: int):
         self._rounds = rounds
-        self.session: _PlainSession | _RoundsSession
+        self.session: _RoundsSession
 
     def new_session(self, context=None, now=None, rt=None) -> Session:
-        if self._rounds is None:
-            self.session = _PlainSession()
-        else:
-            assert rt is not None
-            self.session = _RoundsSession(rt, self._rounds)
+        assert rt is not None
+        self.session = _RoundsSession(rt, self._rounds)
         return self.session
 
     @property
@@ -417,7 +424,7 @@ class TestBlocking:
     """A policy whose sessions answer in the call that asked."""
 
     def test_a_session_that_answers_in_its_own_call_is_called_one_time(self, opened):
-        policy = _EchoPolicy()
+        policy = _PlainPolicy()
 
         assert opened(blocking(policy))({'x': 1}) == [{'action': {'x': 1}}]
         assert policy.session.calls == 1
@@ -451,7 +458,6 @@ class TestBlocking:
         """Nobody else can: the runtime is the session's own, made where the session was."""
         policy = _EchoPolicy(rounds=1)
         session = blocking(policy).new_session()
-        assert isinstance(policy.session, _RoundsSession)
         session.close()
 
         with pytest.raises(RuntimeError):
@@ -463,12 +469,16 @@ class _Weights:
 
 
 def test_close_frees_what_the_functions_held(serve):
-    """A closed runtime drops its functions, so the policy that closes next can free the weights."""
+    """A closed runtime drops its functions, so the policy that closes next can free the weights.
+
+    The live session keeps its ``Caller``: the runtime is the only place a function reference lives.
+    """
     weights = _Weights()
     gone = weakref.ref(weights)
     executor = serve(infer=partial(operator.is_, weights))
+    caller = Caller(executor, 'infer')
     del weights
 
     assert gone() is not None
     executor.close()
-    assert gone() is None
+    assert (gone(), caller.idle) == (None, True)

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -4,13 +4,14 @@ import logging
 import operator
 import threading
 import time
+import weakref
 from contextvars import ContextVar
 from functools import partial
 
 import pytest
 
-from positronic.policy.base import Answer, NotAnswered, Session
-from positronic.policy.executor import Caller, Executor, call_until_answered
+from positronic.policy.base import Answer, Caller, NotAnswered, Session
+from positronic.policy.executor import Executor, call_until_answered
 
 # How long a test waits for the worker threads before calling the call lost.
 TIMEOUT_SEC = 5.0
@@ -352,7 +353,7 @@ class _RoundsSession(Session):
     def __call__(self, obs):
         self.calls += 1
         result = None if self._infer.idle else self._infer.take()
-        if self._infer.idle and self._left > 0:
+        if self._left > 0:
             self._left -= 1
             self._infer.start(obs)
             return None
@@ -368,19 +369,13 @@ class TestCallUntilAnswered:
         assert call_until_answered(session, serve(), {'x': 1}) == [{'action': {'x': 1}}]
         assert session.calls == 1
 
-    def test_a_session_is_called_again_for_the_function_it_started(self, serve):
+    @pytest.mark.parametrize(('rounds', 'calls'), [(1, 2), (2, 3)])
+    def test_a_session_is_called_again_for_every_function_it_starts(self, serve, rounds, calls):
         rt = serve(echo=lambda obs: obs)
-        session = _RoundsSession(rt, rounds=1)
+        session = _RoundsSession(rt, rounds=rounds)
 
         assert call_until_answered(session, rt, {'x': 1}) == {'x': 1}
-        assert session.calls == 2
-
-    def test_a_session_is_called_again_for_every_function_it_starts(self, serve):
-        rt = serve(echo=lambda obs: obs)
-        session = _RoundsSession(rt, rounds=2)
-
-        assert call_until_answered(session, rt, {'x': 1}) == {'x': 1}
-        assert session.calls == 3
+        assert session.calls == calls
 
     def test_a_session_that_starts_nothing_and_answers_none_is_called_one_time(self, serve):
         rt = serve(echo=lambda obs: obs)
@@ -388,3 +383,19 @@ class TestCallUntilAnswered:
 
         assert call_until_answered(session, rt, {'x': 1}) is None
         assert session.calls == 1
+
+
+class _Weights:
+    """Stands in for what a function is declared with: model weights, a socket."""
+
+
+def test_close_frees_what_the_functions_held(serve):
+    """A closed runtime drops its functions, so the policy that closes next can free the weights."""
+    weights = _Weights()
+    gone = weakref.ref(weights)
+    executor = serve(infer=partial(operator.is_, weights))
+    del weights
+
+    assert gone() is not None
+    executor.close()
+    assert gone() is None

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -353,19 +353,21 @@ class TestBlocking:
         assert policy.session.calls == 1
 
     def test_a_layer_above_it_is_called_one_time_for_one_answer(self, opened):
-        """Why this wraps the policy and not the chain: a layer that encodes the observation, or records
-        it, would otherwise do that work once per call the answer took."""
+        """A layer above ``blocking`` is called once for one answer. That is why ``blocking`` wraps the
+        policy and not the chain: a layer that encodes the observation, or records it, would otherwise do
+        that work once per call the answer took."""
         layer, policy = _CountingLayer(), _EchoPolicy(rounds=2)
 
         assert opened(layer.wrap(blocking(policy)))({'x': 1}) == {'x': 1}
         assert (layer.calls, policy.session.calls) == (1, 3)
 
     def test_it_serves_its_functions_itself(self):
-        """Nothing above builds a runtime for them: they are already run by the time an answer comes out."""
+        """A blocking policy runs its own functions, so nothing above it builds a runtime for them."""
         assert blocking(_EchoPolicy(rounds=1)).functions == {}
 
     def test_closing_the_session_closes_the_runtime_it_made(self):
-        """Nobody else can: the runtime is the session's own, made where the session was."""
+        """The session owns the runtime it was made with, and closing the session is the only way to
+        close it."""
         policy = _EchoPolicy(rounds=1)
         session = blocking(policy).new_session()
         session.close()
@@ -380,10 +382,7 @@ class _Weights:
 
 
 def test_close_frees_what_the_functions_held(serve):
-    """A closed runtime drops its functions, so the policy that closes next can free the weights.
-
-    The live session keeps its ``Caller``: the runtime is the only place a function reference lives.
-    """
+    """A closed runtime drops its functions, so the policy that closes next can free the weights."""
     weights = _Weights()
     gone = weakref.ref(weights)
     executor = serve(infer=partial(operator.is_, weights))

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -9,8 +9,8 @@ from functools import partial
 
 import pytest
 
-from positronic.policy.base import Answer, NotAnswered
-from positronic.policy.executor import Executor
+from positronic.policy.base import Answer, NotAnswered, Session
+from positronic.policy.executor import Caller, Executor, call_until_answered
 
 # How long a test waits for the worker threads before calling the call lost.
 TIMEOUT_SEC = 5.0
@@ -134,6 +134,21 @@ def test_a_call_is_in_flight_until_it_answers(serve):
     assert not executor.in_flight
 
 
+def test_nothing_is_owed_before_a_call(serve):
+    assert not serve(add=operator.add).owes_an_answer
+
+
+def test_an_answer_stays_owed_after_its_call_lands_until_it_is_read(serve):
+    executor = serve(add=operator.add)
+    answer = settled(executor.fns['add'](2, 3))
+
+    assert not executor.in_flight
+    assert executor.owes_an_answer
+
+    answer.result()
+    assert not executor.owes_an_answer
+
+
 def test_wait_returns_once_every_call_has_answered(serve):
     executor = serve(sleep=partial(time.sleep, 0.05), add=operator.add)
 
@@ -216,3 +231,160 @@ def test_close_stays_quiet_about_a_call_that_answered(serve, caplog):
         executor.close()
 
     assert caplog.text == ''
+
+
+def _raises() -> None:
+    raise ValueError('the call failed')
+
+
+class TestCaller:
+    """One session's use of one served function."""
+
+    def test_a_caller_of_an_unserved_function_fails_where_it_is_built(self, serve):
+        with pytest.raises(KeyError):
+            Caller(serve(add=operator.add), 'infer')
+
+    def test_a_fresh_caller_is_idle(self, serve):
+        assert Caller(serve(add=operator.add), 'add').idle
+
+    def test_a_started_call_is_no_longer_idle(self, serve):
+        caller = Caller(serve(add=operator.add), 'add')
+        caller.start(2, 3)
+
+        assert not caller.idle
+
+    def test_take_answers_none_while_the_call_is_out(self, serve):
+        release = threading.Event()
+        caller = Caller(serve(gate=release.wait), 'gate')
+        caller.start(TIMEOUT_SEC)
+
+        assert caller.take() is None
+        assert caller.in_flight
+        release.set()
+
+    def test_take_answers_the_result_once_the_call_lands(self, serve):
+        rt = serve(add=operator.add)
+        caller = Caller(rt, 'add')
+        caller.start(2, 3)
+        rt.wait(TIMEOUT_SEC)
+
+        assert caller.take() == 5
+
+    def test_a_taken_call_leaves_the_caller_idle(self, serve):
+        rt = serve(add=operator.add)
+        caller = Caller(rt, 'add')
+        caller.start(2, 3)
+        rt.wait(TIMEOUT_SEC)
+        caller.take()
+
+        assert caller.idle
+        assert not caller.in_flight
+
+    def test_take_raises_what_the_call_raised(self, serve):
+        rt = serve(fail=_raises)
+        caller = Caller(rt, 'fail')
+        caller.start()
+        rt.wait(TIMEOUT_SEC)
+
+        with pytest.raises(ValueError, match='the call failed'):
+            caller.take()
+
+    def test_a_cancelled_call_answers_none(self, serve):
+        rt = serve(add=operator.add)
+        caller = Caller(rt, 'add')
+        caller.start(2, 3)
+        caller.cancel()
+        rt.wait(TIMEOUT_SEC)
+
+        assert caller.take() is None
+
+    def test_a_cancelled_call_still_raises_what_it_raised(self, serve):
+        rt = serve(fail=_raises)
+        caller = Caller(rt, 'fail')
+        caller.start()
+        caller.cancel()
+        rt.wait(TIMEOUT_SEC)
+
+        with pytest.raises(ValueError, match='the call failed'):
+            caller.take()
+
+    def test_a_cancel_ends_with_the_call_it_was_made_against(self, serve):
+        rt = serve(add=operator.add)
+        caller = Caller(rt, 'add')
+        caller.start(2, 3)
+        caller.cancel()
+        rt.wait(TIMEOUT_SEC)
+        caller.take()
+
+        caller.start(4, 5)
+        rt.wait(TIMEOUT_SEC)
+        assert caller.take() == 9
+
+    def test_a_cancel_with_nothing_in_flight_drops_no_later_call(self, serve):
+        rt = serve(add=operator.add)
+        caller = Caller(rt, 'add')
+        caller.cancel()
+
+        caller.start(2, 3)
+        rt.wait(TIMEOUT_SEC)
+        assert caller.take() == 5
+
+
+class _PlainSession(Session):
+    """A session that does its work inside its own call."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, obs):
+        self.calls += 1
+        return [{'action': obs}]
+
+
+class _RoundsSession(Session):
+    """A session that starts one served call per round, and answers the last round's result."""
+
+    def __init__(self, rt: Executor, rounds: int):
+        self._infer = Caller(rt, 'echo')
+        self._left = rounds
+        self.calls = 0
+
+    def __call__(self, obs):
+        self.calls += 1
+        result = None if self._infer.idle else self._infer.take()
+        if self._infer.idle and self._left > 0:
+            self._left -= 1
+            self._infer.start(obs)
+            return None
+        return result
+
+
+class TestCallUntilAnswered:
+    """The way a caller with no control loop of its own reads a session."""
+
+    def test_a_session_that_answers_in_its_own_call_is_called_one_time(self, serve):
+        session = _PlainSession()
+
+        assert call_until_answered(session, serve(), {'x': 1}) == [{'action': {'x': 1}}]
+        assert session.calls == 1
+
+    def test_a_session_is_called_again_for_the_function_it_started(self, serve):
+        rt = serve(echo=lambda obs: obs)
+        session = _RoundsSession(rt, rounds=1)
+
+        assert call_until_answered(session, rt, {'x': 1}) == {'x': 1}
+        assert session.calls == 2
+
+    def test_a_session_is_called_again_for_every_function_it_starts(self, serve):
+        rt = serve(echo=lambda obs: obs)
+        session = _RoundsSession(rt, rounds=2)
+
+        assert call_until_answered(session, rt, {'x': 1}) == {'x': 1}
+        assert session.calls == 3
+
+    def test_a_session_that_starts_nothing_and_answers_none_is_called_one_time(self, serve):
+        rt = serve(echo=lambda obs: obs)
+        session = _RoundsSession(rt, rounds=0)
+
+        assert call_until_answered(session, rt, {'x': 1}) is None
+        assert session.calls == 1

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -10,7 +10,7 @@ from functools import partial
 
 import pytest
 
-from positronic.policy.base import Answer, Caller, DelegatingSession, Layer, NotAnswered, Policy, Session
+from positronic.policy.base import Answer, DelegatingSession, Layer, NotAnswered, Policy, Session
 from positronic.policy.executor import Executor, blocking
 
 # How long a test waits for the worker threads before calling the call lost.
@@ -238,99 +238,6 @@ def _raises() -> None:
     raise ValueError('the call failed')
 
 
-class TestCaller:
-    """One session's use of one served function."""
-
-    def test_a_caller_of_an_unserved_function_fails_where_it_is_built(self, serve):
-        with pytest.raises(AssertionError, match='infer'):
-            Caller(serve(add=operator.add), 'infer')
-
-    def test_a_fresh_caller_is_idle(self, serve):
-        assert Caller(serve(add=operator.add), 'add').idle
-
-    def test_a_started_call_is_no_longer_idle(self, serve):
-        caller = Caller(serve(add=operator.add), 'add')
-        caller.start(2, 3)
-
-        assert not caller.idle
-
-    def test_take_answers_none_while_the_call_is_out(self, serve):
-        release = threading.Event()
-        caller = Caller(serve(gate=release.wait), 'gate')
-        caller.start(TIMEOUT_SEC)
-
-        assert caller.take() is None
-        assert caller.in_flight
-        release.set()
-
-    def test_take_answers_the_result_once_the_call_lands(self, serve):
-        rt = serve(add=operator.add)
-        caller = Caller(rt, 'add')
-        caller.start(2, 3)
-        rt.wait(TIMEOUT_SEC)
-
-        assert caller.take() == 5
-
-    def test_a_taken_call_leaves_the_caller_idle(self, serve):
-        rt = serve(add=operator.add)
-        caller = Caller(rt, 'add')
-        caller.start(2, 3)
-        rt.wait(TIMEOUT_SEC)
-        caller.take()
-
-        assert caller.idle
-        assert not caller.in_flight
-
-    def test_take_raises_what_the_call_raised(self, serve):
-        rt = serve(fail=_raises)
-        caller = Caller(rt, 'fail')
-        caller.start()
-        rt.wait(TIMEOUT_SEC)
-
-        with pytest.raises(ValueError, match='the call failed'):
-            caller.take()
-
-    def test_a_cancelled_call_answers_none(self, serve):
-        rt = serve(add=operator.add)
-        caller = Caller(rt, 'add')
-        caller.start(2, 3)
-        caller.cancel()
-        rt.wait(TIMEOUT_SEC)
-
-        assert caller.take() is None
-
-    def test_a_cancelled_call_still_raises_what_it_raised(self, serve):
-        rt = serve(fail=_raises)
-        caller = Caller(rt, 'fail')
-        caller.start()
-        caller.cancel()
-        rt.wait(TIMEOUT_SEC)
-
-        with pytest.raises(ValueError, match='the call failed'):
-            caller.take()
-
-    def test_a_cancel_ends_with_the_call_it_was_made_against(self, serve):
-        rt = serve(add=operator.add)
-        caller = Caller(rt, 'add')
-        caller.start(2, 3)
-        caller.cancel()
-        rt.wait(TIMEOUT_SEC)
-        caller.take()
-
-        caller.start(4, 5)
-        rt.wait(TIMEOUT_SEC)
-        assert caller.take() == 9
-
-    def test_a_cancel_with_nothing_in_flight_drops_no_later_call(self, serve):
-        rt = serve(add=operator.add)
-        caller = Caller(rt, 'add')
-        caller.cancel()
-
-        caller.start(2, 3)
-        rt.wait(TIMEOUT_SEC)
-        assert caller.take() == 5
-
-
 class _PlainSession(Session):
     """A session that does its work inside its own call."""
 
@@ -346,16 +253,19 @@ class _RoundsSession(Session):
     """A session that starts one served call per round, and answers the last round's result."""
 
     def __init__(self, rt, rounds: int):
-        self.infer = Caller(rt, 'echo')
+        self._rt = rt
+        self._answer = None
         self._left = rounds
         self.calls = 0
 
     def __call__(self, obs):
         self.calls += 1
-        result = None if self.infer.idle else self.infer.take()
+        result = None
+        if self._answer is not None:
+            result, self._answer = self._answer.result(), None
         if self._left > 0:
             self._left -= 1
-            self.infer.start(obs)
+            self._answer = self._rt.fns['echo'](obs)
             return None
         return result
 
@@ -460,8 +370,9 @@ class TestBlocking:
         session = blocking(policy).new_session()
         session.close()
 
+        # The session's own runtime is closed, so the function it would start is gone.
         with pytest.raises(RuntimeError):
-            policy.session.infer.start({'x': 1})
+            policy.session({'x': 1})
 
 
 class _Weights:
@@ -476,9 +387,8 @@ def test_close_frees_what_the_functions_held(serve):
     weights = _Weights()
     gone = weakref.ref(weights)
     executor = serve(infer=partial(operator.is_, weights))
-    caller = Caller(executor, 'infer')
     del weights
 
     assert gone() is not None
     executor.close()
-    assert (gone(), caller.idle) == (None, True)
+    assert gone() is None

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -234,10 +234,6 @@ def test_close_stays_quiet_about_a_call_that_answered(serve, caplog):
     assert caplog.text == ''
 
 
-def _raises() -> None:
-    raise ValueError('the call failed')
-
-
 class _PlainSession(Session):
     """A session that does its work inside its own call."""
 
@@ -247,6 +243,9 @@ class _PlainSession(Session):
     def __call__(self, obs):
         self.calls += 1
         return [{'action': obs}]
+
+
+_ECHO = 'echo'
 
 
 class _RoundsSession(Session):
@@ -265,7 +264,7 @@ class _RoundsSession(Session):
             result, self._answer = self._answer.result(), None
         if self._left > 0:
             self._left -= 1
-            self._answer = self._rt.fns['echo'](obs)
+            self._answer = self._rt.fns[_ECHO](obs)
             return None
         return result
 
@@ -294,7 +293,7 @@ class _EchoPolicy(Policy):
 
     @property
     def functions(self):
-        return {'echo': lambda obs: obs}
+        return {_ECHO: lambda obs: obs}
 
 
 class _CountingLayer(Layer):

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -10,8 +10,8 @@ from functools import partial
 
 import pytest
 
-from positronic.policy.base import Answer, Caller, NotAnswered, Session
-from positronic.policy.executor import Executor, call_until_answered
+from positronic.policy.base import Answer, Caller, DelegatingSession, Layer, NotAnswered, Policy, Session
+from positronic.policy.executor import Executor, blocking
 
 # How long a test waits for the worker threads before calling the call lost.
 TIMEOUT_SEC = 5.0
@@ -345,44 +345,117 @@ class _PlainSession(Session):
 class _RoundsSession(Session):
     """A session that starts one served call per round, and answers the last round's result."""
 
-    def __init__(self, rt: Executor, rounds: int):
-        self._infer = Caller(rt, 'echo')
+    def __init__(self, rt, rounds: int):
+        self.infer = Caller(rt, 'echo')
         self._left = rounds
         self.calls = 0
 
     def __call__(self, obs):
         self.calls += 1
-        result = None if self._infer.idle else self._infer.take()
+        result = None if self.infer.idle else self.infer.take()
         if self._left > 0:
             self._left -= 1
-            self._infer.start(obs)
+            self.infer.start(obs)
             return None
         return result
 
 
-class TestCallUntilAnswered:
-    """The way a caller with no control loop of its own reads a session."""
+class _EchoPolicy(Policy):
+    """Serves ``echo``, and makes sessions that take ``rounds`` calls of it to answer."""
 
-    def test_a_session_that_answers_in_its_own_call_is_called_one_time(self, serve):
-        session = _PlainSession()
+    def __init__(self, rounds: int | None = None):
+        self._rounds = rounds
+        self.session: _PlainSession | _RoundsSession
 
-        assert call_until_answered(session, serve(), {'x': 1}) == [{'action': {'x': 1}}]
-        assert session.calls == 1
+    def new_session(self, context=None, now=None, rt=None) -> Session:
+        if self._rounds is None:
+            self.session = _PlainSession()
+        else:
+            assert rt is not None
+            self.session = _RoundsSession(rt, self._rounds)
+        return self.session
+
+    @property
+    def functions(self):
+        return {'echo': lambda obs: obs}
+
+
+class _CountingLayer(Layer):
+    """Counts the calls that reach the session it wraps."""
+
+    def __init__(self):
+        self.calls = 0
+
+    class _Session(DelegatingSession):
+        def __init__(self, inner: Session, layer: '_CountingLayer'):
+            super().__init__(inner)
+            self._layer = layer
+
+        def __call__(self, obs):
+            self._layer.calls += 1
+            return self._inner(obs)
+
+    def make_session(self, inner, context, now):
+        return self._Session(inner, self)
+
+
+@pytest.fixture
+def opened():
+    """Opens the sessions a test asks for, and closes every one at teardown."""
+    sessions = []
+
+    def make(policy: Policy) -> Session:
+        sessions.append(policy.new_session())
+        return sessions[-1]
+
+    yield make
+    for session in sessions:
+        session.close()
+
+
+class TestBlocking:
+    """A policy whose sessions answer in the call that asked."""
+
+    def test_a_session_that_answers_in_its_own_call_is_called_one_time(self, opened):
+        policy = _EchoPolicy()
+
+        assert opened(blocking(policy))({'x': 1}) == [{'action': {'x': 1}}]
+        assert policy.session.calls == 1
 
     @pytest.mark.parametrize(('rounds', 'calls'), [(1, 2), (2, 3)])
-    def test_a_session_is_called_again_for_every_function_it_starts(self, serve, rounds, calls):
-        rt = serve(echo=lambda obs: obs)
-        session = _RoundsSession(rt, rounds=rounds)
+    def test_a_session_is_called_again_for_every_function_it_starts(self, opened, rounds, calls):
+        policy = _EchoPolicy(rounds)
 
-        assert call_until_answered(session, rt, {'x': 1}) == {'x': 1}
-        assert session.calls == calls
+        assert opened(blocking(policy))({'x': 1}) == {'x': 1}
+        assert policy.session.calls == calls
 
-    def test_a_session_that_starts_nothing_and_answers_none_is_called_one_time(self, serve):
-        rt = serve(echo=lambda obs: obs)
-        session = _RoundsSession(rt, rounds=0)
+    def test_a_session_that_starts_nothing_and_answers_none_is_called_one_time(self, opened):
+        policy = _EchoPolicy(rounds=0)
 
-        assert call_until_answered(session, rt, {'x': 1}) is None
-        assert session.calls == 1
+        assert opened(blocking(policy))({'x': 1}) is None
+        assert policy.session.calls == 1
+
+    def test_a_layer_above_it_is_called_one_time_for_one_answer(self, opened):
+        """Why this wraps the policy and not the chain: a layer that encodes the observation, or records
+        it, would otherwise do that work once per call the answer took."""
+        layer, policy = _CountingLayer(), _EchoPolicy(rounds=2)
+
+        assert opened(layer.wrap(blocking(policy)))({'x': 1}) == {'x': 1}
+        assert (layer.calls, policy.session.calls) == (1, 3)
+
+    def test_it_serves_its_functions_itself(self):
+        """Nothing above builds a runtime for them: they are already run by the time an answer comes out."""
+        assert blocking(_EchoPolicy(rounds=1)).functions == {}
+
+    def test_closing_the_session_closes_the_runtime_it_made(self):
+        """Nobody else can: the runtime is the session's own, made where the session was."""
+        policy = _EchoPolicy(rounds=1)
+        session = blocking(policy).new_session()
+        assert isinstance(policy.session, _RoundsSession)
+        session.close()
+
+        with pytest.raises(RuntimeError):
+            policy.session.infer.start({'x': 1})
 
 
 class _Weights:

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -204,7 +204,11 @@ class RemoteStubPolicy(Policy):
     round-trips ``RemoteSession.__call__`` and records the ``policy.infer`` span independent of any layer."""
 
     def __init__(
-        self, command: roboarm.command.CommandType | None = None, target_grip: float = 0.33, wall_sec: float = 0.0
+        self,
+        command: roboarm.command.CommandType | None = None,
+        target_grip: float = 0.33,
+        wall_sec: float = 0.0,
+        chunk: list[dict[str, Any]] | None = None,
     ) -> None:
         if command is None:
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
@@ -212,10 +216,11 @@ class RemoteStubPolicy(Policy):
         self.command = command
         self.target_grip = float(target_grip)
         self.wall_sec = wall_sec
+        self._chunk = chunk
 
     def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
         assert rt is not None, 'the harness supplies the runtime'
-        action = [{'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': 0.0}]
+        action = self._chunk or [{'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': 0.0}]
         return RemoteSession(_FakeInferenceSession(action, self.wall_sec), rt)
 
     @property
@@ -1721,6 +1726,17 @@ def test_a_reply_is_scheduled_only_while_the_trial_still_has_budget(world, expir
     assert bool(harness._schedules[keys.ROBOT_COMMAND]) is scheduled
 
 
+def slow_chunk(span_sec: float = 0.2, steps: int = 10) -> list[dict[str, Any]]:
+    """A chunk of ``steps`` waypoints over ``span_sec``, which a scheduler plays for that long before it
+    asks again."""
+    dt = span_sec / steps
+    pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
+    return [
+        {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), keys.TARGET_GRIP: float(i), keys.ACTION_TIMESTAMP: i * dt}
+        for i in range(steps)
+    ]
+
+
 class _SlowSession(Session):
     """A session whose inference costs ``wall_sec`` of real time and returns a fixed-length chunk."""
 
@@ -1731,16 +1747,7 @@ class _SlowSession(Session):
 
     def __call__(self, obs):
         time.sleep(self._wall_sec)
-        dt = self._span_sec / self._steps
-        pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
-        return [
-            {
-                keys.ROBOT_COMMAND: CartesianPosition(pose=pose),
-                keys.TARGET_GRIP: float(i),
-                keys.ACTION_TIMESTAMP: i * dt,
-            }
-            for i in range(self._steps)
-        ]
+        return slow_chunk(self._span_sec, self._steps)
 
 
 class SlowPolicy(Policy):
@@ -1828,10 +1835,14 @@ def _run_episode(
 
 def _slow_policies(wall_sec: float) -> list:
     """A model that takes ``wall_sec`` in each home it can run in: inside the session call, and inside a
-    function the session starts and returns from at once. The trial pays the same for both."""
+    function the session starts and returns from at once. The trial pays the same for both.
+
+    Both answer the same chunk. A shorter one from either would be played out sooner, and that home would
+    run the model more times over the trial for the comparison to charge.
+    """
     return [
         pytest.param(SlowPolicy(wall_sec=wall_sec), id='in-the-call'),
-        pytest.param(RemoteStubPolicy(wall_sec=wall_sec), id='in-a-function'),
+        pytest.param(RemoteStubPolicy(wall_sec=wall_sec, chunk=slow_chunk()), id='in-a-function'),
     ]
 
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1837,8 +1837,8 @@ def _slow_policies(wall_sec: float) -> list:
     """A model that takes ``wall_sec`` in each home it can run in: inside the session call, and inside a
     function the session starts and returns from at once. The trial pays the same for both.
 
-    Both answer the same chunk. A shorter one from either would be played out sooner, and that home would
-    run the model more times over the trial for the comparison to charge.
+    Both answer the same chunk. A shorter chunk is played out sooner, so the home that answered it runs
+    the model more times over the trial and pays more for it.
     """
     return [
         pytest.param(SlowPolicy(wall_sec=wall_sec), id='in-the-call'),

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -137,10 +137,11 @@ def main(
     rec = Recorder(pos3.sync(output_dir))
     tapped = rec.tap(_TAP).wrap(policy)
     rt = Executor(tapped.functions)
-    session = tapped.new_session({keys.TASK: task} if task else None, time.time, rt)
-    meta = dict(session.meta)
-    name = label or _recording_name(meta)
+    session = None
     try:
+        session = tapped.new_session({keys.TASK: task} if task else None, time.time, rt)
+        meta = dict(session.meta)
+        name = label or _recording_name(meta)
         actions = call_until_answered(session, rt, obs)
         if actions is not None:
             actions = [a for a in actions if is_action(a)]  # drop the codec's keyless validity sentinel
@@ -157,7 +158,8 @@ def main(
     finally:
         # The runtime closes first: a round trip in flight uses the socket that the session closes.
         rt.close()
-        session.close()
+        if session is not None:
+            session.close()
 
 
 @pos3.with_mirror()

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -34,7 +34,7 @@ from positronic import keys
 from positronic.dataset.dataset import Dataset
 from positronic.drivers.roboarm.command import CartesianPosition, JointDelta
 from positronic.policy import Policy, Recorder, is_action
-from positronic.policy.executor import Executor, call_until_answered
+from positronic.policy.executor import blocking
 
 # Tap name; the recorder logs each obs/action entity under ``{_TAP}/{key}`` (see recording.py).
 _TAP = 'raw'
@@ -135,14 +135,12 @@ def main(
     image_keys = [k for k in obs if k.startswith(keys.IMAGE_PREFIX)]
 
     rec = Recorder(pos3.sync(output_dir))
-    tapped = rec.tap(_TAP).wrap(policy)
-    rt = Executor(tapped.functions)
-    session = None
+    tapped = rec.tap(_TAP).wrap(blocking(policy))
+    session = tapped.new_session({keys.TASK: task} if task else None, time.time)
+    meta = dict(session.meta)
+    name = label or _recording_name(meta)
     try:
-        session = tapped.new_session({keys.TASK: task} if task else None, time.time, rt)
-        meta = dict(session.meta)
-        name = label or _recording_name(meta)
-        actions = call_until_answered(session, rt, obs)
+        actions = session(obs)
         if actions is not None:
             actions = [a for a in actions if is_action(a)]  # drop the codec's keyless validity sentinel
         n = 0 if actions is None else len(actions)
@@ -156,10 +154,7 @@ def main(
             # only known after inference — a velocity chunk drops the 3D trajectory view.
             rr.send_blueprint(_blueprint(image_keys, _is_cartesian_chunk(actions)))
     finally:
-        # The runtime closes first: a round trip in flight uses the socket that the session closes.
-        rt.close()
-        if session is not None:
-            session.close()
+        session.close()
 
 
 @pos3.with_mirror()

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -34,7 +34,7 @@ from positronic import keys
 from positronic.dataset.dataset import Dataset
 from positronic.drivers.roboarm.command import CartesianPosition, JointDelta
 from positronic.policy import Policy, Recorder, is_action
-from positronic.policy.executor import Executor
+from positronic.policy.executor import Executor, call_until_answered
 
 # Tap name; the recorder logs each obs/action entity under ``{_TAP}/{key}`` (see recording.py).
 _TAP = 'raw'
@@ -141,12 +141,7 @@ def main(
     meta = dict(session.meta)
     name = label or _recording_name(meta)
     try:
-        # A session that gives its inference to a served function answers on the call after the one that
-        # asked. Ask again once the runtime has nothing in flight.
-        actions = session(obs)
-        if actions is None:
-            rt.wait()
-            actions = session(obs)
+        actions = call_until_answered(session, rt, obs)
         if actions is not None:
             actions = [a for a in actions if is_action(a)]  # drop the codec's keyless validity sentinel
         n = 0 if actions is None else len(actions)

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -42,7 +42,6 @@ def _detect_device() -> str:
     return 'cpu'
 
 
-# The name this policy serves its model call under.
 _INFER = 'infer'
 
 
@@ -81,8 +80,9 @@ class _LerobotSession(Session):
         if not self._answer.done():
             return None
         answer, cancelled = self._answer, self._cancelled
-        # Both are cleared before the read, because ``result`` raises what the model call raised. A cancel
-        # then ends with the answer it was made against, and does not drop the next chunk.
+        # The answer and the flag are cleared before the read, because ``result`` raises what the model
+        # call raised. A cancel then ends with the answer it was made against, and never drops the next
+        # chunk.
         self._answer, self._cancelled = None, False
         result = answer.result()
         return None if cancelled else result

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable, Mapping
+from functools import partial
 from typing import Any
 
 import configuronic as cfn
@@ -13,6 +15,8 @@ from lerobot.policies.pretrained import PreTrainedPolicy
 from positronic import keys
 from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
+from positronic.policy.base import Runtime
+from positronic.policy.executor import Caller
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.observation import TASK_FIELD
 from positronic.policy.spec import PolicySource, inline
@@ -39,28 +43,44 @@ def _detect_device() -> str:
     return 'cpu'
 
 
+# The name this policy serves its model call under.
+INFER = 'infer'
+
+
+def _infer(policy: PreTrainedPolicy, device: str, obs: dict[str, Any]) -> list[dict[str, Any]]:
+    """One model call: an observation in, an action chunk out."""
+    obs_int = {}
+    for key, val in obs.items():
+        if key == TASK_FIELD:
+            obs_int[key] = val
+        elif isinstance(val, np.ndarray):
+            if key.startswith('observation.images.'):
+                val = np.transpose(val.astype(np.float32) / 255.0, (2, 0, 1))
+            val = val[np.newaxis, ...]
+            obs_int[key] = torch.from_numpy(val).to(device)
+        else:
+            obs_int[key] = torch.as_tensor(val).to(device)
+
+    action = policy.predict_action_chunk(obs_int)
+    action = action.squeeze(0).cpu().numpy()
+    return [{'action': a} for a in action]
+
+
 class _LerobotSession(Session):
-    def __init__(self, policy, device: str, meta: dict[str, Any]):
-        self._policy = policy
-        self._device = device
+    """Per-episode session that gives the model call to the runtime, and answers the chunk on a later call."""
+
+    def __init__(self, rt: Runtime, meta: dict[str, Any]):
+        self._infer = Caller(rt, INFER)
         self._meta = meta
 
-    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
-        obs_int = {}
-        for key, val in obs.items():
-            if key == TASK_FIELD:
-                obs_int[key] = val
-            elif isinstance(val, np.ndarray):
-                if key.startswith('observation.images.'):
-                    val = np.transpose(val.astype(np.float32) / 255.0, (2, 0, 1))
-                val = val[np.newaxis, ...]
-                obs_int[key] = torch.from_numpy(val).to(self._device)
-            else:
-                obs_int[key] = torch.as_tensor(val).to(self._device)
+    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
+        if self._infer.idle:
+            self._infer.start(obs)
+            return None
+        return self._infer.take()
 
-        action = self._policy.predict_action_chunk(obs_int)
-        action = action.squeeze(0).cpu().numpy()
-        return [{'action': a} for a in action]
+    def cancel(self):
+        self._infer.cancel()
 
     @property
     def meta(self) -> dict[str, Any]:
@@ -93,8 +113,17 @@ class LerobotPolicy(Policy):
         self._meta = extra_meta or {}
 
     def new_session(self, context=None, now=None, rt=None):
+        if rt is None:
+            raise ValueError(
+                'A lerobot session runs its model on a runtime: pass rt to new_session. The harness passes '
+                'one, and a caller that opens a session outside the harness must pass one too.'
+            )
         self._policy.reset()
-        return _LerobotSession(self._policy, self._device, self._meta)
+        return _LerobotSession(rt, self._meta)
+
+    @property
+    def functions(self) -> Mapping[str, Callable[..., Any]]:
+        return {INFER: partial(_infer, self._policy, self._device)}
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -15,7 +15,7 @@ from lerobot.policies.pretrained import PreTrainedPolicy
 from positronic import keys
 from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
-from positronic.policy.base import Caller, Runtime
+from positronic.policy.base import Answer, Runtime
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.observation import TASK_FIELD
 from positronic.policy.spec import PolicySource, inline
@@ -69,17 +69,28 @@ class _LerobotSession(Session):
     """Per-episode session that gives the model call to the runtime, and answers the chunk on a later call."""
 
     def __init__(self, rt: Runtime, meta: dict[str, Any]):
-        self._infer = Caller(rt, _INFER)
+        self._rt = rt
         self._meta = meta
+        self._answer: Answer | None = None
+        self._cancelled = False
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
-        if self._infer.idle:
-            self._infer.start(obs)
+        if self._answer is None:
+            self._answer = self._rt.fns[_INFER](obs)
             return None
-        return self._infer.take()
+        if not self._answer.done():
+            return None
+        answer, cancelled = self._answer, self._cancelled
+        # Both are cleared before the read, because ``result`` raises what the model call raised. A cancel
+        # then ends with the answer it was made against, and does not drop the next chunk.
+        self._answer, self._cancelled = None, False
+        result = answer.result()
+        return None if cancelled else result
 
     def cancel(self):
-        self._infer.cancel()
+        # The cancel says the world the chunk applies to has gone. The session still reads the model call
+        # for its failure, and drops the chunk that comes with it.
+        self._cancelled = self._answer is not None
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -42,42 +42,6 @@ def _detect_device() -> str:
     return 'cpu'
 
 
-_INFER = 'infer'
-
-
-class _LerobotSession(Session):
-    """Per-episode session that gives the model call to the runtime, and answers the chunk on a later call."""
-
-    def __init__(self, rt: Runtime, meta: dict[str, Any]):
-        self._rt = rt
-        self._meta = meta
-        self._answer: Answer | None = None
-        self._cancelled = False
-
-    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
-        if self._answer is None:
-            self._answer = self._rt.fns[_INFER](obs)
-            return None
-        if not self._answer.done():
-            return None
-        answer, cancelled = self._answer, self._cancelled
-        # The answer and the flag are cleared before the read, because ``result`` raises what the model
-        # call raised. A cancel then ends with the answer it was made against, and never drops the next
-        # chunk.
-        self._answer, self._cancelled = None, False
-        result = answer.result()
-        return None if cancelled else result
-
-    def cancel(self):
-        # The cancel says the world the chunk applies to has gone. The session still reads the model call
-        # for its failure, and drops the chunk that comes with it.
-        self._cancelled = self._answer is not None
-
-    @property
-    def meta(self) -> dict[str, Any]:
-        return self._meta
-
-
 def warm_observation(config: PreTrainedConfig) -> dict[str, Any]:
     """Zero-filled inputs matching the features ``config`` declares.
 
@@ -117,6 +81,40 @@ def _infer(policy: PreTrainedPolicy, device: str, obs: dict[str, Any]) -> list[d
 
 
 class LerobotPolicy(Policy):
+    _INFER = 'infer'
+
+    class _Session(Session):
+        """Per-episode session that gives the model call to the runtime, and answers the chunk on a later call."""
+
+        def __init__(self, rt: Runtime, meta: dict[str, Any]):
+            self._rt = rt
+            self._meta = meta
+            self._answer: Answer | None = None
+            self._cancelled = False
+
+        def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
+            if self._answer is None:
+                self._answer = self._rt.fns[LerobotPolicy._INFER](obs)
+                return None
+            if not self._answer.done():
+                return None
+            answer, cancelled = self._answer, self._cancelled
+            # The answer and the flag are cleared before the read, because ``result`` raises what the model
+            # call raised. A cancel then ends with the answer it was made against, and never drops the next
+            # chunk.
+            self._answer, self._cancelled = None, False
+            result = answer.result()
+            return None if cancelled else result
+
+        def cancel(self):
+            # The cancel says the world the chunk applies to has gone. The session still reads the model call
+            # for its failure, and drops the chunk that comes with it.
+            self._cancelled = self._answer is not None
+
+        @property
+        def meta(self) -> dict[str, Any]:
+            return self._meta
+
     def __init__(self, policy: PreTrainedPolicy, device: str | None = None, extra_meta: dict[str, Any] | None = None):
         self._device = device or _detect_device()
         self._policy = policy.to(self._device)
@@ -126,11 +124,11 @@ class LerobotPolicy(Policy):
         if rt is None:
             raise ValueError('A lerobot session runs its model on a runtime: pass rt to new_session.')
         self._policy.reset()
-        return _LerobotSession(rt, self._meta)
+        return LerobotPolicy._Session(rt, self._meta)
 
     @property
     def functions(self) -> Mapping[str, Callable[..., Any]]:
-        return {_INFER: partial(_infer, self._policy, self._device)}
+        return {self._INFER: partial(_infer, self._policy, self._device)}
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -45,25 +45,6 @@ def _detect_device() -> str:
 _INFER = 'infer'
 
 
-def _infer(policy: PreTrainedPolicy, device: str, obs: dict[str, Any]) -> list[dict[str, Any]]:
-    """One model call: an observation in, an action chunk out."""
-    obs_int = {}
-    for key, val in obs.items():
-        if key == TASK_FIELD:
-            obs_int[key] = val
-        elif isinstance(val, np.ndarray):
-            if key.startswith('observation.images.'):
-                val = np.transpose(val.astype(np.float32) / 255.0, (2, 0, 1))
-            val = val[np.newaxis, ...]
-            obs_int[key] = torch.from_numpy(val).to(device)
-        else:
-            obs_int[key] = torch.as_tensor(val).to(device)
-
-    action = policy.predict_action_chunk(obs_int)
-    action = action.squeeze(0).cpu().numpy()
-    return [{'action': a} for a in action]
-
-
 class _LerobotSession(Session):
     """Per-episode session that gives the model call to the runtime, and answers the chunk on a later call."""
 
@@ -114,6 +95,25 @@ def warm_observation(config: PreTrainedConfig) -> dict[str, Any]:
         else:
             obs[name] = np.zeros(feature.shape, dtype=np.float32)
     return obs
+
+
+def _infer(policy: PreTrainedPolicy, device: str, obs: dict[str, Any]) -> list[dict[str, Any]]:
+    """One model call: an observation in, an action chunk out."""
+    obs_int = {}
+    for key, val in obs.items():
+        if key == TASK_FIELD:
+            obs_int[key] = val
+        elif isinstance(val, np.ndarray):
+            if key.startswith('observation.images.'):
+                val = np.transpose(val.astype(np.float32) / 255.0, (2, 0, 1))
+            val = val[np.newaxis, ...]
+            obs_int[key] = torch.from_numpy(val).to(device)
+        else:
+            obs_int[key] = torch.as_tensor(val).to(device)
+
+    action = policy.predict_action_chunk(obs_int)
+    action = action.squeeze(0).cpu().numpy()
+    return [{'action': a} for a in action]
 
 
 class LerobotPolicy(Policy):

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -15,8 +15,7 @@ from lerobot.policies.pretrained import PreTrainedPolicy
 from positronic import keys
 from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
-from positronic.policy.base import Runtime
-from positronic.policy.executor import Caller
+from positronic.policy.base import Caller, Runtime
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.observation import TASK_FIELD
 from positronic.policy.spec import PolicySource, inline
@@ -44,7 +43,7 @@ def _detect_device() -> str:
 
 
 # The name this policy serves its model call under.
-INFER = 'infer'
+_INFER = 'infer'
 
 
 def _infer(policy: PreTrainedPolicy, device: str, obs: dict[str, Any]) -> list[dict[str, Any]]:
@@ -70,7 +69,7 @@ class _LerobotSession(Session):
     """Per-episode session that gives the model call to the runtime, and answers the chunk on a later call."""
 
     def __init__(self, rt: Runtime, meta: dict[str, Any]):
-        self._infer = Caller(rt, INFER)
+        self._infer = Caller(rt, _INFER)
         self._meta = meta
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
@@ -114,16 +113,13 @@ class LerobotPolicy(Policy):
 
     def new_session(self, context=None, now=None, rt=None):
         if rt is None:
-            raise ValueError(
-                'A lerobot session runs its model on a runtime: pass rt to new_session. The harness passes '
-                'one, and a caller that opens a session outside the harness must pass one too.'
-            )
+            raise ValueError('A lerobot session runs its model on a runtime: pass rt to new_session.')
         self._policy.reset()
         return _LerobotSession(rt, self._meta)
 
     @property
     def functions(self) -> Mapping[str, Callable[..., Any]]:
-        return {INFER: partial(_infer, self._policy, self._device)}
+        return {_INFER: partial(_infer, self._policy, self._device)}
 
     @property
     def meta(self) -> dict[str, Any]:


### PR DESCRIPTION
Rung 4 of #661. A model that runs in this process gives its work to the runtime, the way remote inference does since #665. After this rung no rig-side session call blocks the control loop.

## What changes

`LerobotPolicy` declares its model call as the function `infer`. Its session starts the call and answers `None`, then answers the chunk on a later call. It is the only in-process pipeline in the repository; the other vendors run behind the server and change in a later rung.

`RemoteSession` already carried this state machine. It moves into `Caller` in `base.py`, and both sessions use the one copy. `Caller` passes its arguments through, so each session sends what its own function takes.

`blocking(policy)` is for a caller with no control loop to give the time back to — a server request, a warmup, a probe. Its sessions wait out the functions they start, so they answer in the call that asked. It wraps the policy rather than the chain, so every layer above sees one call per answer: a codec sizes the images one time and a recording tap writes the observation one time.

`Executor.close` points every function name at a closed stub, so what a function was declared with goes with it. Until now a policy's weights outlived `policy.close()` until a cyclic pass, which is the checkpoint-switch path.

`Executor` gains `owes_an_answer`. `blocking` tests that rather than `in_flight`, because a call that lands before the test would leave its answer unread.

## Test plan

- `uv run --locked pytest`: 1690 passed, 8 skipped.
- `test_in_process_equals_remote_for_same_pipeline` asserts the symmetry rather than documenting its absence: its scripted policy now serves a function, so both halves answer on the call after the one that asked.
- `Caller` and `blocking` have their own tests in `positronic/policy/tests/test_executor.py`, including that a layer above `blocking` is called one time for one answer, and that a closed runtime frees what its functions held.
- The lerobot vendor path has no local coverage: its tests need the `lerobot` extra, and `torch` is absent from the default venv.
