### PR TITLE
Let one runner build the world for both eval paths

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -106,18 +106,19 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 ### A console of your own
 
-Anything richer — a web console, a foot pedal, a rig UI — is a `Driver` of its own rather than a plug-in. It decides when an episode starts, and `run_world` builds the world around it: the harness, the recorder, the devices, and every wire between them. A driver reads what it decides from itself — the keyboard operator reads the terminal in its own loop — so the runner wires nothing of it but the `perform_task` call and `done`.
+Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller: it decides when an episode starts, and `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. A driver reads what it decides from itself — the keyboard operator reads the terminal in its own loop — so the runner wires nothing of it but that call and `done`.
 
 ```python
 import pimm
-from positronic.cli.eval.run import Driver, prepare_output_dir, run_world
+from positronic.cli.eval.run import prepare_output_dir, run_world
+from positronic.eval import Task
 
 
-class MyConsole(Driver):
+class MyConsole(pimm.ControlSystem):
     """Asks `perform_task` for a `Task` per episode, and emits the episode's terminal on `done`."""
 
     def __init__(self):
-        super().__init__()
+        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict](self)
         self.done = pimm.ControlSystemEmitter[dict](self)
 
     def run(self, should_stop, clock):

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -106,40 +106,48 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 ### A console of your own
 
-Anything richer — a web console, a foot pedal, a rig UI — is a binary of its own rather than a plug-in: it composes its own `pimm.World` out of the public pieces, and nothing in the library needs to know which surface is driving. The shape, for a **hardware** embodiment:
+Anything richer — a web console, a foot pedal, a rig UI — is a `Driver` of its own rather than a plug-in. It decides when an episode starts, and `run_world` builds the world around it. Nothing in the library needs to know which surface is driving. The same runner takes a **simulated** embodiment: it reads `embodiment.simulated`, and gives a sim world virtual time, message-stamped recording and foreground producers. One scheduler round is then one control period.
 
 ```python
-from contextlib import nullcontext
-
 import pimm
-from positronic import wire
-from positronic.cli.eval.run import prepare_output_dir
-from positronic.dataset.local_dataset import LocalDatasetWriter
-from positronic.policy.harness import Harness
+from positronic import keys
+from positronic.cli.eval.run import Driver, prepare_output_dir, run_world
+from positronic.gui import dpg_ui
 
-# The setup under the `try` can raise — `prepare_output_dir` syncs a directory and snapshots
-# sources into it, `LocalDatasetWriter` scans the one it is given — and the policy is yours to
-# close from the moment you first touch it.
+
+class MyConsole(Driver):
+    """Asks `perform_task` for a `Task` per episode, and emits the episode's terminal on `done`."""
+
+    def __init__(self, embodiment):
+        super().__init__()
+        self._embodiment = embodiment
+        self._viewer = dpg_ui()
+        self.done = pimm.ControlSystemEmitter[dict](self)
+        self.jog = pimm.ControlSystemEmitter(self)
+
+    def wire(self, world, harness):
+        for name, obs in self._embodiment.observations.items():
+            if name.startswith(keys.IMAGE_PREFIX):
+                world.connect(obs.source, self._viewer.cameras[name])
+        world.connect(self.jog, harness.manual_command)
+        return (self._viewer,)
+
+    def run(self, should_stop, clock):
+        ...
+
+
+# `prepare_output_dir` syncs a directory and snapshots the sources into it, and it can raise. The
+# policy is yours to close from the moment you first touch it. `None` records nothing.
 try:
-    # `None` where the run records nothing, which is why the writer is a nullcontext below.
-    output_dir = prepare_output_dir(output_dir)
-    harness = Harness(policy, embodiment)
-    console = MyConsole()  # asks `perform_task` for a `Task` per episode and emits its terminal on `done`
-
-    writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
-    with writer_cm as writer, pimm.World() as world:
-        ds_agent = wire.wire_embodiment(world, harness, embodiment, writer, done=console.done)
-        world.connect(console.perform_task, harness.perform_task)
-        if ds_agent is not None:
-            world.connect(harness.ds_command, ds_agent.command)
-        world.run([harness, console], [*embodiment.control_systems, ds_agent])
+    console = MyConsole(embodiment)
+    run_world(policy, embodiment, console, prepare_output_dir(output_dir), done=console.done)
 finally:
     policy.close()
 ```
 
-**A simulated embodiment is not this.** Three things change together, and a copy of the shape above records a sim run against the wall clock: the world takes `virtual_time=True`, `wire_embodiment` takes `TimeMode.MESSAGE`, and the producers are scheduled in the foreground beside the harness rather than as background processes, so one scheduler round is one control period. `_run_world` in [`positronic/cli/eval/run.py`](../positronic/cli/eval/run.py) is the worked version, including why the ordering within a round is what it is.
+`run_world` connects `perform_task` and `done` itself. `wire` connects everything else the console brings, and returns what the runner must schedule. The example connects two things. The viewer takes every observation named with the `positronic.keys.IMAGE_PREFIX` convention on its `cameras`. The jog channel goes into `harness.manual_command`, which the harness applies only while it is idle. The world stops when any of its control systems returns, so the console ends the run by returning from its loop.
 
-The world stops when any of its control systems returns, so the console ends the run by returning from its loop. To show the cameras, connect every observation whose name starts with `positronic.keys.IMAGE_PREFIX` into a viewer's `cameras` — `positronic.gui.dpg_ui()` is one, and the naming convention is what identifies a camera on the wire. To let the operator jog the arm between episodes, emit robot commands into `harness.manual_command`, which the harness applies only while idle. To count down an episode's remaining time, read `harness.deadline_ns`: it carries the instant on the world's clock the live episode ends at, so the time left is that value minus your own `clock.now_ns()`. An episode publishes its deadline once the rig is ready — after the task's prepare handlers answer, so the reset costs the episode nothing. It is `None` whenever no deadline stands — no episode running, or one whose task has no `timeout_sec`.
+To count down an episode's remaining time, read `harness.deadline_ns`: it carries the instant on the world's clock the live episode ends at, so the time left is that value minus your own `clock.now_ns()`. An episode publishes its deadline once the rig is ready — after the task's prepare handlers answer, so the reset costs the episode nothing. It is `None` whenever no deadline stands — no episode running, or one whose task has no `timeout_sec`.
 
 ## Recording and Replay
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -106,31 +106,19 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 ### A console of your own
 
