### PR TITLE
Stop the openpi subprocess from taking the whole GPU

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -92,6 +92,26 @@ jobs:
           PYTHONPATH: ${{ env.PYTHONPATH }}:$PWD
         run: uv run pytest positronic/vendors/lerobot/tests
 
+  openpi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable caching
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv venv --python 3.13
+
+      - name: Install dependencies
+        run: uv sync --locked --extra openpi
+
+      - name: Run openpi vendor tests
+        env:
+          PYTHONPATH: ${{ env.PYTHONPATH }}:$PWD
+        run: uv run pytest positronic/vendors/openpi/tests
+
   lockfile-portability:
     strategy:
       fail-fast: false

--- a/docker/CONTEXTS.md
+++ b/docker/CONTEXTS.md
@@ -31,6 +31,12 @@ When running `docker --context <remote> compose run ...`, volume paths in `docke
 CACHE_ROOT=/home/<user> docker --context vm-train compose run -d --service-ports openpi-server ...
 ```
 
+## Restart policy
+
+Start a container with `--restart on-failure:2`, not `--restart unless-stopped`. A container that crashes and
+restarts reports `Up 1 second` to every `docker ps`, which reads as a slow start. A restart policy that hides a
+crash costs more than the crash.
+
 ## VM management
 
 Start: `../internal/scripts/start.sh train`

--- a/docker/CONTEXTS.md
+++ b/docker/CONTEXTS.md
@@ -34,8 +34,8 @@ CACHE_ROOT=/home/<user> docker --context vm-train compose run -d --service-ports
 ## Restart policy
 
 Start a container with `--restart on-failure:2`, not `--restart unless-stopped`. A container that crashes and
-restarts reports `Up 1 second` to every `docker ps`, which reads as a slow start. A restart policy that hides a
-crash costs more than the crash.
+restarts reports `Up 1 second` to every `docker ps`, which reads as a slow start. `on-failure:2` stops the
+container after the second crash, so `docker ps` shows it dead and `docker logs` gives the fault.
 
 ## VM management
 

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -142,6 +142,26 @@ emits absolute `JointPosition` chunks executed at RoboLab's leaderboard cadence 
 - `--recording_dir`: (Optional) Directory for server-side `.rrd` recordings (local or S3)
 - `--idle_timeout_min`: (Optional) Shut down after this many minutes without activity
 
+### Serving More Than One Policy On One GPU
+
+The server starts its OpenPI subprocess with `XLA_PYTHON_CLIENT_PREALLOCATE=false`, so JAX allocates on
+demand. JAX otherwise takes ~75% of the device at its first use, and a second server on that GPU then fails
+with `RESOURCE_EXHAUSTED` while `nvidia-smi` reports the device almost free.
+
+With no preallocation, `XLA_PYTHON_CLIENT_MEM_FRACTION` is a hard cap on what one server allocates. Set it
+per container when you co-host N policies. Leave it unset for one policy: a cap that is too low makes a large
+model fail with the same `RESOURCE_EXHAUSTED`. Three policies held 30.4 GB together on an 80 GB H100 with
+`XLA_PYTHON_CLIENT_MEM_FRACTION=.25`.
+
+The `openpi-server-8001` service is a second server on the same machine, on host port 8001:
+
+```bash
+docker compose run --rm --service-ports -e XLA_PYTHON_CLIENT_MEM_FRACTION=.25 \
+  -v ~/checkpoints:/checkpoints openpi-server-8001 ee \
+  --pipeline.source.checkpoints_dir=/checkpoints/openpi/pi05_positronic_lowmem/experiment_v2/ \
+  --pipeline.ee_frame=None
+```
+
 ### API Endpoints
 
 The server exposes the following endpoints:

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -73,8 +73,12 @@ class OpenpiSubprocess:
         """Start the subprocess and block until it accepts connections, reporting progress."""
         command = self._build_command()
         logger.info(f'Starting OpenPI subprocess: {" ".join(command)}')
+        env = os.environ.copy()
+        # JAX takes ~75% of the GPU at its first use, so a second server on that GPU finds none free.
+        # With no preallocation ``XLA_PYTHON_CLIENT_MEM_FRACTION`` caps each server. Set it per container.
+        env.setdefault('XLA_PYTHON_CLIENT_PREALLOCATE', 'false')
         # Don't pipeline stdout/stderr so we can see the output
-        self.process = subprocess.Popen(command, env=os.environ.copy(), cwd=str(self.openpi_root))
+        self.process = subprocess.Popen(command, env=env, cwd=str(self.openpi_root))
         self._wait_for_ready(on_progress)
 
     def _check_ready(self) -> bool:

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -24,6 +24,8 @@ from positronic.vendors.openpi import codecs, ensure_paligemma_tokenizer
 
 logger = logging.getLogger(__name__)
 
+PREALLOCATE_ENV = 'XLA_PYTHON_CLIENT_PREALLOCATE'
+
 
 ###########################################################################################
 # Subprocess manager for OpenPI WebSocket server
@@ -75,8 +77,7 @@ class OpenpiSubprocess:
         logger.info(f'Starting OpenPI subprocess: {" ".join(command)}')
         env = os.environ.copy()
         # JAX takes ~75% of the GPU at its first use, so a second server on that GPU finds none free.
-        # With no preallocation ``XLA_PYTHON_CLIENT_MEM_FRACTION`` caps each server. Set it per container.
-        env.setdefault('XLA_PYTHON_CLIENT_PREALLOCATE', 'false')
+        env.setdefault(PREALLOCATE_ENV, 'false')
         # Don't pipeline stdout/stderr so we can see the output
         self.process = subprocess.Popen(command, env=env, cwd=str(self.openpi_root))
         self._wait_for_ready(on_progress)

