### PR TITLE
Say which level a checkpoints_dir is wrong at

### DIFF
--- a/positronic/utils/checkpoints.py
+++ b/positronic/utils/checkpoints.py
@@ -4,6 +4,10 @@ import pos3
 
 logger = logging.getLogger(__name__)
 
+# Orbax writes this beside one checkpoint's own payload, and nothing writes it beside numbered checkpoint
+# dirs — so a directory holding it is a checkpoint, and the caller passed a path one level too deep.
+_ORBAX_CHECKPOINT_MARKER = '_CHECKPOINT_METADATA'
+
 
 def list_checkpoints(checkpoints_dir: str, prefix: str = '') -> list[str]:
     """List available checkpoint subdirectories in a checkpoints directory.
@@ -22,6 +26,11 @@ def list_checkpoints(checkpoints_dir: str, prefix: str = '') -> list[str]:
                 checkpoint_nums.append((int(candidate), name))
 
     if not checkpoint_nums:
+        if _ORBAX_CHECKPOINT_MARKER in children:
+            raise ValueError(
+                f'No checkpoint found in {checkpoints_dir}: it is a single checkpoint, not a checkpoints '
+                f'directory. Pass the parent experiment directory, which holds the numbered checkpoints.'
+            )
         raise ValueError(f'No checkpoint found in {checkpoints_dir}. Available files: {children}')
 
     checkpoint_nums.sort(key=lambda pair: pair[0])

--- a/positronic/utils/tests/test_checkpoints.py
+++ b/positronic/utils/tests/test_checkpoints.py
@@ -1,3 +1,5 @@
+import pytest
+
 from positronic.utils import checkpoints as checkpoint_utils
 
 
@@ -14,3 +16,28 @@ def test_list_checkpoints_lists_numeric_checkpoints_sorted(monkeypatch):
     monkeypatch.setattr(checkpoint_utils.pos3, 'ls', fake_ls)
     checkpoints = checkpoint_utils.list_checkpoints('s3://bucket/exp/checkpoints/', prefix='')
     assert checkpoints == ['1', '2', '10']
+
+
+def test_list_checkpoints_names_the_parent_when_given_one_checkpoint(monkeypatch):
+    def fake_ls(_path: str, *, recursive: bool = False):
+        return [
+            's3://bucket/exp/checkpoints/199999/_CHECKPOINT_METADATA',
+            's3://bucket/exp/checkpoints/199999/assets/',
+            's3://bucket/exp/checkpoints/199999/params/',
+            's3://bucket/exp/checkpoints/199999/train_state/',
+        ]
+
+    monkeypatch.setattr(checkpoint_utils.pos3, 'ls', fake_ls)
+    with pytest.raises(ValueError, match='parent experiment directory'):
+        checkpoint_utils.list_checkpoints('s3://bucket/exp/checkpoints/199999/')
+
+
+def test_list_checkpoints_reports_a_directory_without_the_marker_generically(monkeypatch):
+    """``assets`` sits beside numbered checkpoints, so it never marks a directory as one checkpoint."""
+
+    def fake_ls(_path: str, *, recursive: bool = False):
+        return ['s3://bucket/exp/checkpoints/assets/', 's3://bucket/exp/checkpoints/params/']
+
+    monkeypatch.setattr(checkpoint_utils.pos3, 'ls', fake_ls)
+    with pytest.raises(ValueError, match=r'No checkpoint found in .*\. Available files:'):
+        checkpoint_utils.list_checkpoints('s3://bucket/exp/checkpoints/')

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -255,6 +255,28 @@ A `droid` server emits `JointDelta` commands; the driver applies each to the liv
 3. Check checkpoint directory structure: `checkpoints/<checkpoint-id>/`
 4. If using specific checkpoint, verify the checkpoint ID exists
 
+### Checkpoint directory one level too deep
+
+**Problem:** Server exits with "No checkpoint found in `<dir>`: it is a single checkpoint, not a checkpoints directory"
+
+**Solutions:**
+1. `--pipeline.source.checkpoints_dir` takes the experiment directory, which holds the numbered checkpoint
+   subdirectories — drop the trailing checkpoint number from the path
+2. A directory holding `_CHECKPOINT_METADATA`, `assets`, `params` and `train_state` is one checkpoint; its
+   parent is the experiment directory
+
+### Missing `ee_frame`
+
+**Problem:** Server exits with "TypeError: pipeline() missing 1 required positional argument: 'ee_frame'"
+
+**Solutions:**
+1. The EE pipelines (`serve`, `ee`, `ee_joints`, `ee_traj`, `ee_joints_traj`, `ee_flip_grip`) bind no
+   checkpoint, so they state no frame and require `--pipeline.ee_frame`. The `droid`, `droid_jointpos` and
+   `libero` deployments bind their own, which is why moving off one of them needs the flag added
+2. Pass `--pipeline.ee_frame=None` for a checkpoint trained in the rig's `default` frame
+3. Otherwise pass the frame the checkpoint speaks, relative to `default` —
+   `@positronic.drivers.roboarm.models.DROID_EE_FRAME` is the shipped one
+
 ### Action decoding fails
 
 **Problem:** Server returns error during action decoding


### PR DESCRIPTION
`--pipeline.source.checkpoints_dir` takes the experiment directory. Pointing it one level too deep, at a single checkpoint, listed that checkpoint's own contents:

```
ValueError: No checkpoint found in …/199999/.
Available files: ['_CHECKPOINT_METADATA', 'assets', 'params', 'train_state']
```

So the message read as a broken checkpoint rather than a path one level too deep, and cost a wrong diagnosis and a restart.

A directory holding orbax's `_CHECKPOINT_METADATA` is one checkpoint, and nothing writes that marker beside numbered checkpoint dirs. The error now reads `No checkpoint found in <dir>: it is a single checkpoint, not a checkpoints directory. Pass the parent experiment directory, which holds the numbered checkpoints.` `assets` and `params` are not markers — `stats.py` writes `assets` into the experiment directory itself, beside the numbered checkpoints.

One test fails without the marker check. A second fails if the marker reaches as far as `assets`. Both were run against a deliberately broken predicate to confirm each fails for its own reason. An experiment directory with no checkpoints and no marker still gets the existing generic message.

The openpi README's Troubleshooting section gains that symptom, and a second one for `TypeError: pipeline() missing 1 required positional argument: 'ee_frame'`. The EE pipelines bind no checkpoint, so they state no frame and require `--pipeline.ee_frame`; the `droid`, `droid_jointpos` and `libero` deployments bind their own, which is why moving off one of them needs the flag added. `ee_frame` keeps its lack of a default, for the reason `server.py` already states: a missing frame does not error, it puts the arm somewhere else, so a deployment omitting one would be indistinguishable from one that means `None`.

<!-- opened-by: posi-agent -->