-Anything richer — a web console, a foot pedal, a rig UI — is a `Driver` of its own rather than a plug-in. It decides when an episode starts, and `run_world` builds the world around it. Nothing in the library needs to know which surface is driving. The same runner takes a **simulated** embodiment: it reads `embodiment.simulated`, and gives a sim world virtual time, message-stamped recording and foreground producers. One scheduler round is then one control period.
+Anything richer — a web console, a foot pedal, a rig UI — is a `Driver` of its own rather than a plug-in. It decides when an episode starts, and `run_world` builds the world around it: the harness, the recorder, the devices, and every wire between them. A driver reads what it decides from itself — the keyboard operator reads the terminal in its own loop — so the runner wires nothing of it but the `perform_task` call and `done`.
 
 ```python
 import pimm
-from positronic import keys
 from positronic.cli.eval.run import Driver, prepare_output_dir, run_world
-from positronic.gui import dpg_ui
 
 
 class MyConsole(Driver):
     """Asks `perform_task` for a `Task` per episode, and emits the episode's terminal on `done`."""
 
-    def __init__(self, embodiment):
+    def __init__(self):
         super().__init__()
-        self._embodiment = embodiment
-        self._viewer = dpg_ui()
         self.done = pimm.ControlSystemEmitter[dict](self)
-        self.jog = pimm.ControlSystemEmitter(self)
-
-    def wire(self, world, harness):
-        for name, obs in self._embodiment.observations.items():
-            if name.startswith(keys.IMAGE_PREFIX):
-                world.connect(obs.source, self._viewer.cameras[name])
-        world.connect(self.jog, harness.manual_command)
-        return (self._viewer,)
 
     def run(self, should_stop, clock):
         ...
@@ -139,13 +127,15 @@ class MyConsole(Driver):
 # `prepare_output_dir` syncs a directory and snapshots the sources into it, and it can raise. The
 # policy is yours to close from the moment you first touch it. `None` records nothing.
 try:
-    console = MyConsole(embodiment)
+    console = MyConsole()
     run_world(policy, embodiment, console, prepare_output_dir(output_dir), done=console.done)
 finally:
     policy.close()
 ```
 
-`run_world` connects `perform_task` and `done` itself. `wire` connects everything else the console brings, and returns what the runner must schedule. The example connects two things. The viewer takes every observation named with the `positronic.keys.IMAGE_PREFIX` convention on its `cameras`. The jog channel goes into `harness.manual_command`, which the harness applies only while it is idle. The world stops when any of its control systems returns, so the console ends the run by returning from its loop.
+The same runner takes a **simulated** embodiment: it reads `embodiment.simulated`, and gives a sim world virtual time, message-stamped recording and foreground producers. One scheduler round is then one control period. The world stops when any of its control systems returns, so the console ends the run by returning from its loop.
+
+A surface that brings a control system of its own — a camera viewer, a pedal on a socket — composes its own world instead, because only whoever builds a world can wire what runs in it. `run_world` is the shape to copy. To show the cameras, connect every observation named with the `positronic.keys.IMAGE_PREFIX` convention into a viewer's `cameras`; `positronic.gui.dpg_ui()` is one. To let the operator jog the arm between episodes, emit robot commands into `harness.manual_command`, which the harness applies only while it is idle.
 
 To count down an episode's remaining time, read `harness.deadline_ns`: it carries the instant on the world's clock the live episode ends at, so the time left is that value minus your own `clock.now_ns()`. An episode publishes its deadline once the rig is ready — after the task's prepare handlers answer, so the reset costs the episode nothing. It is `None` whenever no deadline stands — no episode running, or one whose task has no `timeout_sec`.
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from collections.abc import Callable, Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from contextlib import contextmanager, nullcontext
 from dataclasses import replace
 from functools import partial
@@ -19,7 +19,7 @@ from positronic.cfg.eval import placeholder
 from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
-from positronic.eval import Embodiment, Eval, Task
+from positronic.eval import Embodiment, Eval, Observation, Task
 from positronic.policy.executor import blocking
 from positronic.policy.harness import Harness
 from positronic.simulator.env_server.telemetry import ATTR_RUN_ID, ENV_RUN_ID, ENV_TELEMETRY_DIR
@@ -47,17 +47,34 @@ def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
     return local_dir
 
 
-class TaskDriver(pimm.ControlSystem):
-    """Walks a plan of tasks, asking for each as an episode through ``perform_task``, and returns —
-    stopping the world — once the last has ended.
+class Driver(pimm.ControlSystem):
+    """Decides when a trial starts, and asks for it as an episode through ``perform_task``.
+
+    ``run_world`` builds one world around one driver: a plan walked to its end, a person at a keyboard, or a
+    console of somebody's own.
+    """
+
+    def __init__(self):
+        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
+
+    def wire(self, world: pimm.World, harness: Harness) -> Sequence[pimm.ControlSystem]:
+        """Connect what this driver adds — a viewer, an input device — and return what the runner schedules.
+
+        The runner connects ``perform_task`` itself, so this is for everything else.
+        """
+        return ()
+
+
+class TaskDriver(Driver):
+    """Walks a plan of tasks, and returns — stopping the world — once the last has ended.
 
     It makes the plan on its first turn, not when it is built. One task is in flight at a time: the next is
     asked for only when the previous episode's terminal comes back, so the plan never overlaps two episodes.
     """
 
     def __init__(self, tasks: Callable[[], Iterable[Task]]):
+        super().__init__()
         self._tasks = tasks
-        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
@@ -71,25 +88,33 @@ class TaskDriver(pimm.ControlSystem):
         yield pimm.Sleep(0.5)
 
 
-def _run_world(policy, ev: Eval, output_dir: Path | None):
-    """Wire one eval's embodiment under a fresh Harness + World and run it to completion.
+def run_world(
+    policy,
+    embodiment: Embodiment,
+    driver: Driver,
+    output_dir: Path | None,
+    *,
+    privileged: dict[str, Observation] | None = None,
+    done: pimm.ControlSystemEmitter | None = None,
+) -> None:
+    """Wire one embodiment under a fresh Harness + World, and run it until a control system returns.
 
-    The driver walks ``ev.tasks``; the shared ``policy``'s lifetime stays with ``main``.
+    Every trial runs here, whoever asks for it: the driver is what an attended run and an unattended one
+    differ by. ``done`` is what ends an episode from outside the policy — the env's terminal in a sim eval,
+    the operator in an attended run. The ``policy``'s lifetime stays with the caller.
     """
