### PR TITLE
Call the policy session on the harness loop thread

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,8 +135,8 @@ trajectory".
 **Inference cost is a fact of the trial, owned by the harness.** The policy declares its heavy work
 as functions, and the framework runs each one off the loop thread. That work costs the trial either
 the wall time it took or nothing: the task's `charge_inference_time` flag asks a sim for the former,
-and a real rig pays it regardless. Only the harness reads the flag. Paying nothing means holding the
-loop for the work, which holds a virtual clock still; paying wall time means letting the world run,
+and a real rig pays it regardless. Only the harness reads the flag. Paying nothing means the loop
+waits for the work, which keeps a virtual clock still; paying wall time means letting the world run,
 though no further ahead of the work's start than wall time has. The clock the harness hands the
 policy stack (`now`) is the world clock, so a scheduling layer stamps its chunk at `now()` and never
 learns the mode.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,13 +132,14 @@ episode lifecycle — nothing else. Scheduling, blending, history stacking and e
 the layer stack around the policy; a session returning `None` means "keep executing the current
 trajectory".
 
-**Inference cost is a fact of the trial, owned by the harness.** A call costs the trial either the
-wall time it took or nothing: the task's `charge_inference_time` flag asks a sim for the former,
+**Inference cost is a fact of the trial, owned by the harness.** The policy declares its heavy work
+as functions, and the framework runs each one off the loop thread. That work costs the trial either
+the wall time it took or nothing: the task's `charge_inference_time` flag asks a sim for the former,
 and a real rig pays it regardless. Only the harness reads the flag. Paying nothing means holding the
-world for the call, which holds a virtual clock still; paying wall time means letting the world run,
-though no further ahead of the call's start than wall time has. The clock the harness hands the
-policy stack (`now`) reads the instant the in-flight call's output takes effect, so a scheduling
-layer stamps its chunk at `now()` and never learns the mode.
+loop for the work, which holds a virtual clock still; paying wall time means letting the world run,
+though no further ahead of the work's start than wall time has. The clock the harness hands the
+policy stack (`now`) is the world clock, so a scheduling layer stamps its chunk at `now()` and never
+learns the mode.
 
 **Recordings are canonical; codecs bind the dialect late.** The dataset records every run in the
 canonical conventions (frames, key names, absolute time) — never in a model's dialect. Every

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -16,6 +16,7 @@ from positronic.offboard.tests.conftest import ANSWER_SEC, round_trip
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.layers import ChunkedSchedule
+from positronic.policy.remote import _prepare_obs
 from positronic.policy.spec import PolicySource, remote
 
 # These fixtures stand in for a server, so they spell the handshake fields rather than importing the
@@ -55,23 +56,22 @@ def _make_image(h, w):
 class TestPrepareObs:
     """The border's own settings. Image geometry is the declared stack's business (see RestrictImageSize)."""
 
-    def test_images_pass_through_untouched_by_default(self, open_session):
-        endpoint, _ = _mock_endpoint()
-        session, _ = open_session(endpoint)
+    def test_images_pass_through_untouched_by_default(self):
         obs = {'cam': _make_image(480, 640), 'state': np.array([1.0])}
-        prepared = session._prepare_obs(obs)
+        prepared = _prepare_obs(obs, compress_images=False)
         assert prepared.keys() == obs.keys()
         assert all(prepared[key] is value for key, value in obs.items())
 
-    def test_compression_reaches_nested_images(self, open_session):
-        endpoint, _ = _mock_endpoint({keys.COMPRESS_IMAGES: True})
-        session, _ = open_session(endpoint)
-        result = session._prepare_obs({
-            'cam': _make_image(48, 64),
-            'video': {'wrist': _make_image(48, 64)},
-            'state': np.array([1.0, 2.0]),
-            keys.TASK: 'pick cube',
-        })
+    def test_compression_reaches_nested_images(self):
+        result = _prepare_obs(
+            {
+                'cam': _make_image(48, 64),
+                'video': {'wrist': _make_image(48, 64)},
+                'state': np.array([1.0, 2.0]),
+                keys.TASK: 'pick cube',
+            },
+            compress_images=True,
+        )
         assert isinstance(result['cam'], dict)
         assert isinstance(result['video']['wrist'], dict)
         np.testing.assert_array_equal(result['state'], np.array([1.0, 2.0]))

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -70,11 +70,10 @@ class Session(ABC):
 
     @abstractmethod
     def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
-        """Predict actions for the given observation.
+        """Predict actions for the given observation, without waiting.
 
-        Answers without waiting. A harness calls this on the loop thread that plays the trajectory and steps
-        every other control system, so a call that waits for a model stalls the rig. Heavy work belongs in
-        ``Policy.functions``, which the framework runs off that thread.
+        A harness calls this on the thread that plays the trajectory and steps every other control system,
+        so a call that waits for a model stalls the rig. Heavy work belongs in ``Policy.functions``.
         """
 
     @property

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -70,7 +70,12 @@ class Session(ABC):
 
     @abstractmethod
     def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
-        """Predict actions for the given observation."""
+        """Predict actions for the given observation.
+
+        Answers without waiting. A harness calls this on the loop thread that plays the trajectory and steps
+        every other control system, so a call that waits for a model stalls the rig. Heavy work belongs in
+        ``Policy.functions``, which the framework runs off that thread.
+        """
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -70,11 +70,8 @@ class Session(ABC):
 
     @abstractmethod
     def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
-        """Predict actions for the given observation, without waiting.
-
-        A harness calls this on the thread that plays the trajectory and steps every other control system,
-        so a call that waits for a model stalls the rig. Heavy work belongs in ``Policy.functions``.
-        """
+        """Predict actions for the given observation, without waiting: heavy work belongs in
+        ``Policy.functions``."""
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -360,11 +360,6 @@ class Harness(pimm.ControlSystem):
         return inputs
 
     def _infer(self, inference: _EpisodeInference, clock: pimm.Clock) -> None:
-        """One round of inference.
-
-        An uncharged trial pays nothing for the model. World time moves only when the loop yields, so the
-        round that starts a function waits for it before it yields.
-        """
         try:
             obs = self._build_obs(clock)
         except pimm.NoValueException:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,10 +1,6 @@
-import concurrent.futures
-import contextvars
-import logging
 import time
 from collections import deque
 from collections.abc import Generator, Iterator
-from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
 import numpy as np
@@ -28,123 +24,65 @@ MAX_ACTION_SKEW_SEC = 60.0
 # and with it the granularity every command timestamp is quantized to.
 POLL_PERIOD_SEC = 0.01
 
-# How long a submitted call may take and still resolve within its round: a layer that skips inference
-# answers in microseconds, a real model call runs far past this and is throttled across rounds.
-SKIP_REPLY_SEC = 0.001
 
+class _EpisodeInference:
+    """One episode's policy session, called on the loop thread, and the runtime that serves the policy's
+    functions to it.
 
-class _InferenceWorker:
-    """One episode's policy session, called one at a time on a thread of its own, and the runtime that
-    serves the policy's functions to it.
-
-    The work is the session call and the function it starts, timed as one. A session that gives its model
-    to the runtime returns at once, so what stays in flight is the function. ``charges_wall_time`` says
-    whether that work costs the trial the wall time it took or nothing. The loop is held for the work,
-    which holds a virtual clock still.
+    A session that gives its model to the runtime returns at once, so what stays in flight is the function.
+    ``charges_wall_time`` says whether that work costs the trial the wall time it took or nothing. The loop
+    is held for the work, which holds a virtual clock still.
     """
 
     def __init__(self, policy: Policy, context: dict[str, Any], charges_wall_time: bool, clock: pimm.Clock) -> None:
         self._charges_wall_time = charges_wall_time
         self._clock = clock
-        # World clock and ``time.monotonic()`` at the start of the work in flight, anchored at the episode's
-        # start so ``effect_time`` reads a trial instant from the moment the session exists.
+        # One instant on two clocks — the world clock and ``time.monotonic()`` — at the start of the work in
+        # flight, so ``hold`` adds a wall duration to a world instant.
         self._t0_ns, self._wall_t0 = clock.now_ns(), time.monotonic()
         self._runtime = Executor(policy.functions)
-        self._session = policy.new_session(context, self.effect_time, self._runtime)
-        self._pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix='harness-session')
-        self._call: Future[list[dict[str, Any]] | None] | None = None
+        try:
+            self._session = policy.new_session(context, clock.now, self._runtime)
+        except BaseException:
+            self._runtime.close()
+            raise
 
     @property
     def meta(self) -> dict[str, Any]:
         return self._session.meta
 
-    @property
-    def idle(self) -> bool:
-        return self._call is None
-
-    @property
-    def done(self) -> bool:
-        """Whether the call in flight has returned."""
-        return self._call is not None and self._call.done()
-
-    def effect_time(self) -> float:
-        """The trial instant the work in flight takes effect."""
-        wall = time.monotonic() - self._wall_t0 if self._charges_wall_time else 0.0
-        return self._t0_ns / 1e9 + wall
-
     @staticmethod
     def _owned(obs: dict[str, Any]) -> dict[str, Any]:
-        """The observation with its arrays copied, so nothing rewrites what the worker is still reading.
+        """The observation with its arrays copied, so nothing rewrites what a function is still reading.
 
         A producer may reuse one buffer for every sample it emits — a camera renders into the array behind
-        the adapter it re-emits each frame — and it keeps stepping while a call charged in wall time runs.
-        Copying at dispatch pays once per call rather than per round.
+        the adapter it re-emits each frame — and it keeps stepping while the function runs.
         """
         return {name: value.copy() if isinstance(value, np.ndarray) else value for name, value in obs.items()}
 
-    def submit(self, obs: dict[str, Any]) -> None:
-        """Start a call on ``obs``. The moment's wait lets a layer that skips inference resolve in the round
-        it was asked."""
+    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
+        """The session's trajectory for ``obs``, and ``None`` when it has nothing to place."""
         # A call that finds a function in flight joins that work rather than starts new work. The anchor
         # stays where the function started, so the trial is charged for it one time.
         if not self._runtime.in_flight:
             self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
-        # The call runs under a copy of the loop's context, so the telemetry it records anchors to the episode
-        # that asked for it even when it outlives that episode's close.
-        context = contextvars.copy_context()
-        self._call = self._pool.submit(context.run, self._session, frozen_view(self._owned(obs)))
-        concurrent.futures.wait([self._call], timeout=SKIP_REPLY_SEC)
+        return self._session(frozen_view(self._owned(obs)))
 
-    @staticmethod
-    def _time_left(deadline: float | None) -> float | None:
-        """Seconds until ``deadline``, never negative; ``None`` for a wait with no deadline."""
-        return None if deadline is None else max(deadline - time.monotonic(), 0.0)
-
-    def throttle(self) -> None:
-        """Slow the loop for the work in flight, as the trial's mode requires.
-
-        The session call and the function it started share one deadline. They are one piece of work, seen
-        from the loop thread and from the runtime.
-        """
-        assert self._call is not None
-        deadline = None
+    def hold(self) -> None:
+        """Hold the loop for the function in flight, as the trial's mode requires."""
+        timeout = None
         if self._charges_wall_time:
             # Wall time cannot be held still, so the loop waits out only the time the world is already ahead by.
-            deadline = time.monotonic() + max(self._clock.now() - self.effect_time(), 0.0)
-        concurrent.futures.wait([self._call], timeout=self._time_left(deadline))
-        self._runtime.wait(self._time_left(deadline))
+            paid_through = self._t0_ns / 1e9 + (time.monotonic() - self._wall_t0)
+            timeout = max(self._clock.now() - paid_through, 0.0)
+        self._runtime.wait(timeout)
 
-    def result(self) -> list[dict[str, Any]] | None:
-        """The returned call's trajectory — ``None`` when it had nothing to place — leaving the worker idle."""
-        assert self._call is not None
-        # Read on the loop thread, so a failing call still seals the episode.
-        actions, self._call = self._call.result(), None
-        return actions
+    def close(self) -> None:
+        """Wait out the function still running, then close the runtime and the session it was serving.
 
-    @staticmethod
-    def _report_abandoned(future: Future[list[dict[str, Any]] | None]) -> None:
-        """Report the failure of a call nobody is waiting for any more."""
-        # rules-allow: swallowed-error — the call outlived the episode that asked for it, so there is no
-        # caller left to raise to; the log is the only place its failure can go.
-        if not future.cancelled() and (exc := future.exception()) is not None:
-            logging.error(f'Inference failed after the episode that asked for it ended: {exc}')
-
-    def abandon(self) -> None:
-        """Let go of the call in flight: its answer lands nowhere and its failure only reaches the log."""
-        if self._call is not None:
-            self._call.add_done_callback(self._report_abandoned)
-            self._call = None
-        self._pool.shutdown(wait=False, cancel_futures=True)
-
-    def join(self) -> None:
-        """Wait out an abandoned call and the function it left running, then close the session both were
-        inside.
-
-        ``shutdown(cancel_futures=True)`` cancels only what is still queued, so until this returns the work
-        still holds the session's resources: a ``RemoteSession``'s websocket, or the in-process model every
-        session shares.
+        Until this returns the function holds what the session holds: a ``RemoteSession``'s websocket, or the
+        in-process model every session of a policy shares.
         """
-        self._pool.shutdown(wait=True)
         self._runtime.close()
         self._session.close()
 
@@ -214,11 +152,10 @@ class _EpisodeTelemetry:
 class Harness(pimm.ControlSystem):
     """Control system that runs the episode lifecycle and plays the policy's trajectory to the drivers.
 
-    The layer owns the trajectory, the harness plays it, one command per channel per round. The session call
-    runs on a worker thread, and the functions it starts run on the runtime's own, so playing continues while
-    the model runs. That work costs the trial either the wall time it took or nothing, with the world held
-    still for it. The ``now`` given to ``new_session`` reads the instant the output of that work takes effect,
-    so layers stamp for it without knowing the mode.
+    The layer owns the trajectory, the harness plays it, one command per channel per round. The session is
+    called on the loop thread and answers inside the round; the functions it starts run on the runtime's own,
+    so playing continues while the model runs. That work costs the trial either the wall time it took or
+    nothing, with the world held still for it.
 
     An episode runs one ``Task``, asked for by a ``perform_task`` call and answered with the terminal
     payload it ended on. The task's ``timeout_sec`` bounds it and a truthy ``done`` within budget ends it
@@ -230,13 +167,13 @@ class Harness(pimm.ControlSystem):
         self._embodiment = embodiment
         self.policy: Policy = policy
         self._static_meta = static_meta or {}
-        # This episode's session and the thread it runs on. ``None`` while no episode is live: while one is,
+        # This episode's session and the runtime serving it. ``None`` while no episode is live: while one is,
         # stepping and recording happen together.
-        self._worker: _InferenceWorker | None = None
+        self._inference: _EpisodeInference | None = None
         # The call this episode answers when it ends.
         self._call: pimm.calls.Call[Task, dict[str, Any]] | None = None
-        # A worker let go of mid-call, kept until the join that makes closing its session safe.
-        self._retiring: _InferenceWorker | None = None
+        # An inference let go of with a function running, kept until the close that waits that function out.
+        self._retired: _EpisodeInference | None = None
         # ``task.timeout_sec``, armed per episode; a task without one has no deadline and ends on ``done`` alone.
         self._deadline: float | None = None
         # Wall-clock telemetry for the live rollout, opened under ``--timing`` and inert otherwise.
@@ -280,7 +217,7 @@ class Harness(pimm.ControlSystem):
             meta[keys.EVAL_TIMEOUT] = self._task.timeout_sec
         # ``policy.meta`` is the static baseline; the session overlays per-episode specifics (e.g. the
         # sampled sub-policy) and wins on conflict.
-        session_meta = self.policy.meta | (self._worker.meta if self._worker else {})
+        session_meta = self.policy.meta | (self._inference.meta if self._inference else {})
         for k, v in flatten_dict(session_meta).items():
             meta[f'{keys.POLICY_META}.{k}'] = v
         meta.update(self._task.meta)
@@ -316,38 +253,28 @@ class Harness(pimm.ControlSystem):
             return pimm.Sleep(POLL_PERIOD_SEC)
         return pimm.Sleep(min(POLL_PERIOD_SEC, max(due - clock.now_ns(), 1) / 1e9))
 
-    def _cancel_session(self) -> None:
-        """Drop everything the episode has going: the schedule being played, and the call on the worker.
+    def _retire_inference(self) -> None:
+        """Let go of this episode's inference, keeping it for ``_reap_inference``: ending an episode must not
+        wait for a model that hangs."""
+        if self._inference is not None:
+            self._retired, self._inference = self._inference, None
 
-        The call is let go of rather than waited for, so a model that hangs cannot hold up the recording's
-        stop or the next trial's prepare. Devices hold their last commanded position; nothing downstream is
-        buffered.
-        """
-        for schedule in self._schedules.values():
-            schedule.clear()
-        self._retire_worker()
-
-    def _retire_worker(self) -> None:
-        """Let go of this episode's worker and the call it is running, keeping it for ``_reap_worker``:
-        ending an episode must not wait for a model that hangs."""
-        if self._worker is not None:
-            self._worker.abandon()
-            self._retiring, self._worker = self._worker, None
-
-    def _reap_worker(self) -> None:
-        """Join the retired worker and close the session its abandoned call was inside."""
-        if self._retiring is not None:
-            self._retiring.join()
-            self._retiring = None
+    def _reap_inference(self) -> None:
+        """Close the retired inference, waiting out the function still inside it."""
+        if self._retired is not None:
+            self._retired.close()
+            self._retired = None
 
     def _finalize_recording(
         self, clock: pimm.Clock, payload: dict[str, Any] | None = None
     ) -> Generator[pimm.Command, None, None]:
         """Commit the live episode: cancel the in-flight chunk, stop the recorder — stamping the
         episode's full static meta (plus any terminal payload) — then close its span."""
