### PR TITLE
Let a session report the model's meta

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5228,22 +5228,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 15,
@@ -5260,38 +5244,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 11,
@@ -5304,22 +5256,6 @@
                 "range": {
                     "startColumn": 11,
                     "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 28,
                     "lineCount": 1
                 }
             }

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -192,6 +192,10 @@ class MySession(Session):
             for pose in predicted_poses
         ]
 
+    @property
+    def meta(self):
+        return {'type': 'my_model'}
+
 
 class MyPolicy(Policy):
     def __init__(self, model):
@@ -199,10 +203,6 @@ class MyPolicy(Policy):
 
     def new_session(self, context=None, rt=None):
         return MySession(self._model)  # per-episode setup goes here
-
-    @property
-    def meta(self):
-        return {'type': 'my_model'}
 
 
 pipeline = StopOnFault() | ChunkedSchedule() | remote | PolicySource(MyPolicy(load_my_model()))

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -98,7 +98,7 @@ class Task:
 # [✓] A config makes each attended trial, so the keyboard path makes none of its own.
 # [✓] A task source makes the plan when the world starts.
 # [✓] One runner builds the world for both.
-# [ ] A session reports the model's meta, so a policy holds none.
+# [✓] A session reports the model's meta, so a policy holds none.
 # [ ] The episode call carries the session that runs it, so the Harness holds no policy.
 # [ ] The episode call names where it records, so the Harness holds no dataset.
 # [ ] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -98,6 +98,9 @@ class Task:
 # [✓] A config makes each attended trial, so the keyboard path makes none of its own.
 # [✓] A task source makes the plan when the world starts.
 # [✓] One runner builds the world for both.
+# [ ] A session reports the model's meta, so a policy holds none.
+# [ ] The episode call carries the session that runs it, so the Harness holds no policy.
+# [ ] The episode call names where it records, so the Harness holds no dataset.
 # [ ] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.
 # [ ] A task carries its instruction as data, so no trial reads it after the reset.
 # [ ] A sim eval config names a selection, and a spec flag narrows it to one task.

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -340,7 +340,6 @@ class PolicyServer:
                 **self.metadata,
                 **self._source.meta(rid),
                 keys.CHECKPOINT_ID: rid,
-                **served.meta,
                 **session.meta,
                 keys.LOCAL_STACK: local_spec,
                 keys.COMPRESS_IMAGES: border.compress_images,

--- a/positronic/offboard/tests/conftest.py
+++ b/positronic/offboard/tests/conftest.py
@@ -94,7 +94,6 @@ def _make_mock_policy(action, meta):
 
     policy = MagicMock()
     policy.new_session.return_value = session
-    policy.meta = meta
     policy.functions = {}  # `Policy.functions` is a mapping, and MagicMock's stand-in is not
     policy._mock_session = session  # expose for assertions
     return policy

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -467,16 +467,6 @@ def test_records_infer_span_when_inference_raises(tmp_path, open_session):
     assert [s.name for s in spans] == [telemetry_keys.SPAN_POLICY_INFER]
 
 
-def test_remote_policy_meta_exposes_server_fields():
-    """RemotePolicy.meta prefixes the server's own fields with ``server.``, before any session exists."""
-    policy, _ = _mock_remote_policy({'checkpoint_path': '/ckpts/abc', 'model_name': 'foo', **CHUNKED_STACK})
-
-    meta = policy.meta
-    assert meta['type'] == 'remote'
-    assert meta['server.checkpoint_path'] == '/ckpts/abc'
-    assert meta['server.model_name'] == 'foo'
-
-
 def test_missing_declaration_fails_before_motion():
     """A handshake carrying no ``local_stack`` leaves nothing to build, so no session opens."""
     policy, _ = _mock_remote_policy({'positronic_version': '0.1.0'})

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -75,7 +75,7 @@ class Session(ABC):
 
     @property
     def meta(self) -> dict[str, Any]:
-        """Session metadata (may include policy meta + per-session info)."""
+        """What this session reports about its model and its episode."""
         return {}
 
     def cancel(self):
@@ -133,11 +133,6 @@ class Policy(ABC):
         """The work this policy runs off the session's thread, by name. The framework serves it as ``rt.fns``."""
         return {}
 