-    embodiment = ev.embodiment
     harness = Harness(policy, embodiment)
-    driver = TaskDriver(ev.tasks)
-
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
     with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
         ds_agent = wire.wire_embodiment(
-            world, harness, embodiment, dataset_writer, time_mode, privileged=ev.privileged, done=ev.done
+            world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
         )
         world.connect(driver.perform_task, harness.perform_task)
         if ds_agent is not None:
             world.connect(harness.ds_command, ds_agent.command)
 
+        driver_systems = driver.wire(world, harness)
         producers = [cs for cs in embodiment.control_systems if cs is not None]
         if embodiment.simulated:
             # Why this order:
@@ -98,9 +123,9 @@ def _run_world(policy, ev: Eval, output_dir: Path | None):
             #   in that same pass.
             # - The producers run last, so what the recorder finds on the channels is the frame the reset
             #   published, with no step in between.
-            world.run([driver, harness, ds_agent, *producers])
+            world.run([driver, *driver_systems, harness, ds_agent, *producers])
         else:
-            world.run([driver, harness], [*producers, ds_agent])
+            world.run([driver, *driver_systems, harness], [*producers, ds_agent])
 
 
 def _validate_timing(embodiments: Iterable[Embodiment], output_dir: str | Path | None) -> None:
@@ -200,7 +225,8 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     try:
         with timed_pass(output_dir, timing, policy):
             for ev in evals:
-                _run_world(policy, ev, output_dir)
+                driver = TaskDriver(ev.tasks)
+                run_world(policy, ev.embodiment, driver, output_dir, privileged=ev.privileged, done=ev.done)
     finally:
         policy.close()
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -47,28 +47,17 @@ def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
     return local_dir
 
 
-class Driver(pimm.ControlSystem):
-    """Decides when a trial starts, and asks for it as an episode through ``perform_task``.
-
-    ``run_world`` builds one world around one driver: a plan walked to its end, a person at a keyboard, or a
-    console of somebody's own. A driver reads whatever it decides from — a plan, a terminal — itself, so the
-    runner wires nothing of it but this call.
-    """
-
-    def __init__(self):
-        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
-
-
-class TaskDriver(Driver):
-    """Walks a plan of tasks, and returns — stopping the world — once the last has ended.
+class TaskDriver(pimm.ControlSystem):
+    """Walks a plan of tasks, asking for each as an episode through ``perform_task``, and returns —
+    stopping the world — once the last has ended.
 
     It makes the plan on its first turn, not when it is built. One task is in flight at a time: the next is
     asked for only when the previous episode's terminal comes back, so the plan never overlaps two episodes.
     """
 
     def __init__(self, tasks: Callable[[], Iterable[Task]]):
-        super().__init__()
         self._tasks = tasks
+        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
@@ -85,7 +74,7 @@ class TaskDriver(Driver):
 def run_world(
     policy,
     embodiment: Embodiment,
-    driver: Driver,
+    driver,
     output_dir: Path | None,
     *,
     privileged: dict[str, Observation] | None = None,
@@ -94,8 +83,11 @@ def run_world(
     """Wire one embodiment under a fresh Harness + World, and run it until a control system returns.
 
     Every trial runs here, whoever asks for it: the driver is what an attended run and an unattended one
-    differ by. ``done`` is what ends an episode from outside the policy — the env's terminal in a sim eval,
-    the operator in an attended run. The ``policy``'s lifetime stays with the caller.
+    differ by. A driver is any control system with a ``perform_task`` caller — a plan walked to its end, a
+    person at a keyboard, a console of somebody's own — and it reads what it decides from itself, so the
+    runner wires nothing of it but that call. ``done`` is what ends an episode from outside the policy: the
+    env's terminal in a sim eval, the operator in an attended run. The ``policy``'s lifetime stays with the
+    caller.
     """
     harness = Harness(policy, embodiment)
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import replace
 from functools import partial
@@ -51,18 +51,12 @@ class Driver(pimm.ControlSystem):
     """Decides when a trial starts, and asks for it as an episode through ``perform_task``.
 
     ``run_world`` builds one world around one driver: a plan walked to its end, a person at a keyboard, or a