-        # Stamped before the worker is retired: the meta overlays what its session reports.
+        # Stamped before the inference is retired: the meta overlays what its session reports.
         stop = DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})})
-        self._cancel_session()
+        for schedule in self._schedules.values():  # devices hold their last commanded position
+            schedule.clear()
+        self._retire_inference()
         self.ds_command.emit(stop)
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
         # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
@@ -369,13 +296,13 @@ class Harness(pimm.ControlSystem):
         self._telemetry.begin(self._task.meta)
         with telemetry.span(telemetry_keys.SPAN_RESET):
             yield from self._ready(should_stop, self._task.prepare_args)
-        # The join waits on the call the last episode abandoned, so the rig is readied before it: a model
-        # that hangs must not leave the devices standing at the setpoint the policy left them. It runs
-        # before the session below, which is what makes closing the abandoned one safe.
-        self._reap_worker()
+        # The close waits out the function the last episode left running, so the rig is readied before it: a
+        # model that hangs must not leave the devices standing at the setpoint the policy left them. It runs
+        # before the session below, because an in-process policy is one model across every episode.
+        self._reap_inference()
         # Read after the reset: an embodiment that learns its task from the scene reports it only once the
         # scene is set up.
-        self._worker = _InferenceWorker(
+        self._inference = _EpisodeInference(
             self.policy, {keys.TASK: self._task.instruction}, self._charges_wall_time, clock
         )
         budget = self._task.timeout_sec
@@ -383,7 +310,7 @@ class Harness(pimm.ControlSystem):
         self._telemetry.start_rollout(clock.now())
         self.ds_command.emit(DsWriterCommand.START())
         # The fresh data is here, later round would read a frame the recording did not open on.
-        self._infer(self._worker, clock)
+        self._infer(self._inference, clock)
 
     def _end_episode(
         self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]
@@ -391,8 +318,8 @@ class Harness(pimm.ControlSystem):
         """Close the live episode: finalize the recording, put the rig back, retire the session, hand the
         terminal back to whoever asked for the episode.
 
-        The worker is retired rather than joined here, so a ``RemoteSession``'s websocket outlives the call
-        still using it.
+        The inference is retired rather than closed here, so a ``RemoteSession``'s websocket outlives the
+        function still using it.
         """
         yield from self._finalize_recording(clock, payload)
         # A powered arm holds the policy's last setpoint until the next trial, so each device the trial placed
@@ -412,7 +339,7 @@ class Harness(pimm.ControlSystem):
 
     def _advance_episode(
         self,
-        worker: _InferenceWorker,
+        inference: _EpisodeInference,
         done: pimm.Message[dict] | None,
         clock: pimm.Clock,
         should_stop: pimm.SignalReceiver,
@@ -421,7 +348,7 @@ class Harness(pimm.ControlSystem):
         if (terminal := self._trial_terminal(done, clock)) is not None:
             yield from self._end_episode(clock, should_stop, terminal)
         else:
-            self._infer(worker, clock)
+            self._infer(inference, clock)
 
     def _build_obs(self, clock: pimm.Clock) -> dict[str, Any]:
         """Read every observation channel and assemble the policy input dict.
@@ -444,24 +371,21 @@ class Harness(pimm.ControlSystem):
         inputs[keys.DESCRIPTOR] = self._embodiment.descriptor
         return inputs
 
-    def _infer(self, worker: _InferenceWorker, clock: pimm.Clock) -> None:
-        """One round of inference: throttle the loop for the call in flight as the trial's mode requires and
-        reschedule on what it returns; with no call in flight, submit one on what the channels hold and give
-        it the rest of the round to return. A channel the rig has never published to defers the round."""
-        if not worker.idle:
-            self._throttle_and_reschedule(worker, clock)
-        if worker.idle:
-            try:
-                obs = self._build_obs(clock)
-            except pimm.NoValueException:
-                return
-            worker.submit(obs)
-            self._throttle_and_reschedule(worker, clock)
+    def _infer(self, inference: _EpisodeInference, clock: pimm.Clock) -> None:
+        """One round of inference: call the session on what the channels hold, place the trajectory it
+        answers, then hold the loop for the function it left running.
 
-    def _throttle_and_reschedule(self, worker: _InferenceWorker, clock: pimm.Clock) -> None:
-        worker.throttle()
-        if worker.done and (trajectory := worker.result()) is not None:
+        The hold comes last, so the round that starts a function does not reach the yield that ends it. A
+        yield moves a virtual clock, and an uncharged trial pays nothing for that function. A channel the
+        rig has never published to defers the round, before any function exists.
+        """
+        try:
+            obs = self._build_obs(clock)
+        except pimm.NoValueException:
+            return
+        if (trajectory := inference(obs)) is not None:
             self._reschedule(trajectory, clock)
+        inference.hold()
 
     @staticmethod
     def _assert_anchored(trajectory: list[dict[str, Any]], now: float) -> None:
@@ -476,11 +400,11 @@ class Harness(pimm.ControlSystem):
     def _reschedule(self, trajectory: list[dict[str, Any]], clock: pimm.Clock) -> None:
         """Replace the schedule being played with the session's trajectory. Every channel it names gets that
         channel's waypoints; one it omits is cleared and holds. The timestamps are already absolute, stamped
-        by the scheduling layer for the instant the call's output takes effect.
+        by the scheduling layer against the harness clock.
         """
         if self._deadline is not None and clock.now() >= self._deadline:
-            # The world reached the deadline while the call was in flight, so its chunk is dropped rather than
-            # placed past the point the trial advertises it stops at; ``_run`` finishes the trial next round.
+            # The world reached the deadline while the function was in flight, so its chunk is dropped rather
+            # than placed past the point the trial advertises it stops at; ``_run`` finishes the trial next round.
             return
         self._assert_anchored(trajectory, clock.now())
         self._telemetry.step()
@@ -532,8 +456,8 @@ class Harness(pimm.ControlSystem):
             # A no-op once the block above has answered: the world coming down under a live episode is the
             # one way a call goes unanswered, and it is the caller's to hear about.
             self._fail_call(RuntimeError('The world stopped before the episode ended'))
-            self._retire_worker()
-            self._reap_worker()
+            self._retire_inference()
+            self._reap_inference()
 
     def _run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         while not should_stop.value:
@@ -545,10 +469,10 @@ class Harness(pimm.ControlSystem):
             # Read every round for the same reason: a terminal landing between episodes belongs to none of
             # them, and left on the wire it would end the next one on its first round.
             done = pimm.read_updated(self.done)
-            if self._worker is not None:
+            if self._inference is not None:
                 if call is not None:  # the live episode is the one that finishes; a second ask is refused
                     call.set_exception(RuntimeError('An episode is already running'))
-                yield from self._advance_episode(self._worker, done, clock, should_stop)
+                yield from self._advance_episode(self._inference, done, clock, should_stop)
             elif call is not None:
                 yield from self._begin_episode(clock, should_stop, call)
             elif manual is not None:
@@ -556,5 +480,5 @@ class Harness(pimm.ControlSystem):
             self._play(clock)
             yield self._pace(clock)
 
-        if self._worker is not None:
+        if self._inference is not None:
             yield from self._finalize_recording(clock)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -59,14 +59,17 @@ class _EpisodeInference:
             self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
         return self._session(frozen_view(self._owned(obs)))
 
-    def wait(self) -> None:
+    def wait(self, should_stop: pimm.SignalReceiver[bool]) -> None:
         """Wait for the function in flight, for as long as the trial charges the loop for it."""
-        timeout = None
         if self._charges_wall_time:
             # Wall time cannot be held still, so the loop waits out only the time the world is already ahead by.
             paid_through = self._t0_ns / 1e9 + (time.monotonic() - self._wall_t0)
-            timeout = max(self._clock.now() - paid_through, 0.0)
-        self._runtime.wait(timeout)
+            self._runtime.wait(max(self._clock.now() - paid_through, 0.0))
+            return
+        # A trial that pays nothing waits the function out. It waits in steps, because a model that never
+        # answers must not also keep the world from coming down.
+        while self._runtime.in_flight and not should_stop.value:
+            self._runtime.wait(POLL_PERIOD_SEC)
 
     def close(self) -> None:
         """Close the runtime, then the session it was serving.
@@ -298,7 +301,7 @@ class Harness(pimm.ControlSystem):
         self._telemetry.start_rollout(clock.now())
         self.ds_command.emit(DsWriterCommand.START())
         # The fresh data is here, later round would read a frame the recording did not open on.
-        self._infer(self._inference, clock)
+        self._infer(self._inference, clock, should_stop)
 
     def _end_episode(
         self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]
@@ -336,7 +339,7 @@ class Harness(pimm.ControlSystem):
         if (terminal := self._trial_terminal(done, clock)) is not None:
             yield from self._end_episode(clock, should_stop, terminal)
         else:
-            self._infer(inference, clock)
+            self._infer(inference, clock, should_stop)
 
     def _build_obs(self, clock: pimm.Clock) -> dict[str, Any]:
         """Read every observation channel and assemble the policy input dict.
@@ -359,14 +362,14 @@ class Harness(pimm.ControlSystem):
         inputs[keys.DESCRIPTOR] = self._embodiment.descriptor
         return inputs
 
-    def _infer(self, inference: _EpisodeInference, clock: pimm.Clock) -> None:
+    def _infer(self, inference: _EpisodeInference, clock: pimm.Clock, should_stop: pimm.SignalReceiver[bool]) -> None:
         try:
             obs = self._build_obs(clock)
         except pimm.NoValueException:
             return  # no function is in flight yet, so this skips no wait
         if (trajectory := inference(obs)) is not None:
             self._reschedule(trajectory, clock)
-        inference.wait()
+        inference.wait(should_stop)
 
     @staticmethod
     def _assert_anchored(trajectory: list[dict[str, Any]], now: float) -> None:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -26,19 +26,12 @@ POLL_PERIOD_SEC = 0.01
 
 
 class _EpisodeInference:
-    """One episode's policy session, called on the loop thread, and the runtime that serves the policy's
-    functions to it.
-
-    A session that gives its model to the runtime returns at once, so what stays in flight is the function.
-    ``charges_wall_time`` says whether that work costs the trial the wall time it took or nothing. The loop
-    is held for the work, which holds a virtual clock still.
-    """
+    """One episode's policy session, and the runtime that serves the policy's functions to it."""
 
     def __init__(self, policy: Policy, context: dict[str, Any], charges_wall_time: bool, clock: pimm.Clock) -> None:
         self._charges_wall_time = charges_wall_time
         self._clock = clock
-        # One instant on two clocks — the world clock and ``time.monotonic()`` — at the start of the work in
-        # flight, so ``hold`` adds a wall duration to a world instant.
+        # One instant on two clocks, so ``hold`` adds a wall duration to a world instant.
         self._t0_ns, self._wall_t0 = clock.now_ns(), time.monotonic()
         self._runtime = Executor(policy.functions)
         try:
@@ -55,15 +48,13 @@ class _EpisodeInference:
     def _owned(obs: dict[str, Any]) -> dict[str, Any]:
         """The observation with its arrays copied, so nothing rewrites what a function is still reading.
 
-        A producer may reuse one buffer for every sample it emits — a camera renders into the array behind
-        the adapter it re-emits each frame — and it keeps stepping while the function runs.
+        A camera renders into the array behind the adapter it re-emits, and it keeps stepping while the
+        function runs.
         """
         return {name: value.copy() if isinstance(value, np.ndarray) else value for name, value in obs.items()}
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
-        """The session's trajectory for ``obs``, and ``None`` when it has nothing to place."""
-        # A call that finds a function in flight joins that work rather than starts new work. The anchor
-        # stays where the function started, so the trial is charged for it one time.
+        # A call that joins work already in flight keeps its anchor, so the trial pays for that work one time.
         if not self._runtime.in_flight:
             self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
         return self._session(frozen_view(self._owned(obs)))
@@ -78,10 +69,9 @@ class _EpisodeInference:
         self._runtime.wait(timeout)
 
     def close(self) -> None:
-        """Wait out the function still running, then close the runtime and the session it was serving.
+        """Close the runtime, then the session it was serving.
 
-        Until this returns the function holds what the session holds: a ``RemoteSession``'s websocket, or the
-        in-process model every session of a policy shares.
+        Until ``Executor.close`` returns, the function in flight still holds the session's websocket or model.
         """
         self._runtime.close()
         self._session.close()
@@ -167,12 +157,11 @@ class Harness(pimm.ControlSystem):
         self._embodiment = embodiment
         self.policy: Policy = policy
         self._static_meta = static_meta or {}
-        # This episode's session and the runtime serving it. ``None`` while no episode is live: while one is,
-        # stepping and recording happen together.
+        # This episode's session and the runtime serving it. ``None`` while no episode is live.
         self._inference: _EpisodeInference | None = None
         # The call this episode answers when it ends.
         self._call: pimm.calls.Call[Task, dict[str, Any]] | None = None
-        # An inference let go of with a function running, kept until the close that waits that function out.
+        # An inference let go of with a function still running.
         self._retired: _EpisodeInference | None = None
         # ``task.timeout_sec``, armed per episode; a task without one has no deadline and ends on ``done`` alone.
         self._deadline: float | None = None
@@ -260,7 +249,6 @@ class Harness(pimm.ControlSystem):
             self._retired, self._inference = self._inference, None
 
     def _reap_inference(self) -> None:
-        """Close the retired inference, waiting out the function still inside it."""
         if self._retired is not None:
             self._retired.close()
             self._retired = None
@@ -296,9 +284,9 @@ class Harness(pimm.ControlSystem):
         self._telemetry.begin(self._task.meta)
         with telemetry.span(telemetry_keys.SPAN_RESET):
             yield from self._ready(should_stop, self._task.prepare_args)
-        # The close waits out the function the last episode left running, so the rig is readied before it: a
-        # model that hangs must not leave the devices standing at the setpoint the policy left them. It runs
-        # before the session below, because an in-process policy is one model across every episode.
+        # The reap waits out the function the last episode left running. It runs after the rig is readied, so
+        # a model that hangs does not leave the devices at the policy's last setpoint, and before the session
+        # below, because an in-process policy is one model across every episode.
         self._reap_inference()
         # Read after the reset: an embodiment that learns its task from the scene reports it only once the
         # scene is set up.
@@ -372,12 +360,11 @@ class Harness(pimm.ControlSystem):
         return inputs
 
     def _infer(self, inference: _EpisodeInference, clock: pimm.Clock) -> None:
-        """One round of inference: call the session on what the channels hold, place the trajectory it
-        answers, then hold the loop for the function it left running.
+        """One round of inference.
 
-        The hold comes last, so the round that starts a function does not reach the yield that ends it. A
-        yield moves a virtual clock, and an uncharged trial pays nothing for that function. A channel the
-        rig has never published to defers the round, before any function exists.
+        The hold comes last. A hold at the top of the round lets the round that starts a function reach the
+        yield that ends it, and a yield moves a virtual clock. A channel the rig has never published to
+        defers the round, before any function exists to hold for.
         """
         try:
             obs = self._build_obs(clock)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -31,7 +31,7 @@ class _EpisodeInference:
     def __init__(self, policy: Policy, context: dict[str, Any], charges_wall_time: bool, clock: pimm.Clock) -> None:
         self._charges_wall_time = charges_wall_time
         self._clock = clock
-        # One instant on two clocks, so ``hold`` adds a wall duration to a world instant.
+        # One instant on two clocks, so ``wait`` adds a wall duration to a world instant.
         self._t0_ns, self._wall_t0 = clock.now_ns(), time.monotonic()
         self._runtime = Executor(policy.functions)
         try:
@@ -59,8 +59,8 @@ class _EpisodeInference:
             self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
         return self._session(frozen_view(self._owned(obs)))
 
-    def hold(self) -> None:
-        """Hold the loop for the function in flight, as the trial's mode requires."""
+    def wait(self) -> None:
+        """Wait for the function in flight, for as long as the trial charges the loop for it."""
         timeout = None
         if self._charges_wall_time:
             # Wall time cannot be held still, so the loop waits out only the time the world is already ahead by.
@@ -362,9 +362,9 @@ class Harness(pimm.ControlSystem):
     def _infer(self, inference: _EpisodeInference, clock: pimm.Clock) -> None:
         """One round of inference.
 
-        The hold comes last. A hold at the top of the round lets the round that starts a function reach the
+        The wait comes last. A wait at the top of the round lets the round that starts a function reach the
         yield that ends it, and a yield moves a virtual clock. A channel the rig has never published to
-        defers the round, before any function exists to hold for.
+        defers the round, before any function exists to wait for.
         """
         try:
             obs = self._build_obs(clock)
@@ -372,7 +372,7 @@ class Harness(pimm.ControlSystem):
             return
         if (trajectory := inference(obs)) is not None:
             self._reschedule(trajectory, clock)
-        inference.hold()
+        inference.wait()
 
     @staticmethod
     def _assert_anchored(trajectory: list[dict[str, Any]], now: float) -> None:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -362,14 +362,13 @@ class Harness(pimm.ControlSystem):
     def _infer(self, inference: _EpisodeInference, clock: pimm.Clock) -> None:
         """One round of inference.
 
-        The wait comes last. A wait at the top of the round lets the round that starts a function reach the
-        yield that ends it, and a yield moves a virtual clock. A channel the rig has never published to
-        defers the round, before any function exists to wait for.
+        An uncharged trial pays nothing for the model. World time moves only when the loop yields, so the
+        round that starts a function waits for it before it yields.
         """
         try:
             obs = self._build_obs(clock)
         except pimm.NoValueException:
-            return
+            return  # no function is in flight yet, so this skips no wait
         if (trajectory := inference(obs)) is not None:
             self._reschedule(trajectory, clock)
         inference.wait()

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -18,22 +18,22 @@ from .spec import from_spec
 INFER = 'infer'
 
 
-def _prepare_value(key: str, value: Any) -> Any:
+def _prepare_value(value: Any) -> Any:
     # Codecs nest images inside dicts and lists (e.g. GR00T), so recurse to reach every image array.
     if isinstance(value, np.ndarray) and value.ndim in (3, 4) and value.shape[-1] == 3:
         # A raw HD frame — especially a (T, H, W, 3) stack — can exceed a proxy's websocket message cap.
         return encode_jpeg(value)
     if isinstance(value, cabc.Mapping):
-        return {k: _prepare_value(k, v) for k, v in value.items()}
+        return {k: _prepare_value(v) for k, v in value.items()}
     if isinstance(value, list | tuple):
-        return type(value)(_prepare_value(key, v) for v in value)
+        return type(value)(_prepare_value(v) for v in value)
     return value
 
 
 def _prepare_obs(obs: cabc.Mapping[str, Any], compress_images: bool) -> dict[str, Any]:
     if not compress_images:
         return dict(obs)
-    return {key: _prepare_value(key, value) for key, value in obs.items()}
+    return {key: _prepare_value(value) for key, value in obs.items()}
 
 
 def round_trip(

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -18,11 +18,37 @@ from .spec import from_spec
 INFER = 'infer'
 
 
-def round_trip(ws_session: InferenceSession, obs: dict[str, Any]) -> list[dict[str, Any]] | dict[str, Any]:
-    """One inference over the wire, timed as the ``policy.infer`` span."""
+def _prepare_value(key: str, value: Any) -> Any:
+    # Codecs nest images inside dicts and lists (e.g. GR00T), so recurse to reach every image array.
+    if isinstance(value, np.ndarray) and value.ndim in (3, 4) and value.shape[-1] == 3:
+        # A raw HD frame — especially a (T, H, W, 3) stack — can exceed a proxy's websocket message cap.
+        return encode_jpeg(value)
+    if isinstance(value, cabc.Mapping):
+        return {k: _prepare_value(k, v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return type(value)(_prepare_value(key, v) for v in value)
+    return value
+
+
+def _prepare_obs(obs: cabc.Mapping[str, Any], compress_images: bool) -> dict[str, Any]:
+    if not compress_images:
+        return dict(obs)
+    return {key: _prepare_value(key, value) for key, value in obs.items()}
+
+
+def round_trip(
+    ws_session: InferenceSession, obs: cabc.Mapping[str, Any], compress_images: bool
+) -> list[dict[str, Any]] | dict[str, Any]:
+    """One inference over the wire, timed as the ``policy.infer`` span.
+
+    The observation is prepared here rather than in the session, because a JPEG encode of an HD frame
+    stack must not run on the thread that calls the session. The span starts after it, because that
+    encode is not inference.
+    """
+    prepared = _prepare_obs(obs, compress_images)
     infer_start_ns = time.time_ns()
     try:
-        return ws_session.infer(obs)
+        return ws_session.infer(prepared)
     finally:
         telemetry.record_span(telemetry_keys.SPAN_POLICY_INFER, infer_start_ns, time.time_ns())
 
@@ -44,22 +70,6 @@ class RemoteSession(Session):
         self._answer: Answer | None = None
         self._cancelled = False
 
-    def _prepare_obs(self, obs: cabc.Mapping[str, Any]) -> dict[str, Any]:
-        if not self._compress_images:
-            return dict(obs)
-        return {key: self._prepare_value(key, value) for key, value in obs.items()}
-
-    def _prepare_value(self, key: str, value: Any) -> Any:
-        # Codecs nest images inside dicts and lists (e.g. GR00T), so recurse to reach every image array.
-        if isinstance(value, np.ndarray) and value.ndim in (3, 4) and value.shape[-1] == 3:
-            # A raw HD frame — especially a (T, H, W, 3) stack — can exceed a proxy's websocket message cap.
-            return encode_jpeg(value)
-        if isinstance(value, cabc.Mapping):
-            return {k: self._prepare_value(k, v) for k, v in value.items()}
-        if isinstance(value, list | tuple):
-            return type(value)(self._prepare_value(key, v) for v in value)
-        return value
-
     def __call__(self, obs: cabc.Mapping[str, Any]) -> list[dict[str, Any]] | None:
         """The trajectory of a round trip that has come back, and ``None`` while one is in flight.
 
@@ -67,9 +77,7 @@ class RemoteSession(Session):
         returns.
         """
         if self._answer is None:
-            # The session prepares the observation, and the function only sends it. The ``policy.infer`` span
-            # times the function, and a JPEG encode of an HD frame stack is not inference.
-            self._answer = self._rt.fns[INFER](self._session, self._prepare_obs(obs))
+            self._answer = self._rt.fns[INFER](self._session, obs, self._compress_images)
             return None
         if not self._answer.done():
             return None

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -204,8 +204,7 @@ class ServedPolicy(Policy):
     it is given, so its inference round-trips ``RemoteSession.__call__`` and records the ``policy.infer``
     span independent of any layer.
 
-    A model that costs wall time, hangs, raises or watches its observation belongs in that session's
-    ``infer``. A session that does any of it inside ``__call__`` would block the loop the harness runs on.
+    A model that costs wall time, hangs or raises belongs in that session's ``infer``.
     """
 
     def __init__(self, session: InferenceSession) -> None:
@@ -1904,8 +1903,7 @@ def test_the_layers_see_every_tick(world):
     """What a temporal stack records: nothing keeps an observation from the layers above the scheduler —
     not the machine time inside the function, and not the rounds in between.
 
-    The trial charges its inference, which is what leaves the world running while the model does. An
-    uncharged trial holds the world for the function, so there is no tick left to miss.
+    The trial charges its inference, because an uncharged one holds the world and leaves no tick to miss.
     """
     ticks = _ObservedTicks()
     _run_episode(

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -23,7 +23,7 @@ from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import DelegatingSession, Layer, Policy, Session
 from positronic.policy.codec import ActionTimestamp
-from positronic.policy.harness import Harness
+from positronic.policy.harness import Harness, _EpisodeInference
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.remote import INFER, RemoteSession, round_trip
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
@@ -670,6 +670,38 @@ def test_the_world_stopping_under_a_live_episode_fails_the_call(world):
 
     with pytest.raises(RuntimeError):
         answer.result()
+
+
+@pytest.mark.timeout(10.0)
+def test_an_uncharged_wait_ends_when_the_world_comes_down(world):
+    """An uncharged trial waits its function out, so a model that never answers would hold the loop for ever.
+    The wait ends on ``should_stop`` as well."""
+    never_answers = threading.Event()
+
+    class _HangingPolicy(Policy):
+        class _Session(Session):
+            def __init__(self, rt):
+                self._rt = rt
+
+            def __call__(self, obs):
+                self._rt.fns[INFER]()
+                return None
+
+        def new_session(self, context=None, now=None, rt=None):
+            assert rt is not None
+            return _HangingPolicy._Session(rt)
+
+        @property
+        def functions(self):
+            return {INFER: never_answers.wait}
+
+    inference = _EpisodeInference(_HangingPolicy(), {}, charges_wall_time=False, clock=world.clock)
+    try:
+        inference({})  # starts the function, which never answers
+        world.request_stop()
+        inference.wait(world.should_stop_reader())
+    finally:
+        never_answers.set()
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -23,7 +23,7 @@ from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import DelegatingSession, Layer, Policy, Session
 from positronic.policy.codec import ActionTimestamp
-from positronic.policy.harness import Harness, _InferenceWorker
+from positronic.policy.harness import Harness
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.remote import INFER, RemoteSession, round_trip
 from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
@@ -199,9 +199,40 @@ class _FakeInferenceSession(InferenceSession):
         pass
 
 
-class RemoteStubPolicy(Policy):
-    """A stub policy served through a real ``RemoteSession`` over a fake inference session, so its inference
-    round-trips ``RemoteSession.__call__`` and records the ``policy.infer`` span independent of any layer."""
+class ServedPolicy(Policy):
+    """A policy whose model runs in a served function: a real ``RemoteSession`` over the ``InferenceSession``
+    it is given, so its inference round-trips ``RemoteSession.__call__`` and records the ``policy.infer``
+    span independent of any layer.
+
+    A model that costs wall time, hangs, raises or watches its observation belongs in that session's
+    ``infer``. A session that does any of it inside ``__call__`` would block the loop the harness runs on.
+    """
+
+    def __init__(self, session: InferenceSession) -> None:
+        self._session = session
+
+    def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
+        assert rt is not None, 'the harness supplies the runtime'
+        return RemoteSession(self._session, rt)
+
+    @property
+    def functions(self):
+        return {INFER: round_trip}
+
+
+def slow_chunk(span_sec: float = 0.2, steps: int = 10) -> list[dict[str, Any]]:
+    """A chunk of ``steps`` waypoints over ``span_sec``, which a scheduler plays for that long before it
+    asks again."""
+    dt = span_sec / steps
+    pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
+    return [
+        {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), keys.TARGET_GRIP: float(i), keys.ACTION_TIMESTAMP: i * dt}
+        for i in range(steps)
+    ]
+
+
+class RemoteStubPolicy(ServedPolicy):
+    """A stub policy answering a canned chunk after ``wall_sec`` of real time."""
 
     def __init__(
         self,
@@ -213,19 +244,10 @@ class RemoteStubPolicy(Policy):
         if command is None:
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
             command = CartesianPosition(pose=pose)
-        self.command = command
-        self.target_grip = float(target_grip)
-        self.wall_sec = wall_sec
-        self._chunk = chunk
-
-    def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
-        assert rt is not None, 'the harness supplies the runtime'
-        action = self._chunk or [{'robot_command': self.command, 'target_grip': self.target_grip, 'timestamp': 0.0}]
-        return RemoteSession(_FakeInferenceSession(action, self.wall_sec), rt)
-
-    @property
-    def functions(self):
-        return {INFER: round_trip}
+        action = chunk or [
+            {keys.ROBOT_COMMAND: command, keys.TARGET_GRIP: float(target_grip), keys.ACTION_TIMESTAMP: 0.0}
+        ]
+        super().__init__(_FakeInferenceSession(action, wall_sec))
 
 
 @pytest.fixture
@@ -652,6 +674,36 @@ def test_the_world_stopping_under_a_live_episode_fails_the_call(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_a_session_that_raises_fails_the_call_that_asked_for_the_episode(world):
+    """The session is called on the loop thread, so its failure reaches whoever asked for the episode rather
+    than the log."""
+
+    class _RaisingSession(Session):
+        def __call__(self, obs):
+            raise RuntimeError('inference boom')
+
+    class _RaisingPolicy(Policy):
+        def new_session(self, context=None, now=None, rt=None):
+            return _RaisingSession()
+
+    harness = Harness(_RaisingPolicy(), make_embodiment())
+    p = _pair_all(world, harness)
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    driver = ManualDriver([
+        (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.01),
+        (None, 0.02),
+    ])
+
+    scheduler = world.start([harness, driver])
+    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
+    with pytest.raises(RuntimeError, match='inference boom'):
+        drive_scheduler(scheduler, steps=40)
+
+    with pytest.raises(RuntimeError, match='inference boom'):
+        answer.result()
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_ends_at_its_timeout(world):
     """Nothing ever lands on ``done``, yet the trial still ends at ``task.timeout_sec``: terminated=False."""
     policy = StubPolicy()
@@ -1010,10 +1062,12 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
 
 @pytest.mark.timeout(3.0)
 def test_timeout_during_inference_drops_the_chunk(world):
-    """A trial whose deadline lapses while the model is still inside its call ends with the call in flight:
-    the trajectory it eventually returns is discarded, never emitted past the advertised termination point."""
+    """A trial whose deadline lapses while the model is still inside its function ends with that function in
+    flight: the trajectory it eventually returns is discarded, never emitted past the advertised termination
+    point."""
     harness = Harness(
-        ChunkedSchedule().wrap(SlowPolicy(wall_sec=0.3)),  # the call runs well past the deadline
+        # the function runs well past the deadline
+        ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3, chunk=slow_chunk())),
         make_embodiment(simulated=True),
     )
     cmd_recorder = RecordingEmitter()
@@ -1086,33 +1140,27 @@ def test_a_call_arriving_mid_episode_is_refused(world):
     assert policy.reset_calls == 1
 
 
-class _FrameWatchingPolicy(Policy):
-    """Reads its camera frame at both ends of a slow call, so a rewrite underneath it shows up as a difference."""
+class _FrameWatchingSession(_FakeInferenceSession):
+    """Reads its camera frame at both ends of a slow function, so a rewrite underneath it shows up as a
+    difference."""
 
     def __init__(self, wall_sec: float):
-        self._wall_sec = wall_sec
+        super().__init__([], wall_sec)
         self.seen: list[tuple[np.ndarray, np.ndarray]] = []
 
-    def new_session(self, context=None, now=None, rt=None):
-        return _FrameWatchingPolicy._Session(self)
-
-    class _Session(Session):
-        def __init__(self, policy: '_FrameWatchingPolicy'):
-            self._policy = policy
-
-        def __call__(self, obs):
-            entry = np.array(obs[CAM])
-            time.sleep(self._policy._wall_sec)
-            self._policy.seen.append((entry, np.array(obs[CAM])))
-            return None
+    def infer(self, obs):
+        entry = np.array(obs[CAM])
+        super().infer(obs)
+        self.seen.append((entry, np.array(obs[CAM])))
+        return []
 
 
 @pytest.mark.timeout(10.0)
 def test_a_producer_reusing_its_buffer_cannot_rewrite_a_pending_observation(world):
-    """A camera renders into the array behind the adapter it re-emits, and a wall-charged call runs while the
-    loop yields — so the observation handed to the worker has to be its own copy."""
-    policy = _FrameWatchingPolicy(wall_sec=0.3)
-    harness = Harness(policy, make_embodiment())
+    """A camera renders into the array behind the adapter it re-emits, and a wall-charged trial keeps the loop
+    stepping while the function runs — so the observation handed to that function has to be its own copy."""
+    watcher = _FrameWatchingSession(wall_sec=0.3)
+    harness = Harness(ServedPolicy(watcher), make_embodiment())
     p = _pair_all(world, harness)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     frame = pimm.shared_memory.NumpySMAdapter((2, 2, 3), np.dtype(np.uint8))
@@ -1133,36 +1181,38 @@ def test_a_producer_reusing_its_buffer_cannot_rewrite_a_pending_observation(worl
     scheduler = world.start([harness, driver])
     drive_scheduler(scheduler, steps=60)
 
-    assert policy.seen, 'the policy was never called'
-    entry, exit_ = policy.seen[0]
-    np.testing.assert_array_equal(entry, exit_, 'the observation was rewritten while the call was in flight')
+    assert watcher.seen, 'the policy was never called'
+    entry, exit_ = watcher.seen[0]
+    np.testing.assert_array_equal(entry, exit_, 'the observation was rewritten while the function was in flight')
 
 
-class _AbandonedCallPolicy(Policy):
-    """Records the order of session openings and call completions, with a call that outlives its episode."""
+class _AbandonedCallPolicy(ServedPolicy):
+    """Records the order of session openings and function completions, with a function that outlives its
+    episode."""
+
+    class _Infer(_FakeInferenceSession):
+        def __init__(self, events: list[str], wall_sec: float):
+            super().__init__([], wall_sec)
+            self._events = events
+
+        def infer(self, obs):
+            answer = super().infer(obs)
+            self._events.append('answered')
+            return answer
 
     def __init__(self, wall_sec: float):
-        self._wall_sec = wall_sec
         self.events: list[str] = []
+        super().__init__(_AbandonedCallPolicy._Infer(self.events, wall_sec))
 
     def new_session(self, context=None, now=None, rt=None):
         self.events.append('open')
-        return _AbandonedCallPolicy._Session(self)
-
-    class _Session(Session):
-        def __init__(self, policy: '_AbandonedCallPolicy'):
-            self._policy = policy
-
-        def __call__(self, obs):
-            time.sleep(self._policy._wall_sec)
-            self._policy.events.append('answered')
-            return None
+        return super().new_session(context, now, rt)
 
 
 @pytest.mark.timeout(10.0)
 def test_a_new_episode_waits_out_the_call_the_last_one_abandoned(world):
-    """An in-process policy is one model across episodes, so opening a session must not overtake a call
-    still inside the previous one — ``new_session`` resets the object that call is using."""
+    """An in-process policy is one model across episodes, so opening a session must not overtake a function
+    still inside the previous one — ``new_session`` resets the object that function is using."""
     policy = _AbandonedCallPolicy(wall_sec=0.4)
     harness = Harness(policy, make_embodiment())
     p = _pair_all(world, harness)
@@ -1171,8 +1221,8 @@ def test_a_new_episode_waits_out_the_call_the_last_one_abandoned(world):
 
     driver = ManualDriver([
         (partial(p['perform_task'], Task(instruction_source='ep1', timeout_sec=None)), 0.0),
-        (emit_obs, 0.01),  # the observation that puts a call on the worker
-        (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),  # while that call is still running
+        (emit_obs, 0.01),  # the observation that starts the function
+        (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),  # while that function is still running
         (partial(p['perform_task'], Task(instruction_source='ep2', timeout_sec=None)), 0.02),
         (None, 0.02),
     ])
@@ -1181,7 +1231,7 @@ def test_a_new_episode_waits_out_the_call_the_last_one_abandoned(world):
     drive_scheduler(scheduler, steps=40)
 
     assert policy.events[:3] == ['open', 'answered', 'open'], (
-        f'the second session opened before the abandoned call answered: {policy.events}'
+        f'the second session opened before the abandoned function answered: {policy.events}'
     )
 
 
@@ -1712,52 +1762,15 @@ def test_anchored_chunk_passes():
 
 @pytest.mark.parametrize(('expired', 'scheduled'), [(True, False), (False, True)])
 def test_a_reply_is_scheduled_only_while_the_trial_still_has_budget(world, expired, scheduled):
-    """A trial advertises the instant it stops at. A call whose rounds in flight carried the world past that
-    instant has its chunk dropped instead of placed, and ``_run`` finishes the trial on the next round."""
-    policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
+    """A trial advertises the instant it stops at. A chunk answered after the world passed that instant is
+    dropped instead of placed, and ``_run`` finishes the trial on the next round."""
+    harness = Harness(StubPolicy(), make_embodiment())
     now = world.clock.now()
     harness._deadline = now - 1.0 if expired else now + 1.0
-    harness._worker = _InferenceWorker(policy, {}, charges_wall_time=True, clock=world.clock)
-    harness._worker.submit({})
 
-    harness._throttle_and_reschedule(harness._worker, world.clock)
+    harness._reschedule(slow_chunk(), world.clock)
 
     assert bool(harness._schedules[keys.ROBOT_COMMAND]) is scheduled
-
-
-def slow_chunk(span_sec: float = 0.2, steps: int = 10) -> list[dict[str, Any]]:
-    """A chunk of ``steps`` waypoints over ``span_sec``, which a scheduler plays for that long before it
-    asks again."""
-    dt = span_sec / steps
-    pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
-    return [
-        {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), keys.TARGET_GRIP: float(i), keys.ACTION_TIMESTAMP: i * dt}
-        for i in range(steps)
-    ]
-
-
-class _SlowSession(Session):
-    """A session whose inference costs ``wall_sec`` of real time and returns a fixed-length chunk."""
-
-    def __init__(self, wall_sec: float, span_sec: float, steps: int):
-        self._wall_sec = wall_sec
-        self._span_sec = span_sec
-        self._steps = steps
-
-    def __call__(self, obs):
-        time.sleep(self._wall_sec)
-        return slow_chunk(self._span_sec, self._steps)
-
-
-class SlowPolicy(Policy):
-    def __init__(self, wall_sec: float = 0.0, span_sec: float = 0.2, steps: int = 10):
-        self._wall_sec = wall_sec
-        self._span_sec = span_sec
-        self._steps = steps
-
-    def new_session(self, context=None, now=None, rt=None):
-        return _SlowSession(self._wall_sec, self._span_sec, self._steps)
 
 
 class _ReplanEarly(Layer):
@@ -1778,7 +1791,8 @@ class _ReplanEarly(Layer):
             if self._replan_at is not None and t0 < self._replan_at:
                 return None
             result = self._inner(obs)
-            assert result is not None, 'the inner policy of this test layer always returns a chunk'
+            if result is None:  # the function it asked has still to answer
+                return None
             anchor = self._now()
             result = [{**action, keys.ACTION_TIMESTAMP: anchor + action[keys.ACTION_TIMESTAMP]} for action in result]
             self._replan_at = t0 + (result[-1][keys.ACTION_TIMESTAMP] - t0) / 2
@@ -1833,50 +1847,37 @@ def _run_episode(
     return grip_recorder.emitted
 
 
-def _slow_policies(wall_sec: float) -> list:
-    """A model that takes ``wall_sec`` in each home it can run in: inside the session call, and inside a
-    function the session starts and returns from at once. The trial pays the same for both.
-
-    Both answer the same chunk. A shorter chunk is played out sooner, so the home that answered it runs
-    the model more times over the trial and pays more for it.
-    """
-    return [
-        pytest.param(SlowPolicy(wall_sec=wall_sec), id='in-the-call'),
-        pytest.param(RemoteStubPolicy(wall_sec=wall_sec, chunk=slow_chunk()), id='in-a-function'),
-    ]
-
-
 @pytest.mark.timeout(20.0)
-@pytest.mark.parametrize('policy', _slow_policies(0.05))
-def test_an_uncharged_call_pauses_the_world(world, policy):
+def test_an_uncharged_call_pauses_the_world(world):
     """Sim's default charges nothing: the world does not advance while the model runs, so the chunk is
-    anchored at the observation's own instant however long the call really took."""
+    anchored at the observation's own instant however long the function really took."""
+    policy = RemoteStubPolicy(wall_sec=0.05, chunk=slow_chunk())
     played = _run_episode(world, policy, ChunkedSchedule(), charge_inference_time=False)
 
     assert played, 'no command was played'
-    assert played[0][0] < 0.05, f'the world paid for the call: first command at {played[0][0]}s'
+    assert played[0][0] < 0.05, f'the world paid for the function: first command at {played[0][0]}s'
 
 
 @pytest.mark.timeout(20.0)
-@pytest.mark.parametrize('policy', _slow_policies(0.2))
-def test_a_charged_call_costs_its_own_wall_duration(world, policy):
+def test_a_charged_call_costs_its_own_wall_duration(world):
     """``charge_inference_time=True`` charges the world what the model really took, so a slow server is scored
     as slow — at the cost of a trace that inherits the machine's noise."""
+    policy = RemoteStubPolicy(wall_sec=0.2, chunk=slow_chunk())
     played = _run_episode(world, policy, ChunkedSchedule(), charge_inference_time=True)
 
     assert played, 'no command was played'
-    assert played[0][0] >= 0.2, f'first command at {played[0][0]}s, under the 0.2s the call took'
+    assert played[0][0] >= 0.2, f'first command at {played[0][0]}s, under the 0.2s the function took'
 
 
 @pytest.mark.timeout(20.0)
-@pytest.mark.parametrize('policy', _slow_policies(0.2))
-def test_a_real_rig_pays_wall_time_whatever_the_trial_asks_for(world, policy):
-    """The knob is sim-only: a real rig pays what its calls take, so a task leaving
+def test_a_real_rig_pays_wall_time_whatever_the_trial_asks_for(world):
+    """The knob is sim-only: a real rig pays what its functions take, so a task leaving
     ``charge_inference_time`` unset does not hold the world for them."""
+    policy = RemoteStubPolicy(wall_sec=0.2, chunk=slow_chunk())
     played = _run_episode(world, policy, ChunkedSchedule(), charge_inference_time=False, simulated=False)
 
     assert played, 'no command was played'
-    assert played[0][0] >= 0.2, f'first command at {played[0][0]}s, under the 0.2s the call took'
+    assert played[0][0] >= 0.2, f'first command at {played[0][0]}s, under the 0.2s the function took'
 
 
 class _ObservedTicks(Layer):
@@ -1901,13 +1902,17 @@ class _ObservedTicks(Layer):
 @pytest.mark.timeout(30.0)
 def test_the_layers_see_every_tick(world):
     """What a temporal stack records: nothing keeps an observation from the layers above the scheduler —
-    not the machine inside the model call, and not the rounds in between."""
+    not the machine time inside the function, and not the rounds in between.
+
+    The trial charges its inference, which is what leaves the world running while the model does. An
+    uncharged trial holds the world for the function, so there is no tick left to miss.
+    """
     ticks = _ObservedTicks()
     _run_episode(
         world,
-        SlowPolicy(wall_sec=0.01, span_sec=0.3, steps=15),
+        RemoteStubPolicy(wall_sec=0.01, chunk=slow_chunk(0.3, 15)),
         ticks | ChunkedSchedule(),
-        charge_inference_time=False,
+        charge_inference_time=True,
         run_sec=1.0,
     )
 
@@ -1921,7 +1926,7 @@ def test_harness_keeps_playing_while_a_call_is_in_flight(world):
     """A layer that replans before its chunk is exhausted leaves waypoints due during inference, and the
     harness emits them on time instead of standing still until the model answers."""
     played = _run_episode(
-        world, SlowPolicy(wall_sec=0.15, span_sec=0.4, steps=20), _ReplanEarly(), charge_inference_time=True
+        world, RemoteStubPolicy(wall_sec=0.15, chunk=slow_chunk(0.4, 20)), _ReplanEarly(), charge_inference_time=True
     )
 
     # The first chunk lands at ~0.15s and spans 0.4s; the second call starts halfway through it (~0.28s) and
@@ -2011,7 +2016,7 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
     """A stop has no waypoints to place: an arm that faults mid-chunk stops in the round its fault is seen."""
     fault_at, period = 0.5, 0.005
     stack = StopOnFault() | ChunkedSchedule()
-    harness = Harness(stack.wrap(SlowPolicy(span_sec=1.0, steps=50)), make_embodiment(simulated=True))
+    harness = Harness(stack.wrap(RemoteStubPolicy(chunk=slow_chunk(1.0, 50))), make_embodiment(simulated=True))
     grip_recorder = _TimedRecorder(world.clock)
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
@@ -2039,23 +2044,20 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
 @pytest.mark.timeout(20.0)
 def test_finish_does_not_wait_for_the_call_in_flight():
     """Finishing ends the episode where it lands: the recording stops while the model is still inside its
-    call, and the failure that call ends in reaches nobody.
+    function, and the failure that function ends in reaches the log alone.
 
-    Real time, real rig: a wall-charged call is the only one the harness leaves in flight across rounds.
+    Real time, real rig: a wall-charged trial is the one that leaves the loop running while a function is in
+    flight.
     """
     hang_sec = 1.0
 
-    class _HangingSession(Session):
-        def __call__(self, obs):
-            time.sleep(hang_sec)
+    class _HangingInfer(_FakeInferenceSession):
+        def infer(self, obs):
+            super().infer(obs)
             raise RuntimeError('inference boom')
 
-    class _HangingPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
-            return _HangingSession()
-
     with pimm.World() as world:
-        harness = Harness(_HangingPolicy(), make_embodiment())
+        harness = Harness(ServedPolicy(_HangingInfer([], hang_sec)), make_embodiment())
         cmd_recorder = RecordingEmitter()
         ds_recorder = _TimedRecorder(world.clock)
         harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -2080,28 +2082,24 @@ def test_finish_does_not_wait_for_the_call_in_flight():
 
     stops = [(t, data) for t, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0][0] - started < hang_sec, 'the stop waited for the call to answer'
+    assert stops[0][0] - started < hang_sec, 'the stop waited for the function to answer'
 
 
 @pytest.mark.timeout(20.0)
 def test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy():
-    """A sweep runs a harness per eval over one shared policy, so a call still inside the model when a run
-    ends would meet the next run's ``new_session`` — or ``policy.close()``. The run outlives its own call."""
+    """A sweep runs a harness per eval over one shared policy, so a function still inside the model when a run
+    ends would meet the next run's ``new_session`` — or ``policy.close()``. The run outlives its own work."""
     hang_sec = 1.0
     left_the_model = threading.Event()
 
-    class _HangingSession(Session):
-        def __call__(self, obs):
-            time.sleep(hang_sec)
+    class _HangingInfer(_FakeInferenceSession):
+        def infer(self, obs):
+            answer = super().infer(obs)
             left_the_model.set()
-            return None
-
-    class _HangingPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
-            return _HangingSession()
+            return answer
 
     with pimm.World() as world:
-        harness = Harness(_HangingPolicy(), make_embodiment())
+        harness = Harness(ServedPolicy(_HangingInfer([], hang_sec)), make_embodiment())
         harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
         harness.commands[keys.TARGET_GRIP]._bind(RecordingEmitter())
         harness.ds_command._bind(RecordingEmitter())
@@ -2121,36 +2119,32 @@ def test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy():
         ])
         drive_scheduler(world.start([harness, driver]), steps=40)
 
-    assert left_the_model.is_set(), 'the run returned with a call still inside the shared policy'
+    assert left_the_model.is_set(), 'the run returned with a function still inside the shared policy'
 
 
 @pytest.mark.timeout(20.0)
 def test_the_session_is_closed_only_once_its_call_has_left_it():
-    """``RemoteSession.close`` shuts the websocket the call in flight is talking over, and ``Session`` asks
-    for no thread safety, so the session is retired with its worker and closed once that worker is joined."""
+    """``RemoteSession.close`` shuts the websocket the function in flight is talking over, and ``Session``
+    asks for no thread safety, so the session is retired with its runtime and closed after it."""
     inside_at_close = []
 
-    class _HangingSession(Session):
+    class _HangingInfer(_FakeInferenceSession):
         def __init__(self):
+            super().__init__([], wall_sec=1.0)
             self.inside = False
 
-        def __call__(self, obs):
+        def infer(self, obs):
             self.inside = True
             try:
-                time.sleep(1.0)
-                return None
+                return super().infer(obs)
             finally:
                 self.inside = False
 
         def close(self):
             inside_at_close.append(self.inside)
 
-    class _HangingPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
-            return _HangingSession()
-
     with pimm.World() as world:
-        harness = Harness(_HangingPolicy(), make_embodiment())
+        harness = Harness(ServedPolicy(_HangingInfer()), make_embodiment())
         harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
         harness.commands[keys.TARGET_GRIP]._bind(RecordingEmitter())
         harness.ds_command._bind(RecordingEmitter())
@@ -2170,7 +2164,7 @@ def test_the_session_is_closed_only_once_its_call_has_left_it():
         ])
         drive_scheduler(world.start([harness, driver]), steps=40)
 
-    assert inside_at_close == [False], 'the session was closed while its own call was still inside it'
+    assert inside_at_close == [False], 'the session was closed while its own function was still inside it'
 
 
 @pytest.mark.timeout(3.0)
@@ -2246,7 +2240,8 @@ def test_manual_commands_are_emitted_as_plain_values(world):
 def test_finishing_discards_a_call_that_is_still_in_flight(world):
     """Finishing while the model is still inside its call throws that answer away: the trajectory it carries
     never reaches the devices."""
-    harness = Harness(ChunkedSchedule().wrap(SlowPolicy(wall_sec=1.0)), make_embodiment(simulated=True))
+    policy = RemoteStubPolicy(wall_sec=1.0, chunk=slow_chunk())
+    harness = Harness(ChunkedSchedule().wrap(policy), make_embodiment(simulated=True))
     cmd_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
     harness.commands[keys.TARGET_GRIP]._bind(RecordingEmitter())
@@ -2262,7 +2257,7 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
     driver = ManualDriver([
         (partial(perform_task, Task(instruction_source='t', timeout_sec=None, charge_inference_time=True)), 0.0),
         (partial(emit_ready_payload, frame_em, robot_em, grip_em, robot_state), 0.001),
-        (None, 0.05),  # well inside the 1.0s the call takes
+        (None, 0.05),  # well inside the 1.0s the function takes
         (partial(done_em.emit, OPERATOR_DONE), 0.0),
         (None, 0.05),
     ])


### PR DESCRIPTION
Rung 5 of #661.

## What

`_InferenceWorker` loses its thread pool and becomes `_EpisodeInference`: one episode's session, the runtime that serves its functions, and the anchor that charges a served function's wall time to the trial. The harness calls the session itself.

With the call inline there is no future to drop, so `SKIP_REPLY_SEC`, `submit`, `result`, `idle`, `done`, `abandon` and `_report_abandoned` die. `Executor.close()` already waits a function out and logs a failure no caller read, under the waiver that path already carries.

The round becomes: build the observation, call the session, place what it answers, then wait for the function it left running. Where the wait sits in the round does not matter: `World.interleave` runs every due loop once and only then advances the clock, so the wait freezes virtual time wherever it sits, and the answer is read one tick after the model starts either way. Measured both ways -- an uncharged trial plays the same 81 commands, first at 0.0100s and last at 1.4900s.

`Session.__call__` now states that it answers without waiting. The harness runs it on the thread that plays the trajectory and steps every other control system; only `Policy.functions` runs off that thread. The dependency is new with this rung, and `Session` did not state it.

## The golden does not move

`golden_pipeline.json.gz` is byte-identical. Its world is virtual and charges nothing for inference, so every wait this rung deletes cost that world no time. #661 records the measurement that settled it. A golden that moves in this rung is a regression to find, not a file to write.

## Tests

Nine tests move their slow model out of `__call__` and into a served function, which is the only home heavy work has left. `SlowPolicy`, `_SlowSession` and `_slow_policies` go; `ServedPolicy` takes an `InferenceSession` and wraps it in a real `RemoteSession`, and `RemoteStubPolicy` builds on it.

Three of the nine -- `test_a_new_episode_waits_out_the_call_the_last_one_abandoned`, `test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy` and `test_the_session_is_closed_only_once_its_call_has_left_it` -- passed unchanged under an inline harness while guarding nothing at all.

Three probes confirm the rewritten tests still guard what they name:

| Break | Tests that fail |
|---|---|
| `wait()` does nothing | the 3 charging tests, and keeps-playing |
| `close()` skips the runtime | 8, including all 3 abandon tests |
| drop the observation copy | exactly the producer-buffer test |

`test_a_reply_is_scheduled_only_while_the_trial_still_has_budget` is rebuilt against `_reschedule`, the rule it pins, because it was the one test that named `_InferenceWorker`. A new test covers the route a session failure now always takes: inline, a raise reaches whoever asked for the episode.

## One deliberate coverage loss

After this rung nothing tests that a session blocking inside `__call__` is a defect, because the framework cannot detect one. The `[in-the-call]` parametrizations were that test and cannot be kept honest. Enforcement moves to the `Session.__call__` contract and to `Policy.functions` being the only home heavy work has left.

## A known limit this PR accepts

A rig-side codec runs on the loop thread now. `RestrictImageSize` is one, and the lerobot pipeline declares it. It costs 3 ms for one 1280x720 frame, 6 ms for two, and 12 ms for a 4-deep stack; a frame already inside the bound costs nothing. The harness holds a bound of 10 ms on how late a command goes out, so the stack case is longer than that bound.

The count of calls does not change. Measured over one trial on a real-rig shape, the codec ran 90 times and the wire sent 4 observations, on `origin/main` and on this branch alike. This PR moves that work onto the loop thread; it does not add work.

The fix moves the transform to the place that decides to send, as the JPEG encode moved into `round_trip`. `RestrictImageSize` is a declared wire layer, so the move changes the handshake, and #661 holds the wire unchanged until rung 9.

## Verification

`uv run --locked pytest` -- 1677 passed, 8 skipped. ruff and basedpyright clean. `check-rules` over all 13 rules: one finding, on `hidden-dependency`, fixed by the `Session.__call__` contract above. Its second half asked for the remaining vendors to migrate first; those sessions are reachable only through their own `server.py` as a `ModelSource`, where `blocking()` wraps them and a blocking call is correct. #661 migrates them at rungs 10..N.