-    @property
-    def meta(self) -> dict[str, Any]:
-        """Static metadata about this policy/model."""
-        return {}
-
     def close(self):  # noqa: B027
         """Release shared resources (model weights, connections, etc.)."""
 
@@ -154,10 +149,6 @@ class DelegatingPolicy(Policy):
     @property
     def functions(self):
         return self._inner.functions
-
-    @property
-    def meta(self):
-        return self._inner.meta
 
     def close(self):
         self._inner.close()
@@ -203,11 +194,6 @@ class Layer:
         """
         raise NotImplementedError(f'{type(self).__name__} is not deliverable to a rig (no wire spec)')
 
-    @property
-    def meta(self) -> dict[str, Any]:
-        """Metadata contributed by this layer (merged into the wrapped policy's meta)."""
-        return {}
-
     def __or__(self, other: Layer) -> Layer:
         if isinstance(other, Layer):
             return _ComposedLayer((*self._layers(), *other._layers()))
@@ -219,10 +205,7 @@ class Layer:
 
 
 class _LayerPolicy(DelegatingPolicy):
-    """Policy produced by ``Layer.wrap()``.
-
-    Delegates session creation to the layer's ``make_session`` and merges meta.
-    """
+    """Policy produced by ``Layer.wrap()``."""
 
     def __init__(self, inner: Policy, layer: Layer):
         super().__init__(inner)
@@ -230,10 +213,6 @@ class _LayerPolicy(DelegatingPolicy):
 
     def new_session(self, context=None, rt=None):
         return self._layer.make_session(self._inner.new_session(context, rt))
-
-    @property
-    def meta(self):
-        return self._inner.meta | self._layer.meta
 
 
 class _ComposedLayer(Layer):

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -12,7 +12,7 @@ Two composition operators:
 import collections.abc as cabc
 from dataclasses import replace
 from functools import partial
-from typing import Any, final
+from typing import Any, final, overload
 
 import numpy as np
 from PIL import Image as PilImage
@@ -84,8 +84,14 @@ class Codec(Layer):
     def make_session(self, inner: Session):
         return _CodecSession(inner, self)
 
+    @overload
+    def __or__(self, other: 'Codec') -> 'Codec': ...
+
+    @overload
+    def __or__(self, other: Layer) -> Layer: ...
+
     @final
-    def __or__(self, other):
+    def __or__(self, other) -> Any:
         if isinstance(other, Codec):
             return _ComposedCodec(self, other)
         if isinstance(other, Layer):

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -210,10 +210,8 @@ class Harness(pimm.ControlSystem):
         meta[keys.EVAL_CHARGE_INFERENCE_TIME] = self._charges_wall_time
         if self._task.timeout_sec is not None:  # the recorder takes no nulls, and an unbounded episode has none
             meta[keys.EVAL_TIMEOUT] = self._task.timeout_sec
-        # ``policy.meta`` is the static baseline; the session overlays per-episode specifics (e.g. the
-        # sampled sub-policy) and wins on conflict.
-        session_meta = self.policy.meta | (self._inference.meta if self._inference else {})
-        for k, v in flatten_dict(session_meta).items():
+        assert self._inference is not None, 'only a live episode has meta'
+        for k, v in flatten_dict(self._inference.meta).items():
             meta[f'{keys.POLICY_META}.{k}'] = v
         meta.update(self._task.meta)
         meta[keys.TASK] = self._task.instruction

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -115,7 +115,7 @@ class _Endpoint(Policy):
 
     def __init__(self, url: str, *, headers: dict[str, str] | None, infer_timeout: float):
         self._client = InferenceClient(url, headers=headers, infer_timeout=infer_timeout)
-        # Filled on first contact, via a throwaway session if ``meta`` is read before any real one exists.
+        # Filled on first contact, through a session opened for it alone.
         self._server_meta: dict[str, Any] | None = None
 
     def server_meta(self) -> dict[str, Any]:
@@ -137,10 +137,6 @@ class _Endpoint(Policy):
     @property
     def functions(self) -> cabc.Mapping[str, cabc.Callable[..., Any]]:
         return {INFER: round_trip}
-
-    @property
-    def meta(self) -> dict[str, Any]:
-        return flatten_dict({keys.TYPE: 'remote', keys.SERVER: self.server_meta()})
 
     def close(self):
         self._client = None
@@ -203,10 +199,6 @@ class RemotePolicy(Policy):
     @property
     def functions(self) -> cabc.Mapping[str, cabc.Callable[..., Any]]:
         return self._policy().functions
-
-    @property
-    def meta(self) -> dict[str, Any]:
-        return self._policy().meta
 
     def close(self):
         self._endpoint.close()

--- a/positronic/policy/spec.py
+++ b/positronic/policy/spec.py
@@ -37,6 +37,7 @@ from positronic.policy.codec import (
     BinarizeGripInference,
     BinarizeGripTraining,
     ChangeEEFrame,
+    Codec,
     FlipGrip,
     RestrictImageSize,
 )
@@ -115,7 +116,7 @@ class Pipeline:
         self.source = source
         # Which side of ``remote`` the conversion sits on is a choice; doing it on both sides is not. Two
         # declarations convert twice, leaving poses at the product while the handshake still names one of them.
-        declared = [c for c in self.components if keys.EE_FRAME in c.meta]
+        declared = [c for c in self.components if isinstance(c, Codec) and keys.EE_FRAME in c.meta]
         if len(declared) > 1:
             raise ValueError(
                 f'{len(declared)} components of this pipeline declare {keys.EE_FRAME}; each converts, so poses '

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -140,10 +140,6 @@ class StubPolicy(Policy):
         self.last_reset_context: dict[str, Any] | None = None
         self._meta: dict[str, object] = meta or {}
 
-    @property
-    def meta(self) -> dict[str, object]:
-        return self._meta
-
     def new_session(self, context=None, rt=None) -> Session:
         self.reset_calls += 1
         self.last_reset_context = context
@@ -585,49 +581,6 @@ def test_episode_meta_stamped_at_finalize(world):
     assert meta['inference.policy.type'] == 'stub'
     assert meta['inference.policy.checkpoint'] == 'v1'
     assert meta[keys.TASK] == 'test'
-
-
-@pytest.mark.timeout(3.0)
-def test_episode_meta_includes_policy_static_meta(world):
-    """Static fields exposed only via ``Policy.meta`` (empty ``Session.meta``) must
-    still reach episode metadata once the policy is wrapped."""
-
-    class _StaticMetaSession(Session):
-        def __init__(self, command):
-            self._command = command
-
-        def __call__(self, obs, time_ns):
-            return [{keys.ROBOT_COMMAND: self._command, 'target_grip': 0.0, 'timestamp': 0.0}]
-
-    class _StaticMetaPolicy(Policy):
-        def __init__(self):
-            pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
-            self._command = CartesianPosition(pose=pose)
-
-        def new_session(self, context=None, rt=None):
-            return _StaticMetaSession(self._command)  # Session.meta defaults to {}
-
-        @property
-        def meta(self):
-            return {'checkpoint': 'v1', 'type': 'static'}
-
-    harness = Harness(_StaticMetaPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
-    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
-    driver = ManualDriver([
-        (partial(p['perform_task'], Task(instruction_source='t', timeout_sec=None)), 0.0),
-        (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.01),
-        (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),
-        (None, 0.02),
-    ])
-    scheduler = world.start([harness, driver])
-    drive_scheduler(scheduler, steps=25)
-
-    stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert len(stops) == 1
-    meta = stops[0].static_data
-    assert meta['inference.policy.checkpoint'] == 'v1'
-    assert meta['inference.policy.type'] == 'static'
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_policy_io.py
+++ b/positronic/policy/tests/test_policy_io.py
@@ -145,13 +145,15 @@ class _PassthroughCodec(Codec):
         return data
 
 
-class _MetaPolicy(Policy):
-    def new_session(self, context=None, rt=None):
-        return _FixedSession({})
-
+class _MetaSession(_FixedSession):
     @property
     def meta(self):
         return {'base_key': 'base_value'}
+
+
+class _MetaPolicy(Policy):
+    def new_session(self, context=None, rt=None):
+        return _MetaSession({})
 
 
 _T0_OBS = {obs_keys.OBS_TIME_NS: 0}
@@ -277,10 +279,10 @@ def test_codec_composition():
 
 
 def test_codec_wrap_meta_merges():
-    """Test that wrapped policy meta merges base and codec meta."""
+    """A wrapped session reports the base meta and the codec meta."""
     codec = ActionTiming(fps=15.0, horizon_sec=1.0)
     policy = codec.wrap(_MetaPolicy())
-    meta = policy.meta
+    meta = policy.new_session().meta
     assert meta['base_key'] == 'base_value'
     assert meta['action_fps'] == 15.0
     assert meta['action_horizon_sec'] == 1.0

--- a/positronic/policy/tests/test_recording.py
+++ b/positronic/policy/tests/test_recording.py
@@ -39,10 +39,6 @@ class _TrackingPolicy(Policy):
         self.session_count += 1
         return _TrackingSession(self._actions, {'policy_key': 'policy_value'})
 
-    @property
-    def meta(self):
-        return {'policy_key': 'policy_value'}
-
 
 class _CapturingSession(Session):
     """Innermost session that snapshots the Recorder's carried timeline state when called."""
@@ -167,9 +163,9 @@ def test_tap_delegates_inner_call(tmp_path):
 
 
 def test_tap_meta_passthrough(tmp_path):
-    """A tap contributes no meta; inner meta passes through."""
-    policy = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy())
-    assert policy.meta == {'policy_key': 'policy_value'}
+    """A tap passes the inner meta through, and adds the path it records to."""
+    session = Recorder(tmp_path).tap('t').wrap(_TrackingPolicy()).new_session()
+    assert session.meta['policy_key'] == 'policy_value'
 
 
 def test_obs_log_filtering_uses_pure_tap_names(tmp_path):

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -30,10 +30,6 @@ class _IdlePolicy(Policy):
         self.warmed = True
         return IdleSession(self)
 
-    @property
-    def meta(self):
-        return {}
-
     def close(self):
         self.closed = True
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -201,9 +201,9 @@ class Gr00tSubprocess:
 
 
 class _Gr00tSession(Session):
-    def __init__(self, client: PolicyClient, checkpoint_path: str):
+    def __init__(self, client: PolicyClient, meta: dict[str, Any]):
         self._client = client
-        self._checkpoint_path = checkpoint_path
+        self._meta = meta
 
     def __call__(self, obs, time_ns):
         action_response, _info = self._client.get_action(obs)
@@ -215,7 +215,7 @@ class _Gr00tSession(Session):
 
     @property
     def meta(self):
-        return {keys.CHECKPOINT_PATH: self._checkpoint_path}
+        return self._meta
 
 
 class Gr00tPolicy(Policy):
@@ -223,11 +223,11 @@ class Gr00tPolicy(Policy):
 
     def __init__(self, groot: Gr00tSubprocess, checkpoint_path: str):
         self._groot = groot
-        self._checkpoint_path = checkpoint_path
+        self._meta = {keys.CHECKPOINT_PATH: checkpoint_path}
 
     def new_session(self, context=None, rt=None):
         self._groot.client.reset()
-        return _Gr00tSession(self._groot.client, self._checkpoint_path)
+        return _Gr00tSession(self._groot.client, self._meta)
 
     def close(self):
         self._groot.stop()

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -201,8 +201,9 @@ class Gr00tSubprocess:
 
 
 class _Gr00tSession(Session):
-    def __init__(self, client: PolicyClient):
+    def __init__(self, client: PolicyClient, checkpoint_path: str):
         self._client = client
+        self._checkpoint_path = checkpoint_path
 
     def __call__(self, obs, time_ns):
         action_response, _info = self._client.get_action(obs)
@@ -211,6 +212,10 @@ class _Gr00tSession(Session):
         assert len(lengths) == 1, f'All values in action must have the same length, got {lengths}'
         time_horizon = lengths.pop()
         return [{k: v[i] for k, v in action.items()} for i in range(time_horizon)]
+
+    @property
+    def meta(self):
+        return {keys.CHECKPOINT_PATH: self._checkpoint_path}
 
 
 class Gr00tPolicy(Policy):
@@ -222,11 +227,7 @@ class Gr00tPolicy(Policy):
 
     def new_session(self, context=None, rt=None):
         self._groot.client.reset()
-        return _Gr00tSession(self._groot.client)
-
-    @property
-    def meta(self):
-        return {keys.CHECKPOINT_PATH: self._checkpoint_path}
+        return _Gr00tSession(self._groot.client, self._checkpoint_path)
 
     def close(self):
         self._groot.stop()

--- a/positronic/vendors/lerobot/policy.py
+++ b/positronic/vendors/lerobot/policy.py
@@ -106,10 +106,6 @@ class LerobotPolicy(Policy):
         self._policy.reset()
         return _LerobotSession(self._policy, self._preprocessor, self._postprocessor, self._device, self._meta)
 
-    @property
-    def meta(self) -> dict[str, Any]:
-        return self._meta.copy()
-
     def close(self):
         if self._policy is not None:
             del self._policy

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -130,10 +130,6 @@ class LerobotPolicy(Policy):
     def functions(self) -> Mapping[str, Callable[..., Any]]:
         return {self._INFER: partial(_infer, self._policy, self._device)}
 
-    @property
-    def meta(self) -> dict[str, Any]:
-        return self._meta.copy()
-
     def close(self):
         if self._policy is not None:
             del self._policy

--- a/positronic/vendors/lerobot_0_3_3/tests/test_server.py
+++ b/positronic/vendors/lerobot_0_3_3/tests/test_server.py
@@ -5,6 +5,7 @@ from fastapi import WebSocketDisconnect
 from starlette.datastructures import QueryParams
 
 from positronic.offboard.protocol import deserialise
+from positronic.policy.executor import blocking
 from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.spec import remote
 
@@ -64,10 +65,9 @@ def test_handshake_metadata_does_not_depend_on_the_factory(monkeypatch):
         policy_factory=lambda _path: MagicMock(spec=lerobot_server.PreTrainedPolicy, config=_act_config()),
         checkpoints_dir='s3://bucket/exp',
     )
-    assert source.load('42').meta == {
-        'type': 'act',
-        'checkpoint_path': 's3://bucket/exp/checkpoints/42/pretrained_model',
-    }
+    session = blocking(source.load('42')).new_session()
+    assert session.meta == {'type': 'act', 'checkpoint_path': 's3://bucket/exp/checkpoints/42/pretrained_model'}
+    session.close()
 
 
 def _make_server(checkpoint: str | None) -> PolicyServer:
@@ -88,7 +88,6 @@ async def test_lerobot_server_uses_configured_checkpoint(monkeypatch):
     async def fake_get_policy(checkpoint_id: str, websocket=None):
         requested['checkpoint_id'] = checkpoint_id
         policy = MagicMock()
-        policy.meta = {'model_name': 'test'}
         policy.new_session.return_value.meta = {}
         return policy
 

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -69,10 +69,6 @@ class MolmoAct2Policy(Policy):
     def new_session(self, context=None, rt=None) -> Session:
         return _MolmoAct2Session(self._model, self._processor, self._norm_tag, self._num_steps, self._meta)
 
-    @property
-    def meta(self) -> dict[str, Any]:
-        return self._meta.copy()
-
     def close(self):
         if self._model is not None:
             del self._model


### PR DESCRIPTION
## Summary
- `Policy.meta`, `DelegatingPolicy.meta` and `Layer.meta` go. A session is the only source of the model's meta.
- Every vendor policy gives its meta to the session it opens. `_Gr00tSession` takes one; the others already had it.
- `RemoteSession.meta` already reported the server fields, so `_Endpoint.meta` and `RemotePolicy.meta` go. The handshake keeps `session.meta` and drops `served.meta`.
- The harness reads `self._inference.meta` alone, under an assert: only a live episode builds the episode meta.
- `Pipeline` scans the codecs for the `ee_frame` declaration. Only a codec declares one, and only a codec's session merges it into the episode, so a plain layer's meta would be dropped without a message.
- `docs/connect-your-model.md` moves `meta` into the example's session.
- Three new boxes join the eval roadmap; this change ticks the first.

## Test plan
- `uv run --locked pytest` — 1691 passed, 8 skipped
- `uv run --locked ruff check .` and `uv run --locked ruff format --check .` — clean
- basedpyright — 0 errors, and the baseline goes down by 8