-    console of somebody's own.
+    console of somebody's own. A driver reads whatever it decides from — a plan, a terminal — itself, so the
+    runner wires nothing of it but this call.
     """
 
     def __init__(self):
         self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
-
-    def wire(self, world: pimm.World, harness: Harness) -> Sequence[pimm.ControlSystem]:
-        """Connect what this driver adds — a viewer, an input device — and return what the runner schedules.
-
-        The runner connects ``perform_task`` itself, so this is for everything else.
-        """
-        return ()
 
 
 class TaskDriver(Driver):
@@ -114,7 +108,6 @@ def run_world(
         if ds_agent is not None:
             world.connect(harness.ds_command, ds_agent.command)
 
-        driver_systems = driver.wire(world, harness)
         producers = [cs for cs in embodiment.control_systems if cs is not None]
         if embodiment.simulated:
             # Why this order:
@@ -123,9 +116,9 @@ def run_world(
             #   in that same pass.
             # - The producers run last, so what the recorder finds on the channels is the frame the reset
             #   published, with no step in between.
-            world.run([driver, *driver_systems, harness, ds_agent, *producers])
+            world.run([driver, harness, ds_agent, *producers])
         else:
-            world.run([driver, *driver_systems, harness], [*producers, ds_agent])
+            world.run([driver, harness], [*producers, ds_agent])
 
 
 def _validate_timing(embodiments: Iterable[Embodiment], output_dir: str | Path | None) -> None:

--- a/positronic/drivers/keyboard.py
+++ b/positronic/drivers/keyboard.py
@@ -1,38 +1,31 @@
-import logging
 import select
 import sys
 import termios
 import tty
-
-import pimm
-
-logger = logging.getLogger(__name__)
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 
 
-class KeyboardControl(pimm.ControlSystem):
-    def __init__(self, quit_key: str | None = None):
-        self.quit_key = quit_key
-        self.keyboard_inputs = pimm.ControlSystemEmitter(self)
+def _pressed_key() -> str | None:
+    """The key just typed, or ``None`` when nobody typed one. It never waits."""
+    ready, _, _ = select.select([sys.stdin], [], [], 0.0)
+    return sys.stdin.read(1) if ready else None
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        # Check if stdin is a TTY before attempting terminal operations
-        if not sys.stdin.isatty():
-            print('WARNING: KeyboardControl cannot read input - stdin is not a terminal', file=sys.stderr)
-            logger.warning('KeyboardControl cannot read input - stdin is not a terminal')
-            return
 
-        fd = sys.stdin.fileno()
-        old_settings = termios.tcgetattr(fd)
-        tty.setcbreak(fd)
+@contextmanager
+def key_reader() -> Iterator[Callable[[], str | None] | None]:
+    """Put the terminal in cbreak mode, and yield a reader of one key press at a time.
 
-        try:
-            while not should_stop.value:
-                r, _, _ = select.select([sys.stdin], [], [], 0.0)
-                if r:
-                    key = sys.stdin.read(1)
-                    if key == self.quit_key:
-                        return
-                    self.keyboard_inputs.emit(key)
-                yield pimm.Sleep(0.01)
-        finally:
-            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+    Yields ``None`` where stdin is not a terminal: there is nothing to read a key from, and the caller
+    decides what a run without an operator does.
+    """
+    if not sys.stdin.isatty():
+        yield None
+        return
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    tty.setcbreak(fd)
+    try:
+        yield _pressed_key
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)

--- a/positronic/drivers/keyboard.py
+++ b/positronic/drivers/keyboard.py
@@ -1,3 +1,4 @@
+import logging
 import select
 import sys
 import termios
@@ -5,9 +6,13 @@ import tty
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 
+import pimm
+
+logger = logging.getLogger(__name__)
+
 
 def _pressed_key() -> str | None:
-    """The key just typed, or ``None`` when nobody typed one. It never waits."""
+    """The key just typed, or ``None`` where nobody typed one. It never waits."""
     ready, _, _ = select.select([sys.stdin], [], [], 0.0)
     return sys.stdin.read(1) if ready else None
 
@@ -16,8 +21,8 @@ def _pressed_key() -> str | None:
 def key_reader() -> Iterator[Callable[[], str | None] | None]:
     """Put the terminal in cbreak mode, and yield a reader of one key press at a time.
 
-    Yields ``None`` where stdin is not a terminal: there is nothing to read a key from, and the caller
-    decides what a run without an operator does.
+    Yields ``None`` where stdin is not a terminal: there is no key to read, and what a run without an
+    operator does is the caller's to decide.
     """
     if not sys.stdin.isatty():
         yield None
@@ -29,3 +34,31 @@ def key_reader() -> Iterator[Callable[[], str | None] | None]:
         yield _pressed_key
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+
+class KeyboardControl(pimm.ControlSystem):
+    """Reads the terminal a key at a time and emits each one. ``quit_key`` returns, which stops the world.
+
+    ``_each_round`` is what a key does. A subclass answers it to do something else, and gets it every round,
+    key or no key, so work of its own between presses has somewhere to run.
+    """
+
+    def __init__(self, quit_key: str | None = None):
+        self.quit_key = quit_key
+        self.keyboard_inputs = pimm.ControlSystemEmitter[str](self)
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        with key_reader() as read_key:
+            if read_key is None:
+                logger.warning('no key can be read: stdin is not a terminal')
+                return
+            while not should_stop.value:
+                key = read_key()
+                if key is not None and key == self.quit_key:
+                    return
+                self._each_round(key)
+                yield pimm.Sleep(0.01)
+
+    def _each_round(self, key: str | None) -> None:
+        if key is not None:
+            self.keyboard_inputs.emit(key)

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -97,7 +97,7 @@ class Task:
 # [✓] The recorder keeps what is on the wire when it opens, and a producer publishes the scene as it answers.
 # [✓] A config makes each attended trial, so the keyboard path makes none of its own.
 # [✓] A task source makes the plan when the world starts.
-# [ ] One runner builds the world for both.
+# [✓] One runner builds the world for both.
 # [ ] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.
 # [ ] A task carries its instruction as data, so no trial reads it after the reset.
 # [ ] A sim eval config names a selection, and a spec flag narrows it to one task.

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -2,8 +2,7 @@
 aliases over ``cli.eval.run``."""
 
 from collections import Counter
-from collections.abc import Callable
-from contextlib import nullcontext
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import configuronic as cfn
@@ -14,29 +13,36 @@ import positronic.cfg.embodiment
 import positronic.cfg.eval.real.droid
 import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
-from positronic import keys, wire
+from positronic import keys
 from positronic.cfg.eval.sim.positronic import stack_cubes
-from positronic.cli.eval.run import prepare_output_dir, run
-from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
+from positronic.cli.eval.run import Driver, prepare_output_dir, run, run_world
+from positronic.dataset.local_dataset import load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
 from positronic.eval import Embodiment, Task
 from positronic.policy.harness import Harness
 
 
