### PR TITLE
Let a config make each attended trial

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -94,7 +94,7 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 **Unattended (`sim`):** a driver walks the eval's tasks — `--eval.trial_count=10` episodes back-to-back, each ending when its task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
 
-**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--task`, `--embodiment`, `--policy` and `--output_dir`. `--task` names the config that makes each trial, so every press draws a new start pose. Set the goal with `--task.instruction="..."`. Manual evaluation and debugging on hardware.
+**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, so every press draws a new start pose. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
 
 ### A console of your own
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -94,7 +94,7 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 **Unattended (`sim`):** a driver walks the eval's tasks — `--eval.trial_count=10` episodes back-to-back, each ending when its task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
 
-**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, so every press draws a new start pose. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
+**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, one per press. The default draws a new start pose for every one of them. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
 
 ### A console of your own
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -94,7 +94,7 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 **Unattended (`sim`):** a driver walks the eval's tasks — `--eval.trial_count=10` episodes back-to-back, each ending when its task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
 
-**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--task`, `--embodiment`, `--policy` and `--output_dir`. Manual evaluation and debugging on hardware.
+**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--task`, `--embodiment`, `--policy` and `--output_dir`. `--task` names the config that makes each trial, so every press draws a new start pose. Set the goal with `--task.instruction="..."`. Manual evaluation and debugging on hardware.
 
 ### A console of your own
 

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -23,8 +23,8 @@ def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] |
 
 @cfn.config(instruction=UNIFIED_TASK, timeout=None)
 def attended_trial(instruction: str, timeout: float | None) -> Callable[[], Task]:
-    """The trial an attended droid run asks for at each press. The operator ends the episode, so the
-    trial needs no budget."""
+    """The trial an attended droid run asks for at each press. Without a ``timeout`` the operator ends
+    the episode."""
     return partial(_droid_trial, instruction, timeout)
 
 

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -22,8 +22,8 @@ def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] |
 
 
 @cfn.config(instruction=UNIFIED_TASK, timeout=None)
-def attended_trial(instruction: str, timeout: float | None) -> Callable[[], Task]:
-    """The trial an attended droid run asks for at each press. Without a ``timeout`` the operator ends
+def attended_trials(instruction: str, timeout: float | None) -> Callable[[], Task]:
+    """The trials an attended droid run gets, one per press. Without a ``timeout`` the operator ends
     the episode."""
     return partial(_droid_trial, instruction, timeout)
 

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -1,3 +1,7 @@
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
 import configuronic as cfn
 
 from positronic import keys
@@ -7,23 +11,33 @@ from positronic.cfg.hardware.roboarm import droid_start_pose
 from positronic.eval import Eval, Task
 
 
+def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] | None = None) -> Task:
+    """One droid trial. A person fills the tote before the trial, so the trial asks for no scene."""
+    return Task(
+        instruction_source=instruction,
+        timeout_sec=timeout,
+        prepare_args={keys.ARM: droid_start_pose(), keys.GRIPPER: 0.0},
+        meta=meta or {},
+    )
+
+
+@cfn.config(instruction=UNIFIED_TASK, timeout=None)
+def attended_trial(instruction: str, timeout: float | None) -> Callable[[], Task]:
+    """The trial an attended droid run asks for at each press. The operator ends the episode, so the
+    trial needs no budget."""
+    return partial(_droid_trial, instruction, timeout)
+
+
 @cfn.config(embodiment=droid, timeout=180, trial_count=1)
 def _droid_pick_place(embodiment, instruction, timeout, trial_count):
     """A real droid tote pick-and-place eval: the embodiment is the physical Franka, the task carries the instruction.
 
-    The rig has no scene of its own to seed, so nothing asks for one: filling the tote is a person's, and
-    they do it before the sweep starts. The outcome is the operator's annotation, since real has no
-    ground-truth source to compute one from.
+    The outcome is the operator's annotation, since real has no ground-truth source to compute one from.
     """
     return Eval(
         embodiment,
         [
-            Task(
-                instruction_source=instruction,
-                timeout_sec=timeout,
-                prepare_args={keys.ARM: droid_start_pose(), keys.GRIPPER: 0.0},
-                meta={keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count},
-            )
+            _droid_trial(instruction, timeout, {keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count})
             for trial in range(trial_count)
         ],
     )

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -95,7 +95,7 @@ class Task:
 # [✓] A trial's reset is every ``prepare`` it asks for — scene, arm, gripper — and it opens once all answer.
 # [✓] ``command.Reset`` goes: a robot is moved by a ``prepare`` call that names where to go.
 # [✓] The recorder keeps what is on the wire when it opens, and a producer publishes the scene as it answers.
-# [ ] An eval config names what its rig starts at, attended or not, so the keyboard path builds no trial of its own.
+# [✓] A config makes each attended trial, so the keyboard path makes none of its own.
 # [ ] One runner builds the world for both.
 @dataclass
 class Eval:

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -4,7 +4,6 @@ aliases over ``cli.eval.run``."""
 from collections import Counter
 from collections.abc import Callable
 from contextlib import nullcontext
-from functools import partial
 from typing import Any
 
 import configuronic as cfn
@@ -12,11 +11,11 @@ import pos3
 
 import pimm
 import positronic.cfg.embodiment
+import positronic.cfg.eval.real.droid
 import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
 from positronic import keys, wire
 from positronic.cfg.eval.sim.positronic import stack_cubes
-from positronic.cfg.hardware.roboarm import droid_start_pose
 from positronic.cli.eval.run import prepare_output_dir, run
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
@@ -65,22 +64,9 @@ class KeyboardOperator(pimm.ControlSystem):
             print(f'Episode failed: {e}')
 
 
-def _attended_task(instruction: str) -> Task:
-    """The trial one keypress asks for.
-
-    Nothing asks for the scene: pressing for the trial is the operator saying it is set up. Nothing holds
-    the episode to a budget either — the operator is what ends it.
-    """
-    return Task(
-        instruction_source=instruction, timeout_sec=None, prepare_args={keys.ARM: droid_start_pose(), keys.GRIPPER: 0.0}
-    )
-
-
-def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
+def real(policy, embodiment: Embodiment, task: Callable[[], Task], output_dir=None):
     """Run one hardware embodiment attended and headless, the keyboard deciding when an episode starts and
     finishes.
-
-    Every episode starts the arm at a pose drawn around the Franka's nominal joints, with the fingers open.
 
     The world is composed here rather than by the runner: an attended surface is the binary's own business,
     and the keyboard is the only one this library ships. There is no viewer — a console that shows the
@@ -91,7 +77,7 @@ def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
     # A rig that cannot be put at a start pose fails the run at startup rather than at the first press.
-    unknown = sorted(set(_attended_task('').prepare_args) - set(embodiment.prepare_handlers))
+    unknown = sorted(set(task().prepare_args) - set(embodiment.prepare_handlers))
     if unknown:
         raise ValueError(f'{unknown} is not something {embodiment.descriptor or "this rig"} readies')
 
@@ -104,11 +90,11 @@ def real(policy, embodiment: Embodiment, task: str | None, output_dir=None):
         policy.close()
 
 
-def _run_attended(policy, embodiment: Embodiment, task: str | None, output_dir) -> None:
+def _run_attended(policy, embodiment: Embodiment, task: Callable[[], Task], output_dir) -> None:
     """Record from a warmed policy until the keyboard returns. The caller owns the policy."""
     output_dir = prepare_output_dir(output_dir)
     keyboard = KeyboardControl(quit_key='q')
-    operator = KeyboardOperator(partial(_attended_task, task or ''))
+    operator = KeyboardOperator(task)
     harness = Harness(policy, embodiment)
     print('Keyboard controls: [s]tart, sto[p], [q]uit')
 
@@ -123,7 +109,12 @@ def _run_attended(policy, embodiment: Embodiment, task: str | None, output_dir) 
         world.run([harness, keyboard, operator], [*producers, ds_agent])
 
 
-real_cfg = cfn.Config(real, embodiment=positronic.cfg.embodiment.droid, policy=policy_cfg.placeholder)
+real_cfg = cfn.Config(
+    real,
+    embodiment=positronic.cfg.embodiment.droid,
+    task=positronic.cfg.eval.real.droid.attended_trial,
+    policy=policy_cfg.placeholder,
+)
 
 
 # Console entry point for [project.scripts].

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -76,10 +76,6 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     """
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
-    # A rig that cannot be put at a start pose fails the run at startup rather than at the first press.
-    unknown = sorted(set(next_task().prepare_args) - set(embodiment.prepare_handlers))
-    if unknown:
-        raise ValueError(f'{unknown} is not something {embodiment.descriptor or "this rig"} readies')
 
     # The policy is this function's to close from here on, and everything below can raise:
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `LocalDatasetWriter`

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -108,7 +108,7 @@ def _run_attended(policy, embodiment: Embodiment, next_task: Callable[[], Task],
 real_cfg = cfn.Config(
     real,
     embodiment=positronic.cfg.embodiment.droid,
-    next_task=positronic.cfg.eval.real.droid.attended_trial,
+    next_task=positronic.cfg.eval.real.droid.attended_trials,
     policy=policy_cfg.placeholder,
 )
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -64,7 +64,7 @@ class KeyboardOperator(pimm.ControlSystem):
             print(f'Episode failed: {e}')
 
 
-def real(policy, embodiment: Embodiment, task: Callable[[], Task], output_dir=None):
+def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir=None):
     """Run one hardware embodiment attended and headless, the keyboard deciding when an episode starts and
     finishes.
 
@@ -77,7 +77,7 @@ def real(policy, embodiment: Embodiment, task: Callable[[], Task], output_dir=No
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
     # A rig that cannot be put at a start pose fails the run at startup rather than at the first press.
-    unknown = sorted(set(task().prepare_args) - set(embodiment.prepare_handlers))
+    unknown = sorted(set(next_task().prepare_args) - set(embodiment.prepare_handlers))
     if unknown:
         raise ValueError(f'{unknown} is not something {embodiment.descriptor or "this rig"} readies')
 
@@ -85,16 +85,16 @@ def real(policy, embodiment: Embodiment, task: Callable[[], Task], output_dir=No
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `LocalDatasetWriter`
     # scans the one it is given.
     try:
-        _run_attended(policy, embodiment, task, output_dir)
+        _run_attended(policy, embodiment, next_task, output_dir)
     finally:
         policy.close()
 
 
-def _run_attended(policy, embodiment: Embodiment, task: Callable[[], Task], output_dir) -> None:
+def _run_attended(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir) -> None:
     """Record from a warmed policy until the keyboard returns. The caller owns the policy."""
     output_dir = prepare_output_dir(output_dir)
     keyboard = KeyboardControl(quit_key='q')
-    operator = KeyboardOperator(task)
+    operator = KeyboardOperator(next_task)
     harness = Harness(policy, embodiment)
     print('Keyboard controls: [s]tart, sto[p], [q]uit')
 
@@ -112,7 +112,7 @@ def _run_attended(policy, embodiment: Embodiment, task: Callable[[], Task], outp
 real_cfg = cfn.Config(
     real,
     embodiment=positronic.cfg.embodiment.droid,
-    task=positronic.cfg.eval.real.droid.attended_trial,
+    next_task=positronic.cfg.eval.real.droid.attended_trial,
     policy=policy_cfg.placeholder,
 )
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -27,8 +27,7 @@ class KeyboardOperator(pimm.ControlSystem):
     """Turns keystrokes into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one.
 
     It holds the pending answers because that is where an episode's terminal — and any refused ask —
-    arrives; both are printed as they land. ``next_task`` is called per press, so each trial draws its own
-    start pose.
+    arrives; both are printed as they land. ``next_task`` is called once per press.
     """
 
     def __init__(self, next_task: Callable[[], Task]):

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -294,7 +294,9 @@ class Harness(pimm.ControlSystem):
     def _ready(self, should_stop: pimm.SignalReceiver, args: dict[str, Any]) -> Generator[pimm.Command, None, None]:
         """Ask each device in ``args`` for the value it names, and come back once every one has answered."""
         unknown = sorted(set(args) - set(self.prepare))
-        assert not unknown, f'{unknown} is not something this embodiment readies, so nothing would be asked'
+        if unknown:
+            rig = self._embodiment.descriptor or 'this rig'
+            raise ValueError(f'{unknown} is not something {rig} readies; it readies {sorted(self.prepare)}')
         ready = pimm.calls.all_of([self.prepare[name](arg) for name, arg in args.items()])
         while not ready.done() and not should_stop.value:
             yield pimm.Yield() if self._embodiment.simulated else pimm.Sleep(POLL_PERIOD_SEC)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -949,7 +949,8 @@ def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     """Only the handlers a task names are asked, so a name matching none of them would go unasked and the
     trial would open on a rig nothing readied."""
     scene = _Scene(lambda _params: None)
-    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    embodiment = make_embodiment(descriptor='yam', prepare_handlers={keys.SCENE: scene.env_reset})
+    harness = Harness(StubPolicy(), embodiment)
     p = _pair_all(world, harness)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
 
@@ -958,9 +959,10 @@ def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
         Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: JointPosition(np.zeros(7))})
     )
 
-    with pytest.raises(AssertionError, match='not something this embodiment readies'):
+    named = r"\['arm'\] is not something yam readies; it readies \['scene'\]"
+    with pytest.raises(ValueError, match=named):
         drive_scheduler(scheduler, steps=50)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         answer.result()  # and whoever asked for the trial hears it, rather than reading a clean episode
 
 

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from collections.abc import Callable
 from dataclasses import replace
 from functools import partial
 from typing import Any
@@ -63,6 +64,11 @@ def _embodiment(simulated: bool = False) -> Embodiment:
     )
 
 
+def _trial(instruction: str = 'stub') -> Callable[[], Task]:
+    prepare_args = {keys.ARM: 'start-pose', keys.GRIPPER: 0.0}
+    return partial(Task, instruction_source=instruction, timeout_sec=None, prepare_args=prepare_args)
+
+
 @pytest.mark.timeout(30.0)
 def test_the_keyboard_path_ends_when_the_keyboard_returns(monkeypatch):
     """How an attended run finishes: ``KeyboardControl`` returns, the world stops, ``real`` closes the policy.
@@ -72,7 +78,7 @@ def test_the_keyboard_path_ends_when_the_keyboard_returns(monkeypatch):
     monkeypatch.setattr(sys, 'stdin', io.StringIO())
     policy = _IdlePolicy()
 
-    real(policy=policy, embodiment=_embodiment(), task='stub')
+    real(policy=policy, embodiment=_embodiment(), task=_trial())
 
     assert policy.closed
     # Not warmed: an attended run opens no throwaway session here. A binary that wants an endpoint
@@ -84,7 +90,7 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
     """It composes a real-time world and records against the wall clock, which a simulated embodiment needs
     neither of."""
     with pytest.raises(ValueError, match='sim'):
-        real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), task='stub')
+        real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), task=_trial())
 
 
 def test_the_keyboard_path_refuses_a_rig_it_cannot_put_at_a_start_pose():
@@ -92,7 +98,7 @@ def test_the_keyboard_path_refuses_a_rig_it_cannot_put_at_a_start_pose():
     before a run begins rather than at the first press."""
     bare = replace(_embodiment(), prepare_handlers={}, control_systems=())
     with pytest.raises(ValueError, match="'gripper'"):
-        real(policy=_IdlePolicy(), embodiment=bare, task='stub')
+        real(policy=_IdlePolicy(), embodiment=bare, task=_trial())
 
 
 class _ScriptedKeyboard(pimm.ControlSystem):
@@ -124,7 +130,7 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
     policy = _IdlePolicy()
     monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard(policy))
 
-    real(policy=policy, embodiment=_embodiment(), task='pick up the cube')
+    real(policy=policy, embodiment=_embodiment(), task=_trial('pick up the cube'))
 
     assert policy.observations, 'the episode never opened'
     assert policy.observations[0][keys.TASK] == 'pick up the cube'

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -78,7 +78,7 @@ def test_the_keyboard_path_ends_when_the_keyboard_returns(monkeypatch):
     monkeypatch.setattr(sys, 'stdin', io.StringIO())
     policy = _IdlePolicy()
 
-    real(policy=policy, embodiment=_embodiment(), task=_trial())
+    real(policy=policy, embodiment=_embodiment(), next_task=_trial())
 
     assert policy.closed
     # Not warmed: an attended run opens no throwaway session here. A binary that wants an endpoint
@@ -90,7 +90,7 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
     """It composes a real-time world and records against the wall clock, which a simulated embodiment needs
     neither of."""
     with pytest.raises(ValueError, match='sim'):
-        real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), task=_trial())
+        real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), next_task=_trial())
 
 
 def test_the_keyboard_path_refuses_a_rig_it_cannot_put_at_a_start_pose():
@@ -98,7 +98,7 @@ def test_the_keyboard_path_refuses_a_rig_it_cannot_put_at_a_start_pose():
     before a run begins rather than at the first press."""
     bare = replace(_embodiment(), prepare_handlers={}, control_systems=())
     with pytest.raises(ValueError, match="'gripper'"):
-        real(policy=_IdlePolicy(), embodiment=bare, task=_trial())
+        real(policy=_IdlePolicy(), embodiment=bare, next_task=_trial())
 
 
 class _ScriptedKeyboard(pimm.ControlSystem):
@@ -130,7 +130,7 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
     policy = _IdlePolicy()
     monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard(policy))
 
-    real(policy=policy, embodiment=_embodiment(), task=_trial('pick up the cube'))
+    real(policy=policy, embodiment=_embodiment(), next_task=_trial('pick up the cube'))
 
     assert policy.observations, 'the episode never opened'
     assert policy.observations[0][keys.TASK] == 'pick up the cube'

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -1,7 +1,6 @@
 import io
 import sys
 from collections.abc import Callable
-from dataclasses import replace
 from functools import partial
 from typing import Any
 
@@ -91,14 +90,6 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
     neither of."""
     with pytest.raises(ValueError, match='sim'):
         real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), next_task=_trial())
-
-
-def test_the_keyboard_path_refuses_a_rig_it_cannot_put_at_a_start_pose():
-    """Every attended episode places the arm and opens the fingers, so a rig that readies neither is caught
-    before a run begins rather than at the first press."""
-    bare = replace(_embodiment(), prepare_handlers={}, control_systems=())
-    with pytest.raises(ValueError, match="'gripper'"):
-        real(policy=_IdlePolicy(), embodiment=bare, next_task=_trial())
 
 
 class _ScriptedKeyboard(pimm.ControlSystem):


### PR DESCRIPTION
## Summary

The attended keyboard path built its own trial: `_attended_task` in `positronic/inference.py` named the Franka's start pose and an open gripper in the binary. A config names them now.

- `positronic/cfg/eval/real/droid.py` gains `attended_trial`, a config that returns a `Callable[[], Task]`. `KeyboardOperator` calls it once per press, so each trial draws its own start pose.
- `real` takes `task: Callable[[], Task]` in place of `task: str | None`, and hands it straight to the operator. It no longer knows what a trial holds. `--task.instruction="..."` sets the goal and `--task.timeout=120` adds a budget; the default has none, because the operator ends the episode.
- Both droid configs build their trial through `_droid_trial`, so the start pose and the open gripper are written once. `_droid_pick_place` asks for `trial_count` of them and numbers each.
- Roadmap box in `positronic/eval.py` ticked: "A config makes each attended trial, so the keyboard path makes none of its own."

The rig check in `real` still runs at startup and still names the rig, so `--embodiment=yam` refuses before a world is built.

## Test plan

- `uv run --locked pytest` — 1669 passed, 8 skipped
- `uv run --locked ruff check .` clean
- `uv run --locked positronic-inference real --help` resolves `task` to `positronic.cfg.eval.real.droid.attended_trial`
- Instantiated both droid configs by hand: two calls of the attended factory give two different poses and two separate `meta` dicts, and `pick_place` still numbers its trials
- Not run on hardware