### PR TITLE
Read a remote policy's auth headers from a file named by path

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -56,7 +56,7 @@ uv run positronic-inference sim \
 
 Accepted forms: `host`, `host:port`, and `https://host[:port][/api/v1/session[/<model_id>]]` (`http`, `ws` and `wss` work too), each with an optional query. `https`/`wss` enable TLS. An omitted port is the scheme's own — 443 for TLS and 80 otherwise — so name the port a server listens on (`:8000` for every vendor server's default). Naming no model id serves the checkpoint the server pinned at startup.
 
-**Credentials stay out of the URL**, which is meant to be safe to paste around: they ride headers instead. A server gated on a bearer token — whether it checks the token itself, as every endpoint [`workflows/nebius/serve.sh`](../workflows/nebius/README.md) creates does, or sits behind a proxy that checks it — is reached with `.authed_remote`, which reads the token from `AUTH_TOKEN` and raises if it is unset. For any other scheme, name the headers yourself: `--policy.headers='{"Modal-Key": "..."}'`.
+**Credentials stay out of the URL**, which is meant to be safe to paste around: they ride headers instead. A server gated on a bearer token — whether it checks the token itself, as every endpoint [`workflows/nebius/serve.sh`](../workflows/nebius/README.md) creates does, or sits behind a proxy that checks it — is reached with `.authed_remote`, which reads the token from `AUTH_TOKEN` and raises if it is unset. For any other scheme, write the headers as a JSON object in a file and name the file: `.file_authed_remote` with `--policy.headers.path=~/.config/endpoint/headers.json`.
 
 ```bash
 uv run positronic-inference sim \
@@ -69,7 +69,15 @@ uv run positronic-inference sim \
 
 The model source (`checkpoints_dir`, `checkpoint`, device...) is fixed at server launch — `source.*` params are rejected; name a checkpoint in the URL path instead. Bad params fail at connect with a clear server error. Full rules in the [Offboard README](../positronic/offboard/README.md).
 
-**Credentials stay out of the URL.** `--policy.headers='{"Modal-Key": "..."}'` passes auth headers for a fronted endpoint, so the URL itself is safe to paste around. Against a Nebius endpoint use `.authed_remote` or `.nebius_remote`, which build the bearer header for you (see [the Nebius workflow README](../workflows/nebius/README.md#authenticated-inference)).
+**Credentials stay out of the URL, and out of the command line.** `.file_authed_remote` reads a fronted endpoint's auth headers from the JSON file at `--policy.headers.path`, so neither the URL nor `sys.argv` carries one — and `save_run_metadata()` writes `sys.argv` beside the run's episodes. Against a Nebius endpoint use `.authed_remote` or `.nebius_remote`, which build the bearer header for you (see [the Nebius workflow README](../workflows/nebius/README.md#authenticated-inference)).
+
+```bash
+uv run positronic-inference sim \
+  --policy=.file_authed_remote \
+  --policy.url=https://<endpoint-managed-url> \
+  --policy.headers.path=~/.config/endpoint/headers.json \
+  --output_dir=~/datasets/inference_logs/exp_v1
+```
 
 **What crosses the wire is the server's call, not the client's.** A server that wants smaller frames declares `RestrictImageSize` in its rig-side stack (640x640 by default); one behind a proxy with a message-size cap declares `remote(compress_images=True)` and the rig JPEG-encodes frames before sending. A server whose checkpoint speaks a different end-effector frame declares `ChangeEEFrame` with the transform placing that frame relative to the rig's `default`, and the rig converts poses (see [End-effector frames](codecs.md#end-effector-frames)). The client builds whatever the handshake declares, and only that — connecting to a server that declares no stack fails with an error naming the version it runs. What the declared stack must achieve is checked where it matters: the harness refuses to emit an action scheduled further than `MAX_ACTION_SKEW_SEC` from now, which is what a stack that never anchored its chunk to the rig's clock produces.
 

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -1,4 +1,6 @@
+import json
 import os
+from pathlib import Path
 
 import configuronic as cfn
 
@@ -38,7 +40,29 @@ def nebius_bearer_headers():
     return {AUTH_HEADER: bearer(nebius.auth_token())}
 
 
-# Neither carries a default URL: it names one specific endpoint, and a token must not be handed to
-# whichever host a stale default points at.
+@cfn.config()
+def file_headers(path: str) -> dict[str, str]:
+    """The header set at ``path``: a JSON object of header name to value.
+
+    A path, so no credential reaches this process's command line.
+    """
+    file = Path(path).expanduser()
+    try:
+        parsed = json.loads(file.read_text())
+    except Exception as exc:
+        problem = f'could not be read as a header set ({type(exc).__name__})'
+    else:
+        if isinstance(parsed, dict) and parsed and all(isinstance(s, str) for kv in parsed.items() for s in kv):
+            return parsed
+        problem = 'must hold a JSON object of at least one header, every name and value a string'
+        del parsed  # A frame's locals reach a traceback that renders them, and this frame raises below.
+    # `from None`: a failed read or parse keeps what it choked on, a `UnicodeDecodeError` its whole
+    # byte string, and a chained cause carries that into the traceback.
+    raise ValueError(f'{file}: {problem}') from None
+
+
+# None of these carries a default URL: each names one specific endpoint, and a credential must not be
+# handed to whichever host a stale default points at.
 authed_remote = cfn.Config(RemotePolicy, headers=bearer_headers)
 nebius_remote = cfn.Config(RemotePolicy, headers=nebius_bearer_headers)
+file_authed_remote = cfn.Config(RemotePolicy, headers=file_headers)

--- a/positronic/cfg/policy.py
+++ b/positronic/cfg/policy.py
@@ -61,8 +61,7 @@ def file_headers(path: str) -> dict[str, str]:
     raise ValueError(f'{file}: {problem}') from None
 
 
-# None of these carries a default URL: each names one specific endpoint, and a credential must not be
-# handed to whichever host a stale default points at.
+# The caller names the URL: a default would hand the credential to whatever host it points at.
 authed_remote = cfn.Config(RemotePolicy, headers=bearer_headers)
 nebius_remote = cfn.Config(RemotePolicy, headers=nebius_bearer_headers)
 file_authed_remote = cfn.Config(RemotePolicy, headers=file_headers)

--- a/positronic/cfg/tests/test_policy.py
+++ b/positronic/cfg/tests/test_policy.py
@@ -1,0 +1,49 @@
+import json
+
+import pytest
+
+from positronic.cfg.policy import file_headers
+
+SECRET = 'ak-do-not-print-me'
+
+
+def test_file_headers_reads_the_json_object(tmp_path):
+    path = tmp_path / 'headers.json'
+    path.write_text(json.dumps({'Modal-Key': SECRET, 'Modal-Secret': 'as-also-secret'}))
+
+    assert file_headers(path=str(path)) == {'Modal-Key': SECRET, 'Modal-Secret': 'as-also-secret'}
+
+
+def test_file_headers_expands_a_tilde_path(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    (tmp_path / 'headers.json').write_text(json.dumps({'X-Api-Key': SECRET}))
+
+    assert file_headers(path='~/headers.json') == {'X-Api-Key': SECRET}
+
+
+def test_file_headers_names_a_path_it_could_not_read(tmp_path):
+    absent = tmp_path / 'absent.json'
+
+    with pytest.raises(ValueError) as excinfo:
+        file_headers(path=str(absent))
+
+    assert str(absent) in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    'content',
+    [json.dumps([SECRET]), json.dumps({'Modal-Key': [SECRET]}), json.dumps({}), f'Modal-Key: {SECRET}', SECRET],
+    ids=['array', 'non-string value', 'empty object', 'not json', 'bare token'],
+)
+def test_file_headers_refuses_what_is_not_a_header_set_without_quoting_it(tmp_path, content):
+    """The refusal names the path and quotes nothing from the content, by message or by chain."""
+    path = tmp_path / 'headers.json'
+    path.write_text(content)
+
+    with pytest.raises(ValueError) as excinfo:
+        file_headers(path=str(path))
+
+    assert str(path) in str(excinfo.value)
+    assert SECRET not in str(excinfo.value)
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__


### PR DESCRIPTION
`positronic.cfg.policy` takes a header set as a value, so authenticating to a Modal-served endpoint means writing `--policy.headers='{"Modal-Key": ...}'` on the command line. The credential then sits in three places nobody clears it out of: `/proc/<pid>/cmdline` for the life of the process, readable by every account on the box; the run log, which echoes the invocation it was launched with; and `run_metadata_*.yaml`, whose `command` field is `sys.argv.copy()` (`positronic/utils/__init__.py:182`) and which `save_run_metadata()` writes into the run's output directory — and therefore into the S3 prefix the episodes are delivered through. On a partner round that is their credential shipping out with their data.

This adds `file_headers`, which reads the set from a JSON file the command line names by path, and `file_authed_remote`, which composes it with `RemotePolicy` beside `authed_remote` and `nebius_remote`. `--policy.headers.path=~/.config/rollout/headers.json` puts a path in argv and nothing else. `docs/inference.md` names that form in both places it covers a fronted endpoint; a grep over every markdown file finds no credential-bearing header example left.

The header set is a file rather than two more environment variables because an endpoint on a managed tunnel authenticates with a bearer token that has no Modal pair to compose, so the shape has to stay arbitrary name/value. It carries no default URL, for the reason the comment above `authed_remote` already gives: nothing about a file on disk says which host its credential belongs to, so the argument holds harder here than it does for the environment.

`path` stays `str` and converts on the first line of the body. configuronic parses a CLI value with `ast.literal_eval` and falls back to `str`, so a `Path` annotation would describe something that never arrives — the same reasoning, and the same ticket, as the note on `prepare_output_dir` in `positronic/cli/eval/run.py`. `~` expands, per #616.

A file that is missing, unreadable, not JSON, not an object, empty, or holding a non-string name or value is refused. The refusal names the path, takes the failure's type name and nothing else from what went wrong, and is raised unchained with the parsed content already out of the frame. A file that fails one check is normally carrying live credentials in the rest of it, so a message quoting the offender re-leaks one while claiming to validate; and a chained `JSONDecodeError` keeps the whole document on `.doc`, where any traceback renderer that shows exception attributes will print it.

The prior art is `rollouts_console.cfg.endpoint_headers` on the platform side, which closed the same hole for the batch launcher (internal#437). That distribution pins an old positronic, so the library itself still had no file path to offer — this closes it at the layer every consumer reaches. Tracked as internal#762.

Verified: five tests pin the refusal path, and they were run against a naive implementation that quotes the content and chains the cause. All five fail there — on the message for a JSON array, on the chain for a non-JSON file. Separately, `file_authed_remote.override(url=..., **{'headers.path': p})` was instantiated end to end: the headers reach the client and `sys.argv` holds only the path.

The header names in the tests are arbitrary fixture data. `file_headers` never matches on a header name — it returns whatever the file holds — so they are not a contract anything else spells back.

<!-- opened-by: posi-agent -->