-class KeyboardOperator(pimm.ControlSystem):
+class KeyboardOperator(Driver):
     """Turns keystrokes into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one.
 
     It holds the pending answers because that is where an episode's terminal — and any refused ask —
-    arrives; both are printed as they land. ``next_task`` is called once per press.
+    arrives; both are printed as they land. ``next_task`` is called once per press. The keyboard is the
+    operator's own, so ``q`` returns from it and brings the world down.
     """
 
     def __init__(self, next_task: Callable[[], Task]):
+        super().__init__()
         self._next_task = next_task
+        self._keyboard = KeyboardControl(quit_key='q')
         self.keystrokes = pimm.ControlSystemReceiver[str](self)
-        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
+    def wire(self, world: pimm.World, harness: Harness) -> Sequence[pimm.ControlSystem]:
+        world.connect(self._keyboard.keyboard_inputs, self.keystrokes)
+        return (self._keyboard,)
+
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        print('Keyboard controls: [s]tart, sto[p], [q]uit')
         pending: list[pimm.calls.Answer[dict[str, Any]]] = []
         while not should_stop.value:
             if (key := pimm.value_updated(self.keystrokes)) is not None:
@@ -67,41 +73,22 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     """Run one hardware embodiment attended and headless, the keyboard deciding when an episode starts and
     finishes.
 
-    The world is composed here rather than by the runner: an attended surface is the binary's own business,
-    and the keyboard is the only one this library ships. There is no viewer — a console that shows the
-    cameras is a binary of its own, composing a world around ``Harness``, ``wire.wire_embodiment`` and
-    ``gui.dpg_ui``. A run ends when ``KeyboardControl`` returns — on ``q``, or on a stdin that is not a
-    terminal — since a control system returning stops the world.
+    The keyboard is the only attended surface this library ships, and there is no viewer — a console that
+    shows the cameras is a ``Driver`` of its own, wiring ``gui.dpg_ui`` into the world ``run_world`` builds.
+    A run ends when ``KeyboardControl`` returns — on ``q``, or on a stdin that is not a terminal — since a
+    control system returning stops the world.
     """
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
 
     # The policy is this function's to close from here on, and everything below can raise:
-    # `prepare_output_dir` syncs a directory and snapshots sources into it, and `LocalDatasetWriter`
-    # scans the one it is given.
+    # `prepare_output_dir` syncs a directory and snapshots sources into it, and `run_world` opens the
+    # dataset it is given.
     try:
-        _run_attended(policy, embodiment, next_task, output_dir)
+        operator = KeyboardOperator(next_task)
+        run_world(policy, embodiment, operator, prepare_output_dir(output_dir), done=operator.done)
     finally:
         policy.close()
-
-
-def _run_attended(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir) -> None:
-    """Record from a warmed policy until the keyboard returns. The caller owns the policy."""
-    output_dir = prepare_output_dir(output_dir)
-    keyboard = KeyboardControl(quit_key='q')
-    operator = KeyboardOperator(next_task)
-    harness = Harness(policy, embodiment)
-    print('Keyboard controls: [s]tart, sto[p], [q]uit')
-
-    writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
-    with writer_cm as dataset_writer, pimm.World() as world:
-        ds_agent = wire.wire_embodiment(world, harness, embodiment, dataset_writer, done=operator.done)
-        world.connect(keyboard.keyboard_inputs, operator.keystrokes)
-        world.connect(operator.perform_task, harness.perform_task)
-        if ds_agent is not None:
-            world.connect(harness.ds_command, ds_agent.command)
-        producers = [cs for cs in embodiment.control_systems if cs is not None]
-        world.run([harness, keyboard, operator], [*producers, ds_agent])
 
 
 real_cfg = cfn.Config(

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -1,6 +1,7 @@
 """Legacy ``positronic-inference`` CLI: the attended keyboard ``real`` path plus the ``sim`` and ``stats``
 aliases over ``cli.eval.run``."""
 
+import logging
 from collections import Counter
 from collections.abc import Callable
 from typing import Any
@@ -20,44 +21,40 @@ from positronic.dataset.local_dataset import load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
 from positronic.eval import Embodiment, Task
 
+logger = logging.getLogger(__name__)
+
 
 class KeyboardOperator(KeyboardControl):
     """The keyboard that runs episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one,
     ``q`` ends the run.
 
-    It holds the pending answers because that is where an episode's terminal — and any refused ask —
-    arrives; both are printed as they land. ``next_task`` is called once per press.
+    One episode is in flight at a time: a press while one runs is declined here, with a warning. It holds
+    the pending answer because that is where the episode's terminal — or a refused ask — arrives, and it
+    logs that as it lands. ``next_task`` is called once per accepted press.
     """
 
     def __init__(self, next_task: Callable[[], Task]):
         super().__init__(quit_key='q')
         self._next_task = next_task
-        self._pending: list[pimm.calls.Answer[dict[str, Any]]] = []
+        self._pending: pimm.calls.Answer[dict[str, Any]] | None = None
         self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
     def _each_round(self, key: str | None) -> None:
         super()._each_round(key)
+        if self._pending is not None and self._pending.done():
+            try:  # rules-allow: swallowed-error — the operator is who this failure is for
+                logger.info(f'Episode ended: {self._pending.result()}')
+            except Exception as e:
+                logger.error(f'Episode failed: {e}')
+            self._pending = None
         match key:
+            case 's' if self._pending is not None:
+                logger.warning('An episode is already running: press [p] to stop it')
             case 's':
-                self._pending.append(self.perform_task(self._next_task()))
+                self._pending = self.perform_task(self._next_task())
             case 'p':
                 self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
-        running = []
-        for answer in self._pending:
-            if answer.done():
-                self._report(answer)
-            else:
-                running.append(answer)
-        self._pending = running
-
-    @staticmethod
-    def _report(answer: pimm.calls.Answer[dict[str, Any]]) -> None:
-        """Print what the episode ended on, or why it never will."""
-        try:  # rules-allow: swallowed-error — the operator is who this failure is for
-            print(f'Episode ended: {answer.result()}')
-        except Exception as e:
-            print(f'Episode failed: {e}')
 
 
 def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir=None):
