### PR TITLE
Give both slow-policy homes the same chunk, so a trial pays them alike

### DIFF
--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -204,7 +204,12 @@ class RemoteStubPolicy(Policy):
     round-trips ``RemoteSession.__call__`` and records the ``policy.infer`` span independent of any layer."""
 
     def __init__(
-        self, command: roboarm.command.CommandType | None = None, target_grip: float = 0.33, wall_sec: float = 0.0
+        self,
+        command: roboarm.command.CommandType | None = None,
+        target_grip: float = 0.33,
+        wall_sec: float = 0.0,
+        span_sec: float = 0.0,
+        steps: int = 1,
     ) -> None:
         if command is None:
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
@@ -212,10 +217,16 @@ class RemoteStubPolicy(Policy):
         self.command = command
         self.target_grip = float(target_grip)
         self.wall_sec = wall_sec
+        self.span_sec = span_sec
+        self.steps = steps
 
     def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
         assert rt is not None, 'the harness supplies the runtime'
-        action = [{'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': 0.0}]
+        dt = self.span_sec / self.steps
+        action = [
+            {'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': i * dt}
+            for i in range(self.steps)
+        ]
         return RemoteSession(_FakeInferenceSession(action, self.wall_sec), rt)
 
     @property
@@ -1828,10 +1839,15 @@ def _run_episode(
 
 def _slow_policies(wall_sec: float) -> list:
     """A model that takes ``wall_sec`` in each home it can run in: inside the session call, and inside a
-    function the session starts and returns from at once. The trial pays the same for both."""
+    function the session starts and returns from at once. The trial pays the same for both.
+
+    Both return a chunk of the same shape, so the schedule replans at the same cadence and the two run the
+    model the same number of times. A shorter chunk on one side is exhausted sooner, and that side pays
+    ``wall_sec`` again every round it replans."""
+    span_sec, steps = 0.2, 10
     return [
-        pytest.param(SlowPolicy(wall_sec=wall_sec), id='in-the-call'),
-        pytest.param(RemoteStubPolicy(wall_sec=wall_sec), id='in-a-function'),
+        pytest.param(SlowPolicy(wall_sec=wall_sec, span_sec=span_sec, steps=steps), id='in-the-call'),
+        pytest.param(RemoteStubPolicy(wall_sec=wall_sec, span_sec=span_sec, steps=steps), id='in-a-function'),
     ]
 
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -224,7 +224,7 @@ class RemoteStubPolicy(Policy):
         assert rt is not None, 'the harness supplies the runtime'
         dt = self.span_sec / self.steps
         action = [
-            {'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': i * dt}
+            {keys.ROBOT_COMMAND: self.command, keys.TARGET_GRIP: self.target_grip, keys.ACTION_TIMESTAMP: i * dt}
             for i in range(self.steps)
         ]
         return RemoteSession(_FakeInferenceSession(action, self.wall_sec), rt)
@@ -1841,9 +1841,8 @@ def _slow_policies(wall_sec: float) -> list:
     """A model that takes ``wall_sec`` in each home it can run in: inside the session call, and inside a
     function the session starts and returns from at once. The trial pays the same for both.
 
-    Both return a chunk of the same shape, so the schedule replans at the same cadence and the two run the
-    model the same number of times. A shorter chunk on one side is exhausted sooner, and that side pays
-    ``wall_sec`` again every round it replans."""
+    Both return the same chunk shape: a shorter one is exhausted sooner, so that side replans more often
+    and pays ``wall_sec`` again each time."""
     span_sec, steps = 0.2, 10
     return [
         pytest.param(SlowPolicy(wall_sec=wall_sec, span_sec=span_sec, steps=steps), id='in-the-call'),


### PR DESCRIPTION
## What

`_slow_policies` in `test_harness.py` runs one model in two homes — inside the session call (`SlowPolicy`) and inside a function the session starts and returns from at once (`RemoteStubPolicy`) — and the three tests over it assert a trial pays the same for both. The two returned different chunk shapes, so it did not. `RemoteStubPolicy` now takes the `span_sec` / `steps` its counterpart already took, and `_slow_policies` names one span and one step count for both.

## Why

`SlowPolicy` returns a ten-step chunk spanning 0.2s; the remote stub returned one waypoint at 0.0. A one-waypoint chunk is exhausted the round it arrives, so that side replanned every round and paid its `wall_sec` sleep again each time — **151 calls against 9** over the same 1.5s episode, **7.6s of real sleeping against 0.5s** (measured on this branch's parent by counting `infer` calls on each path).

That is what crossed the 20s timeout on the macOS runner, which is slower than the Linux ones and runs four xdist workers at once. `test_an_uncharged_call_pauses_the_world[in-a-function]` has failed on `main` since #670 landed the parametrization — on `d3067f09` and again on `52e15cc0`, while the three Linux jobs stayed green. The other four commits of that window failed on the certificate test #669 fixed, which is why the break reads as older than it is.

The alternative was to raise the timeout or shorten `wall_sec`. Both leave the asymmetry in place: the parametrization exists to say the two homes cost the same, and a reader comparing them would go on being told something untrue. Equalising the chunk makes the docstring's claim hold and is what drops the cost.

The stub's action dict spelled `robot_command` / `target_grip` / `timestamp` as literals while `_SlowSession` two hundred lines above reads the same three off `keys`. That line is rewritten here, so it now reads them off `keys` too (`hardcoded-keys`).

## Verification

`uv run --locked pytest --no-cov` — 1668 passed, 8 skipped. `test_harness.py` alone: 8.5s against 15.2s, and `test_an_uncharged_call_pauses_the_world[in-a-function]` drops from 7.65s to under 0.81s, which is where its `in-the-call` twin already sat. The two parametrizations of `test_a_charged_call_costs_its_own_wall_duration` now cost 0.82s each. `pre-commit run --hook-stage pre-commit` green, basedpyright included.

Not verified from here: the macOS runner itself. The fix is a 15× cut in the wall time of the test that timed out, not a change to what it asserts, so CI on this PR is what confirms it.

<!-- opened-by: posi-agent -->