### PR TITLE
Call a policy session with the time, not with a clock

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,7 +138,7 @@ the wall time it took or nothing: the task's `charge_inference_time` flag asks a
 and a real rig pays it regardless. Only the harness reads the flag. Paying nothing means the loop
 waits for the work, which keeps a virtual clock still; paying wall time means letting the world run,
 though no further ahead of the work's start than wall time has. The harness reads the world clock and
-gives the reading to the policy stack as the call's `time`. A scheduling layer stamps its chunk with
+gives the reading to the policy stack as the call's `time_ns`. A scheduling layer stamps its chunk with
 that value, and never learns the mode.
 
 **Recordings are canonical; codecs bind the dialect late.** The dataset records every run in the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,9 +137,9 @@ as functions, and the framework runs each one off the loop thread. That work cos
 the wall time it took or nothing: the task's `charge_inference_time` flag asks a sim for the former,
 and a real rig pays it regardless. Only the harness reads the flag. Paying nothing means the loop
 waits for the work, which keeps a virtual clock still; paying wall time means letting the world run,
-though no further ahead of the work's start than wall time has. The clock the harness hands the
-policy stack (`now`) is the world clock, so a scheduling layer stamps its chunk at `now()` and never
-learns the mode.
+though no further ahead of the work's start than wall time has. The harness reads the world clock and
+gives the reading to the policy stack as the call's `time`. A scheduling layer stamps its chunk with
+that value, and never learns the mode.
 
 **Recordings are canonical; codecs bind the dialect late.** The dataset records every run in the
 canonical conventions (frames, key names, absolute time) — never in a model's dialect. Every

--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -44,7 +44,7 @@ A returned trajectory also needs timing — *when* each action runs. That is han
 | `ActionHorizon` | `ActionHorizon(horizon_sec)` (positional) | Drops decoded actions whose relative `timestamp` is `>= horizon_sec`. Single (untimestamped) actions pass through. At training time surfaces `action_horizon_sec`. (`codec.py:245`) |
 | `ActionTiming` | `ActionTiming(fps=..., horizon_sec=None)` | Factory: returns `ActionTimestamp(fps=fps) \| ActionHorizon(horizon_sec)` when `horizon_sec` is set, otherwise just `ActionTimestamp(fps=fps)`. (`codec.py:289`) |
 