@@ -76,7 +73,7 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     # dataset it is given.
     try:
         operator = KeyboardOperator(next_task)
-        print('Keyboard controls: [s]tart, sto[p], [q]uit')
+        logger.info('Keyboard controls: [s]tart, sto[p], [q]uit')
         run_world(policy, embodiment, operator, prepare_output_dir(output_dir), done=operator.done)
     finally:
         policy.close()

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -1,8 +1,9 @@
 """Legacy ``positronic-inference`` CLI: the attended keyboard ``real`` path plus the ``sim`` and ``stats``
 aliases over ``cli.eval.run``."""
 
+import logging
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import Any
 
 import configuronic as cfn
@@ -17,48 +18,49 @@ from positronic import keys
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.cli.eval.run import Driver, prepare_output_dir, run, run_world
 from positronic.dataset.local_dataset import load_all_datasets
-from positronic.drivers.keyboard import KeyboardControl
+from positronic.drivers.keyboard import key_reader
 from positronic.eval import Embodiment, Task
-from positronic.policy.harness import Harness
+
+logger = logging.getLogger(__name__)
 
 
 class KeyboardOperator(Driver):
-    """Turns keystrokes into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one.
+    """Turns key presses into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one,
+    ``q`` ends the run.
 
-    It holds the pending answers because that is where an episode's terminal — and any refused ask —
-    arrives; both are printed as they land. ``next_task`` is called once per press. The keyboard is the
-    operator's own, so ``q`` returns from it and brings the world down.
+    The terminal is the operator's own device, read where every other device is read: in its own loop. It
+    holds the pending answers because that is where an episode's terminal — and any refused ask — arrives;
+    both are printed as they land. ``next_task`` is called once per press.
     """
 
     def __init__(self, next_task: Callable[[], Task]):
         super().__init__()
         self._next_task = next_task
-        self._keyboard = KeyboardControl(quit_key='q')
-        self.keystrokes = pimm.ControlSystemReceiver[str](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
-    def wire(self, world: pimm.World, harness: Harness) -> Sequence[pimm.ControlSystem]:
-        world.connect(self._keyboard.keyboard_inputs, self.keystrokes)
-        return (self._keyboard,)
-
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        print('Keyboard controls: [s]tart, sto[p], [q]uit')
         pending: list[pimm.calls.Answer[dict[str, Any]]] = []
-        while not should_stop.value:
-            if (key := pimm.value_updated(self.keystrokes)) is not None:
-                match key:
+        with key_reader() as read_key:
+            if read_key is None:
+                logger.warning('no episode can start: stdin is not a terminal')
+                return
+            print('Keyboard controls: [s]tart, sto[p], [q]uit')
+            while not should_stop.value:
+                match read_key():
                     case 's':
                         pending.append(self.perform_task(self._next_task()))
                     case 'p':
                         self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
-            running = []
-            for answer in pending:
-                if answer.done():
-                    self._report(answer)
-                else:
-                    running.append(answer)
-            pending = running
-            yield pimm.Sleep(0.01)
+                    case 'q':
+                        return
+                running = []
+                for answer in pending:
+                    if answer.done():
+                        self._report(answer)
+                    else:
+                        running.append(answer)
+                pending = running
+                yield pimm.Sleep(0.01)
 
     @staticmethod
     def _report(answer: pimm.calls.Answer[dict[str, Any]]) -> None:
@@ -74,9 +76,8 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     finishes.
 
     The keyboard is the only attended surface this library ships, and there is no viewer — a console that
-    shows the cameras is a ``Driver`` of its own, wiring ``gui.dpg_ui`` into the world ``run_world`` builds.
-    A run ends when ``KeyboardControl`` returns — on ``q``, or on a stdin that is not a terminal — since a
-    control system returning stops the world.
+    shows the cameras composes a world of its own. A run ends when the operator returns — on ``q``, or on a
+    stdin that is not a terminal — since a control system returning stops the world.
     """
     if embodiment.simulated:
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -1,7 +1,6 @@
 """Legacy ``positronic-inference`` CLI: the attended keyboard ``real`` path plus the ``sim`` and ``stats``
 aliases over ``cli.eval.run``."""
 
-import logging
 from collections import Counter
 from collections.abc import Callable
 from typing import Any
@@ -16,51 +15,41 @@ import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
 from positronic import keys
 from positronic.cfg.eval.sim.positronic import stack_cubes
-from positronic.cli.eval.run import Driver, prepare_output_dir, run, run_world
+from positronic.cli.eval.run import prepare_output_dir, run, run_world
 from positronic.dataset.local_dataset import load_all_datasets
-from positronic.drivers.keyboard import key_reader
+from positronic.drivers.keyboard import KeyboardControl
 from positronic.eval import Embodiment, Task
 
-logger = logging.getLogger(__name__)
 
-
-class KeyboardOperator(Driver):
-    """Turns key presses into episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one,
+class KeyboardOperator(KeyboardControl):
+    """The keyboard that runs episodes: ``s`` asks for one through ``perform_task``, ``p`` ends the live one,
     ``q`` ends the run.
 
