### PR TITLE
Match the raise-abandons test doubles to the current session signatures

### DIFF
--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1163,11 +1163,11 @@ def test_an_episode_abandoned_by_a_raise_withdraws_the_deadline(world):
     """An episode a raise abandons withdraws its deadline like any other close."""
 
     class _BoomSession(Session):
-        def __call__(self, obs):
+        def __call__(self, obs, time_ns):
             raise RuntimeError('inference boom')
 
     class _BoomPolicy(Policy):
-        def new_session(self, context=None, now=None, rt=None):
+        def new_session(self, context=None, rt=None):
             return _BoomSession()
 
     harness = Harness(_BoomPolicy(), make_embodiment())


### PR DESCRIPTION
`main` is red at 917111a0 — both `Check code style` and `Run unit tests` fail, on the same two lines.

`_BoomSession.__call__` took `(obs)` and `_BoomPolicy.new_session` took `(context, now, rt)`. basedpyright rejects both as incompatible overrides, and the harness calls the session with the time, so the test raises `TypeError: __call__() takes 2 positional arguments but 3 were given` at `harness.py:61` on every platform in the matrix.

## Why it got in

Neither pull request was wrong on its own.

- #676 changed `Session.__call__` to take `time_ns` and `Policy.new_session` to take `rt`.
- #662 wrote this test against the signatures as they stood before it, and merged after.

Each was green alone. A type checker only sees an override against its base once both are on one branch, so the pair is red and neither PR's own CI could have caught it.

## Scope

Every other double in `test_harness.py` already uses these signatures. A grep over `main` for the stale shapes returns these two methods and nothing else:

    git grep -nE "def __call__\(self, obs\):" origin/main -- '*.py'
    git grep -nE "def new_session\(self.*\bnow\b" origin/main -- '*.py'

## Verified

- `uv run --locked basedpyright` — 0 errors, 0 warnings (was 2 errors)
- `uv run --locked pytest positronic/policy/tests/test_harness.py` — 78 passed
- `ruff check` and `ruff format --check` clean

<!-- opened-by: posi-agent -->