--- a/positronic/vendors/openpi/tests/test_server.py
+++ b/positronic/vendors/openpi/tests/test_server.py
@@ -1,0 +1,28 @@
+from unittest import mock
+
+import pytest
+
+pytest.importorskip('openpi_client')
+
+from positronic.vendors.openpi.server import OpenpiSubprocess  # noqa: E402
+
+
+def _subprocess_env(monkeypatch) -> dict[str, str]:
+    """The environment ``start`` gives the openpi subprocess."""
+    monkeypatch.setattr(OpenpiSubprocess, '_wait_for_ready', lambda self, on_progress: None)
+    with mock.patch('subprocess.Popen') as popen:
+        OpenpiSubprocess(checkpoint_dir='/checkpoints/exp/1000', config_name='pi05_positronic_lowmem').start()
+    return popen.call_args.kwargs['env']
+
+
+def test_the_subprocess_does_not_preallocate_the_gpu(monkeypatch):
+    """JAX takes ~75% of the device at its first use, which leaves a second server on that GPU none."""
+    monkeypatch.delenv('XLA_PYTHON_CLIENT_PREALLOCATE', raising=False)
+
+    assert _subprocess_env(monkeypatch)['XLA_PYTHON_CLIENT_PREALLOCATE'] == 'false'
+
+
+def test_the_preallocation_setting_of_the_environment_reaches_the_subprocess(monkeypatch):
+    monkeypatch.setenv('XLA_PYTHON_CLIENT_PREALLOCATE', 'true')
+
+    assert _subprocess_env(monkeypatch)['XLA_PYTHON_CLIENT_PREALLOCATE'] == 'true'

--- a/positronic/vendors/openpi/tests/test_server.py
+++ b/positronic/vendors/openpi/tests/test_server.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip('openpi_client')
 
-from positronic.vendors.openpi.server import OpenpiSubprocess  # noqa: E402
+from positronic.vendors.openpi.server import PREALLOCATE_ENV, OpenpiSubprocess  # noqa: E402
 
 
 def _subprocess_env(monkeypatch) -> dict[str, str]:
@@ -17,12 +17,12 @@ def _subprocess_env(monkeypatch) -> dict[str, str]:
 
 def test_the_subprocess_does_not_preallocate_the_gpu(monkeypatch):
     """JAX takes ~75% of the device at its first use, which leaves a second server on that GPU none."""
-    monkeypatch.delenv('XLA_PYTHON_CLIENT_PREALLOCATE', raising=False)
+    monkeypatch.delenv(PREALLOCATE_ENV, raising=False)
 
-    assert _subprocess_env(monkeypatch)['XLA_PYTHON_CLIENT_PREALLOCATE'] == 'false'
+    assert _subprocess_env(monkeypatch)[PREALLOCATE_ENV] == 'false'
 
 
 def test_the_preallocation_setting_of_the_environment_reaches_the_subprocess(monkeypatch):
-    monkeypatch.setenv('XLA_PYTHON_CLIENT_PREALLOCATE', 'true')
+    monkeypatch.setenv(PREALLOCATE_ENV, 'true')
 
-    assert _subprocess_env(monkeypatch)['XLA_PYTHON_CLIENT_PREALLOCATE'] == 'true'
+    assert _subprocess_env(monkeypatch)[PREALLOCATE_ENV] == 'true'


### PR DESCRIPTION
JAX preallocates \~75% of the GPU at its first use. `OpenpiSubprocess.start` launched the
openpi server with the inherited environment, so the first server on a GPU claimed the device
and a second one died with `RESOURCE_EXHAUSTED: Out of memory while trying to allocate
2415919104 bytes` while `nvidia-smi` read 12.7 GB used of 81.5 GB — 84% of the device free.

`docker/docker-compose.yml` ships an `openpi-server-8001` service whose only purpose is a
second openpi server on one box, so this was a shipped configuration that could not work.

Ticket: [internal#774 — openpi server preallocates the whole GPU](https://github.com/Positronic-Robotics/internal/issues/774)

## What this ships

- `positronic/vendors/openpi/server.py` — `start` sets `XLA_PYTHON_CLIENT_PREALLOCATE=false`
  on the subprocess environment with `setdefault`, so an operator-set value survives.
  `PREALLOCATE_ENV` holds the name, and the test imports it.
- `positronic/vendors/openpi/tests/test_server.py` — the subprocess gets `false` by default,
  and an environment that already names the variable reaches it unchanged. The first fails
  without the fix; the second fails if `setdefault` becomes an assignment.
- `positronic/vendors/openpi/README.md` — a section under *4. Serve Inference* on serving
  more than one policy on one GPU, with the `openpi-server-8001` invocation.
- `docker/CONTEXTS.md` — a restart policy note: `--restart unless-stopped` reports a
  crash-looping container as `Up 1 second` to every `docker ps`.
- `.github/workflows/unit-test.yaml` — an `openpi` job, mirroring `lerobot`. The new test
  needs `openpi_client`, which no job installed, so `pytest.importorskip` would otherwise
  have skipped it everywhere.

## No default for `XLA_PYTHON_CLIENT_MEM_FRACTION`

With no preallocation that variable is a hard cap on total allocation, so a default would
fail a large model in the ordinary single-tenant case. It is a deployment knob: the README
gives the per-container form and the measured figures — `.25` held three policies in 30.4 GB
on an 80 GB H100.

`positronic/vendors/openpi/train.py` keeps its own `XLA_PYTHON_CLIENT_MEM_FRACTION=0.995`.
That is single-tenant training and wants the device.

<!-- opened-by: posi-agent -->