-    The terminal is the operator's own device, read where every other device is read: in its own loop. It
-    holds the pending answers because that is where an episode's terminal — and any refused ask — arrives;
-    both are printed as they land. ``next_task`` is called once per press.
+    It holds the pending answers because that is where an episode's terminal — and any refused ask —
+    arrives; both are printed as they land. ``next_task`` is called once per press.
     """
 
     def __init__(self, next_task: Callable[[], Task]):
-        super().__init__()
+        super().__init__(quit_key='q')
         self._next_task = next_task
+        self._pending: list[pimm.calls.Answer[dict[str, Any]]] = []
+        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        pending: list[pimm.calls.Answer[dict[str, Any]]] = []
-        with key_reader() as read_key:
-            if read_key is None:
-                logger.warning('no episode can start: stdin is not a terminal')
-                return
-            print('Keyboard controls: [s]tart, sto[p], [q]uit')
-            while not should_stop.value:
-                match read_key():
-                    case 's':
-                        pending.append(self.perform_task(self._next_task()))
-                    case 'p':
-                        self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
-                    case 'q':
-                        return
-                running = []
-                for answer in pending:
-                    if answer.done():
-                        self._report(answer)
-                    else:
-                        running.append(answer)
-                pending = running
-                yield pimm.Sleep(0.01)
+    def _each_round(self, key: str | None) -> None:
+        super()._each_round(key)
+        match key:
+            case 's':
+                self._pending.append(self.perform_task(self._next_task()))
+            case 'p':
+                self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
+        running = []
+        for answer in self._pending:
+            if answer.done():
+                self._report(answer)
+            else:
+                running.append(answer)
+        self._pending = running
 
     @staticmethod
     def _report(answer: pimm.calls.Answer[dict[str, Any]]) -> None:
@@ -87,6 +76,7 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     # dataset it is given.
     try:
         operator = KeyboardOperator(next_task)
+        print('Keyboard controls: [s]tart, sto[p], [q]uit')
         run_world(policy, embodiment, operator, prepare_output_dir(output_dir), done=operator.done)
     finally:
         policy.close()

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -1,6 +1,8 @@
 import io
 import sys
+import time
 from collections.abc import Callable
+from contextlib import nullcontext
 from functools import partial
 from typing import Any
 
@@ -69,8 +71,8 @@ def _trial(instruction: str = 'stub') -> Callable[[], Task]:
 
 
 @pytest.mark.timeout(30.0)
-def test_the_keyboard_path_ends_when_the_keyboard_returns(monkeypatch):
-    """How an attended run finishes: ``KeyboardControl`` returns, the world stops, ``real`` closes the policy.
+def test_the_keyboard_path_ends_when_the_operator_returns(monkeypatch):
+    """How an attended run finishes: the operator returns, the world stops, ``real`` closes the policy.
 
     A stdin that is not a terminal is the return the test can force; ``q`` is the other one.
     """
@@ -92,26 +94,30 @@ def test_the_keyboard_path_refuses_a_simulated_embodiment():
         real(policy=_IdlePolicy(), embodiment=_embodiment(simulated=True), next_task=_trial())
 
 
-class _ScriptedKeyboard(pimm.ControlSystem):
-    """Stands in for ``KeyboardControl``: starts an episode, stops it once it is running, returns as ``q`` would.
+class _ScriptedKeys:
+    """Stands in for a person at the terminal: starts an episode, stops it once it is running, then quits.
 
     ``policy`` is what says the episode is running. The rig's devices are spawned, so how long they take to
-    answer the trial's prepare is nothing a beat between keystrokes could name.
+    answer the trial's prepare is nothing a fixed beat could name. The beat between the stop and the quit is
+    the window in which the operator prints what the episode ended on.
     """
 
-    def __init__(self, policy):
+    def __init__(self, policy, beat_sec: float = 0.3):
         self._policy = policy
-        self.keyboard_inputs = pimm.ControlSystemEmitter[str](self)
+        self._beat_sec = beat_sec
+        self._started = False
+        self._stopped_at: float | None = None
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
-        yield pimm.Sleep(0.1)
-        self.keyboard_inputs.emit('s')
-        while not self._policy.observations:
-            if should_stop.value:
-                return
-            yield pimm.Sleep(0.01)
-        self.keyboard_inputs.emit('p')
-        yield pimm.Sleep(0.3)
+    def __call__(self) -> str | None:
+        if not self._started:
+            self._started = True
+            return 's'
+        if self._stopped_at is None:
+            if not self._policy.observations:
+                return None
+            self._stopped_at = time.monotonic()
+            return 'p'
+        return 'q' if time.monotonic() - self._stopped_at > self._beat_sec else None
 
 
 @pytest.mark.timeout(30.0)
@@ -119,7 +125,7 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
     """The press is the whole start signal: the rig's devices ready, the episode opens on the instruction it
     was given, and it runs until the operator stops it."""
     policy = _IdlePolicy()
-    monkeypatch.setattr(inference, 'KeyboardControl', lambda quit_key: _ScriptedKeyboard(policy))
+    monkeypatch.setattr(inference, 'key_reader', partial(nullcontext, _ScriptedKeys(policy)))
 
     real(policy=policy, embodiment=_embodiment(), next_task=_trial('pick up the cube'))
 
@@ -129,13 +135,14 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
     assert policy.closed
 
 
-def test_the_operator_reports_an_ask_the_harness_refuses(capsys):
+def test_the_operator_reports_an_ask_the_harness_refuses(monkeypatch, capsys):
     """The operator does not police who may start an episode: every press is asked for, and what comes back
     is printed as it lands."""
     task = Task(instruction_source='pick', timeout_sec=None)
+    presses = iter(['s', 's'])
+    monkeypatch.setattr(inference, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
     operator = KeyboardOperator(lambda: task)
     with pimm.World(virtual_time=True) as world:
-        keystrokes = world.pair(operator.keystrokes)
         harness = world.pair(operator.perform_task)
         received = []
 
@@ -146,8 +153,7 @@ def test_the_operator_reports_an_ask_the_harness_refuses(capsys):
                 if len(received) > 1:
                     call.set_exception(RuntimeError('An episode is already running'))
 
-        press = partial(keystrokes.emit, 's')
-        driver = scripted_driver((press, 0.05), (refuse_a_second_ask, 0.05), (press, 0.05), (refuse_a_second_ask, 0.05))
+        driver = scripted_driver((refuse_a_second_ask, 0.05), (refuse_a_second_ask, 0.05))
         drive_scheduler(world.start([operator, driver]))
 
     assert received == [task, task]

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import sys
 import time
 from collections.abc import Callable
@@ -122,23 +123,23 @@ class _ScriptedKeys:
 
 
 @pytest.mark.timeout(30.0)
-def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
+def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, caplog):
     """The press is the whole start signal: the rig's devices ready, the episode opens on the instruction it
     was given, and it runs until the operator stops it."""
     policy = _IdlePolicy()
     monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, _ScriptedKeys(policy)))
 
-    real(policy=policy, embodiment=_embodiment(), next_task=_trial('pick up the cube'))
+    with caplog.at_level(logging.INFO):
+        real(policy=policy, embodiment=_embodiment(), next_task=_trial('pick up the cube'))
 
     assert policy.observations, 'the episode never opened'
     assert policy.observations[0][keys.TASK] == 'pick up the cube'
-    assert keys.ENDED_BY_OPERATOR in capsys.readouterr().out
+    assert keys.ENDED_BY_OPERATOR in caplog.text
     assert policy.closed
 
 
-def test_the_operator_reports_an_ask_the_harness_refuses(monkeypatch, capsys):
-    """The operator does not police who may start an episode: every press is asked for, and what comes back
-    is printed as it lands."""
+def test_the_operator_declines_a_press_while_an_episode_runs(monkeypatch, caplog):
+    """One episode at a time is the operator's own rule: the second press never reaches the harness."""
     task = Task(instruction_source='pick', timeout_sec=None)
     presses = iter(['s', 's'])
     monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
