### PR TITLE
Narrow a run's published scores to the value a board ranks on

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -12,7 +12,7 @@ The library depends on `pydantic` and `httpx` and nothing else, so a service tha
 platform installs it on its own, at the exact version it was written against:
 
 ```bash
-uv add "positronic-platform-client==0.2.0"
+uv add "positronic-platform-client==0.3.0"
 ```
 
 `platform_client` never imports `positronic`. The commands a user drives it with — `positronic eval

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -30,10 +30,7 @@ PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 
 
 class Scores(BaseModel):
-    """A finished run's published score. `primary` holds the value a board ranks on.
-
-    The run's own `scores.json` holds the full record.
-    """
+    """A finished run's published score. `primary` holds the value a board ranks on."""
 
     primary: float | None = None
 

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -32,10 +32,9 @@ PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 class Scores(BaseModel):
     """A finished run's published score. `primary` holds the value a board ranks on.
 
-    The run's own `scores.json` holds more: the per-task counts, the episode count, and the number
-    of episodes that recorded no outcome. None of them changes a rank. A board is public, so a
-    field here goes to every competitor, and the per-task counts would tell them which task of the
-    eval is the hard one. A submitter reads their own per-task detail from the episodes they get.
+    The run's own `scores.json` holds the full record: the per-task counts, the episode count and
+    the number of episodes that recorded no outcome. A board is public and ranks on `primary`
+    alone, so this model publishes none of them.
     """
 
     primary: float | None = None

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -29,12 +29,23 @@ def _public(status: SubmissionStatus) -> SubmissionStatus:
 PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 
 
+class TaskScore(BaseModel):
+    """One task's trials, with the count beside the share."""
+
+    trials: int
+    successes: int
+    success_rate: float
+
+
 class Scores(BaseModel):
-    """The scorer's output for a finished run. `primary` is the value a board ranks on."""
+    """The scorer's output for a finished run. `primary` is the value a board ranks on.
+
+    `per_task` pairs each rate with the counts it rests on.
+    """
 
     primary: float | None = None
     success_rate: float | None = None
-    per_task: dict[str, float] = Field(default_factory=dict)
+    per_task: dict[str, TaskScore] = Field(default_factory=dict)
     episodes: int = 0
     unscored: int = 0
 

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -29,25 +29,16 @@ def _public(status: SubmissionStatus) -> SubmissionStatus:
 PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 
 
-class TaskScore(BaseModel):
-    """One task's trials, with the count beside the share."""
-
-    trials: int
-    successes: int
-    success_rate: float
-
-
 class Scores(BaseModel):
-    """The scorer's output for a finished run. `primary` is the value a board ranks on.
+    """A finished run's published score. `primary` holds the value a board ranks on.
 
-    `per_task` pairs each rate with the counts it rests on.
+    The run's own `scores.json` holds more: the per-task counts, the episode count, and the number
+    of episodes that recorded no outcome. None of them changes a rank. A board is public, so a
+    field here goes to every competitor, and the per-task counts would tell them which task of the
+    eval is the hard one. A submitter reads their own per-task detail from the episodes they get.
     """
 
     primary: float | None = None
-    success_rate: float | None = None
-    per_task: dict[str, TaskScore] = Field(default_factory=dict)
-    episodes: int = 0
-    unscored: int = 0
 
 
 # The rule keys a caller matches on: a 429 names one in its `details`, and `quota_for` takes one.

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -30,7 +30,7 @@ PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 
 
 class Scores(BaseModel):
-    """A finished run's published score. `primary` holds the value a board ranks on."""
+    """A finished run's published score. `primary` is its value under the eval's primary metric."""
 
     primary: float | None = None
 

--- a/client/platform_client/responses.py
+++ b/client/platform_client/responses.py
@@ -32,9 +32,7 @@ PublicStatus = Annotated[Slugged[SubmissionStatus], AfterValidator(_public)]
 class Scores(BaseModel):
     """A finished run's published score. `primary` holds the value a board ranks on.
 
-    The run's own `scores.json` holds the full record: the per-task counts, the episode count and
-    the number of episodes that recorded no outcome. A board is public and ranks on `primary`
-    alone, so this model publishes none of them.
+    The run's own `scores.json` holds the full record.
     """
 
     primary: float | None = None

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -51,7 +51,6 @@ from platform_client.responses import (
     SubmissionListResponse,
     SubmissionListRow,
     SubmissionView,
-    TaskScore,
 )
 from platform_client.slug import slug_of
 from pydantic import BaseModel, Tag, TypeAdapter, ValidationError
@@ -60,13 +59,7 @@ AT = datetime(2026, 3, 4, 5, 6, 7, tzinfo=UTC)
 SUB = SubmissionId(0x1F)
 USER = UserId(0xA0)
 
-SCORES = Scores(
-    primary=0.75,
-    success_rate=0.5,
-    per_task={'banana_in_bowl': TaskScore(trials=4, successes=3, success_rate=0.75)},
-    episodes=4,
-    unscored=0,
-)
+SCORES = Scores(primary=0.75)
 
 DAILY = QuotaLimit(
     key=QUOTA_SUBMISSIONS_DAY,

--- a/client/platform_client/tests/test_models.py
+++ b/client/platform_client/tests/test_models.py
@@ -51,6 +51,7 @@ from platform_client.responses import (
     SubmissionListResponse,
     SubmissionListRow,
     SubmissionView,
+    TaskScore,
 )
 from platform_client.slug import slug_of
 from pydantic import BaseModel, Tag, TypeAdapter, ValidationError
@@ -59,7 +60,13 @@ AT = datetime(2026, 3, 4, 5, 6, 7, tzinfo=UTC)
 SUB = SubmissionId(0x1F)
 USER = UserId(0xA0)
 
-SCORES = Scores(primary=0.75, success_rate=0.5, per_task={'banana_in_bowl': 0.75}, episodes=4, unscored=0)
+SCORES = Scores(
+    primary=0.75,
+    success_rate=0.5,
+    per_task={'banana_in_bowl': TaskScore(trials=4, successes=3, success_rate=0.75)},
+    episodes=4,
+    unscored=0,
+)
 
 DAILY = QuotaLimit(
     key=QUOTA_SUBMISSIONS_DAY,

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "positronic-platform-client"
-version = "0.2.0"
+version = "0.3.0"
 description = "Typed wire contract and HTTP client for the Positronic evaluation platform API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/positronic/cli/examples/nebius_competition/submit_sample.py
+++ b/positronic/cli/examples/nebius_competition/submit_sample.py
@@ -89,7 +89,7 @@ def main() -> None:
             if not isinstance(view, FinishedSubmissionView):
                 raise SystemExit(f'finished as {view.status.name}, with no result to read')
             print(f'finished as {view.status.name}')
-            print(f'primary {view.scores.primary} over {view.scores.episodes} episodes')
+            print(f'primary {view.scores.primary}')
         except PlatformError as exc:
             offered = f'\nevals on offer: {", ".join(exc.evals)}' if exc.evals is not None else ''
             raise SystemExit(f'{exc.code.name}: {exc.message}{offered}') from exc

--- a/positronic/cli/examples/walkthrough.py
+++ b/positronic/cli/examples/walkthrough.py
@@ -99,7 +99,7 @@ def walkthrough(
     # A terminal view that is not finished carries no result, so there is no score to report.
     if not isinstance(view, FinishedSubmissionView):
         raise SystemExit(f'   {view.status.name}, with no result to read')
-    print(f'   primary {view.scores.primary} over {view.scores.episodes} episodes')
+    print(f'   primary {view.scores.primary}')
     print(f'   result  {view.artifacts.result}')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # (.github/workflows/release.yaml). Pinned exactly, because that package guarantees no
     # backwards compatibility: a floating requirement would let a fresh install of THIS release
     # resolve a contract it was never built against.
-    "positronic-platform-client==0.2.0",
+    "positronic-platform-client==0.3.0",
     "psutil",  # `positronic-server` enumerates local interfaces to name a wildcard bind's addresses
     "pyarrow",
     "pydantic",

--- a/uv.lock
+++ b/uv.lock
@@ -5095,7 +5095,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/45/029c72cffe797d826
 
 [[package]]
 name = "positronic-platform-client"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
`Scores` is what a finished submission publishes and what a board row carries. It held five
fields: `primary`, `success_rate`, `per_task`, `episodes` and `unscored`. It now holds
`primary` and nothing else.

## Why each field leaves

A board ranks on `primary` alone (`rankings.py`, `PRIMARY_SCORE_KEY`). Every board is public,
so each field here is republished for every competitor's best submission.

- **`per_task`** decides nothing the platform does. It tells every competitor which task of the
  eval is the hard one, which is an overfitting hint. The submitter can already build it from
  the redacted episodes they receive: each `meta.json` carries the task and `eval.success`. So
  the field adds nothing for its owner and adds a hint for everybody else.
- **`success_rate`** is `primary` under a second name. The scorer computes one rate and assigns
  it to both fields. One fact under two names, with two owners, is the shape that caused the
  defect this branch started from.
- **`episodes`** and **`unscored`** are inputs to the ranking decision, not outputs for
  publication. One eval is live at a time, it pins a fixed trial list, and the platform fails a
  run that does not score every trial. So both values are the same on every row a board ranks.

## What keeps the full record

`platform_runner.scorer.Scores` is unchanged. It still writes `primary`, `success_rate`,
`per_task`, `episodes` and `unscored` into the participant's own `scores.json`, and the
platform reads the completeness facts from that blob. The two models now differ on purpose:
the scorer records, the client publishes a subset. The platform repository pins that as a
subset test, so a field added here that the scorer does not write fails a build.

## Breaking change

This narrows a published response shape. A consumer that reads `scores.success_rate`,
`scores.per_task`, `scores.episodes` or `scores.unscored` breaks. The client goes 0.2.0 to
0.3.0; the root pin and the client README's install command both follow it.

Both example scripts read `view.scores.episodes` and now print `primary` alone:
`positronic/cli/examples/walkthrough.py` and
`positronic/cli/examples/nebius_competition/submit_sample.py`.

## Checks

`pytest client` — 239 passed.

<!-- opened-by: posi-agent -->