-These timestamps are **relative** — seconds from the start of the trajectory. The model and codecs never see wall-clock time; the real-time client anchors each offset to its own clock the moment inference returns (`now + timestamp`), so execution starts at inference-finish and the round-trip latency is absorbed. Stamping a per-action timestamp rather than a fixed rate is deliberate: it lets non-uniform timings and client-side scheduling strategies share one wire format. See [How inference works](connect-your-model.md#how-inference-works) for the full reasoning.
+These timestamps are **relative** — seconds from the start of the trajectory. The model and codecs never see wall-clock time; the real-time client anchors each offset to the clock reading it gave to the call that returns the chunk (`time + timestamp`), which absorbs the round-trip latency. Stamping a per-action timestamp rather than a fixed rate is deliberate: it lets non-uniform timings and client-side scheduling strategies share one wire format. See [How inference works](connect-your-model.md#how-inference-works) for the full reasoning.
 
 ## End-effector frames
 

--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -44,7 +44,7 @@ A returned trajectory also needs timing — *when* each action runs. That is han
 | `ActionHorizon` | `ActionHorizon(horizon_sec)` (positional) | Drops decoded actions whose relative `timestamp` is `>= horizon_sec`. Single (untimestamped) actions pass through. At training time surfaces `action_horizon_sec`. (`codec.py:245`) |
 | `ActionTiming` | `ActionTiming(fps=..., horizon_sec=None)` | Factory: returns `ActionTimestamp(fps=fps) \| ActionHorizon(horizon_sec)` when `horizon_sec` is set, otherwise just `ActionTimestamp(fps=fps)`. (`codec.py:289`) |
 
-These timestamps are **relative** — seconds from the start of the trajectory. The model and codecs never see wall-clock time; the real-time client anchors each offset to the clock reading it gave to the call that returns the chunk (`time + timestamp`), which absorbs the round-trip latency. Stamping a per-action timestamp rather than a fixed rate is deliberate: it lets non-uniform timings and client-side scheduling strategies share one wire format. See [How inference works](connect-your-model.md#how-inference-works) for the full reasoning.
+These timestamps are **relative** — seconds from the start of the trajectory. The model and codecs never see wall-clock time; the real-time client anchors each offset to the clock reading it gave to the call that returns the chunk (`time_ns` in seconds, plus `timestamp`), which absorbs the round-trip latency. Stamping a per-action timestamp rather than a fixed rate is deliberate: it lets non-uniform timings and client-side scheduling strategies share one wire format. See [How inference works](connect-your-model.md#how-inference-works) for the full reasoning.
 
 ## End-effector frames
 

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -127,7 +127,7 @@ The normal response is a list of action dicts — a short trajectory. (A single 
 |-------|------|-------------|
 | `robot_command` | command object | Control command (see below) |
 | `target_grip` | float | Target gripper closure in `[0, 1]`: 0 = open, 1 = closed |
-| `timestamp` | float | Execution time in seconds from the start of the returned trajectory (e.g. `i / action_fps` for the i-th action). The client runs each action at `time + timestamp`, where `time` is the clock reading it gave to the call that returned the prediction. A single action dict returned *outside* a list is auto-stamped `0.0`; give every action in a list its own `timestamp`, or they all collapse onto one instant and fire at once. |
+| `timestamp` | float | Execution time in seconds from the start of the returned trajectory (e.g. `i / action_fps` for the i-th action). The client runs each action at the call's `time_ns` in seconds, plus `timestamp`, where `time_ns` is the clock reading it gave to the call that returned the prediction. A single action dict returned *outside* a list is auto-stamped `0.0`; give every action in a list its own `timestamp`, or they all collapse onto one instant and fire at once. |
 
 The `robot_command` field says what the arm is asked to do. Build one of the commands in
 [`positronic.drivers.roboarm.command`](../positronic/drivers/roboarm/command.py):
@@ -181,7 +181,7 @@ class MySession(Session):
     def __init__(self, model):
         self._model = model
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         # obs holds the raw keys from the wire table above. Pick what you need:
         images = obs['image.exterior']
         ee = obs['robot_state.ee_pose']
@@ -213,7 +213,7 @@ The pipeline reads left to right: everything left of the `remote` marker is the 
 
 The left side is not optional: a pipeline with nothing there is refused when the server starts, and a rig refuses a handshake that declares nothing. It needs a scheduler in particular, and `StopOnFault` outside that scheduler — an arm that is faulted or busy is not taking the plan it was given, so the layer answers the empty trajectory and the rig stops rather than resuming a chunk stamped before. Actions come back timestamped relative to their chunk, and `ChunkedSchedule` is what turns those into times on the rig's clock; a stack that leaves them relative — or anchors them twice — makes the harness reject the chunk at the first inference, since it schedules nothing more than `MAX_ACTION_SKEW_SEC` from now.
 
-The session's `time` argument is the caller's clock reading in seconds. A session reads no clock of its own, and a policy that schedules nothing accepts the value and ignores it.
+The session's `time_ns` argument is the caller's clock reading in nanoseconds, the same unit the observation's `obs_time_ns` carries. A session reads no clock of its own, and a policy that schedules nothing accepts the value and ignores it.
 
 If you put a `Codec` right of the marker (`ChunkedSchedule() | remote | codec | PolicySource(...)`), your session works entirely in *model space* — it receives encoded observations and returns model-native actions, and the codec handles the wire format. A codec that encodes images should also bound them on the rig, so full-resolution frames never cross the wire — that is what the built-in vendor pipelines do:
 
@@ -260,7 +260,7 @@ from positronic.offboard.protocol import serialise, deserialise
 session = policy.new_session()           # one Session per episode/connection
 async for message in websocket.iter_bytes():
     obs = deserialise(message)           # dict with numpy arrays
-    actions = session(obs, time.time())  # list of action dicts (or None)
+    actions = session(obs, time.time_ns())  # list of action dicts (or None)
     await websocket.send_bytes(serialise({"result": actions}))
 ```
 

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -82,7 +82,7 @@ How the client fills the delay and merges successive predictions is a swappable 
 
 Four small concepts make up the API. You meet them whether you use a built-in server or write your own.
 
-**Policy and Session.** A `Policy` is your loaded model: it holds the weights and knows how to start an episode. `policy.new_session()` begins one episode and returns a `Session`. You call the session once per timestep with the latest observation, and it returns the next actions to run. Per-episode state (history, the trajectory in flight) lives in the session — so one `Policy` can serve several robots at once, each with its own `Session`.
+**Policy and Session.** A `Policy` is your loaded model: it holds the weights and knows how to start an episode. `policy.new_session()` begins one episode and returns a `Session`. You call the session once per timestep with the latest observation and your clock reading, and it returns the next actions to run. Per-episode state (history, the trajectory in flight) lives in the session — so one `Policy` can serve several robots at once, each with its own `Session`.
 
 **Codec.** Different models want different inputs: end-effector pose vs joint angles, absolute targets vs deltas, 224×224 vs 512×512 images. A `Codec` translates between the robot's raw data (what is on the wire) and your model's format — `encode` on the way in, `decode` on the way out. The same codec prepares the training data, so a model is served exactly the way it was trained. The full catalog is in the [Codecs Guide](codecs.md).
 
@@ -127,7 +127,7 @@ The normal response is a list of action dicts — a short trajectory. (A single 
 |-------|------|-------------|
 | `robot_command` | command object | Control command (see below) |
 | `target_grip` | float | Target gripper closure in `[0, 1]`: 0 = open, 1 = closed |
-| `timestamp` | float | Execution time in seconds from the start of the returned trajectory (e.g. `i / action_fps` for the i-th action). The client runs each action at `now + timestamp`, where `now` is when the prediction arrived. A single action dict returned *outside* a list is auto-stamped `0.0`; give every action in a list its own `timestamp`, or they all collapse onto one instant and fire at once. |
+| `timestamp` | float | Execution time in seconds from the start of the returned trajectory (e.g. `i / action_fps` for the i-th action). The client runs each action at `time + timestamp`, where `time` is the clock reading it gave to the call that returned the prediction. A single action dict returned *outside* a list is auto-stamped `0.0`; give every action in a list its own `timestamp`, or they all collapse onto one instant and fire at once. |
 
 The `robot_command` field says what the arm is asked to do. Build one of the commands in
 [`positronic.drivers.roboarm.command`](../positronic/drivers/roboarm/command.py):
@@ -181,7 +181,7 @@ class MySession(Session):
     def __init__(self, model):
         self._model = model
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         # obs holds the raw keys from the wire table above. Pick what you need:
         images = obs['image.exterior']
         ee = obs['robot_state.ee_pose']
@@ -197,7 +197,7 @@ class MyPolicy(Policy):
     def __init__(self, model):
         self._model = model
 
-    def new_session(self, context=None, now=None):
+    def new_session(self, context=None, rt=None):
         return MySession(self._model)  # per-episode setup goes here
 
     @property
@@ -213,7 +213,7 @@ The pipeline reads left to right: everything left of the `remote` marker is the 
 
 The left side is not optional: a pipeline with nothing there is refused when the server starts, and a rig refuses a handshake that declares nothing. It needs a scheduler in particular, and `StopOnFault` outside that scheduler — an arm that is faulted or busy is not taking the plan it was given, so the layer answers the empty trajectory and the rig stops rather than resuming a chunk stamped before. Actions come back timestamped relative to their chunk, and `ChunkedSchedule` is what turns those into times on the rig's clock; a stack that leaves them relative — or anchors them twice — makes the harness reject the chunk at the first inference, since it schedules nothing more than `MAX_ACTION_SKEW_SEC` from now.
 
-`new_session`'s `now` argument is the runtime clock that layers scheduling against live time read; a policy that does no scheduling of its own just accepts and ignores it (server-side it is `None`).
+The session's `time` argument is the caller's clock reading in seconds. A session reads no clock of its own, and a policy that schedules nothing accepts the value and ignores it.
 
 If you put a `Codec` right of the marker (`ChunkedSchedule() | remote | codec | PolicySource(...)`), your session works entirely in *model space* — it receives encoded observations and returns model-native actions, and the codec handles the wire format. A codec that encodes images should also bound them on the rig, so full-resolution frames never cross the wire — that is what the built-in vendor pipelines do:
 
@@ -253,12 +253,14 @@ Every message is msgpack. Numpy arrays use a custom extension:
 robot commands:
 
 ```python
+import time
+
 from positronic.offboard.protocol import serialise, deserialise
 
 session = policy.new_session()           # one Session per episode/connection
 async for message in websocket.iter_bytes():
     obs = deserialise(message)           # dict with numpy arrays
-    actions = session(obs)               # list of action dicts (or None)
+    actions = session(obs, time.time())  # list of action dicts (or None)
     await websocket.send_bytes(serialise({"result": actions}))
 ```
 

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -357,8 +357,8 @@ class PolicyServer:
                         # Plain acquire, not the keepalive helper: the client is awaiting a ``result`` and
                         # would mis-parse a ``waiting`` message. Its ``infer_timeout`` bounds the wait.
                         async with self._infer_lock:
-                            # The server reads its own clock, not the rig's. A layer that anchors a chunk
-                            # against the rig's clock must sit left of the ``remote`` marker.
+                            # The server's clock is not the rig's. Nothing right of the ``remote`` marker
+                            # anchors a chunk, so no session here reads this value.
                             actions = await asyncio.to_thread(session, raw_obs, time.time())
                         await websocket.send_bytes(serialise({protocol.RESULT: actions}))
                     except Exception as e:

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -358,7 +358,7 @@ class PolicyServer:
                         # would mis-parse a ``waiting`` message. Its ``infer_timeout`` bounds the wait.
                         async with self._infer_lock:
                             # The server's clock is not the rig's.
-                            actions = await asyncio.to_thread(session, raw_obs, time.time())
+                            actions = await asyncio.to_thread(session, raw_obs, time.time_ns())
                         await websocket.send_bytes(serialise({protocol.RESULT: actions}))
                     except Exception as e:
                         logger.error(f'Error processing message: {e}', exc_info=True)

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -357,7 +357,9 @@ class PolicyServer:
                         # Plain acquire, not the keepalive helper: the client is awaiting a ``result`` and
                         # would mis-parse a ``waiting`` message. Its ``infer_timeout`` bounds the wait.
                         async with self._infer_lock:
-                            actions = await asyncio.to_thread(session, raw_obs)
+                            # The server reads its own clock, not the rig's. A layer that anchors a chunk
+                            # against the rig's clock must sit left of the ``remote`` marker.
+                            actions = await asyncio.to_thread(session, raw_obs, time.time())
                         await websocket.send_bytes(serialise({protocol.RESULT: actions}))
                     except Exception as e:
                         logger.error(f'Error processing message: {e}', exc_info=True)

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -357,8 +357,7 @@ class PolicyServer:
                         # Plain acquire, not the keepalive helper: the client is awaiting a ``result`` and
                         # would mis-parse a ``waiting`` message. Its ``infer_timeout`` bounds the wait.
                         async with self._infer_lock:
-                            # The server's clock is not the rig's. Nothing right of the ``remote`` marker
-                            # anchors a chunk, so no session here reads this value.
+                            # The server's clock is not the rig's.
                             actions = await asyncio.to_thread(session, raw_obs, time.time())
                         await websocket.send_bytes(serialise({protocol.RESULT: actions}))
                     except Exception as e:

--- a/positronic/offboard/server_utils.py
+++ b/positronic/offboard/server_utils.py
@@ -44,7 +44,7 @@ def warmup(policy: Policy, obs: dict[str, Any], on_progress: Callable[[str], Non
     """
     session = blocking(policy).new_session()
     try:
-        run_with_progress(lambda: session(obs), 'Running warmup inference', on_progress)
+        run_with_progress(lambda: session(obs, time.time()), 'Running warmup inference', on_progress)
     finally:
         session.close()
 

--- a/positronic/offboard/server_utils.py
+++ b/positronic/offboard/server_utils.py
@@ -44,7 +44,7 @@ def warmup(policy: Policy, obs: dict[str, Any], on_progress: Callable[[str], Non
     """
     session = blocking(policy).new_session()
     try:
-        run_with_progress(lambda: session(obs, time.time()), 'Running warmup inference', on_progress)
+        run_with_progress(lambda: session(obs, time.time_ns()), 'Running warmup inference', on_progress)
     finally:
         session.close()
 

--- a/positronic/offboard/tests/conftest.py
+++ b/positronic/offboard/tests/conftest.py
@@ -74,15 +74,15 @@ def open_session() -> Generator[Callable[..., tuple[Session, Executor]], None, N
 ANSWER_SEC = 5.0
 
 
-def round_trip(session: Session, rt: Executor, obs, time: float = 0.0) -> list[dict] | None:
+def round_trip(session: Session, rt: Executor, obs, time_ns: int = 0) -> list[dict] | None:
     """What ``session`` answers for ``obs``, over the two calls one round trip takes.
 
-    Both calls get the same ``time``, so a chunk comes back anchored at the value the test passed.
+    Both calls get the same ``time_ns``, so a chunk comes back anchored at the value the test passed.
     """
-    assert session(obs, time) is None, 'a round-trip was already in flight'
+    assert session(obs, time_ns) is None, 'a round-trip was already in flight'
     rt.wait(ANSWER_SEC)
     assert not rt.in_flight, 'the round-trip never came back'
-    return session(obs, time)
+    return session(obs, time_ns)
 
 
 def _make_mock_policy(action, meta):

--- a/positronic/offboard/tests/conftest.py
+++ b/positronic/offboard/tests/conftest.py
@@ -61,9 +61,9 @@ def open_session() -> Generator[Callable[..., tuple[Session, Executor]], None, N
     """Opens a policy's session against a runtime that serves its functions, as the harness does."""
     runtimes: list[Executor] = []
 
-    def make(policy: Policy, now=None) -> tuple[Session, Executor]:
+    def make(policy: Policy) -> tuple[Session, Executor]:
         runtimes.append(Executor(policy.functions))
-        return policy.new_session(None, now, runtimes[-1]), runtimes[-1]
+        return policy.new_session(None, runtimes[-1]), runtimes[-1]
 
     yield make
     for runtime in runtimes:
@@ -74,12 +74,15 @@ def open_session() -> Generator[Callable[..., tuple[Session, Executor]], None, N
 ANSWER_SEC = 5.0
 
 
-def round_trip(session: Session, rt: Executor, obs) -> list[dict] | None:
-    """What ``session`` answers for ``obs``, over the two calls one round trip takes."""
-    assert session(obs) is None, 'a round-trip was already in flight'
+def round_trip(session: Session, rt: Executor, obs, time: float = 0.0) -> list[dict] | None:
+    """What ``session`` answers for ``obs``, over the two calls one round trip takes.
+
+    Both calls get the same ``time``, so a chunk comes back anchored at the value the test passed.
+    """
+    assert session(obs, time) is None, 'a round-trip was already in flight'
     rt.wait(ANSWER_SEC)
     assert not rt.in_flight, 'the round-trip never came back'
-    return session(obs)
+    return session(obs, time)
 
 
 def _make_mock_policy(action, meta):

--- a/positronic/offboard/tests/test_offboard.py
+++ b/positronic/offboard/tests/test_offboard.py
@@ -1,4 +1,5 @@
 from types import MappingProxyType
+from unittest.mock import ANY
 
 import numpy as np
 import pytest
@@ -33,7 +34,7 @@ def test_inference_client_connect_and_infer(inference_server, mock_policy):
         action = session.infer(obs)
 
         assert action['action_data'] == [1, 2, 3]
-        mock_policy._mock_session.assert_called_with(obs)
+        mock_policy._mock_session.assert_called_with(obs, ANY)
     finally:
         session.close()
 
@@ -82,9 +83,9 @@ def test_session_url_selects_the_model(multi_policy_server):
     finally:
         beta_session.close()
 
-    policies['alpha']._mock_session.assert_any_call({'obs': 'alpha'})
-    policies['beta']._mock_session.assert_any_call({'obs': 'beta'})
-    policies['alpha']._mock_session.assert_any_call({'obs': 'default'})
+    policies['alpha']._mock_session.assert_any_call({'obs': 'alpha'}, ANY)
+    policies['beta']._mock_session.assert_any_call({'obs': 'beta'}, ANY)
+    policies['alpha']._mock_session.assert_any_call({'obs': 'default'}, ANY)
 
 
 def test_wire_serialisation_accepts_mappingproxy():

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -335,14 +335,14 @@ def test_a_call_while_a_round_trip_is_in_flight_answers_none(open_session):
     mock_ws.infer.side_effect = blocked
     session, rt = open_session(endpoint)
 
-    assert session({}) is None
+    assert session({}, 0.0) is None
     assert started.wait(ANSWER_SEC), 'the round-trip never started'
-    assert session({}) is None
+    assert session({}, 0.0) is None
     assert mock_ws.infer.call_count == 1
 
     release.set()
     rt.wait(ANSWER_SEC)
-    assert session({}) == chunk
+    assert session({}, 0.0) == chunk
 
 
 def test_opening_a_session_without_a_runtime_is_refused():
@@ -360,12 +360,12 @@ def test_cancel_drops_the_chunk_of_the_round_trip_in_flight(open_session):
     endpoint, mock_ws = _mock_endpoint(infer_return=[{'a': 1, 'timestamp': 0.0}])
     session, rt = open_session(endpoint)
 
-    assert session({}) is None
+    assert session({}, 0.0) is None
     rt.wait(ANSWER_SEC)
     session.cancel()
 
-    assert session({}) is None  # the cancelled answer, read and thrown away
-    assert session({}) is None  # a round-trip of its own
+    assert session({}, 0.0) is None  # the cancelled answer, read and thrown away
+    assert session({}, 0.0) is None  # a round-trip of its own
     rt.wait(ANSWER_SEC)
     assert mock_ws.infer.call_count == 2
 
@@ -377,12 +377,12 @@ def test_a_cancelled_round_trip_still_raises_what_it_failed_with(open_session):
     mock_ws.infer.side_effect = TimeoutError('server stalled')
     session, rt = open_session(endpoint)
 
-    assert session({}) is None
+    assert session({}, 0.0) is None
     rt.wait(ANSWER_SEC)
     session.cancel()
 
     with pytest.raises(TimeoutError, match='server stalled'):
-        session({})
+        session({}, 0.0)
 
 
 def test_a_cancel_dies_with_the_answer_it_was_made_against(open_session):
@@ -392,11 +392,11 @@ def test_a_cancel_dies_with_the_answer_it_was_made_against(open_session):
     mock_ws.infer.side_effect = [TimeoutError('server stalled'), [{'a': 1, 'timestamp': 0.0}]]
     session, rt = open_session(endpoint)
 
-    assert session({}) is None
+    assert session({}, 0.0) is None
     rt.wait(ANSWER_SEC)
     session.cancel()
     with pytest.raises(TimeoutError, match='server stalled'):
-        session({})
+        session({}, 0.0)
 
     assert round_trip(session, rt, {}) == [{'a': 1, 'timestamp': 0.0}]
 
@@ -414,7 +414,7 @@ def test_closing_a_session_with_a_round_trip_in_flight_is_refused(open_session):
     mock_ws.infer.side_effect = blocked
     session, _rt = open_session(endpoint)
 
-    assert session({}) is None
+    assert session({}, 0.0) is None
     with pytest.raises(AssertionError, match='close the runtime'):
         session.close()
 
@@ -493,11 +493,10 @@ def test_empty_declaration_fails_before_motion():
 
 def test_declared_stack_built_at_session_open(open_session):
     """The server-declared local stack runs in front of the connection."""
-    clock = [1.0]
     policy, mock_ws = _mock_remote_policy(CHUNKED_STACK, infer_return=[{'a': 1, 'timestamp': 0.0}])
-    session, rt = open_session(policy, now=lambda: clock[0])
+    session, rt = open_session(policy)
 
-    assert round_trip(session, rt, {keys.OBS_TIME_NS: 0}) == [{'a': 1, 'timestamp': 1.0}]
+    assert round_trip(session, rt, {keys.OBS_TIME_NS: 0}, 1.0) == [{'a': 1, 'timestamp': 1.0}]
 
 
 def test_unknown_declared_entry_fails_before_motion():
@@ -534,7 +533,7 @@ def test_a_command_crossing_a_live_websocket_arrives_typed(start_server, make_mo
     served = make_mock_policy(wire_action, {'model_name': 'm'})
     host, port, _ = start_server(ChunkedSchedule() | remote | PolicySource(served))
 
-    session, rt = open_session(RemotePolicy(f'{host}:{port}'), now=lambda: 0.0)
+    session, rt = open_session(RemotePolicy(f'{host}:{port}'))
     actions = round_trip(session, rt, {keys.OBS_TIME_NS: 0})
 
     assert actions is not None, 'the chunk was swallowed before any command reached a driver'
@@ -548,7 +547,7 @@ def test_remote_policy_lifecycle(inference_server, mock_policy, open_session):
     host, port = inference_server
 
     policy = RemotePolicy(f'{host}:{port}')
-    session, rt = open_session(policy, now=lambda: 0.0)
+    session, rt = open_session(policy)
 
     meta = session.meta
     assert meta['server.model_name'] == 'test_model'
@@ -562,14 +561,14 @@ def test_remote_policy_lifecycle(inference_server, mock_policy, open_session):
     session.close()
 
     # New session
-    session2, _ = open_session(policy, now=lambda: 0.0)
+    session2, _ = open_session(policy)
     session2.close()
 
 
 def test_remote_session_meta(inference_server, open_session):
     """Session meta must include server metadata."""
     host, port = inference_server
-    session, _ = open_session(RemotePolicy(f'{host}:{port}'), now=lambda: 0.0)
+    session, _ = open_session(RemotePolicy(f'{host}:{port}'))
 
     meta = session.meta
     assert meta['type'] == 'remote'

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -335,14 +335,14 @@ def test_a_call_while_a_round_trip_is_in_flight_answers_none(open_session):
     mock_ws.infer.side_effect = blocked
     session, rt = open_session(endpoint)
 
-    assert session({}, 0.0) is None
+    assert session({}, 0) is None
     assert started.wait(ANSWER_SEC), 'the round-trip never started'
-    assert session({}, 0.0) is None
+    assert session({}, 0) is None
     assert mock_ws.infer.call_count == 1
 
     release.set()
     rt.wait(ANSWER_SEC)
-    assert session({}, 0.0) == chunk
+    assert session({}, 0) == chunk
 
 
 def test_opening_a_session_without_a_runtime_is_refused():
@@ -360,12 +360,12 @@ def test_cancel_drops_the_chunk_of_the_round_trip_in_flight(open_session):
     endpoint, mock_ws = _mock_endpoint(infer_return=[{'a': 1, 'timestamp': 0.0}])
     session, rt = open_session(endpoint)
 
-    assert session({}, 0.0) is None
+    assert session({}, 0) is None
     rt.wait(ANSWER_SEC)
     session.cancel()
 
-    assert session({}, 0.0) is None  # the cancelled answer, read and thrown away
-    assert session({}, 0.0) is None  # a round-trip of its own
+    assert session({}, 0) is None  # the cancelled answer, read and thrown away
+    assert session({}, 0) is None  # a round-trip of its own
     rt.wait(ANSWER_SEC)
     assert mock_ws.infer.call_count == 2
 
@@ -377,12 +377,12 @@ def test_a_cancelled_round_trip_still_raises_what_it_failed_with(open_session):
     mock_ws.infer.side_effect = TimeoutError('server stalled')
     session, rt = open_session(endpoint)
 
-    assert session({}, 0.0) is None
+    assert session({}, 0) is None
     rt.wait(ANSWER_SEC)
     session.cancel()
 
     with pytest.raises(TimeoutError, match='server stalled'):
-        session({}, 0.0)
+        session({}, 0)
 
 
 def test_a_cancel_dies_with_the_answer_it_was_made_against(open_session):
@@ -392,11 +392,11 @@ def test_a_cancel_dies_with_the_answer_it_was_made_against(open_session):
     mock_ws.infer.side_effect = [TimeoutError('server stalled'), [{'a': 1, 'timestamp': 0.0}]]
     session, rt = open_session(endpoint)
 
-    assert session({}, 0.0) is None
+    assert session({}, 0) is None
     rt.wait(ANSWER_SEC)
     session.cancel()
     with pytest.raises(TimeoutError, match='server stalled'):
-        session({}, 0.0)
+        session({}, 0)
 
     assert round_trip(session, rt, {}) == [{'a': 1, 'timestamp': 0.0}]
 
@@ -414,7 +414,7 @@ def test_closing_a_session_with_a_round_trip_in_flight_is_refused(open_session):
     mock_ws.infer.side_effect = blocked
     session, _rt = open_session(endpoint)
 
-    assert session({}, 0.0) is None
+    assert session({}, 0) is None
     with pytest.raises(AssertionError, match='close the runtime'):
         session.close()
 
@@ -496,7 +496,7 @@ def test_declared_stack_built_at_session_open(open_session):
     policy, mock_ws = _mock_remote_policy(CHUNKED_STACK, infer_return=[{'a': 1, 'timestamp': 0.0}])
     session, rt = open_session(policy)
 
-    assert round_trip(session, rt, {keys.OBS_TIME_NS: 0}, 1.0) == [{'a': 1, 'timestamp': 1.0}]
+    assert round_trip(session, rt, {keys.OBS_TIME_NS: 0}, int(1e9)) == [{'a': 1, 'timestamp': 1.0}]
 
 
 def test_unknown_declared_entry_fails_before_motion():

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -246,7 +246,7 @@ class _ScriptedSession(Session):
         self._rt = rt
         self._answer = None
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         if self._answer is None:
             self._answer = self._rt.fns[_INFER](obs)
             return None
@@ -279,8 +279,8 @@ def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):
 
     local_session, local_rt = open_session(inline(pipeline()))
 
-    remote_actions = round_trip(remote_session, rt, {keys.OBS_TIME_NS: 0}, 100.0)
-    local_actions = round_trip(local_session, local_rt, {keys.OBS_TIME_NS: 0}, 100.0)
+    remote_actions = round_trip(remote_session, rt, {keys.OBS_TIME_NS: 0}, int(100e9))
+    local_actions = round_trip(local_session, local_rt, {keys.OBS_TIME_NS: 0}, int(100e9))
     assert remote_actions == local_actions
     # Three scripted actions plus the chunk-closing validity sentinel ActionTimestamp appends.
     assert local_actions == [
@@ -291,8 +291,8 @@ def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):
     ]
 
     # Both gate identically while the chunk plays out.
-    assert remote_session({keys.OBS_TIME_NS: 0}, 100.15) is None
-    assert local_session({keys.OBS_TIME_NS: 0}, 100.15) is None
+    assert remote_session({keys.OBS_TIME_NS: 0}, int(100.15e9)) is None
+    assert local_session({keys.OBS_TIME_NS: 0}, int(100.15e9)) is None
 
     remote_session.close()
 

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -4,7 +4,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Generator
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import configuronic as cfn
 import httpx
@@ -65,7 +65,7 @@ def test_full_inference_cycle(stub_server):
         obs = {'image': 'test'}
         result = session.infer(obs)
         assert result == [{'action': [1, 2, 3]}]
-        policy._mock_session.assert_called_with(obs)
+        policy._mock_session.assert_called_with(obs, ANY)
     finally:
         session.close()
 
@@ -205,7 +205,7 @@ def test_warmup_runs_one_inference_and_ends_its_session(make_mock_policy):
 
     warmup(policy, obs)
 
-    policy._mock_session.assert_called_once_with(obs)
+    policy._mock_session.assert_called_once_with(obs, ANY)
     policy._mock_session.close.assert_called_once()
 
 
@@ -246,7 +246,7 @@ class _ScriptedSession(Session):
         self._rt = rt
         self._answer = None
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         if self._answer is None:
             self._answer = self._rt.fns[_INFER](obs)
             return None
@@ -259,7 +259,7 @@ class _ScriptedSession(Session):
 class _ScriptedPolicy(Policy):
     """Deterministic base policy: every session serves the same untimestamped chunk from its runtime."""
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
+    def new_session(self, context=None, rt=None) -> Session:
         assert rt is not None
         return _ScriptedSession(rt)
 
@@ -274,15 +274,13 @@ def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):
     def pipeline():
         return ChunkedSchedule() | remote | ActionTimestamp(fps=10.0) | PolicySource(_ScriptedPolicy())
 
-    clock = [100.0]
-
     host, port, _server = start_server(pipeline())
-    remote_session, rt = open_session(RemotePolicy(f'{host}:{port}'), now=lambda: clock[0])
+    remote_session, rt = open_session(RemotePolicy(f'{host}:{port}'))
 
-    local_session, local_rt = open_session(inline(pipeline()), now=lambda: clock[0])
+    local_session, local_rt = open_session(inline(pipeline()))
 
-    remote_actions = round_trip(remote_session, rt, {keys.OBS_TIME_NS: 0})
-    local_actions = round_trip(local_session, local_rt, {keys.OBS_TIME_NS: 0})
+    remote_actions = round_trip(remote_session, rt, {keys.OBS_TIME_NS: 0}, 100.0)
+    local_actions = round_trip(local_session, local_rt, {keys.OBS_TIME_NS: 0}, 100.0)
     assert remote_actions == local_actions
     # Three scripted actions plus the chunk-closing validity sentinel ActionTimestamp appends.
     assert local_actions == [
@@ -293,9 +291,8 @@ def test_in_process_equals_remote_for_same_pipeline(start_server, open_session):
     ]
 
     # Both gate identically while the chunk plays out.
-    clock[0] = 100.15
-    assert remote_session({keys.OBS_TIME_NS: 0}) is None
-    assert local_session({keys.OBS_TIME_NS: 0}) is None
+    assert remote_session({keys.OBS_TIME_NS: 0}, 100.15) is None
+    assert local_session({keys.OBS_TIME_NS: 0}, 100.15) is None
 
     remote_session.close()
 

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -186,7 +186,7 @@ class Layer:
         """Apply this layer to a policy. Default: wrap every session it creates via ``make_session``."""
         return _LayerPolicy(policy, self)
 
-    def make_session(self, inner: Session, context: dict[str, Any] | None) -> Session:
+    def make_session(self, inner: Session) -> Session:
         """Make this layer's session around ``inner``."""
         raise NotImplementedError('Override make_session or wrap')
 
@@ -229,7 +229,7 @@ class _LayerPolicy(DelegatingPolicy):
         self._layer = layer
 
     def new_session(self, context=None, rt=None):
-        return self._layer.make_session(self._inner.new_session(context, rt), context)
+        return self._layer.make_session(self._inner.new_session(context, rt))
 
     @property
     def meta(self):

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -51,7 +51,7 @@ class Session(ABC):
     a function to get actions::
 
         session = policy.new_session(context)
-        trajectory = session(obs, time)
+        trajectory = session(obs, time_ns)
 
     **Plain-data contract**: sessions accept and return only plain data
     (dicts, lists, numpy arrays, scalars). No tensors or custom objects.
@@ -66,11 +66,11 @@ class Session(ABC):
     """
 
     @abstractmethod
-    def __call__(self, obs: Mapping[str, Any], time: float) -> list[dict[str, Any]] | None:
+    def __call__(self, obs: Mapping[str, Any], time_ns: int) -> list[dict[str, Any]] | None:
         """Predict actions for the given observation, without waiting: heavy work belongs in
         ``Policy.functions``.
 
-        ``time`` is the caller's clock reading in seconds. A session reads no clock of its own.
+        ``time_ns`` is the caller's clock reading in nanoseconds. A session reads no clock of its own.
         """
 
     @property
@@ -96,8 +96,8 @@ class DelegatingSession(Session):
     def __init__(self, inner: Session):
         self._inner = inner
 
-    def __call__(self, obs, time):
-        return self._inner(obs, time)
+    def __call__(self, obs, time_ns):
+        return self._inner(obs, time_ns)
 
     @property
     def meta(self):

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -4,9 +4,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from typing import Any, ClassVar
 
-Now = Callable[[], float]
-
-
 # Structural keys of the wire spec: ``|`` serializes as ``{SEQ: [...]}``, ``&`` as ``{PAR: [...]}``.
 SEQ = 'seq'
 PAR = 'par'
@@ -54,7 +51,7 @@ class Session(ABC):
     a function to get actions::
 
         session = policy.new_session(context)
-        trajectory = session(obs)
+        trajectory = session(obs, time)
 
     **Plain-data contract**: sessions accept and return only plain data
     (dicts, lists, numpy arrays, scalars). No tensors or custom objects.
@@ -69,9 +66,12 @@ class Session(ABC):
     """
 
     @abstractmethod
-    def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+    def __call__(self, obs: Mapping[str, Any], time: float) -> list[dict[str, Any]] | None:
         """Predict actions for the given observation, without waiting: heavy work belongs in
-        ``Policy.functions``."""
+        ``Policy.functions``.
+
+        ``time`` is the caller's clock reading in seconds. A session reads no clock of its own.
+        """
 
     @property
     def meta(self) -> dict[str, Any]:
@@ -96,8 +96,8 @@ class DelegatingSession(Session):
     def __init__(self, inner: Session):
         self._inner = inner
 
-    def __call__(self, obs):
-        return self._inner(obs)
+    def __call__(self, obs, time):
+        return self._inner(obs, time)
 
     @property
     def meta(self):
@@ -119,15 +119,11 @@ class Policy(ABC):
     """
 
     @abstractmethod
-    def new_session(
-        self, context: dict[str, Any] | None = None, now: Now | None = None, rt: Runtime | None = None
-    ) -> Session:
+    def new_session(self, context: dict[str, Any] | None = None, rt: Runtime | None = None) -> Session:
         """Create a new inference session for an episode.
 
         Args:
             context: The episode's task description.
-            now: The runtime clock (current time in seconds), supplied by the harness and passed down
-                to every wrapped session. ``None`` where no runtime clock exists (server-side, warmup).
             rt: This session's runtime, serving ``functions``. ``None`` only where no caller supplied one.
                 A session that needs one refuses to open without it.
         """
@@ -152,8 +148,8 @@ class DelegatingPolicy(Policy):
     def __init__(self, inner: Policy):
         self._inner = inner
 
-    def new_session(self, context=None, now=None, rt=None):
-        return self._inner.new_session(context, now, rt)
+    def new_session(self, context=None, rt=None):
+        return self._inner.new_session(context, rt)
 
     @property
     def functions(self):
@@ -187,14 +183,10 @@ class Layer:
     """
 
     def wrap(self, policy: Policy) -> Policy:
-        """Apply this layer to a policy. Default: wrap every session it creates via ``make_session``.
-
-        Composition happens at config time; the runtime clock reaches the wrapped
-        sessions through ``new_session``.
-        """
+        """Apply this layer to a policy. Default: wrap every session it creates via ``make_session``."""
         return _LayerPolicy(policy, self)
 
-    def make_session(self, inner: Session, context: dict[str, Any] | None, now: Now | None) -> Session:
+    def make_session(self, inner: Session, context: dict[str, Any] | None) -> Session:
         """Make this layer's session around ``inner``."""
         raise NotImplementedError('Override make_session or wrap')
 
@@ -236,8 +228,8 @@ class _LayerPolicy(DelegatingPolicy):
         super().__init__(inner)
         self._layer = layer
 
-    def new_session(self, context=None, now=None, rt=None):
-        return self._layer.make_session(self._inner.new_session(context, now, rt), context, now)
+    def new_session(self, context=None, rt=None):
+        return self._layer.make_session(self._inner.new_session(context, rt), context)
 
     @property
     def meta(self):

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -81,7 +81,7 @@ class Codec(Layer):
     def meta(self) -> dict:
         return {}
 
-    def make_session(self, inner: Session, context):
+    def make_session(self, inner: Session):
         return _CodecSession(inner, self)
 
     @final

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -81,7 +81,7 @@ class Codec(Layer):
     def meta(self) -> dict:
         return {}
 
-    def make_session(self, inner: Session, context, now):
+    def make_session(self, inner: Session, context):
         return _CodecSession(inner, self)
 
     @final
@@ -107,9 +107,9 @@ class _CodecSession(DelegatingSession):
         super().__init__(inner)
         self._codec = codec
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         encoded = self._codec.encode(obs)
-        action = self._inner(encoded)
+        action = self._inner(encoded, time)
         if action is None:
             return None
         return self._codec.decode(action)
@@ -223,9 +223,8 @@ def is_action(entry: dict) -> bool:
 class ActionTimestamp(Codec):
     """Stamps each decoded action with a relative ``timestamp`` (seconds from trajectory start).
 
-    Assigns ``timestamp = i * (1/fps)`` starting at 0. The harness converts these
-    relative timestamps to absolute wall time at emission, anchoring execution to
-    inference-finish rather than inference-start.
+    Assigns ``timestamp = i * (1/fps)`` starting at 0. ``ChunkedSchedule`` anchors these
+    relative timestamps to the ``time`` of the call that emits the chunk.
 
     A K-action chunk covers K periods, so the list is closed with a sentinel entry —
     a dict carrying only ``timestamp = K * (1/fps)`` and no command keys — stating when

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -107,9 +107,9 @@ class _CodecSession(DelegatingSession):
         super().__init__(inner)
         self._codec = codec
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         encoded = self._codec.encode(obs)
-        action = self._inner(encoded, time)
+        action = self._inner(encoded, time_ns)
         if action is None:
             return None
         return self._codec.decode(action)
@@ -224,7 +224,7 @@ class ActionTimestamp(Codec):
     """Stamps each decoded action with a relative ``timestamp`` (seconds from trajectory start).
 
     Assigns ``timestamp = i * (1/fps)`` starting at 0. The scheduler anchors them to the
-    ``time`` of the call that emits the chunk.
+    ``time_ns`` of the call that emits the chunk.
 
     A K-action chunk covers K periods, so the list is closed with a sentinel entry —
     a dict carrying only ``timestamp = K * (1/fps)`` and no command keys — stating when

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -223,8 +223,8 @@ def is_action(entry: dict) -> bool:
 class ActionTimestamp(Codec):
     """Stamps each decoded action with a relative ``timestamp`` (seconds from trajectory start).
 
-    Assigns ``timestamp = i * (1/fps)`` starting at 0. ``ChunkedSchedule`` anchors these
-    relative timestamps to the ``time`` of the call that emits the chunk.
+    Assigns ``timestamp = i * (1/fps)`` starting at 0. The scheduler anchors them to the
+    ``time`` of the call that emits the chunk.
 
     A K-action chunk covers K periods, so the list is closed with a sentinel entry —
     a dict carrying only ``timestamp = K * (1/fps)`` and no command keys — stating when

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -120,10 +120,10 @@ class _BlockingPolicy(DelegatingPolicy):
             super().__init__(inner)
             self._rt = rt
 
-        def __call__(self, obs: Mapping[str, Any], time: float) -> list[dict[str, Any]] | None:
+        def __call__(self, obs: Mapping[str, Any], time_ns: int) -> list[dict[str, Any]] | None:
             # The inner session reads an answer only on a later call. A test of ``in_flight`` would exit
             # on a call that lands while the session call runs, leaving its answer unread.
-            while (actions := self._inner(obs, time)) is None and self._rt.owes_an_answer:
+            while (actions := self._inner(obs, time_ns)) is None and self._rt.owes_an_answer:
                 self._rt.wait()
             return actions
 
@@ -151,7 +151,7 @@ def blocking(policy: Policy) -> Policy:
 
     For a caller with no control loop to give the time back to — a server request, a warmup, a probe.
     Layers wrap the result rather than the other way round, so each sees one call per answer. Layers that
-    ``policy`` composes itself are inside, so those still run once per call, each with the ``time`` of the
-    call that asked.
+    ``policy`` composes itself are inside, so those still run once per call, each with the ``time_ns`` of
+    the call that asked.
     """
     return _BlockingPolicy(policy)

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -120,10 +120,10 @@ class _BlockingPolicy(DelegatingPolicy):
             super().__init__(inner)
             self._rt = rt
 
-        def __call__(self, obs: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+        def __call__(self, obs: Mapping[str, Any], time: float) -> list[dict[str, Any]] | None:
             # The inner session reads an answer only on a later call. A test of ``in_flight`` would exit
             # on a call that lands while the session call runs, leaving its answer unread.
-            while (actions := self._inner(obs)) is None and self._rt.owes_an_answer:
+            while (actions := self._inner(obs, time)) is None and self._rt.owes_an_answer:
                 self._rt.wait()
             return actions
 
@@ -132,11 +132,11 @@ class _BlockingPolicy(DelegatingPolicy):
             self._rt.close()
             self._inner.close()
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
+    def new_session(self, context=None, rt=None) -> Session:
         assert rt is None, 'a blocking policy serves its own functions; nothing above it runs them'
         own = Executor(self._inner.functions)
         try:
-            return _BlockingPolicy._Session(self._inner.new_session(context, now, own), own)
+            return _BlockingPolicy._Session(self._inner.new_session(context, own), own)
         except BaseException:
             own.close()
             raise
@@ -151,6 +151,7 @@ def blocking(policy: Policy) -> Policy:
 
     For a caller with no control loop to give the time back to — a server request, a warmup, a probe.
     Layers wrap the result rather than the other way round, so each sees one call per answer. Layers that
-    ``policy`` composes itself are inside, so those still run once per call.
+    ``policy`` composes itself are inside, so those still run once per call. Each of those gets the ``time``
+    of the call that asked, so a layer below anchors its chunk before the wait, not after it.
     """
     return _BlockingPolicy(policy)

--- a/positronic/policy/executor.py
+++ b/positronic/policy/executor.py
@@ -151,7 +151,7 @@ def blocking(policy: Policy) -> Policy:
 
     For a caller with no control loop to give the time back to — a server request, a warmup, a probe.
     Layers wrap the result rather than the other way round, so each sees one call per answer. Layers that
-    ``policy`` composes itself are inside, so those still run once per call. Each of those gets the ``time``
-    of the call that asked, so a layer below anchors its chunk before the wait, not after it.
+    ``policy`` composes itself are inside, so those still run once per call, each with the ``time`` of the
+    call that asked.
     """
     return _BlockingPolicy(policy)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -35,7 +35,7 @@ class _EpisodeInference:
         self._t0_ns, self._wall_t0 = clock.now_ns(), time.monotonic()
         self._runtime = Executor(policy.functions)
         try:
-            self._session = policy.new_session(context, clock.now, self._runtime)
+            self._session = policy.new_session(context, self._runtime)
         except BaseException:
             self._runtime.close()
             raise
@@ -54,10 +54,11 @@ class _EpisodeInference:
         return {name: value.copy() if isinstance(value, np.ndarray) else value for name, value in obs.items()}
 
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
+        now_ns = self._clock.now_ns()
         # A call that joins work already in flight keeps its anchor, so the trial pays for that work one time.
         if not self._runtime.in_flight:
-            self._t0_ns, self._wall_t0 = self._clock.now_ns(), time.monotonic()
-        return self._session(frozen_view(self._owned(obs)))
+            self._t0_ns, self._wall_t0 = now_ns, time.monotonic()
+        return self._session(frozen_view(self._owned(obs)), now_ns / 1e9)
 
     def wait(self, should_stop: pimm.SignalReceiver[bool]) -> None:
         """Wait for the function in flight, for as long as the trial charges the loop for it."""

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -58,7 +58,7 @@ class _EpisodeInference:
         # A call that joins work already in flight keeps its anchor, so the trial pays for that work one time.
         if not self._runtime.in_flight:
             self._t0_ns, self._wall_t0 = now_ns, time.monotonic()
-        return self._session(frozen_view(self._owned(obs)), now_ns / 1e9)
+        return self._session(frozen_view(self._owned(obs)), now_ns)
 
     def wait(self, should_stop: pimm.SignalReceiver[bool]) -> None:
         """Wait for the function in flight, for as long as the trial charges the loop for it."""

--- a/positronic/policy/layers.py
+++ b/positronic/policy/layers.py
@@ -1,9 +1,8 @@
 """Composable policy layers — scheduling, fault handling and temporal frame stacking.
 
 Layers are serving-time concerns wrapped around a policy with ``|`` (left is outermost). Most read time
-from the observation (``obs_time_ns``); only ``ChunkedSchedule`` needs the live clock — it anchors a chunk
-to inference *completion*, which the pre-inference observation stamp cannot give — so the harness passes
-``now`` (a ``Callable[[], float]`` in seconds) to ``new_session`` and it reaches that one session.
+from the observation (``obs_time_ns``); ``ChunkedSchedule`` anchors a chunk with the ``time`` of the call,
+which is the caller's clock reading in seconds.
 """
 
 from collections import deque
@@ -12,7 +11,7 @@ import numpy as np
 
 from positronic import keys
 from positronic.drivers.roboarm import RobotStatus
-from positronic.policy.base import DelegatingSession, Layer, Now, Session
+from positronic.policy.base import DelegatingSession, Layer, Session
 
 
 def _obs_time(obs) -> float:
@@ -47,13 +46,13 @@ class StopOnFault(Layer):
     WIRE_NAME = 'stop_on_fault'
 
     class _Session(DelegatingSession):
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             if _arms_available(obs):
-                return self._inner(obs)
+                return self._inner(obs, time)
             self.cancel()
             return []
 
-    def make_session(self, inner: Session, context, now: Now | None):
+    def make_session(self, inner: Session, context):
         return StopOnFault._Session(inner)
 
     def to_spec(self):
@@ -64,9 +63,8 @@ class ChunkedSchedule(Layer):
     """Wait for the current trajectory to finish before calling the inner policy again.
 
     Owns relative→absolute time conversion: the sessions below (codecs, models) emit relative timestamps;
-    this layer anchors them to ``now()`` *after* inner inference returns, so execution aligns to
-    inference-finish (not inference-start). Returns ``None`` ("keep executing the current trajectory")
-    until the last action's timestamp is reached, then calls the inner policy.
+    this layer anchors them to the ``time`` of the call. Returns ``None`` ("keep executing the current
+    trajectory") until the last action's timestamp is reached, then calls the inner policy.
     """
 
     WIRE_NAME = 'chunked_schedule'
@@ -74,31 +72,22 @@ class ChunkedSchedule(Layer):
     class _Session(DelegatingSession):
         """Skips inner calls while the current trajectory plays; stamps absolute on emit."""
 
-        def __init__(self, inner: Session, now: Now | None):
+        def __init__(self, inner: Session):
             super().__init__(inner)
-            self._now = now
             self._trajectory_end: float | None = None
 
-        def __call__(self, obs):
-            if self._now is None:
-                raise ValueError(
-                    'ChunkedSchedule needs a clock to run inference: pass now (a callable returning seconds) to '
-                    'new_session. The harness supplies it; a direct RemotePolicy.new_session() outside the harness '
-                    'must too.'
-                )
+        def __call__(self, obs, time):
             if self._trajectory_end is not None and _obs_time(obs) < self._trajectory_end:
                 return None
-            result = self._inner(obs)
+            result = self._inner(obs, time)
             if result is not None:
                 # A single-action session may return a bare dict, and a no-codec path may omit
                 # ``timestamp`` (servers can stamp/truncate themselves); normalize both so an
                 # immediate action executes instead of raising.
                 if isinstance(result, dict):
                     result = [result]
-                # Anchor to post-inference time so execution starts when inference *finished*.
                 # Copy dicts so we don't mutate caller-owned data (sessions may reuse templates).
-                now = self._now()
-                result = [{**r, keys.ACTION_TIMESTAMP: now + r.get(keys.ACTION_TIMESTAMP, 0.0)} for r in result]
+                result = [{**r, keys.ACTION_TIMESTAMP: time + r.get(keys.ACTION_TIMESTAMP, 0.0)} for r in result]
                 self._trajectory_end = result[-1][keys.ACTION_TIMESTAMP] if result else None
             return result
 
@@ -106,8 +95,8 @@ class ChunkedSchedule(Layer):
             self._trajectory_end = None
             super().cancel()
 
-    def make_session(self, inner: Session, context, now: Now | None):
-        return ChunkedSchedule._Session(inner, now)
+    def make_session(self, inner: Session, context):
+        return ChunkedSchedule._Session(inner)
 
     def to_spec(self):
         return {'name': self.WIRE_NAME}
@@ -184,10 +173,10 @@ class TemporalStack(Layer):
             self._keys = keys
             self._buffer = _StackBuffer(offsets_sec, pad_start=pad_start)
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             now = _obs_time(obs)
             self._buffer.append(now, {k: obs[k] for k in self._keys})
-            return self._inner({**obs, **self._buffer.sample(now)})
+            return self._inner({**obs, **self._buffer.sample(now)}, time)
 
         def cancel(self):
             self._buffer.reset()
@@ -202,7 +191,7 @@ class TemporalStack(Layer):
             'in-range targets and the stack would be empty'
         )
 
-    def make_session(self, inner: Session, context, now: Now | None):
+    def make_session(self, inner: Session, context):
         return TemporalStack._Session(inner, self._keys, self._offsets_sec, self._pad_start)
 
     def to_spec(self):

--- a/positronic/policy/layers.py
+++ b/positronic/policy/layers.py
@@ -52,7 +52,7 @@ class StopOnFault(Layer):
             self.cancel()
             return []
 
-    def make_session(self, inner: Session, context):
+    def make_session(self, inner: Session):
         return StopOnFault._Session(inner)
 
     def to_spec(self):
@@ -65,6 +65,9 @@ class ChunkedSchedule(Layer):
     Owns relative→absolute time conversion: the sessions below (codecs, models) emit relative timestamps;
     this layer anchors them to the ``time`` of the call. Returns ``None`` ("keep executing the current
     trajectory") until the last action's timestamp is reached, then calls the inner policy.
+
+    The call's ``time`` and the observation's ``obs_time_ns`` must be readings of one clock: the anchor
+    comes from the first, and the test for a complete chunk uses the second.
     """
 
     WIRE_NAME = 'chunked_schedule'
@@ -95,7 +98,7 @@ class ChunkedSchedule(Layer):
             self._trajectory_end = None
             super().cancel()
 
-    def make_session(self, inner: Session, context):
+    def make_session(self, inner: Session):
         return ChunkedSchedule._Session(inner)
 
     def to_spec(self):
@@ -191,7 +194,7 @@ class TemporalStack(Layer):
             'in-range targets and the stack would be empty'
         )
 
-    def make_session(self, inner: Session, context):
+    def make_session(self, inner: Session):
         return TemporalStack._Session(inner, self._keys, self._offsets_sec, self._pad_start)
 
     def to_spec(self):

--- a/positronic/policy/layers.py
+++ b/positronic/policy/layers.py
@@ -1,8 +1,8 @@
 """Composable policy layers — scheduling, fault handling and temporal frame stacking.
 
 Layers are serving-time concerns wrapped around a policy with ``|`` (left is outermost). Most read time
-from the observation (``obs_time_ns``); ``ChunkedSchedule`` anchors a chunk with the ``time`` of the call,
-which is the caller's clock reading in seconds.
+from the observation (``obs_time_ns``); ``ChunkedSchedule`` anchors a chunk with the ``time_ns`` of the
+call, which is the caller's clock reading in nanoseconds.
 """
 
 from collections import deque
@@ -46,9 +46,9 @@ class StopOnFault(Layer):
     WIRE_NAME = 'stop_on_fault'
 
     class _Session(DelegatingSession):
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             if _arms_available(obs):
-                return self._inner(obs, time)
+                return self._inner(obs, time_ns)
             self.cancel()
             return []
 
@@ -63,10 +63,11 @@ class ChunkedSchedule(Layer):
     """Wait for the current trajectory to finish before calling the inner policy again.
 
     Owns relative→absolute time conversion: the sessions below (codecs, models) emit relative timestamps;
-    this layer anchors them to the ``time`` of the call. Returns ``None`` ("keep executing the current
-    trajectory") until the last action's timestamp is reached, then calls the inner policy.
+    this layer anchors them to the call's ``time_ns``, in the seconds a timestamp is written in. Returns
+    ``None`` ("keep executing the current trajectory") until the last action's timestamp is reached, then
+    calls the inner policy.
 
-    The call's ``time`` and the observation's ``obs_time_ns`` must be readings of one clock: the anchor
+    The call's ``time_ns`` and the observation's ``obs_time_ns`` must be readings of one clock: the anchor
     comes from the first, and the test for a complete chunk uses the second.
     """
 
@@ -79,10 +80,10 @@ class ChunkedSchedule(Layer):
             super().__init__(inner)
             self._trajectory_end: float | None = None
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             if self._trajectory_end is not None and _obs_time(obs) < self._trajectory_end:
                 return None
-            result = self._inner(obs, time)
+            result = self._inner(obs, time_ns)
             if result is not None:
                 # A single-action session may return a bare dict, and a no-codec path may omit
                 # ``timestamp`` (servers can stamp/truncate themselves); normalize both so an
@@ -90,7 +91,8 @@ class ChunkedSchedule(Layer):
                 if isinstance(result, dict):
                     result = [result]
                 # Copy dicts so we don't mutate caller-owned data (sessions may reuse templates).
-                result = [{**r, keys.ACTION_TIMESTAMP: time + r.get(keys.ACTION_TIMESTAMP, 0.0)} for r in result]
+                anchor = time_ns / 1e9
+                result = [{**r, keys.ACTION_TIMESTAMP: anchor + r.get(keys.ACTION_TIMESTAMP, 0.0)} for r in result]
                 self._trajectory_end = result[-1][keys.ACTION_TIMESTAMP] if result else None
             return result
 
@@ -176,10 +178,10 @@ class TemporalStack(Layer):
             self._keys = keys
             self._buffer = _StackBuffer(offsets_sec, pad_start=pad_start)
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             now = _obs_time(obs)
             self._buffer.append(now, {k: obs[k] for k in self._keys})
-            return self._inner({**obs, **self._buffer.sample(now)}, time)
+            return self._inner({**obs, **self._buffer.sample(now)}, time_ns)
 
         def cancel(self):
             self._buffer.reset()

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -35,8 +35,7 @@ The robot's actual gripper is overlaid the same way in white for predicted-vs-re
 Every field is *also* logged as ``rr.Scalars`` on a dedicated ``action_time`` timeline
 (each action stamped at the inference-request time plus its horizon offset), so a
 ``TimeSeriesView`` reads commanded values with real axes. That anchor is the call's ``obs_time_ns``,
-and ``ChunkedSchedule`` anchors execution to the ``time`` of the same call, so the plotted time can
-differ from the executed time. Select ``action_time`` to see them.
+and the execution time can differ. Select ``action_time`` to see them.
 
 Entity paths are ``{tap_name}/{data_key}``. A tap's incoming observation keys and
 outgoing action keys share that namespace; in the rare case the same key appears on
@@ -243,8 +242,7 @@ def _log_action_series(path: str, arr: np.ndarray, horizon: np.ndarray, base_ns:
 
     Each action is stamped at ``base_ns + horizon_i``, where ``base_ns`` is the
     inference-request time; successive chunks lay out along one clock so a ``TimeSeriesView``
-    has real axes. ``ChunkedSchedule`` anchors the same commands to the ``time`` of the call, so
-    the plotted time can differ from the executed time.
+    has real axes. The plotted time is the request time, and the execution time can differ.
     """
     arr = np.asarray(arr, dtype=np.float64)
     if arr.ndim == 1:

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -458,7 +458,7 @@ class _RecordingTapSession(DelegatingSession):
         if bp is not None:
             rr.send_blueprint(bp)
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         rec = self._rec
         outermost = rec._depth == 0
         if outermost:
@@ -469,7 +469,7 @@ class _RecordingTapSession(DelegatingSession):
                 self._set_timelines()
                 self._log(self._name, obs)
 
-            actions = self._inner(obs, time)
+            actions = self._inner(obs, time_ns)
 
             if actions is not None:
                 with self._stream:

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -34,9 +34,9 @@ separation along the jaw axis encodes grip on a fixed scale and the color encode
 The robot's actual gripper is overlaid the same way in white for predicted-vs-realized.
 Every field is *also* logged as ``rr.Scalars`` on a dedicated ``action_time`` timeline
 (each action stamped at the inference-request time plus its horizon offset), so a
-``TimeSeriesView`` reads commanded values with real axes. That anchor is the pre-inference
-``obs_time_ns``, so it precedes the harness's true execution time (stamped after
-inference by ``ChunkedSchedule``) by the inference latency. Select ``action_time`` to see them.
+``TimeSeriesView`` reads commanded values with real axes. That anchor is the call's ``obs_time_ns``,
+and ``ChunkedSchedule`` anchors execution to the ``time`` of the same call, so the plotted time can
+differ from the executed time. Select ``action_time`` to see them.
 
 Entity paths are ``{tap_name}/{data_key}``. A tap's incoming observation keys and
 outgoing action keys share that namespace; in the rare case the same key appears on
@@ -243,9 +243,8 @@ def _log_action_series(path: str, arr: np.ndarray, horizon: np.ndarray, base_ns:
 
     Each action is stamped at ``base_ns + horizon_i``, where ``base_ns`` is the
     inference-request time; successive chunks lay out along one clock so a ``TimeSeriesView``
-    has real axes. This precedes true execution by the inference latency: the harness's
-    ``ChunkedSchedule`` anchors commands at ``now()`` *after* inference, which a recorder
-    tap sitting inside it cannot observe.
+    has real axes. ``ChunkedSchedule`` anchors the same commands to the ``time`` of the call, so
+    the plotted time can differ from the executed time.
     """
     arr = np.asarray(arr, dtype=np.float64)
     if arr.ndim == 1:
@@ -364,7 +363,7 @@ class _RecordingTap(Layer):
         self._rec = rec
         self._name = name
 
-    def make_session(self, inner: Session, context, now) -> Session:
+    def make_session(self, inner: Session, context) -> Session:
         stream = self._rec._open_stream()
         return _RecordingTapSession(inner, self._rec, self._name, stream)
 
@@ -461,7 +460,7 @@ class _RecordingTapSession(DelegatingSession):
         if bp is not None:
             rr.send_blueprint(bp)
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         rec = self._rec
         outermost = rec._depth == 0
         if outermost:
@@ -472,7 +471,7 @@ class _RecordingTapSession(DelegatingSession):
                 self._set_timelines()
                 self._log(self._name, obs)
 
-            actions = self._inner(obs)
+            actions = self._inner(obs, time)
 
             if actions is not None:
                 with self._stream:

--- a/positronic/policy/recording.py
+++ b/positronic/policy/recording.py
@@ -363,7 +363,7 @@ class _RecordingTap(Layer):
         self._rec = rec
         self._name = name
 
-    def make_session(self, inner: Session, context) -> Session:
+    def make_session(self, inner: Session) -> Session:
         stream = self._rec._open_stream()
         return _RecordingTapSession(inner, self._rec, self._name, stream)
 

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -70,7 +70,7 @@ class RemoteSession(Session):
         self._answer: Answer | None = None
         self._cancelled = False
 
-    def __call__(self, obs: cabc.Mapping[str, Any], time: float) -> list[dict[str, Any]] | None:
+    def __call__(self, obs: cabc.Mapping[str, Any], time_ns: int) -> list[dict[str, Any]] | None:
         """The trajectory of a round trip that has come back, and ``None`` while one is in flight.
 
         A server answer of one action becomes a 1-element list, which is the form ``Session.__call__``

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -70,7 +70,7 @@ class RemoteSession(Session):
         self._answer: Answer | None = None
         self._cancelled = False
 
-    def __call__(self, obs: cabc.Mapping[str, Any]) -> list[dict[str, Any]] | None:
+    def __call__(self, obs: cabc.Mapping[str, Any], time: float) -> list[dict[str, Any]] | None:
         """The trajectory of a round trip that has come back, and ``None`` while one is in flight.
 
         A server answer of one action becomes a 1-element list, which is the form ``Session.__call__``
@@ -127,7 +127,7 @@ class _Endpoint(Policy):
                 ws_session.close()
         return self._server_meta
 
-    def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
+    def new_session(self, context=None, rt=None) -> RemoteSession:
         if rt is None:
             raise ValueError('A remote session runs its inference on a runtime: pass rt to new_session.')
         compress = bool(self.server_meta().get(keys.COMPRESS_IMAGES))
@@ -197,8 +197,8 @@ class RemotePolicy(Policy):
             self._stacked = stack.wrap(self._endpoint)
         return self._stacked
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
-        return self._policy().new_session(context, now, rt)
+    def new_session(self, context=None, rt=None) -> Session:
+        return self._policy().new_session(context, rt)
 
     @property
     def functions(self) -> cabc.Mapping[str, cabc.Callable[..., Any]]:

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -241,14 +241,14 @@ class _PlainPolicy(Policy):
         def __init__(self):
             self.calls = 0
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             self.calls += 1
             return [{'action': obs}]
 
     def __init__(self):
         self.session = _PlainPolicy._Session()
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
+    def new_session(self, context=None, rt=None) -> Session:
         return self.session
 
 
@@ -265,7 +265,7 @@ class _EchoPolicy(Policy):
             self._left = rounds
             self.calls = 0
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             self.calls += 1
             result = None
             if self._answer is not None:
@@ -280,7 +280,7 @@ class _EchoPolicy(Policy):
         self._rounds = rounds
         self.session: _EchoPolicy._Session
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
+    def new_session(self, context=None, rt=None) -> Session:
         assert rt is not None
         self.session = _EchoPolicy._Session(rt, self._rounds)
         return self.session
@@ -301,11 +301,11 @@ class _CountingLayer(Layer):
             super().__init__(inner)
             self._layer = layer
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             self._layer.calls += 1
-            return self._inner(obs)
+            return self._inner(obs, time)
 
-    def make_session(self, inner, context, now):
+    def make_session(self, inner, context):
         return self._Session(inner, self)
 
 
@@ -329,20 +329,20 @@ class TestBlocking:
     def test_a_session_that_answers_in_its_own_call_is_called_one_time(self, opened):
         policy = _PlainPolicy()
 
-        assert opened(blocking(policy))({'x': 1}) == [{'action': {'x': 1}}]
+        assert opened(blocking(policy))({'x': 1}, 0.0) == [{'action': {'x': 1}}]
         assert policy.session.calls == 1
 
     @pytest.mark.parametrize(('rounds', 'calls'), [(1, 2), (2, 3)])
     def test_a_session_is_called_again_for_every_function_it_starts(self, opened, rounds, calls):
         policy = _EchoPolicy(rounds)
 
-        assert opened(blocking(policy))({'x': 1}) == {'x': 1}
+        assert opened(blocking(policy))({'x': 1}, 0.0) == {'x': 1}
         assert policy.session.calls == calls
 
     def test_a_session_that_starts_nothing_and_answers_none_is_called_one_time(self, opened):
         policy = _EchoPolicy(rounds=0)
 
-        assert opened(blocking(policy))({'x': 1}) is None
+        assert opened(blocking(policy))({'x': 1}, 0.0) is None
         assert policy.session.calls == 1
 
     def test_a_layer_above_it_is_called_one_time_for_one_answer(self, opened):
@@ -351,7 +351,7 @@ class TestBlocking:
         that work once per call the answer took."""
         layer, policy = _CountingLayer(), _EchoPolicy(rounds=2)
 
-        assert opened(layer.wrap(blocking(policy)))({'x': 1}) == {'x': 1}
+        assert opened(layer.wrap(blocking(policy)))({'x': 1}, 0.0) == {'x': 1}
         assert (layer.calls, policy.session.calls) == (1, 3)
 
     def test_it_serves_its_functions_itself(self):
@@ -367,7 +367,7 @@ class TestBlocking:
 
         # The session's own runtime is closed, so the function it would start is gone.
         with pytest.raises(RuntimeError):
-            policy.session({'x': 1})
+            policy.session({'x': 1}, 0.0)
 
 
 class _Weights:

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -241,7 +241,7 @@ class _PlainPolicy(Policy):
         def __init__(self):
             self.calls = 0
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             self.calls += 1
             return [{'action': obs}]
 
@@ -265,7 +265,7 @@ class _EchoPolicy(Policy):
             self._left = rounds
             self.calls = 0
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             self.calls += 1
             result = None
             if self._answer is not None:
@@ -301,9 +301,9 @@ class _CountingLayer(Layer):
             super().__init__(inner)
             self._layer = layer
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             self._layer.calls += 1
-            return self._inner(obs, time)
+            return self._inner(obs, time_ns)
 
     def make_session(self, inner):
         return self._Session(inner, self)
@@ -367,7 +367,7 @@ class TestBlocking:
 
         # The session's own runtime is closed, so the function it would start is gone.
         with pytest.raises(RuntimeError):
-            policy.session({'x': 1}, 0.0)
+            policy.session({'x': 1}, 0)
 
 
 class _Weights:

--- a/positronic/policy/tests/test_executor.py
+++ b/positronic/policy/tests/test_executor.py
@@ -305,7 +305,7 @@ class _CountingLayer(Layer):
             self._layer.calls += 1
             return self._inner(obs, time)
 
-    def make_session(self, inner, context):
+    def make_session(self, inner):
         return self._Session(inner, self)
 
 

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -65,7 +65,7 @@ CAPTURED_SIGNALS = (keys.EE_POSE, keys.JOINTS, keys.GRIP)
 
 
 class _ScriptedSession(Session):
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         current = np.asarray(obs[keys.EE_POSE][:3], dtype=np.float32)
         delta = TARGET_POS - current
         chunk = []
@@ -103,19 +103,17 @@ class _SimulatedLatency(DelegatingPolicy):
             self._held: list | None = None
             self._release_at_ns = 0
 
-        def __call__(self, obs, time):
-            # Integer ns, the world's own timeline: a float compare can miss the release instant by one ULP.
-            now_ns = round(time * 1e9)
+        def __call__(self, obs, time_ns):
             if self._held is not None:
-                if now_ns < self._release_at_ns:
+                if time_ns < self._release_at_ns:
                     return None
                 held, self._held = self._held, None
                 return held
             # The chunk is held for ``latency_ns``, so the sessions below stamp it from the release instant.
-            result = self._inner(obs, time + self._latency_ns / 1e9)
+            result = self._inner(obs, time_ns + self._latency_ns)
             if not result:
                 return result
-            self._held, self._release_at_ns = result, now_ns + self._latency_ns
+            self._held, self._release_at_ns = result, time_ns + self._latency_ns
             return None
 
         def cancel(self):

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -41,7 +41,7 @@ from positronic.drivers.roboarm.command import CartesianPosition, CommandType
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
 from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation, Task
 from positronic.geom import Rotation, Transform3D
-from positronic.policy.base import DelegatingPolicy, DelegatingSession, Now, Policy, Session
+from positronic.policy.base import DelegatingPolicy, DelegatingSession, Policy, Session
 from positronic.policy.codec import ActionTiming
 from positronic.policy.harness import Harness
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
@@ -54,7 +54,7 @@ INITIAL_Q = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60, 0.70], dtype=np.flo
 TARGET_POS = np.array([0.50, 0.00, 0.45], dtype=np.float32)
 
 # Fixed deterministic inference latency in world time. Spans >1 control tick (harness loop is
-# 0.01 s) so the post-inference anchoring effect is observable in recorded ts.
+# 0.01 s) so the shift ``_SimulatedLatency`` adds is observable in recorded ts.
 INFERENCE_LATENCY_S = 0.05
 ACTION_FPS = 15.0
 ACTION_HORIZON_S = 0.5  # 8 of every 10-action chunk survives truncation
@@ -65,7 +65,7 @@ CAPTURED_SIGNALS = (keys.EE_POSE, keys.JOINTS, keys.GRIP)
 
 
 class _ScriptedSession(Session):
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         current = np.asarray(obs[keys.EE_POSE][:3], dtype=np.float32)
         delta = TARGET_POS - current
         chunk = []
@@ -80,10 +80,10 @@ class ScriptedProportionalPolicy(Policy):
     """Pure proportional controller toward ``TARGET_POS``.
 
     Reads ``robot_state.ee_pose`` only; returns a 10-action chunk. No RNG, no
-    clock, no images. Codec stamps/truncates; the harness anchors/schedules.
+    clock, no images. Codec stamps/truncates; ``ChunkedSchedule`` anchors and the harness plays.
     """
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         return _ScriptedSession()
 
 
@@ -97,22 +97,22 @@ class _SimulatedLatency(DelegatingPolicy):
         self._latency_ns = round(latency_sec * 1e9)
 
     class _Session(DelegatingSession):
-        def __init__(self, inner: Session, now: Now, latency_ns: int):
+        def __init__(self, inner: Session, latency_ns: int):
             super().__init__(inner)
-            self._now = now
             self._latency_ns = latency_ns
             self._held: list | None = None
             self._release_at_ns = 0
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             # Integer ns, the world's own timeline: a float compare can miss the release instant by one ULP.
-            now_ns = round(self._now() * 1e9)
+            now_ns = round(time * 1e9)
             if self._held is not None:
                 if now_ns < self._release_at_ns:
                     return None
                 held, self._held = self._held, None
                 return held
-            result = self._inner(obs)
+            # The chunk is held for ``latency_ns``, so the sessions below stamp it from the release instant.
+            result = self._inner(obs, time + self._latency_ns / 1e9)
             if not result:
                 return result
             self._held, self._release_at_ns = result, now_ns + self._latency_ns
@@ -122,12 +122,8 @@ class _SimulatedLatency(DelegatingPolicy):
             self._held = None
             super().cancel()
 
-    def new_session(self, context=None, now=None, rt=None):
-        assert now is not None, 'the harness supplies the clock'
-        latency_ns = self._latency_ns
-        return _SimulatedLatency._Session(
-            self._inner.new_session(context, lambda: now() + latency_ns / 1e9, rt), now, latency_ns
-        )
+    def new_session(self, context=None, rt=None):
+        return _SimulatedLatency._Session(self._inner.new_session(context, rt), self._latency_ns)
 
 
 class FakeRobot(pimm.ControlSystem):

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1827,7 +1827,7 @@ class _ReplanEarly(Layer):
             self._replan_at = t0 + (result[-1][keys.ACTION_TIMESTAMP] - t0) / 2
             return result
 
-    def make_session(self, inner: Session, context):
+    def make_session(self, inner: Session):
         return _ReplanEarly._Session(inner)
 
 
@@ -1923,7 +1923,7 @@ class _ObservedTicks(Layer):
             self._seen.append(obs[keys.OBS_TIME_NS] / 1e9)
             return self._inner(obs, time)
 
-    def make_session(self, inner: Session, context):
+    def make_session(self, inner: Session):
         return _ObservedTicks._Session(inner, self.seen)
 
 

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -81,7 +81,7 @@ class _SpySession(Session):
     def __init__(self, policy):
         self._policy = policy
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self._policy.last_obs = obs
         return [{keys.ROBOT_COMMAND: self._policy.command, 'target_grip': self._policy.target_grip, 'timestamp': 0.0}]
 
@@ -108,7 +108,7 @@ class _StubSession(Session):
         self._policy = policy
         self._meta = dict(policy._meta)
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self._policy.last_obs = obs
         self._policy.observations.append(obs)
         return [{keys.ROBOT_COMMAND: self._policy.command, 'target_grip': self._policy.target_grip, 'timestamp': 0.0}]
@@ -152,7 +152,7 @@ class _ChunkSession(Session):
     def __init__(self, policy):
         self._policy = policy
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self._policy.counter += 1
         dt = 0.005
         return [
@@ -586,7 +586,7 @@ def test_episode_meta_includes_policy_static_meta(world):
         def __init__(self, command):
             self._command = command
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             return [{keys.ROBOT_COMMAND: self._command, 'target_grip': 0.0, 'timestamp': 0.0}]
 
     class _StaticMetaPolicy(Policy):
@@ -683,7 +683,7 @@ def test_an_uncharged_wait_ends_when_the_world_comes_down(world):
             def __init__(self, rt):
                 self._rt = rt
 
-            def __call__(self, obs, time):
+            def __call__(self, obs, time_ns):
                 self._rt.fns[INFER]()
                 return None
 
@@ -710,7 +710,7 @@ def test_a_session_that_raises_fails_the_call_that_asked_for_the_episode(world):
     than the log."""
 
     class _RaisingSession(Session):
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             raise RuntimeError('inference boom')
 
     class _RaisingPolicy(Policy):
@@ -1359,7 +1359,7 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
     already is rather than one channel draining on while another stops."""
 
     class _EmptyChunkSession(Session):
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             return []
 
     class EmptyChunkPolicy(Policy):
@@ -1816,14 +1816,15 @@ class _ReplanEarly(Layer):
             super().__init__(inner)
             self._replan_at: float | None = None
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             t0 = obs[keys.OBS_TIME_NS] / 1e9
             if self._replan_at is not None and t0 < self._replan_at:
                 return None
-            result = self._inner(obs, time)
+            result = self._inner(obs, time_ns)
             if result is None:  # the function it asked has still to answer
                 return None
-            result = [{**action, keys.ACTION_TIMESTAMP: time + action[keys.ACTION_TIMESTAMP]} for action in result]
+            anchor = time_ns / 1e9
+            result = [{**action, keys.ACTION_TIMESTAMP: anchor + action[keys.ACTION_TIMESTAMP]} for action in result]
             self._replan_at = t0 + (result[-1][keys.ACTION_TIMESTAMP] - t0) / 2
             return result
 
@@ -1919,9 +1920,9 @@ class _ObservedTicks(Layer):
             super().__init__(inner)
             self._seen = seen
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             self._seen.append(obs[keys.OBS_TIME_NS] / 1e9)
-            return self._inner(obs, time)
+            return self._inner(obs, time_ns)
 
     def make_session(self, inner: Session):
         return _ObservedTicks._Session(inner, self.seen)
@@ -2205,7 +2206,7 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
         def __init__(self):
             self._calls = 0
 
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             self._calls += 1
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
             command = CartesianPosition(pose=pose)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -81,7 +81,7 @@ class _SpySession(Session):
     def __init__(self, policy):
         self._policy = policy
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self._policy.last_obs = obs
         return [{keys.ROBOT_COMMAND: self._policy.command, 'target_grip': self._policy.target_grip, 'timestamp': 0.0}]
 
@@ -97,7 +97,7 @@ class SpyPolicy(Policy):
         self.reset_calls: int = 0
         self.last_reset_context = None
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self.reset_calls += 1
         self.last_reset_context = context
         return _SpySession(self)
@@ -108,7 +108,7 @@ class _StubSession(Session):
         self._policy = policy
         self._meta = dict(policy._meta)
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self._policy.last_obs = obs
         self._policy.observations.append(obs)
         return [{keys.ROBOT_COMMAND: self._policy.command, 'target_grip': self._policy.target_grip, 'timestamp': 0.0}]
@@ -142,7 +142,7 @@ class StubPolicy(Policy):
     def meta(self) -> dict[str, object]:
         return self._meta
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
+    def new_session(self, context=None, rt=None) -> Session:
         self.reset_calls += 1
         self.last_reset_context = context
         return _StubSession(self)
@@ -152,7 +152,7 @@ class _ChunkSession(Session):
     def __init__(self, policy):
         self._policy = policy
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self._policy.counter += 1
         dt = 0.005
         return [
@@ -172,7 +172,7 @@ class ChunkPolicy(StubPolicy):
         super().__init__(*args, **kwargs)
         self.counter = 0
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self.reset_calls += 1
         self.last_reset_context = context
         return _ChunkSession(self)
@@ -210,7 +210,7 @@ class ServedPolicy(Policy):
     def __init__(self, session: InferenceSession) -> None:
         self._session = session
 
-    def new_session(self, context=None, now=None, rt=None) -> RemoteSession:
+    def new_session(self, context=None, rt=None) -> RemoteSession:
         assert rt is not None, 'the harness supplies the runtime'
         return RemoteSession(self._session, rt)
 
@@ -586,7 +586,7 @@ def test_episode_meta_includes_policy_static_meta(world):
         def __init__(self, command):
             self._command = command
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             return [{keys.ROBOT_COMMAND: self._command, 'target_grip': 0.0, 'timestamp': 0.0}]
 
     class _StaticMetaPolicy(Policy):
@@ -594,7 +594,7 @@ def test_episode_meta_includes_policy_static_meta(world):
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
             self._command = CartesianPosition(pose=pose)
 
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             return _StaticMetaSession(self._command)  # Session.meta defaults to {}
 
         @property
@@ -683,11 +683,11 @@ def test_an_uncharged_wait_ends_when_the_world_comes_down(world):
             def __init__(self, rt):
                 self._rt = rt
 
-            def __call__(self, obs):
+            def __call__(self, obs, time):
                 self._rt.fns[INFER]()
                 return None
 
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             assert rt is not None
             return _HangingPolicy._Session(rt)
 
@@ -710,11 +710,11 @@ def test_a_session_that_raises_fails_the_call_that_asked_for_the_episode(world):
     than the log."""
 
     class _RaisingSession(Session):
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             raise RuntimeError('inference boom')
 
     class _RaisingPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             return _RaisingSession()
 
     harness = Harness(_RaisingPolicy(), make_embodiment())
@@ -1235,9 +1235,9 @@ class _AbandonedCallPolicy(ServedPolicy):
         self.events: list[str] = []
         super().__init__(_AbandonedCallPolicy._Infer(self.events, wall_sec))
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self.events.append('open')
-        return super().new_session(context, now, rt)
+        return super().new_session(context, rt)
 
 
 @pytest.mark.timeout(10.0)
@@ -1359,11 +1359,11 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
     already is rather than one channel draining on while another stops."""
 
     class _EmptyChunkSession(Session):
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             return []
 
     class EmptyChunkPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             return _EmptyChunkSession()
 
     harness = Harness(EmptyChunkPolicy(), make_embodiment())
@@ -1812,26 +1812,23 @@ class _ReplanEarly(Layer):
     """
 
     class _Session(DelegatingSession):
-        def __init__(self, inner: Session, now):
+        def __init__(self, inner: Session):
             super().__init__(inner)
-            self._now = now
             self._replan_at: float | None = None
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             t0 = obs[keys.OBS_TIME_NS] / 1e9
             if self._replan_at is not None and t0 < self._replan_at:
                 return None
-            result = self._inner(obs)
+            result = self._inner(obs, time)
             if result is None:  # the function it asked has still to answer
                 return None
-            anchor = self._now()
-            result = [{**action, keys.ACTION_TIMESTAMP: anchor + action[keys.ACTION_TIMESTAMP]} for action in result]
+            result = [{**action, keys.ACTION_TIMESTAMP: time + action[keys.ACTION_TIMESTAMP]} for action in result]
             self._replan_at = t0 + (result[-1][keys.ACTION_TIMESTAMP] - t0) / 2
             return result
 
-    def make_session(self, inner: Session, context, now):
-        assert now is not None  # the harness always passes its clock
-        return _ReplanEarly._Session(inner, now)
+    def make_session(self, inner: Session, context):
+        return _ReplanEarly._Session(inner)
 
 
 class _TimedRecorder(pimm.SignalEmitter):
@@ -1922,11 +1919,11 @@ class _ObservedTicks(Layer):
             super().__init__(inner)
             self._seen = seen
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             self._seen.append(obs[keys.OBS_TIME_NS] / 1e9)
-            return self._inner(obs)
+            return self._inner(obs, time)
 
-    def make_session(self, inner: Session, context, now):
+    def make_session(self, inner: Session, context):
         return _ObservedTicks._Session(inner, self.seen)
 
 
@@ -2208,7 +2205,7 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
         def __init__(self):
             self._calls = 0
 
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             self._calls += 1
             pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
             command = CartesianPosition(pose=pose)
@@ -2220,7 +2217,7 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
             return [{keys.ROBOT_COMMAND: command, keys.ACTION_TIMESTAMP: i * 0.01} for i in range(10)]
 
     class _GripThenArmPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             return _GripThenArm()
 
     harness = Harness(ChunkedSchedule().wrap(_GripThenArmPolicy()), make_embodiment())

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -55,14 +55,14 @@ class TestStopOnFault:
     @pytest.mark.parametrize('unavailable', [RobotStatus.ERROR, RobotStatus.BUSY])
     def test_an_unavailable_arm_stops_what_is_executing(self, unavailable):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None)
+        session = StopOnFault().make_session(inner)
 
         assert session(_obs(0.0, unavailable), 0.0) == []
         assert inner.call_count == 0, 'the model was asked about an arm that is not tracking it'
 
     def test_an_available_arm_reaches_the_model(self):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None)
+        session = StopOnFault().make_session(inner)
 
         assert session(_obs(0.0, RobotStatus.AVAILABLE), 0.0) is not None
         assert inner.call_count == 1
@@ -70,7 +70,7 @@ class TestStopOnFault:
     def test_an_observation_with_no_arm_status_reaches_the_model(self):
         """A probe replaying a recording has no arm to stop for."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None)
+        session = StopOnFault().make_session(inner)
 
         assert session({keys.OBS_TIME_NS: 0}, 0.0) is not None
         assert inner.call_count == 1
@@ -79,7 +79,7 @@ class TestStopOnFault:
         """Whichever arm is unavailable stops the pair, and the status counts as its number: a server-side stack
         reads it off a wire with no enum to carry."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None)
+        session = StopOnFault().make_session(inner)
         obs = {
             keys.OBS_TIME_NS: 0,
             f'{keys.ROBOT_STATE}.left.status': int(RobotStatus.AVAILABLE),
@@ -92,7 +92,7 @@ class TestStopOnFault:
     def test_the_status_a_recording_carries_for_a_taken_arm_stops_the_policy(self):
         """The numbers are the contract between a rig and a server: 1 is an arm its driver has taken."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None)
+        session = StopOnFault().make_session(inner)
 
         assert (RobotStatus.AVAILABLE, RobotStatus.BUSY, RobotStatus.ERROR) == (0, 1, 3)
         assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 1}, 0.0) == []
@@ -101,7 +101,7 @@ class TestStopOnFault:
     def test_the_status_published_for_a_travelling_arm_reaches_the_model(self):
         """The wire protocol publishes 2 for an arm on its way to a setpoint, which is one taking commands."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None)
+        session = StopOnFault().make_session(inner)
 
         assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 2}, 0.0) is not None
         assert inner.call_count == 1
@@ -109,7 +109,7 @@ class TestStopOnFault:
     def test_a_status_no_arm_answers_to_raises(self):
         """A number outside ``RobotStatus`` is the rig and the server disagreeing about the protocol, which
         is not something to drive an arm through."""
-        session = StopOnFault().make_session(_ConstSession([]), None)
+        session = StopOnFault().make_session(_ConstSession([]))
 
         with pytest.raises(ValueError):
             session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 99}, 0.0)
@@ -142,7 +142,7 @@ class TestChunkedSchedule:
         """A session that waits for a served function answers ``None``, which is no trajectory. The layer
         passes the ``None`` on and asks again on the next observation."""
         inner = _ScriptedSession([None, None, [{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]])
-        session = ChunkedSchedule().make_session(inner, None)
+        session = ChunkedSchedule().make_session(inner)
 
         assert session(_obs(0.0), 1.0) is None
         assert session(_obs(0.1), 1.0) is None

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -32,7 +32,7 @@ class _ConstSession(Session):
         self._actions = actions
         self.call_count = 0
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self.call_count += 1
         return self._actions
 
@@ -57,14 +57,14 @@ class TestStopOnFault:
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
         session = StopOnFault().make_session(inner)
 
-        assert session(_obs(0.0, unavailable), 0.0) == []
+        assert session(_obs(0.0, unavailable), 0) == []
         assert inner.call_count == 0, 'the model was asked about an arm that is not tracking it'
 
     def test_an_available_arm_reaches_the_model(self):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
         session = StopOnFault().make_session(inner)
 
-        assert session(_obs(0.0, RobotStatus.AVAILABLE), 0.0) is not None
+        assert session(_obs(0.0, RobotStatus.AVAILABLE), 0) is not None
         assert inner.call_count == 1
 
     def test_an_observation_with_no_arm_status_reaches_the_model(self):
@@ -72,7 +72,7 @@ class TestStopOnFault:
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
         session = StopOnFault().make_session(inner)
 
-        assert session({keys.OBS_TIME_NS: 0}, 0.0) is not None
+        assert session({keys.OBS_TIME_NS: 0}, 0) is not None
         assert inner.call_count == 1
 
     def test_either_arm_of_a_bimanual_rig_stops_the_pair(self):
@@ -86,7 +86,7 @@ class TestStopOnFault:
             f'{keys.ROBOT_STATE}.right.status': int(RobotStatus.ERROR),
         }
 
-        assert session(obs, 0.0) == []
+        assert session(obs, 0) == []
         assert inner.call_count == 0
 
     def test_the_status_a_recording_carries_for_a_taken_arm_stops_the_policy(self):
@@ -95,7 +95,7 @@ class TestStopOnFault:
         session = StopOnFault().make_session(inner)
 
         assert (RobotStatus.AVAILABLE, RobotStatus.BUSY, RobotStatus.ERROR) == (0, 1, 3)
-        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 1}, 0.0) == []
+        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 1}, 0) == []
         assert inner.call_count == 0
 
     def test_the_status_published_for_a_travelling_arm_reaches_the_model(self):
@@ -103,7 +103,7 @@ class TestStopOnFault:
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
         session = StopOnFault().make_session(inner)
 
-        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 2}, 0.0) is not None
+        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 2}, 0) is not None
         assert inner.call_count == 1
 
     def test_a_status_no_arm_answers_to_raises(self):
@@ -112,7 +112,7 @@ class TestStopOnFault:
         session = StopOnFault().make_session(_ConstSession([]))
 
         with pytest.raises(ValueError):
-            session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 99}, 0.0)
+            session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 99}, 0)
 
     def test_recovery_plans_afresh_instead_of_resuming(self):
         """The stop resets the scheduler below it, so the first observation from an available arm infers
@@ -120,9 +120,9 @@ class TestStopOnFault:
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 1.0}])
         session = (StopOnFault() | ChunkedSchedule()).wrap(inner).new_session()
 
-        assert session(_obs(0.0), 0.0) is not None  # a chunk that runs until 1.0
-        assert session(_obs(0.2, RobotStatus.ERROR), 0.2) == []
-        assert session(_obs(0.3), 0.3) is not None
+        assert session(_obs(0.0), 0) is not None  # a chunk that runs until 1.0
+        assert session(_obs(0.2, RobotStatus.ERROR), int(0.2e9)) == []
+        assert session(_obs(0.3), int(0.3e9)) is not None
 
 
 class _ScriptedSession(Session):
@@ -132,7 +132,7 @@ class _ScriptedSession(Session):
         self._script = list(script)
         self.call_count = 0
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self.call_count += 1
         return self._script.pop(0)
 
@@ -144,9 +144,9 @@ class TestChunkedSchedule:
         inner = _ScriptedSession([None, None, [{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]])
         session = ChunkedSchedule().make_session(inner)
 
-        assert session(_obs(0.0), 1.0) is None
-        assert session(_obs(0.1), 1.0) is None
-        assert session(_obs(0.2), 1.0) == [{'v': 1, keys.ACTION_TIMESTAMP: 1.0}]
+        assert session(_obs(0.0), int(1e9)) is None
+        assert session(_obs(0.1), int(1e9)) is None
+        assert session(_obs(0.2), int(1e9)) == [{'v': 1, keys.ACTION_TIMESTAMP: 1.0}]
         assert inner.call_count == 3
 
     def test_first_call_runs_inference(self):
@@ -154,7 +154,7 @@ class TestChunkedSchedule:
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
         policy = ChunkedSchedule().wrap(inner)
         session = policy.new_session()
-        result = session(_obs(), 1.0)
+        result = session(_obs(), int(1e9))
         assert result is not None
         assert len(result) == 2
         # Timestamps stamped to absolute by ChunkedSchedule.
@@ -166,16 +166,16 @@ class TestChunkedSchedule:
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
         policy = ChunkedSchedule().wrap(inner)
         session = policy.new_session()
-        session(_obs(), 1.0)
-        assert session(_obs(), 1.2) is None
-        assert session(_obs(), 1.4) is None
+        session(_obs(), int(1e9))
+        assert session(_obs(), int(1.2e9)) is None
+        assert session(_obs(), int(1.4e9)) is None
 
     def test_re_infers_after_trajectory_consumed(self):
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
         session = ChunkedSchedule().wrap(inner).new_session()
-        session(_obs(1.0), 1.0)  # trajectory ends at 1.5
-        assert session(_obs(1.3), 1.3) is None
-        result = session(_obs(1.6), 1.6)
+        session(_obs(1.0), int(1e9))  # trajectory ends at 1.5
+        assert session(_obs(1.3), int(1.3e9)) is None
+        result = session(_obs(1.6), int(1.6e9))
         assert result is not None
         assert inner._session.call_count == 2
 
@@ -183,17 +183,17 @@ class TestChunkedSchedule:
         """Single action at ts=0 → trajectory_end is the call's time → next tick re-infers."""
         policy = ChunkedSchedule().wrap(_ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]))
         session = policy.new_session()
-        session(_obs(1.0), 1.0)
-        result = session(_obs(1.01), 1.01)
+        session(_obs(1.0), int(1e9))
+        result = session(_obs(1.01), int(1.01e9))
         assert result is not None
 
     def test_expiry_is_judged_at_the_observation_instant(self):
         """Whether the trajectory has run out is a question about the observation, not about the call's time."""
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
         session = ChunkedSchedule().wrap(inner).new_session()
-        session(_obs(1.0), 2.0)  # anchored at the call's time 2.0, so the trajectory ends at 2.5
-        assert session(_obs(2.4), 2.0) is None
-        assert session(_obs(2.6), 2.0) is not None
+        session(_obs(1.0), int(2e9))  # anchored at the call's time 2.0, so the trajectory ends at 2.5
+        assert session(_obs(2.4), int(2e9)) is None
+        assert session(_obs(2.6), int(2e9)) is not None
 
 
 class TestPipelineComposition:
@@ -204,7 +204,7 @@ class TestPipelineComposition:
         assert isinstance(pipeline, Layer)
         policy = pipeline.wrap(_ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]))
         session = policy.new_session()
-        result = session({keys.OBS_TIME_NS: int(1e9), 'v': np.array([5.0])}, 1.0)
+        result = session({keys.OBS_TIME_NS: int(1e9), 'v': np.array([5.0])}, int(1e9))
         assert result is not None
         assert result[0]['v'] == 1
 
@@ -214,7 +214,7 @@ class TestPipelineComposition:
         assert isinstance(pipeline, Layer)
         policy = pipeline.wrap(_ConstPolicy([{'action': 'test', keys.ACTION_TIMESTAMP: 0.0}]))
         session = policy.new_session()
-        result = session(_obs(), 1.0)
+        result = session(_obs(), int(1e9))
         assert result is not None
 
     def test_full_pipeline(self):
@@ -225,11 +225,11 @@ class TestPipelineComposition:
         # → ChunkedSchedule shifts to 1.0, 1.1, 1.2, 1.3, 1.4 (call time 1.0).
         policy = pipeline.wrap(_ConstPolicy([{'action': f'a{i}'} for i in range(5)]))
         session = policy.new_session()
-        result = session(_obs(), 1.0)
+        result = session(_obs(), int(1e9))
         assert result is not None
         assert result[0][keys.ACTION_TIMESTAMP] == 1.0
         # Second call within trajectory window returns None (ChunkedSchedule).
-        assert session(_obs(), 1.2) is None
+        assert session(_obs(), int(1.2e9)) is None
 
     def test_codec_and_stays_codec_only(self):
         """& only works between codecs, not layers."""
@@ -271,7 +271,7 @@ class _CaptureSession(Session):
     def __init__(self):
         self.seen = []
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self.seen.append(obs)
         return []
 
@@ -331,7 +331,7 @@ class TestTemporalStack:
     def test_pad_start_repeats_oldest(self):
         inner = _CapturePolicy()
         session = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS).wrap(inner).new_session()
-        session(_stack_obs(0.0, 1.0), 0.0)
+        session(_stack_obs(0.0, 1.0), 0)
         stack = inner.session.seen[0]['v']
         assert stack.shape == (3, 1)
         assert (stack == 1.0).all()
@@ -341,14 +341,14 @@ class TestTemporalStack:
         layer = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS, pad_start=False)
         session = layer.wrap(inner).new_session()
 
-        session(_stack_obs(0.0, 1.0), 0.0)
+        session(_stack_obs(0.0, 1.0), 0)
         assert inner.session.seen[0]['v'].shape == (1, 1)
 
-        session(_stack_obs(0.1, 2.0), 0.1)
+        session(_stack_obs(0.1, 2.0), int(0.1e9))
         assert inner.session.seen[1]['v'].shape == (2, 1)
         assert inner.session.seen[1]['v'][:, 0].tolist() == [1.0, 2.0]
 
-        session(_stack_obs(0.2, 3.0), 0.2)
+        session(_stack_obs(0.2, 3.0), int(0.2e9))
         assert inner.session.seen[2]['v'].shape == (3, 1)
         assert inner.session.seen[2]['v'][:, 0].tolist() == [1.0, 2.0, 3.0]
 
@@ -360,7 +360,7 @@ class TestTemporalStack:
             layer = TemporalStack(keys=('v',), offsets_sec=offsets, pad_start=pad_start)
             session = layer.wrap(inner).new_session()
             for i in range(4):
-                session(_stack_obs(0.1 * i, float(i)), 0.1 * i)
+                session(_stack_obs(0.1 * i, float(i)), round(0.1 * i * 1e9))
             stacks[pad_start] = inner.session.seen[-1]['v']
         assert stacks[True].shape == stacks[False].shape == (3, 1)
         assert (stacks[True] == stacks[False]).all()
@@ -550,16 +550,16 @@ class TestPipe:
         policy = spec.inline(ChunkedSchedule() | spec.remote | ActionTimestamp(fps=10.0) | spec.PolicySource(inner))
         assert isinstance(policy, Policy)
         session = policy.new_session()
-        result = session(_obs(), 1.0)
+        result = session(_obs(), int(1e9))
         assert result is not None
         assert result[0][keys.ACTION_TIMESTAMP] == 1.0
-        assert session(_obs(), 1.2) is None
+        assert session(_obs(), int(1.2e9)) is None
 
     def test_inline_tolerates_marker_less_pipe(self):
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
         policy = spec.inline(ChunkedSchedule() | spec.PolicySource(inner))
         session = policy.new_session()
-        result = session(_obs(), 1.0)
+        result = session(_obs(), int(1e9))
         assert result is not None and result[0][keys.ACTION_TIMESTAMP] == 1.0
 
     def test_inline_bare_source_pipe_is_the_loaded_policy(self):

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -27,25 +27,12 @@ from positronic.policy.layers import ChunkedSchedule, StopOnFault, TemporalStack
 from positronic.policy.observation import ObservationCodec
 
 
-class _FakeClock:
-    """Minimal clock stub for unit tests — caller sets ``t`` directly."""
-
-    def __init__(self, t: float = 0.0):
-        self.t = t
-
-    def now(self) -> float:
-        return self.t
-
-    def now_ns(self) -> int:
-        return int(self.t * 1e9)
-
-
 class _ConstSession(Session):
     def __init__(self, actions):
         self._actions = actions
         self.call_count = 0
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self.call_count += 1
         return self._actions
 
@@ -55,7 +42,7 @@ class _ConstPolicy(Policy):
         self._actions = actions
         self._session: _ConstSession | None = None
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self._session = _ConstSession(self._actions)
         return self._session
 
@@ -68,74 +55,74 @@ class TestStopOnFault:
     @pytest.mark.parametrize('unavailable', [RobotStatus.ERROR, RobotStatus.BUSY])
     def test_an_unavailable_arm_stops_what_is_executing(self, unavailable):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None)
 
-        assert session(_obs(0.0, unavailable)) == []
+        assert session(_obs(0.0, unavailable), 0.0) == []
         assert inner.call_count == 0, 'the model was asked about an arm that is not tracking it'
 
     def test_an_available_arm_reaches_the_model(self):
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None)
 
-        assert session(_obs(0.0, RobotStatus.AVAILABLE)) is not None
+        assert session(_obs(0.0, RobotStatus.AVAILABLE), 0.0) is not None
         assert inner.call_count == 1
 
     def test_an_observation_with_no_arm_status_reaches_the_model(self):
         """A probe replaying a recording has no arm to stop for."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None)
 
-        assert session({keys.OBS_TIME_NS: 0}) is not None
+        assert session({keys.OBS_TIME_NS: 0}, 0.0) is not None
         assert inner.call_count == 1
 
     def test_either_arm_of_a_bimanual_rig_stops_the_pair(self):
         """Whichever arm is unavailable stops the pair, and the status counts as its number: a server-side stack
         reads it off a wire with no enum to carry."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None)
         obs = {
             keys.OBS_TIME_NS: 0,
             f'{keys.ROBOT_STATE}.left.status': int(RobotStatus.AVAILABLE),
             f'{keys.ROBOT_STATE}.right.status': int(RobotStatus.ERROR),
         }
 
-        assert session(obs) == []
+        assert session(obs, 0.0) == []
         assert inner.call_count == 0
 
     def test_the_status_a_recording_carries_for_a_taken_arm_stops_the_policy(self):
         """The numbers are the contract between a rig and a server: 1 is an arm its driver has taken."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None)
 
         assert (RobotStatus.AVAILABLE, RobotStatus.BUSY, RobotStatus.ERROR) == (0, 1, 3)
-        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 1}) == []
+        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 1}, 0.0) == []
         assert inner.call_count == 0
 
     def test_the_status_published_for_a_travelling_arm_reaches_the_model(self):
         """The wire protocol publishes 2 for an arm on its way to a setpoint, which is one taking commands."""
         inner = _ConstSession([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
-        session = StopOnFault().make_session(inner, None, None)
+        session = StopOnFault().make_session(inner, None)
 
-        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 2}) is not None
+        assert session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 2}, 0.0) is not None
         assert inner.call_count == 1
 
     def test_a_status_no_arm_answers_to_raises(self):
         """A number outside ``RobotStatus`` is the rig and the server disagreeing about the protocol, which
         is not something to drive an arm through."""
-        session = StopOnFault().make_session(_ConstSession([]), None, None)
+        session = StopOnFault().make_session(_ConstSession([]), None)
 
         with pytest.raises(ValueError):
-            session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 99})
+            session({keys.OBS_TIME_NS: 0, keys.ROBOT_STATUS: 99}, 0.0)
 
     def test_recovery_plans_afresh_instead_of_resuming(self):
         """The stop resets the scheduler below it, so the first observation from an available arm infers
         again rather than waiting out the chunk stamped before."""
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 1.0}])
-        session = (StopOnFault() | ChunkedSchedule()).wrap(inner).new_session(now=_FakeClock(t=0.0).now)
+        session = (StopOnFault() | ChunkedSchedule()).wrap(inner).new_session()
 
-        assert session(_obs(0.0)) is not None  # a chunk that runs until 1.0
-        assert session(_obs(0.2, RobotStatus.ERROR)) == []
-        assert session(_obs(0.3)) is not None
+        assert session(_obs(0.0), 0.0) is not None  # a chunk that runs until 1.0
+        assert session(_obs(0.2, RobotStatus.ERROR), 0.2) == []
+        assert session(_obs(0.3), 0.3) is not None
 
 
 class _ScriptedSession(Session):
@@ -145,7 +132,7 @@ class _ScriptedSession(Session):
         self._script = list(script)
         self.call_count = 0
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self.call_count += 1
         return self._script.pop(0)
 
@@ -155,20 +142,19 @@ class TestChunkedSchedule:
         """A session that waits for a served function answers ``None``, which is no trajectory. The layer
         passes the ``None`` on and asks again on the next observation."""
         inner = _ScriptedSession([None, None, [{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]])
-        session = ChunkedSchedule().make_session(inner, None, _FakeClock(t=1.0).now)
+        session = ChunkedSchedule().make_session(inner, None)
 
-        assert session(_obs(0.0)) is None
-        assert session(_obs(0.1)) is None
-        assert session(_obs(0.2)) == [{'v': 1, keys.ACTION_TIMESTAMP: 1.0}]
+        assert session(_obs(0.0), 1.0) is None
+        assert session(_obs(0.1), 1.0) is None
+        assert session(_obs(0.2), 1.0) == [{'v': 1, keys.ACTION_TIMESTAMP: 1.0}]
         assert inner.call_count == 3
 
     def test_first_call_runs_inference(self):
         # Relative timestamps: trajectory of duration 0.5s
-        clock = _FakeClock(t=1.0)
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
         policy = ChunkedSchedule().wrap(inner)
-        session = policy.new_session(now=clock.now)
-        result = session(_obs())
+        session = policy.new_session()
+        result = session(_obs(), 1.0)
         assert result is not None
         assert len(result) == 2
         # Timestamps stamped to absolute by ChunkedSchedule.
@@ -176,85 +162,74 @@ class TestChunkedSchedule:
         assert result[1][keys.ACTION_TIMESTAMP] == 1.5
 
     def test_returns_none_while_trajectory_active(self):
-        # Trajectory starts at clock=1.0, ends at 1.0+0.5=1.5.
-        clock = _FakeClock(t=1.0)
+        # The trajectory starts at the call time 1.0 and ends at 1.0+0.5=1.5.
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
         policy = ChunkedSchedule().wrap(inner)
-        session = policy.new_session(now=clock.now)
-        session(_obs())
-        clock.t = 1.2
-        assert session(_obs()) is None
-        clock.t = 1.4
-        assert session(_obs()) is None
+        session = policy.new_session()
+        session(_obs(), 1.0)
+        assert session(_obs(), 1.2) is None
+        assert session(_obs(), 1.4) is None
 
     def test_re_infers_after_trajectory_consumed(self):
-        clock = _FakeClock(t=1.0)
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
-        session = ChunkedSchedule().wrap(inner).new_session(now=clock.now)
-        session(_obs(1.0))  # trajectory ends at clock=1.5
-        assert session(_obs(1.3)) is None
-        clock.t = 1.6
-        result = session(_obs(1.6))
+        session = ChunkedSchedule().wrap(inner).new_session()
+        session(_obs(1.0), 1.0)  # trajectory ends at 1.5
+        assert session(_obs(1.3), 1.3) is None
+        result = session(_obs(1.6), 1.6)
         assert result is not None
         assert inner._session.call_count == 2
 
     def test_single_action_refires_immediately_after(self):
-        """Single action at ts=0 → trajectory_end = now → next tick re-infers."""
-        clock = _FakeClock(t=1.0)
+        """Single action at ts=0 → trajectory_end is the call's time → next tick re-infers."""
         policy = ChunkedSchedule().wrap(_ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]))
-        session = policy.new_session(now=clock.now)
-        session(_obs(1.0))
-        clock.t = 1.01
-        result = session(_obs(1.01))
+        session = policy.new_session()
+        session(_obs(1.0), 1.0)
+        result = session(_obs(1.01), 1.01)
         assert result is not None
 
     def test_expiry_is_judged_at_the_observation_instant(self):
-        """Whether the trajectory has run out is a question about the observation, not about ``now``."""
+        """Whether the trajectory has run out is a question about the observation, not about the call's time."""
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}, {'v': 2, keys.ACTION_TIMESTAMP: 0.5}])
-        session = ChunkedSchedule().wrap(inner).new_session(now=_FakeClock(t=2.0).now)
-        session(_obs(1.0))  # anchored at now()=2.0, so the trajectory ends at 2.5
-        assert session(_obs(2.4)) is None
-        assert session(_obs(2.6)) is not None
+        session = ChunkedSchedule().wrap(inner).new_session()
+        session(_obs(1.0), 2.0)  # anchored at the call's time 2.0, so the trajectory ends at 2.5
+        assert session(_obs(2.4), 2.0) is None
+        assert session(_obs(2.6), 2.0) is not None
 
 
 class TestPipelineComposition:
     """Test | operator across Layer and Codec types."""
 
     def test_layer_pipe_layer(self):
-        clock = _FakeClock(t=1.0)
         pipeline = TemporalStack(keys=('v',), offsets_sec=(0.0,)) | ChunkedSchedule()
         assert isinstance(pipeline, Layer)
         policy = pipeline.wrap(_ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}]))
-        session = policy.new_session(now=clock.now)
-        result = session({keys.OBS_TIME_NS: int(1e9), 'v': np.array([5.0])})
+        session = policy.new_session()
+        result = session({keys.OBS_TIME_NS: int(1e9), 'v': np.array([5.0])}, 1.0)
         assert result is not None
         assert result[0]['v'] == 1
 
     def test_codec_pipe_layer(self):
-        clock = _FakeClock(t=1.0)
         codec = ActionTimestamp(fps=10.0)
         pipeline = codec | ChunkedSchedule()
         assert isinstance(pipeline, Layer)
         policy = pipeline.wrap(_ConstPolicy([{'action': 'test', keys.ACTION_TIMESTAMP: 0.0}]))
-        session = policy.new_session(now=clock.now)
-        result = session(_obs())
+        session = policy.new_session()
+        result = session(_obs(), 1.0)
         assert result is not None
 
     def test_full_pipeline(self):
-        clock = _FakeClock(t=1.0)
         codec = ActionTimestamp(fps=10.0)
         pipeline = ChunkedSchedule() | codec
         assert isinstance(pipeline, Layer)
         # 5 raw actions → codec stamps relative 0.0, 0.1, 0.2, 0.3, 0.4
-        # → ChunkedSchedule shifts to 1.0, 1.1, 1.2, 1.3, 1.4 (clock=1.0).
+        # → ChunkedSchedule shifts to 1.0, 1.1, 1.2, 1.3, 1.4 (call time 1.0).
         policy = pipeline.wrap(_ConstPolicy([{'action': f'a{i}'} for i in range(5)]))
-        session = policy.new_session(now=clock.now)
-        result = session(_obs())
+        session = policy.new_session()
+        result = session(_obs(), 1.0)
         assert result is not None
         assert result[0][keys.ACTION_TIMESTAMP] == 1.0
         # Second call within trajectory window returns None (ChunkedSchedule).
-        clock.t = 1.2
-        assert session(_obs()) is None
+        assert session(_obs(), 1.2) is None
 
     def test_codec_and_stays_codec_only(self):
         """& only works between codecs, not layers."""
@@ -296,7 +271,7 @@ class _CaptureSession(Session):
     def __init__(self):
         self.seen = []
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self.seen.append(obs)
         return []
 
@@ -305,7 +280,7 @@ class _CapturePolicy(Policy):
     def __init__(self):
         self.session = _CaptureSession()
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         return self.session
 
 
@@ -354,28 +329,26 @@ class TestTemporalStack:
     OFFSETS = (-0.2, -0.1, 0.0)
 
     def test_pad_start_repeats_oldest(self):
-        clock = _FakeClock(t=0.0)
         inner = _CapturePolicy()
-        session = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS).wrap(inner).new_session(now=clock.now)
-        session(_stack_obs(0.0, 1.0))
+        session = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS).wrap(inner).new_session()
+        session(_stack_obs(0.0, 1.0), 0.0)
         stack = inner.session.seen[0]['v']
         assert stack.shape == (3, 1)
         assert (stack == 1.0).all()
 
     def test_no_pad_start_grows_from_one(self):
-        clock = _FakeClock(t=0.0)
         inner = _CapturePolicy()
         layer = TemporalStack(keys=('v',), offsets_sec=self.OFFSETS, pad_start=False)
-        session = layer.wrap(inner).new_session(now=clock.now)
+        session = layer.wrap(inner).new_session()
 
-        session(_stack_obs(0.0, 1.0))
+        session(_stack_obs(0.0, 1.0), 0.0)
         assert inner.session.seen[0]['v'].shape == (1, 1)
 
-        session(_stack_obs(0.1, 2.0))
+        session(_stack_obs(0.1, 2.0), 0.1)
         assert inner.session.seen[1]['v'].shape == (2, 1)
         assert inner.session.seen[1]['v'][:, 0].tolist() == [1.0, 2.0]
 
-        session(_stack_obs(0.2, 3.0))
+        session(_stack_obs(0.2, 3.0), 0.2)
         assert inner.session.seen[2]['v'].shape == (3, 1)
         assert inner.session.seen[2]['v'][:, 0].tolist() == [1.0, 2.0, 3.0]
 
@@ -383,12 +356,11 @@ class TestTemporalStack:
         offsets = self.OFFSETS
         stacks = {}
         for pad_start in (True, False):
-            clock = _FakeClock(t=0.0)
             inner = _CapturePolicy()
             layer = TemporalStack(keys=('v',), offsets_sec=offsets, pad_start=pad_start)
-            session = layer.wrap(inner).new_session(now=clock.now)
+            session = layer.wrap(inner).new_session()
             for i in range(4):
-                session(_stack_obs(0.1 * i, float(i)))
+                session(_stack_obs(0.1 * i, float(i)), 0.1 * i)
             stacks[pad_start] = inner.session.seen[-1]['v']
         assert stacks[True].shape == stacks[False].shape == (3, 1)
         assert (stacks[True] == stacks[False]).all()
@@ -574,23 +546,20 @@ class TestPipe:
             _ = pipeline | spec.PolicySource(_ConstPolicy([]))
 
     def test_inline_full_pipe(self):
-        clock = _FakeClock(t=1.0)
         inner = _ConstPolicy([{'action': f'a{i}'} for i in range(5)])
         policy = spec.inline(ChunkedSchedule() | spec.remote | ActionTimestamp(fps=10.0) | spec.PolicySource(inner))
         assert isinstance(policy, Policy)
-        session = policy.new_session(now=clock.now)
-        result = session(_obs())
+        session = policy.new_session()
+        result = session(_obs(), 1.0)
         assert result is not None
         assert result[0][keys.ACTION_TIMESTAMP] == 1.0
-        clock.t = 1.2
-        assert session(_obs()) is None
+        assert session(_obs(), 1.2) is None
 
     def test_inline_tolerates_marker_less_pipe(self):
-        clock = _FakeClock(t=1.0)
         inner = _ConstPolicy([{'v': 1, keys.ACTION_TIMESTAMP: 0.0}])
         policy = spec.inline(ChunkedSchedule() | spec.PolicySource(inner))
-        session = policy.new_session(now=clock.now)
-        result = session(_obs())
+        session = policy.new_session()
+        result = session(_obs(), 1.0)
         assert result is not None and result[0][keys.ACTION_TIMESTAMP] == 1.0
 
     def test_inline_bare_source_pipe_is_the_loaded_policy(self):

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -119,7 +119,7 @@ class _FixedSession(Session):
     def __init__(self, result):
         self._result = result
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         return self._result
 
 
@@ -127,12 +127,12 @@ class _ChunkPolicy(Policy):
     def __init__(self, actions: list[dict]):
         self._actions = actions
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         return _FixedSession(list(self._actions))
 
 
 class _SinglePolicy(Policy):
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         return _FixedSession({'v': 42})
 
 
@@ -146,7 +146,7 @@ class _PassthroughCodec(Codec):
 
 
 class _MetaPolicy(Policy):
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         return _FixedSession({})
 
     @property
@@ -162,7 +162,7 @@ def test_action_horizon_sec_truncates_chunk():
     # action_horizon_sec=0.1s at action_fps=30 -> 3 actions
     codec = ActionTiming(fps=30.0, horizon_sec=0.1)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert [r['v'] for r in result if 'v' in r] == [0, 1, 2]
     assert result[-1] == {'timestamp': pytest.approx(0.1)}  # horizon sentinel
 
@@ -171,7 +171,7 @@ def test_action_horizon_sec_none_returns_full_chunk():
     actions = [{'v': i} for i in range(5)]
     codec = ActionTiming(fps=30.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert len(result) == 6  # 5 actions + timestamp sentinel
 
 
@@ -180,7 +180,7 @@ def test_action_horizon_sec_larger_than_chunk():
     # action_horizon_sec=10s at action_fps=10 -> 100 actions max, but only 3 available
     codec = ActionTiming(fps=10.0, horizon_sec=10.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert len(result) == 4  # 3 actions + timestamp sentinel (nothing truncated)
 
 
@@ -188,7 +188,7 @@ def test_timestamps_embedded_in_actions():
     actions = [{'v': i} for i in range(4)]
     codec = ActionTiming(fps=10.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert len(result) == 5  # 4 actions + timestamp sentinel
     for i, action in enumerate(result):
         assert action['timestamp'] == pytest.approx(i * 0.1)
@@ -199,7 +199,7 @@ def test_action_horizon_sec_seconds_truncates():
     # 0.1s at 30fps -> 3 actions
     codec = ActionTiming(fps=30.0, horizon_sec=0.1)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert len(result) == 4  # 3 actions + horizon sentinel
     dt = 1.0 / 30.0
     for i, action in enumerate(result):
@@ -250,7 +250,7 @@ def test_action_timestamp_and_horizon_compose():
     actions = [{'v': i} for i in range(10)]
     codec = ActionHorizon(0.3) | ActionTimestamp(fps=10.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert len(result) == 4  # 3 actions + horizon sentinel
     assert [r['v'] for r in result if 'v' in r] == [0, 1, 2]
     assert result[-1] == {'timestamp': pytest.approx(0.3)}  # horizon sentinel
@@ -259,7 +259,7 @@ def test_action_timestamp_and_horizon_compose():
 def test_single_action_has_zero_timestamp():
     codec = ActionTiming(fps=15.0)
     policy = codec.wrap(_SinglePolicy())
-    result = policy.new_session()(_T0_OBS)
+    result = policy.new_session()(_T0_OBS, 0.0)
     assert isinstance(result, dict)
     assert result['timestamp'] == 0.0
     assert result['v'] == 42

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -119,7 +119,7 @@ class _FixedSession(Session):
     def __init__(self, result):
         self._result = result
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         return self._result
 
 
@@ -162,7 +162,7 @@ def test_action_horizon_sec_truncates_chunk():
     # action_horizon_sec=0.1s at action_fps=30 -> 3 actions
     codec = ActionTiming(fps=30.0, horizon_sec=0.1)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert [r['v'] for r in result if 'v' in r] == [0, 1, 2]
     assert result[-1] == {'timestamp': pytest.approx(0.1)}  # horizon sentinel
 
@@ -171,7 +171,7 @@ def test_action_horizon_sec_none_returns_full_chunk():
     actions = [{'v': i} for i in range(5)]
     codec = ActionTiming(fps=30.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert len(result) == 6  # 5 actions + timestamp sentinel
 
 
@@ -180,7 +180,7 @@ def test_action_horizon_sec_larger_than_chunk():
     # action_horizon_sec=10s at action_fps=10 -> 100 actions max, but only 3 available
     codec = ActionTiming(fps=10.0, horizon_sec=10.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert len(result) == 4  # 3 actions + timestamp sentinel (nothing truncated)
 
 
@@ -188,7 +188,7 @@ def test_timestamps_embedded_in_actions():
     actions = [{'v': i} for i in range(4)]
     codec = ActionTiming(fps=10.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert len(result) == 5  # 4 actions + timestamp sentinel
     for i, action in enumerate(result):
         assert action['timestamp'] == pytest.approx(i * 0.1)
@@ -199,7 +199,7 @@ def test_action_horizon_sec_seconds_truncates():
     # 0.1s at 30fps -> 3 actions
     codec = ActionTiming(fps=30.0, horizon_sec=0.1)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert len(result) == 4  # 3 actions + horizon sentinel
     dt = 1.0 / 30.0
     for i, action in enumerate(result):
@@ -250,7 +250,7 @@ def test_action_timestamp_and_horizon_compose():
     actions = [{'v': i} for i in range(10)]
     codec = ActionHorizon(0.3) | ActionTimestamp(fps=10.0)
     policy = codec.wrap(_ChunkPolicy(actions))
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert len(result) == 4  # 3 actions + horizon sentinel
     assert [r['v'] for r in result if 'v' in r] == [0, 1, 2]
     assert result[-1] == {'timestamp': pytest.approx(0.3)}  # horizon sentinel
@@ -259,7 +259,7 @@ def test_action_timestamp_and_horizon_compose():
 def test_single_action_has_zero_timestamp():
     codec = ActionTiming(fps=15.0)
     policy = codec.wrap(_SinglePolicy())
-    result = policy.new_session()(_T0_OBS, 0.0)
+    result = policy.new_session()(_T0_OBS, 0)
     assert isinstance(result, dict)
     assert result['timestamp'] == 0.0
     assert result['v'] == 42

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -20,7 +20,7 @@ class _TrackingSession(Session):
         self._actions = actions
         self._meta = meta
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         return list(self._actions)
 
     @property
@@ -53,7 +53,7 @@ class _CapturingSession(Session):
         self.seen_timeline_values = None
         self.seen_depth = None
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self.seen_timeline_values = dict(self._rec._timeline_values)
         self.seen_depth = self._rec._depth
         return list(self._actions)
@@ -116,7 +116,7 @@ def test_a_cartesian_chunk_records_the_mode_beside_its_trajectory(tmp_path):
     actions = [{keys.ROBOT_COMMAND: CartesianPosition(pose=pose, mode=mode), 'timestamp': 0.0}]
 
     rec = Recorder(tmp_path)
-    rec.tap('t').wrap(_TrackingPolicy(actions)).new_session()({'x': 1.0, keys.WALL_TIME_NS: 1}, 0.0)
+    rec.tap('t').wrap(_TrackingPolicy(actions)).new_session()({'x': 1.0, keys.WALL_TIME_NS: 1}, 0)
 
     assert any('mode.impedance.kq' in path for path in rec._series_paths), rec._series_paths
     assert not any(path.endswith('cartesian_pos/pose') for path in rec._series_paths), 'the pose is the trajectory'
@@ -162,7 +162,7 @@ def test_tap_delegates_inner_call(tmp_path):
     actions = [{'v': 1, 'timestamp': 0.0}, {'v': 2, 'timestamp': 0.1}]
     policy = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy(actions))
     session = policy.new_session()
-    result = session({'x': 1.0, keys.WALL_TIME_NS: 1_000_000}, 0.0)
+    result = session({'x': 1.0, keys.WALL_TIME_NS: 1_000_000}, 0)
     assert result == actions
 
 
@@ -184,7 +184,7 @@ def test_obs_log_filtering_uses_pure_tap_names(tmp_path):
             'joints_list': [0.1, 0.2, 0.3],
             keys.GRIP: 0.5,
         },
-        0.0,
+        0,
     )
 
     assert 'cam/camera' in rec._image_paths
@@ -206,13 +206,13 @@ def test_logs_command_chunk_without_mutating(tmp_path):
         {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), 'target_grip': 0.6, 'timestamp': 0.1},
     ]
     session = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy(actions)).new_session()
-    result = session({'x': 1.0, keys.WALL_TIME_NS: 1}, 0.0)
+    result = session({'x': 1.0, keys.WALL_TIME_NS: 1}, 0)
     assert result[0][keys.ROBOT_COMMAND] is actions[0][keys.ROBOT_COMMAND]  # unchanged on return
 
 
 def test_handles_none_actions(tmp_path):
     class _NoneSession(Session):
-        def __call__(self, obs, time):
+        def __call__(self, obs, time_ns):
             return None
 
     class _NonePolicy(Policy):
@@ -220,7 +220,7 @@ def test_handles_none_actions(tmp_path):
             return _NoneSession()
 
     session = Recorder(tmp_path).tap('t').wrap(_NonePolicy()).new_session()
-    assert session({'x': 1.0}, 0.0) is None
+    assert session({'x': 1.0}, 0) is None
     assert session._step == 1
 
 
@@ -244,7 +244,7 @@ def test_two_taps_log_both_seams(tmp_path):
     actions = [{'v': 1.0, 'timestamp': 0.0}]
     policy = (rec.tap('raw') | rec.tap('server')).wrap(_TrackingPolicy(actions))
     session = policy.new_session()
-    session({'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.WALL_TIME_NS: 1}, 0.0)
+    session({'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.WALL_TIME_NS: 1}, 0)
 
     assert 'raw/camera' in rec._image_paths
     assert 'server/camera' in rec._image_paths
@@ -257,7 +257,7 @@ def test_timeline_values_captured_once_and_carried(tmp_path):
     policy = (rec.tap('raw') | rec.tap('server')).wrap(inner)
     session = policy.new_session()
 
-    session({keys.WALL_TIME_NS: 111, keys.OBS_TIME_NS: 222, 'x': 1.0}, 0.0)
+    session({keys.WALL_TIME_NS: 111, keys.OBS_TIME_NS: 222, 'x': 1.0}, 0)
 
     # Both taps entered before the inner session ran, and both share the values
     # captured once from the raw obs at the outermost tap.
@@ -273,7 +273,7 @@ def test_partial_timelines_only_set_present_keys(tmp_path):
     inner = _CapturingPolicy(rec, [{'v': 1.0, 'timestamp': 0.0}])
     session = rec.tap('raw').wrap(inner).new_session()
 
-    session({keys.WALL_TIME_NS: 555, 'x': 1.0}, 0.0)  # no obs_time_ns
+    session({keys.WALL_TIME_NS: 555, 'x': 1.0}, 0)  # no obs_time_ns
     assert inner.last_session.seen_timeline_values == {'wall_time': 555}
 
 

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -20,7 +20,7 @@ class _TrackingSession(Session):
         self._actions = actions
         self._meta = meta
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         return list(self._actions)
 
     @property
@@ -35,7 +35,7 @@ class _TrackingPolicy(Policy):
         self._actions = actions or [{'action': np.array([1.0, 2.0], dtype=np.float32), 'timestamp': 0.0}]
         self.session_count = 0
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self.session_count += 1
         return _TrackingSession(self._actions, {'policy_key': 'policy_value'})
 
@@ -53,7 +53,7 @@ class _CapturingSession(Session):
         self.seen_timeline_values = None
         self.seen_depth = None
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self.seen_timeline_values = dict(self._rec._timeline_values)
         self.seen_depth = self._rec._depth
         return list(self._actions)
@@ -65,7 +65,7 @@ class _CapturingPolicy(Policy):
         self._actions = actions
         self.last_session = None
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self.last_session = _CapturingSession(self._rec, self._actions)
         return self.last_session
 
@@ -116,7 +116,7 @@ def test_a_cartesian_chunk_records_the_mode_beside_its_trajectory(tmp_path):
     actions = [{keys.ROBOT_COMMAND: CartesianPosition(pose=pose, mode=mode), 'timestamp': 0.0}]
 
     rec = Recorder(tmp_path)
-    rec.tap('t').wrap(_TrackingPolicy(actions)).new_session()({'x': 1.0, keys.WALL_TIME_NS: 1})
+    rec.tap('t').wrap(_TrackingPolicy(actions)).new_session()({'x': 1.0, keys.WALL_TIME_NS: 1}, 0.0)
 
     assert any('mode.impedance.kq' in path for path in rec._series_paths), rec._series_paths
     assert not any(path.endswith('cartesian_pos/pose') for path in rec._series_paths), 'the pose is the trajectory'
@@ -162,7 +162,7 @@ def test_tap_delegates_inner_call(tmp_path):
     actions = [{'v': 1, 'timestamp': 0.0}, {'v': 2, 'timestamp': 0.1}]
     policy = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy(actions))
     session = policy.new_session()
-    result = session({'x': 1.0, keys.WALL_TIME_NS: 1_000_000})
+    result = session({'x': 1.0, keys.WALL_TIME_NS: 1_000_000}, 0.0)
     assert result == actions
 
 
@@ -175,14 +175,17 @@ def test_tap_meta_passthrough(tmp_path):
 def test_obs_log_filtering_uses_pure_tap_names(tmp_path):
     rec = Recorder(tmp_path)
     session = rec.tap('cam').wrap(_TrackingPolicy([{'v': 1.0, 'timestamp': 0.0}])).new_session()
-    session({
-        keys.WALL_TIME_NS: 1_000_000,
-        keys.TASK: 'pick up the cube',
-        'camera': np.zeros((4, 4, 3), dtype=np.uint8),
-        'joint_pos': np.array([1.0, 2.0], dtype=np.float32),
-        'joints_list': [0.1, 0.2, 0.3],
-        keys.GRIP: 0.5,
-    })
+    session(
+        {
+            keys.WALL_TIME_NS: 1_000_000,
+            keys.TASK: 'pick up the cube',
+            'camera': np.zeros((4, 4, 3), dtype=np.uint8),
+            'joint_pos': np.array([1.0, 2.0], dtype=np.float32),
+            'joints_list': [0.1, 0.2, 0.3],
+            keys.GRIP: 0.5,
+        },
+        0.0,
+    )
 
     assert 'cam/camera' in rec._image_paths
     assert 'cam/joint_pos' in rec._numeric_paths
@@ -203,21 +206,21 @@ def test_logs_command_chunk_without_mutating(tmp_path):
         {keys.ROBOT_COMMAND: CartesianPosition(pose=pose), 'target_grip': 0.6, 'timestamp': 0.1},
     ]
     session = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy(actions)).new_session()
-    result = session({'x': 1.0, keys.WALL_TIME_NS: 1})
+    result = session({'x': 1.0, keys.WALL_TIME_NS: 1}, 0.0)
     assert result[0][keys.ROBOT_COMMAND] is actions[0][keys.ROBOT_COMMAND]  # unchanged on return
 
 
 def test_handles_none_actions(tmp_path):
     class _NoneSession(Session):
-        def __call__(self, obs):
+        def __call__(self, obs, time):
             return None
 
     class _NonePolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             return _NoneSession()
 
     session = Recorder(tmp_path).tap('t').wrap(_NonePolicy()).new_session()
-    assert session({'x': 1.0}) is None
+    assert session({'x': 1.0}, 0.0) is None
     assert session._step == 1
 
 
@@ -241,7 +244,7 @@ def test_two_taps_log_both_seams(tmp_path):
     actions = [{'v': 1.0, 'timestamp': 0.0}]
     policy = (rec.tap('raw') | rec.tap('server')).wrap(_TrackingPolicy(actions))
     session = policy.new_session()
-    session({'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.WALL_TIME_NS: 1})
+    session({'camera': np.zeros((4, 4, 3), dtype=np.uint8), keys.WALL_TIME_NS: 1}, 0.0)
 
     assert 'raw/camera' in rec._image_paths
     assert 'server/camera' in rec._image_paths
@@ -254,7 +257,7 @@ def test_timeline_values_captured_once_and_carried(tmp_path):
     policy = (rec.tap('raw') | rec.tap('server')).wrap(inner)
     session = policy.new_session()
 
-    session({keys.WALL_TIME_NS: 111, keys.OBS_TIME_NS: 222, 'x': 1.0})
+    session({keys.WALL_TIME_NS: 111, keys.OBS_TIME_NS: 222, 'x': 1.0}, 0.0)
 
     # Both taps entered before the inner session ran, and both share the values
     # captured once from the raw obs at the outermost tap.
@@ -270,7 +273,7 @@ def test_partial_timelines_only_set_present_keys(tmp_path):
     inner = _CapturingPolicy(rec, [{'v': 1.0, 'timestamp': 0.0}])
     session = rec.tap('raw').wrap(inner).new_session()
 
-    session({keys.WALL_TIME_NS: 555, 'x': 1.0})  # no obs_time_ns
+    session({keys.WALL_TIME_NS: 555, 'x': 1.0}, 0.0)  # no obs_time_ns
     assert inner.last_session.seen_timeline_values == {'wall_time': 555}
 
 

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -136,11 +136,11 @@ def main(
 
     rec = Recorder(pos3.sync(output_dir))
     tapped = rec.tap(_TAP).wrap(blocking(policy))
-    session = tapped.new_session({keys.TASK: task} if task else None, time.time)
+    session = tapped.new_session({keys.TASK: task} if task else None)
     meta = dict(session.meta)
     name = label or _recording_name(meta)
     try:
-        actions = session(obs)
+        actions = session(obs, now_ns / 1e9)
         if actions is not None:
             actions = [a for a in actions if is_action(a)]  # drop the codec's keyless validity sentinel
         n = 0 if actions is None else len(actions)

--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -140,7 +140,7 @@ def main(
     meta = dict(session.meta)
     name = label or _recording_name(meta)
     try:
-        actions = session(obs, now_ns / 1e9)
+        actions = session(obs, now_ns)
         if actions is not None:
             actions = [a for a in actions if is_action(a)]  # drop the codec's keyless validity sentinel
         n = 0 if actions is None else len(actions)

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -369,7 +369,7 @@ class _JointposChunks(Policy):
         self.chunk_len = chunk_len
         self.chunks = 0
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         return _JointposChunkSession(self)
 
 
@@ -377,7 +377,7 @@ class _JointposChunkSession(Session):
     def __init__(self, policy: _JointposChunks):
         self._policy = policy
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self._policy.chunks += 1
         return [
             {keys.ROBOT_COMMAND: self._policy.command, 'target_grip': self._policy.chunks * 100.0 + i}

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -377,7 +377,7 @@ class _JointposChunkSession(Session):
     def __init__(self, policy: _JointposChunks):
         self._policy = policy
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self._policy.chunks += 1
         return [
             {keys.ROBOT_COMMAND: self._policy.command, 'target_grip': self._policy.chunks * 100.0 + i}

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -126,7 +126,7 @@ class IdleSession(Session):
     def __init__(self, policy):
         self._policy = policy
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         self._policy.observations.append(obs)
         return []
 

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -126,7 +126,7 @@ class IdleSession(Session):
     def __init__(self, policy):
         self._policy = policy
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         self._policy.observations.append(obs)
         return []
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -261,7 +261,7 @@ class _DreamZeroSession(Session):
         self._client = client
         self._session_id = session_id
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         obs = dict(obs)
         obs[roboarena.SESSION_ID] = self._session_id
         action_array = np.asarray(self._client.infer(obs))

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -261,7 +261,7 @@ class _DreamZeroSession(Session):
         self._client = client
         self._session_id = session_id
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         obs = dict(obs)
         obs[roboarena.SESSION_ID] = self._session_id
         action_array = np.asarray(self._client.infer(obs))
@@ -286,7 +286,7 @@ class DreamZeroPolicy(Policy):
     def __init__(self, sp: DreamZeroSubprocess):
         self._subprocess = sp
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         client = RoboarenaClient(port=self._subprocess.roboarena_port)
         client.connect()
         return _DreamZeroSession(client, str(uuid.uuid4()))

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -204,7 +204,7 @@ class _Gr00tSession(Session):
     def __init__(self, client: PolicyClient):
         self._client = client
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         action_response, _info = self._client.get_action(obs)
         action = {k: v[0] for k, v in action_response.items()}
         lengths = {len(v) for v in action.values()}
@@ -220,7 +220,7 @@ class Gr00tPolicy(Policy):
         self._groot = groot
         self._checkpoint_path = checkpoint_path
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self._groot.client.reset()
         return _Gr00tSession(self._groot.client)
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -204,7 +204,7 @@ class _Gr00tSession(Session):
     def __init__(self, client: PolicyClient):
         self._client = client
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         action_response, _info = self._client.get_action(obs)
         action = {k: v[0] for k, v in action_response.items()}
         lengths = {len(v) for v in action.values()}

--- a/positronic/vendors/lerobot/policy.py
+++ b/positronic/vendors/lerobot/policy.py
@@ -38,7 +38,7 @@ class _LerobotSession(Session):
         self._device = device
         self._meta = meta
 
-    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
+    def __call__(self, obs: dict[str, Any], time: float) -> list[dict[str, Any]]:
         obs_int = {}
         for key, val in obs.items():
             if key == TASK_FIELD:
@@ -102,7 +102,7 @@ class LerobotPolicy(Policy):
         """The checkpoint's own declaration of what this policy takes."""
         return self._policy.config
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         self._policy.reset()
         return _LerobotSession(self._policy, self._preprocessor, self._postprocessor, self._device, self._meta)
 

--- a/positronic/vendors/lerobot/policy.py
+++ b/positronic/vendors/lerobot/policy.py
@@ -38,7 +38,7 @@ class _LerobotSession(Session):
         self._device = device
         self._meta = meta
 
-    def __call__(self, obs: dict[str, Any], time: float) -> list[dict[str, Any]]:
+    def __call__(self, obs: dict[str, Any], time_ns: int) -> list[dict[str, Any]]:
         obs_int = {}
         for key, val in obs.items():
             if key == TASK_FIELD:

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -92,7 +92,7 @@ class LerobotPolicy(Policy):
             self._answer: Answer | None = None
             self._cancelled = False
 
-        def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
+        def __call__(self, obs: dict[str, Any], time: float) -> list[dict[str, Any]] | None:
             if self._answer is None:
                 self._answer = self._rt.fns[LerobotPolicy._INFER](obs)
                 return None
@@ -120,7 +120,7 @@ class LerobotPolicy(Policy):
         self._policy = policy.to(self._device)
         self._meta = extra_meta or {}
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         if rt is None:
             raise ValueError('A lerobot session runs its model on a runtime: pass rt to new_session.')
         self._policy.reset()

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -92,7 +92,7 @@ class LerobotPolicy(Policy):
             self._answer: Answer | None = None
             self._cancelled = False
 
-        def __call__(self, obs: dict[str, Any], time: float) -> list[dict[str, Any]] | None:
+        def __call__(self, obs: dict[str, Any], time_ns: int) -> list[dict[str, Any]] | None:
             if self._answer is None:
                 self._answer = self._rt.fns[LerobotPolicy._INFER](obs)
                 return None

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -32,7 +32,7 @@ class _MolmoAct2Session(Session):
         self._num_steps = num_steps
         self._meta = meta
 
-    def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]]:
+    def __call__(self, obs: dict[str, Any], time: float) -> list[dict[str, Any]]:
         # predict_action is decorated @torch.no_grad() and manages its own precision: the model loads
         # in bfloat16 and runs bf16 throughout (its autocast path only guards fp32 inputs), so an
         # external torch.inference_mode() / torch.autocast wrap or a detach() would all be redundant.
@@ -66,7 +66,7 @@ class MolmoAct2Policy(Policy):
         self._num_steps = num_steps
         self._meta = {keys.TYPE: 'molmoact2', 'norm_tag': norm_tag}
 
-    def new_session(self, context=None, now=None, rt=None) -> Session:
+    def new_session(self, context=None, rt=None) -> Session:
         return _MolmoAct2Session(self._model, self._processor, self._norm_tag, self._num_steps, self._meta)
 
     @property

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -32,7 +32,7 @@ class _MolmoAct2Session(Session):
         self._num_steps = num_steps
         self._meta = meta
 
-    def __call__(self, obs: dict[str, Any], time: float) -> list[dict[str, Any]]:
+    def __call__(self, obs: dict[str, Any], time_ns: int) -> list[dict[str, Any]]:
         # predict_action is decorated @torch.no_grad() and manages its own precision: the model loads
         # in bfloat16 and runs bf16 throughout (its autocast path only guards fp32 inputs), so an
         # external torch.inference_mode() / torch.autocast wrap or a detach() would all be redundant.

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -128,7 +128,7 @@ class _OpenpiSession(Session):
     def __init__(self, client: WebsocketClientPolicy):
         self._client = client
 
-    def __call__(self, obs, time):
+    def __call__(self, obs, time_ns):
         response = self._client.infer(obs)
         actions = response['actions']
         return [{'action': a} for a in actions]

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -128,7 +128,7 @@ class _OpenpiSession(Session):
     def __init__(self, client: WebsocketClientPolicy):
         self._client = client
 
-    def __call__(self, obs):
+    def __call__(self, obs, time):
         response = self._client.infer(obs)
         actions = response['actions']
         return [{'action': a} for a in actions]
@@ -140,7 +140,7 @@ class OpenpiPolicy(Policy):
     def __init__(self, subproc: OpenpiSubprocess):
         self._subproc = subproc
 
-    def new_session(self, context=None, now=None, rt=None):
+    def new_session(self, context=None, rt=None):
         client = self._subproc.client
         client.reset()
         return _OpenpiSession(client)


### PR DESCRIPTION
Rung 6 of #661.

## What changes

`Session.__call__(obs)` becomes `Session.__call__(obs, time_ns)`, where `time_ns` is the caller's clock reading in nanoseconds — the same scale the observation's `obs_time_ns` carries. The clock itself leaves the policy API: the `Now` alias, the `now` argument of `Policy.new_session` and of `Layer.make_session`, and every caller that supplied one.

`ChunkedSchedule` was the one layer that used the clock. It anchors a chunk with the call's `time_ns` and converts once, where it writes a `timestamp` in seconds. Its "needs a clock" `ValueError` goes: a caller can no longer fail to supply one.

The harness reads its world clock one time per call and passes the reading down. Each other driver passes its own reading: the offboard server and the warmup read the wall clock, `probe` passes the instant it stamped its observation with. None of them converts, because they all already hold nanoseconds.

`base.py` loses its one mention of the harness, which sat in the docstring of the `now` argument. `Layer.make_session` also loses `context`: no layer reads it, and the target design's signature does not carry it.

## Behaviour

The harness path is unchanged, and `positronic/policy/tests/golden_pipeline.json.gz` does not move. `ChunkedSchedule` anchors on the call where the `Answer` resolves, and no session call blocks since #673, so the reading taken at the start of that call equals what `now()` returned after the inner call.

One path does change. `blocking()` waits inside one call, so a layer under it anchors the chunk before the wait rather than after it. That reaches `probe` and the server's warmup, neither of which plays the chunk. `blocking()`'s docstring states it.

## Known limits

- The server passes `time.time_ns()` where it passed `now=None` before. A scheduling layer placed right of the `remote` marker now anchors against the server's clock instead of refusing to run. The rig's `MAX_ACTION_SKEW_SEC` check still catches the result.
- `layers.py` names the harness in three comments this rung does not rewrite. #661's invariant is not met yet.

## Test plan

`uv run --locked pytest`: 1677 passed, 8 skipped. ruff clean, basedpyright 0 errors. The golden file is byte-identical (md5 `4ce319042d23a50c9c9726135cd5cc3a`).