@@ -147,15 +148,12 @@ def test_the_operator_reports_an_ask_the_harness_refuses(monkeypatch, capsys):
         harness = world.pair(operator.perform_task)
         received = []
 
-        def refuse_a_second_ask():
-            """Stand in for the harness's one-episode-at-a-time rule: hold the first call, refuse the rest."""
-            for call in harness.incoming():
-                received.append(call.request)
-                if len(received) > 1:
-                    call.set_exception(RuntimeError('An episode is already running'))
+        def hold_the_ask():
+            """Stand in for a harness running the episode it was asked for: take the call, answer nothing."""
+            received.extend(call.request for call in harness.incoming())
 
-        driver = scripted_driver((refuse_a_second_ask, 0.05), (refuse_a_second_ask, 0.05))
+        driver = scripted_driver((hold_the_ask, 0.05), (hold_the_ask, 0.05))
         drive_scheduler(world.start([operator, driver]))
 
-    assert received == [task, task]
-    assert 'already running' in capsys.readouterr().out
+    assert received == [task]
+    assert 'already running' in caplog.text

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -9,7 +9,8 @@ from typing import Any
 import pytest
 
 import pimm
-from positronic import inference, keys
+from positronic import keys
+from positronic.drivers import keyboard
 from positronic.eval import Embodiment, Task
 from positronic.inference import KeyboardOperator, real
 from positronic.policy import Policy
@@ -71,7 +72,7 @@ def _trial(instruction: str = 'stub') -> Callable[[], Task]:
 
 
 @pytest.mark.timeout(30.0)
-def test_the_keyboard_path_ends_when_the_operator_returns(monkeypatch):
+def test_the_keyboard_path_ends_when_the_keyboard_returns(monkeypatch):
     """How an attended run finishes: the operator returns, the world stops, ``real`` closes the policy.
 
     A stdin that is not a terminal is the return the test can force; ``q`` is the other one.
@@ -125,7 +126,7 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, capsys):
     """The press is the whole start signal: the rig's devices ready, the episode opens on the instruction it
     was given, and it runs until the operator stops it."""
     policy = _IdlePolicy()
-    monkeypatch.setattr(inference, 'key_reader', partial(nullcontext, _ScriptedKeys(policy)))
+    monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, _ScriptedKeys(policy)))
 
     real(policy=policy, embodiment=_embodiment(), next_task=_trial('pick up the cube'))
 
@@ -140,7 +141,7 @@ def test_the_operator_reports_an_ask_the_harness_refuses(monkeypatch, capsys):
     is printed as it lands."""
     task = Task(instruction_source='pick', timeout_sec=None)
     presses = iter(['s', 's'])
-    monkeypatch.setattr(inference, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
+    monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
     operator = KeyboardOperator(lambda: task)
     with pimm.World(virtual_time=True) as world:
         harness = world.pair(operator.perform_task)


### PR DESCRIPTION
Roadmap box: **One runner builds the world for both.**

The attended (`real`) path and the unattended (`sim`) path each composed their own `pimm.World`, wired the same embodiment the same way, and split main/background systems by hand. This makes one runner serve both.

## What changes

- `_run_world` becomes the public `run_world(policy, embodiment, driver, output_dir, *, privileged, done)`. It builds the Harness, the writer, the World, wires the embodiment, and schedules everything. `_run_attended` goes.
- A driver is any control system with a `perform_task` caller. There is no base class: `run_world` takes it unannotated, as it takes the policy.
- `KeyboardOperator` becomes a `KeyboardControl`. The base reads the terminal and answers `_each_round(key)` with what a key does — emit it, by default. The operator overrides that, so the attended world holds one control system and nothing has to connect a keyboard to it. Wiring belongs to whoever builds the world.
- `KeyboardControl` keeps the terminal handling as a `key_reader()` context manager, which yields `None` where stdin is not a terminal.
- `docs/inference.md` — a console of somebody's own is a driver plus a call to `run_world`. A surface that brings a control system of its own still composes its own world, since only whoever builds a world can wire what runs in it.

## Notes for review

- Commits 2 and 3 are a detour: the middle one deletes `KeyboardControl` and the last one restores it as the operator's base. Read the branch as a whole.
- `_each_round` is an extension point with one override today. `KeyboardControl` still stands alone and still emits every key, and the operator's override calls `super()` first, so it stays substitutable.
- The attended world was real-time and message-free; the shared runner derives both from `embodiment.simulated`, and `real` still refuses a simulated embodiment up front.
- A stdin that is not a terminal ends the run as before, and reports it through the log rather than through stderr as well.

## Test plan

- `uv run --locked pytest` — 1678 passed, 8 skipped.
- Both paths keep their end-to-end tests: `positronic/tests/test_inference.py` (attended, with a real terminal check and a scripted key reader) and `positronic/cli/eval/tests/test_run.py` (unattended sweep).
- ruff and basedpyright clean.