### PR TITLE
Give a Linux video frame the shape the other cameras give

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -3330,14 +3330,6 @@
                     "endColumn": 29,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
             }
         ],
         "./positronic/drivers/camera/luxonis.py": [

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -3332,30 +3332,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 18,

--- a/pimm/logging.py
+++ b/pimm/logging.py
@@ -39,6 +39,7 @@ _NOISY_LIBRARY_LOGGERS = (
     'boto3',
     's3transfer',  # per part of a multipart upload
     'asyncio',  # per selector event, under its debug mode
+    'linuxpy',  # per ioctl, which is several times a frame for every camera
 )
 
 

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -37,26 +37,25 @@ class LinuxVideo(pimm.ControlSystem):
 
     @staticmethod
     def _framed(data: np.ndarray, frame, bytes_per_pixel: int) -> np.ndarray | None:
-        """``data`` shaped as the frame it belongs to, or ``None`` where the buffer arrived short.
-
-        A camera hands over a buffer with its tail missing when the bus is busy, and several cameras on one
-        controller are enough to see it. A partial frame has nothing to read, and the next one is a
-        thirtieth of a second away.
-        """
+        """``data`` shaped as the frame it belongs to, or ``None`` where it is short of one."""
         if data.size != frame.height * frame.width * bytes_per_pixel:
             return None
         return data.reshape((frame.height, frame.width, bytes_per_pixel))
 
-    def _images(self, frame, codec_context) -> list[np.ndarray]:
-        """Every image the buffer ``frame`` carries, as RGB. Empty where the buffer arrived short."""
+    def _images(self, frame, codec_context) -> list[np.ndarray] | None:
+        """Every image the buffer ``frame`` carries, as RGB, or ``None`` where it is short of a frame.
+
+        A compressed buffer whole enough to read may still carry no image: the parser and the decoder both
+        hold data back until they have a frame to give, so an empty list is a wait, not a loss.
+        """
         data = np.frombuffer(frame.data, dtype=np.uint8)
         match frame.pixel_format:
             case PixelFormat.YUYV:
                 raw = self._framed(data, frame, 2)
-                return [] if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_YUYV)]
+                return None if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_YUYV)]
             case PixelFormat.UYVY:
                 raw = self._framed(data, frame, 2)
-                return [] if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_UYVY)]
+                return None if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_UYVY)]
             case _ if frame.pixel_format in _CODECS:
                 codec_ctx = codec_context(_CODECS[frame.pixel_format])
                 # `av` types what it parses as `bytes` and carries `decode` on the subclasses of
@@ -69,7 +68,7 @@ class LinuxVideo(pimm.ControlSystem):
                 ]
             case _:
                 raw = self._framed(data, frame, 3)  # assume 3 bytes per pixel (RGB/BGR)
-                return [] if raw is None else [raw]
+                return None if raw is None else [raw]
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         codec_contexts = {}
@@ -92,15 +91,20 @@ class LinuxVideo(pimm.ControlSystem):
                 break
 
             images = self._images(frame, codec_context)
-            if not images:
+            if images is None:
                 short += 1
                 if short == 1:
                     logger.warning('%s handed over a buffer short of a frame', self.device_path)
-
-            for image in images:
-                self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(image, self._frame_adapter)
+            elif len(images) == 1:
+                self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(images[0], self._frame_adapter)
                 self.frame.emit(self._frame_adapter)
                 self.fps_counter.tick()
+            else:
+                # A buffer that decodes to several images emits them with nothing read in between, so one
+                # adapter shared between them would show every reader the last image.
+                for image in images:
+                    self.frame.emit(pimm.shared_memory.NumpySMAdapter.lazy_init(image, None))
+                    self.fps_counter.tick()
 
             yield pimm.Yield()  # Give control back to the world
 

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -19,9 +19,10 @@ class LinuxVideo(pimm.ControlSystem):
         self.fps = fps
         self.pixel_format = pixel_format
         self.fps_counter = pimm.utils.RateCounter(f'LinuxVideo {device_path}')
-        self.frame: pimm.SignalEmitter = pimm.ControlSystemEmitter(self)
+        self.frame = pimm.ControlSystemEmitter[pimm.shared_memory.NumpySMAdapter](self)
+        self._frame_adapter = None  # Lazy init
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:  # noqa: C901
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
         codec_mapping = {
             PixelFormat.H264: 'h264',
             PixelFormat.HEVC: 'hevc',
@@ -49,33 +50,31 @@ class LinuxVideo(pimm.ControlSystem):
                 break
 
             data = np.frombuffer(frame.data, dtype=np.uint8)
-            result = None
 
             match frame.pixel_format:
                 case PixelFormat.YUYV:
                     data = data.reshape((frame.height, frame.width, 2))
-                    result = {'image': cv2.cvtColor(data, cv2.COLOR_YUV2RGB_YUYV)}
+                    images = [cv2.cvtColor(data, cv2.COLOR_YUV2RGB_YUYV)]
                 case PixelFormat.UYVY:
                     data = data.reshape((frame.height, frame.width, 2))
-                    result = {'image': cv2.cvtColor(data, cv2.COLOR_YUV2RGB_UYVY)}
+                    images = [cv2.cvtColor(data, cv2.COLOR_YUV2RGB_UYVY)]
                 case _ if frame.pixel_format in codec_mapping:
-                    codec_name = codec_mapping[frame.pixel_format]
-                    codec_ctx = get_codec_context(codec_name)
-                    packets = codec_ctx.parse(data)
-                    for packet in packets:
-                        frames = codec_ctx.decode(packet)
-                        if len(frames) == 1:
-                            result = {'image': frames[0].to_ndarray(format='rgb24')}
-                        else:
-                            for i, decoded_frame in enumerate(frames):
-                                result[f'image_{i}'] = decoded_frame.to_ndarray(format='rgb24')
+                    codec_ctx = get_codec_context(codec_mapping[frame.pixel_format])
+                    # `av` types what it parses as `bytes` and carries `decode` on the subclasses of
+                    # `CodecContext`, so the buffer the device hands over and the base class both read wrong.
+                    packets = codec_ctx.parse(data)  # pyright: ignore[reportArgumentType]
+                    images = [
+                        decoded.to_ndarray(format='rgb24')
+                        for packet in packets
+                        for decoded in codec_ctx.decode(packet)  # pyright: ignore[reportAttributeAccessIssue]
+                    ]
                 case _:
                     # Assume 3 bytes per pixel (RGB/BGR)
-                    rgb_data = data.reshape((frame.height, frame.width, 3))
-                    result = {'image': rgb_data}
+                    images = [data.reshape((frame.height, frame.width, 3))]
 
-            if result is not None:
-                self.frame.emit(result)
+            for image in images:
+                self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(image, self._frame_adapter)
+                self.frame.emit(self._frame_adapter)
                 self.fps_counter.tick()
 
             yield pimm.Yield()  # Give control back to the world

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterator
 
 import av
@@ -9,6 +10,18 @@ from positronic.drivers import vendor_import
 
 with vendor_import('linuxpy', 'Linux video capture', platforms=('linux',)):
     from linuxpy.video.device import Device, PixelFormat
+
+logger = logging.getLogger(__name__)
+
+# The formats a camera may compress in, and what decodes each of them.
+_CODECS = {
+    PixelFormat.H264: 'h264',
+    PixelFormat.HEVC: 'hevc',
+    PixelFormat.VP8: 'vp8',
+    PixelFormat.VP9: 'vp9',
+    PixelFormat.MPEG4: 'mpeg4',
+    PixelFormat.MJPEG: 'mjpeg',
+}
 
 
 class LinuxVideo(pimm.ControlSystem):
@@ -22,18 +35,46 @@ class LinuxVideo(pimm.ControlSystem):
         self.frame = pimm.ControlSystemEmitter[pimm.shared_memory.NumpySMAdapter](self)
         self._frame_adapter = None  # Lazy init
 
+    @staticmethod
+    def _framed(data: np.ndarray, frame, bytes_per_pixel: int) -> np.ndarray | None:
+        """``data`` shaped as the frame it belongs to, or ``None`` where the buffer arrived short.
+
+        A camera hands over a buffer with its tail missing when the bus is busy, and several cameras on one
+        controller are enough to see it. A partial frame has nothing to read, and the next one is a
+        thirtieth of a second away.
+        """
+        if data.size != frame.height * frame.width * bytes_per_pixel:
+            return None
+        return data.reshape((frame.height, frame.width, bytes_per_pixel))
+
+    def _images(self, frame, codec_context) -> list[np.ndarray]:
+        """Every image the buffer ``frame`` carries, as RGB. Empty where the buffer arrived short."""
+        data = np.frombuffer(frame.data, dtype=np.uint8)
+        match frame.pixel_format:
+            case PixelFormat.YUYV:
+                raw = self._framed(data, frame, 2)
+                return [] if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_YUYV)]
+            case PixelFormat.UYVY:
+                raw = self._framed(data, frame, 2)
+                return [] if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_UYVY)]
+            case _ if frame.pixel_format in _CODECS:
+                codec_ctx = codec_context(_CODECS[frame.pixel_format])
+                # `av` types what it parses as `bytes` and carries `decode` on the subclasses of
+                # `CodecContext`, so the buffer the device hands over and the base class both read wrong.
+                packets = codec_ctx.parse(data)  # pyright: ignore[reportArgumentType]
+                return [
+                    decoded.to_ndarray(format='rgb24')
+                    for packet in packets
+                    for decoded in codec_ctx.decode(packet)  # pyright: ignore[reportAttributeAccessIssue]
+                ]
+            case _:
+                raw = self._framed(data, frame, 3)  # assume 3 bytes per pixel (RGB/BGR)
+                return [] if raw is None else [raw]
+
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
-        codec_mapping = {
-            PixelFormat.H264: 'h264',
-            PixelFormat.HEVC: 'hevc',
-            PixelFormat.VP8: 'vp8',
-            PixelFormat.VP9: 'vp9',
-            PixelFormat.MPEG4: 'mpeg4',
-            PixelFormat.MJPEG: 'mjpeg',
-        }
         codec_contexts = {}
 
-        def get_codec_context(codec_name: str) -> av.CodecContext:
+        def codec_context(codec_name: str) -> av.CodecContext:
             """Lazily initialize and return codec context for given codec"""
             if codec_name not in codec_contexts:
                 codec_contexts[codec_name] = av.CodecContext.create(codec_name, 'r')
@@ -45,32 +86,16 @@ class LinuxVideo(pimm.ControlSystem):
         device.set_format(device.info.buffers[0], self.width, self.height, self.pixel_format)
         device.set_fps(device.info.buffers[0], self.fps)
 
+        short = 0
         for frame in device:
             if should_stop.value:
                 break
 
-            data = np.frombuffer(frame.data, dtype=np.uint8)
-
-            match frame.pixel_format:
-                case PixelFormat.YUYV:
-                    data = data.reshape((frame.height, frame.width, 2))
-                    images = [cv2.cvtColor(data, cv2.COLOR_YUV2RGB_YUYV)]
-                case PixelFormat.UYVY:
-                    data = data.reshape((frame.height, frame.width, 2))
-                    images = [cv2.cvtColor(data, cv2.COLOR_YUV2RGB_UYVY)]
-                case _ if frame.pixel_format in codec_mapping:
-                    codec_ctx = get_codec_context(codec_mapping[frame.pixel_format])
-                    # `av` types what it parses as `bytes` and carries `decode` on the subclasses of
-                    # `CodecContext`, so the buffer the device hands over and the base class both read wrong.
-                    packets = codec_ctx.parse(data)  # pyright: ignore[reportArgumentType]
-                    images = [
-                        decoded.to_ndarray(format='rgb24')
-                        for packet in packets
-                        for decoded in codec_ctx.decode(packet)  # pyright: ignore[reportAttributeAccessIssue]
-                    ]
-                case _:
-                    # Assume 3 bytes per pixel (RGB/BGR)
-                    images = [data.reshape((frame.height, frame.width, 3))]
+            images = self._images(frame, codec_context)
+            if not images:
+                short += 1
+                if short == 1:
+                    logger.warning('%s handed over a buffer short of a frame', self.device_path)
 
             for image in images:
                 self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(image, self._frame_adapter)
@@ -79,4 +104,6 @@ class LinuxVideo(pimm.ControlSystem):
 
             yield pimm.Yield()  # Give control back to the world
 
+        if short:
+            logger.warning('%s handed over %d buffers short of a frame', self.device_path, short)
         device.close()

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -85,7 +85,7 @@ class LinuxVideo(pimm.ControlSystem):
         device.set_format(device.info.buffers[0], self.width, self.height, self.pixel_format)
         device.set_fps(device.info.buffers[0], self.fps)
 
-        misframed = 0
+        misframed = overtaken = 0
         for frame in device:
             if should_stop.value:
                 break
@@ -98,19 +98,18 @@ class LinuxVideo(pimm.ControlSystem):
                 misframed += 1
                 if misframed == 1:
                     logger.warning('%s handed over a buffer that is not one frame in size', self.device_path)
-            elif len(images) == 1:
-                self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(images[0], self._frame_adapter)
+            elif images:
+                # The port holds one image and nothing runs between two emissions of the same tick, so a
+                # buffer decoding to several has only its newest to give; the rest are counted, not sent.
+                overtaken += len(images) - 1
+                self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(images[-1], self._frame_adapter)
                 self.frame.emit(self._frame_adapter)
                 self.fps_counter.tick()
-            else:
-                # A buffer that decodes to several images emits them with nothing read in between, so one
-                # adapter shared between them would show every reader the last image.
-                for image in images:
-                    self.frame.emit(pimm.shared_memory.NumpySMAdapter.lazy_init(image, None))
-                    self.fps_counter.tick()
 
             yield pimm.Yield()  # Give control back to the world
 
         if misframed:
             logger.warning('%s handed over %d buffers that are not one frame in size', self.device_path, misframed)
+        if overtaken:
+            logger.warning('%s decoded %d images a newer one of the same buffer overtook', self.device_path, overtaken)
         device.close()

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -70,7 +70,7 @@ class LinuxVideo(pimm.ControlSystem):
                 raw = self._framed(data, frame, 3)  # assume 3 bytes per pixel (RGB/BGR)
                 return None if raw is None else [raw]
 
-    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Sleep]:
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         codec_contexts = {}
 
         def codec_context(codec_name: str) -> av.CodecContext:

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -13,18 +13,18 @@ with vendor_import('linuxpy', 'Linux video capture', platforms=('linux',)):
 
 logger = logging.getLogger(__name__)
 
-# The formats a camera may compress in, and what decodes each of them.
-_CODECS = {
-    PixelFormat.H264: 'h264',
-    PixelFormat.HEVC: 'hevc',
-    PixelFormat.VP8: 'vp8',
-    PixelFormat.VP9: 'vp9',
-    PixelFormat.MPEG4: 'mpeg4',
-    PixelFormat.MJPEG: 'mjpeg',
-}
-
 
 class LinuxVideo(pimm.ControlSystem):
+    # The formats a camera may compress in, and what decodes each of them.
+    _CODECS = {
+        PixelFormat.H264: 'h264',
+        PixelFormat.HEVC: 'hevc',
+        PixelFormat.VP8: 'vp8',
+        PixelFormat.VP9: 'vp9',
+        PixelFormat.MPEG4: 'mpeg4',
+        PixelFormat.MJPEG: 'mjpeg',
+    }
+
     def __init__(self, device_path: str, width: int, height: int, fps: int, pixel_format: str):
         self.device_path = device_path
         self.width = width
@@ -37,13 +37,13 @@ class LinuxVideo(pimm.ControlSystem):
 
     @staticmethod
     def _framed(data: np.ndarray, frame, bytes_per_pixel: int) -> np.ndarray | None:
-        """``data`` shaped as the frame it belongs to, or ``None`` where it is short of one."""
+        """``data`` shaped as the frame it belongs to, or ``None`` where it is not one frame's worth."""
         if data.size != frame.height * frame.width * bytes_per_pixel:
             return None
         return data.reshape((frame.height, frame.width, bytes_per_pixel))
 
     def _images(self, frame, codec_context) -> list[np.ndarray] | None:
-        """Every image the buffer ``frame`` carries, as RGB, or ``None`` where it is short of a frame.
+        """Every image the buffer ``frame`` carries, as RGB, or ``None`` where it is not one frame's worth.
 
         A compressed buffer whole enough to read may still carry no image: the parser and the decoder both
         hold data back until they have a frame to give, so an empty list is a wait, not a loss.
@@ -56,8 +56,8 @@ class LinuxVideo(pimm.ControlSystem):
             case PixelFormat.UYVY:
                 raw = self._framed(data, frame, 2)
                 return None if raw is None else [cv2.cvtColor(raw, cv2.COLOR_YUV2RGB_UYVY)]
-            case _ if frame.pixel_format in _CODECS:
-                codec_ctx = codec_context(_CODECS[frame.pixel_format])
+            case _ if frame.pixel_format in self._CODECS:
+                codec_ctx = codec_context(self._CODECS[frame.pixel_format])
                 # `av` types what it parses as `bytes` and carries `decode` on the subclasses of
                 # `CodecContext`, so the buffer the device hands over and the base class both read wrong.
                 packets = codec_ctx.parse(data)  # pyright: ignore[reportArgumentType]
@@ -85,16 +85,16 @@ class LinuxVideo(pimm.ControlSystem):
         device.set_format(device.info.buffers[0], self.width, self.height, self.pixel_format)
         device.set_fps(device.info.buffers[0], self.fps)
 
-        short = 0
+        misframed = 0
         for frame in device:
             if should_stop.value:
                 break
 
             images = self._images(frame, codec_context)
             if images is None:
-                short += 1
-                if short == 1:
-                    logger.warning('%s handed over a buffer short of a frame', self.device_path)
+                misframed += 1
+                if misframed == 1:
+                    logger.warning('%s handed over a buffer that is not one frame in size', self.device_path)
             elif len(images) == 1:
                 self._frame_adapter = pimm.shared_memory.NumpySMAdapter.lazy_init(images[0], self._frame_adapter)
                 self.frame.emit(self._frame_adapter)
@@ -108,6 +108,6 @@ class LinuxVideo(pimm.ControlSystem):
 
             yield pimm.Yield()  # Give control back to the world
 
-        if short:
-            logger.warning('%s handed over %d buffers short of a frame', self.device_path, short)
+        if misframed:
+            logger.warning('%s handed over %d buffers that are not one frame in size', self.device_path, misframed)
         device.close()

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -91,6 +91,9 @@ class LinuxVideo(pimm.ControlSystem):
                 break
 
             images = self._images(frame, codec_context)
+            # rules-allow: swallowed-error — a busy bus hands over a buffer that is not a whole frame as
+            # ordinary traffic, roughly one per camera per minute of capture on the station's four D405;
+            # the next buffer is a thirtieth of a second away, and the count says how many went
             if images is None:
                 misframed += 1
                 if misframed == 1:

--- a/positronic/drivers/camera/linux_video.py
+++ b/positronic/drivers/camera/linux_video.py
@@ -92,8 +92,8 @@ class LinuxVideo(pimm.ControlSystem):
 
             images = self._images(frame, codec_context)
             # rules-allow: swallowed-error — a busy bus hands over a buffer that is not a whole frame as
-            # ordinary traffic, roughly one per camera per minute of capture on the station's four D405;
-            # the next buffer is a thirtieth of a second away, and the count says how many went
+            # ordinary traffic; the device keeps streaming, the buffers after it read whole, and the count
+            # says how many went
             if images is None:
                 misframed += 1
                 if misframed == 1:

--- a/positronic/drivers/camera/tests/conftest.py
+++ b/positronic/drivers/camera/tests/conftest.py
@@ -1,0 +1,30 @@
+"""A stand-in for the vendor package the Linux video driver imports.
+
+``linuxpy`` ships only in the ``hardware`` extra, so the driver module cannot be imported from a default
+sync. The tests drive a device of their own, so a module carrying the names the driver binds at import is
+enough. Installed here, before any test module imports the driver, and only where the real package is
+absent.
+"""
+
+import importlib.util
+import sys
+import types
+from enum import Enum
+
+VENDOR = 'linuxpy'
+DEVICE_MODULE = f'{VENDOR}.video.device'
+
+if importlib.util.find_spec(VENDOR) is None:
+    # The formats the driver names. The values are the V4L2 four-character codes, as `linuxpy` reports them.
+    pixel_format = Enum('PixelFormat', ['YUYV', 'UYVY', 'RGB24', 'H264', 'HEVC', 'VP8', 'VP9', 'MPEG4', 'MJPEG'])
+
+    device = types.ModuleType(DEVICE_MODULE)
+    device.__dict__.update(Device=object, PixelFormat=pixel_format)
+
+    video = types.ModuleType(f'{VENDOR}.video')
+    video.__dict__.update(device=device)
+
+    package = types.ModuleType(VENDOR)
+    package.__dict__.update(video=video)
+
+    sys.modules.update({VENDOR: package, f'{VENDOR}.video': video, DEVICE_MODULE: device})

--- a/positronic/drivers/camera/tests/conftest.py
+++ b/positronic/drivers/camera/tests/conftest.py
@@ -12,7 +12,8 @@ import types
 from enum import Enum
 
 VENDOR = 'linuxpy'
-DEVICE_MODULE = f'{VENDOR}.video.device'
+VIDEO_MODULE = f'{VENDOR}.video'
+DEVICE_MODULE = f'{VIDEO_MODULE}.device'
 
 if importlib.util.find_spec(VENDOR) is None:
     # The formats the driver names. The values are the V4L2 four-character codes, as `linuxpy` reports them.
@@ -21,10 +22,10 @@ if importlib.util.find_spec(VENDOR) is None:
     device = types.ModuleType(DEVICE_MODULE)
     device.__dict__.update(Device=object, PixelFormat=PixelFormat)
 
-    video = types.ModuleType(f'{VENDOR}.video')
+    video = types.ModuleType(VIDEO_MODULE)
     video.__dict__.update(device=device)
 
     package = types.ModuleType(VENDOR)
     package.__dict__.update(video=video)
 
-    sys.modules.update({VENDOR: package, f'{VENDOR}.video': video, DEVICE_MODULE: device})
+    sys.modules.update({VENDOR: package, VIDEO_MODULE: video, DEVICE_MODULE: device})

--- a/positronic/drivers/camera/tests/conftest.py
+++ b/positronic/drivers/camera/tests/conftest.py
@@ -16,10 +16,10 @@ DEVICE_MODULE = f'{VENDOR}.video.device'
 
 if importlib.util.find_spec(VENDOR) is None:
     # The formats the driver names. The values are the V4L2 four-character codes, as `linuxpy` reports them.
-    pixel_format = Enum('PixelFormat', ['YUYV', 'UYVY', 'RGB24', 'H264', 'HEVC', 'VP8', 'VP9', 'MPEG4', 'MJPEG'])
+    PixelFormat = Enum('PixelFormat', ['YUYV', 'UYVY', 'RGB24', 'H264', 'HEVC', 'VP8', 'VP9', 'MPEG4', 'MJPEG'])
 
     device = types.ModuleType(DEVICE_MODULE)
-    device.__dict__.update(Device=object, PixelFormat=pixel_format)
+    device.__dict__.update(Device=object, PixelFormat=PixelFormat)
 
     video = types.ModuleType(f'{VENDOR}.video')
     video.__dict__.update(device=device)

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -1,5 +1,8 @@
 """What the Linux video driver puts on its frame port, from the buffers a device hands it."""
 
+import io
+
+import av
 import numpy as np
 import pytest
 
@@ -60,20 +63,22 @@ class FakeDevice:
 
 @pytest.fixture
 def device(monkeypatch):
+    """The class the driver opens, replaced by one a test hands frames to. Pass it to ``_driven``."""
     monkeypatch.setattr(linux_video, 'Device', FakeDevice)
+    FakeDevice.to_serve, FakeDevice.opened = [], None
     return FakeDevice
 
 
-def _driven(frames, **kwargs):
-    """A driver over a device carrying ``frames``, with its port recorded, run to exhaustion."""
+def _driven(device, frames, **kwargs):
+    """A driver over ``device`` carrying ``frames``, with its port recorded, run to exhaustion."""
     camera = linux_video.LinuxVideo(
         device_path='/dev/null', width=WIDTH, height=HEIGHT, fps=30, pixel_format='YUYV', **kwargs
     )
     emitted = RecordingEmitter()
     camera.frame._bind(emitted)
-    FakeDevice.to_serve = frames
+    device.to_serve = frames
     list(camera.run(StopFlag(), pimm.world.SystemClock()))
-    opened = FakeDevice.opened
+    opened = device.opened
     assert opened is not None, 'the driver opened no device'
     return emitted, opened
 
@@ -84,7 +89,7 @@ def _yuyv(luma: int) -> bytes:
 
 
 def test_a_yuyv_buffer_reaches_the_port_as_an_image(device):
-    emitted, _ = _driven([FakeFrame(_yuyv(200), linux_video.PixelFormat.YUYV)])
+    emitted, _ = _driven(device, [FakeFrame(_yuyv(200), linux_video.PixelFormat.YUYV)])
 
     assert len(emitted.emitted) == 1
     _, adapter = emitted.emitted[0]
@@ -96,20 +101,20 @@ def test_a_yuyv_buffer_reaches_the_port_as_an_image(device):
 def test_every_buffer_is_one_frame(device):
     frames = [FakeFrame(_yuyv(v), linux_video.PixelFormat.YUYV) for v in (50, 120, 200)]
 
-    emitted, _ = _driven(frames)
+    emitted, _ = _driven(device, frames)
 
     assert len(emitted.emitted) == 3
 
 
 def test_the_device_is_set_to_what_the_driver_was_asked_for(device):
-    _, opened = _driven([FakeFrame(_yuyv(100), linux_video.PixelFormat.YUYV)])
+    _, opened = _driven(device, [FakeFrame(_yuyv(100), linux_video.PixelFormat.YUYV)])
 
     assert opened.format == ('capture', WIDTH, HEIGHT, 'YUYV')
     assert opened.fps == ('capture', 30)
 
 
 def test_the_device_is_closed_when_the_frames_run_out(device):
-    _, opened = _driven([FakeFrame(_yuyv(100), linux_video.PixelFormat.YUYV)])
+    _, opened = _driven(device, [FakeFrame(_yuyv(100), linux_video.PixelFormat.YUYV)])
 
     assert opened.closed
 
@@ -119,7 +124,7 @@ def test_a_buffer_short_of_a_frame_is_dropped(device, caplog):
     short = FakeFrame(_yuyv(200)[: WIDTH * HEIGHT], linux_video.PixelFormat.YUYV)
     whole = FakeFrame(_yuyv(200), linux_video.PixelFormat.YUYV)
 
-    emitted, _ = _driven([short, whole, short])
+    emitted, _ = _driven(device, [short, whole, short])
 
     assert len(emitted.emitted) == 1
     assert 'short of a frame' in caplog.text
@@ -129,7 +134,43 @@ def test_a_buffer_short_of_a_frame_is_dropped(device, caplog):
 def test_a_buffer_of_three_bytes_a_pixel_is_taken_as_it_is(device):
     raw = bytes(range(WIDTH * HEIGHT * 3))
 
-    emitted, _ = _driven([FakeFrame(raw, linux_video.PixelFormat.RGB24)])
+    emitted, _ = _driven(device, [FakeFrame(raw, linux_video.PixelFormat.RGB24)])
 
     _, adapter = emitted.emitted[0]
     np.testing.assert_array_equal(adapter.array, np.frombuffer(raw, dtype=np.uint8).reshape(HEIGHT, WIDTH, 3))
+
+
+def _h264(count: int) -> bytes:
+    """An H.264 stream of ``count`` frames, as a camera that compresses would hand it over."""
+    stream = io.BytesIO()
+    container = av.open(stream, 'w', format='h264')
+    encoded = container.add_stream('libx264', rate=30)
+    encoded.width, encoded.height, encoded.pix_fmt = WIDTH * 16, HEIGHT * 16, 'yuv420p'
+    encoded.options = {'tune': 'zerolatency'}  # a camera streams frames in order, and so must the fixture
+    for i in range(count):
+        image = np.full((HEIGHT * 16, WIDTH * 16, 3), i * 40, np.uint8)
+        for packet in encoded.encode(av.VideoFrame.from_ndarray(image, format='rgb24')):
+            container.mux(packet)
+    for packet in encoded.encode(None):
+        container.mux(packet)
+    container.close()
+    return stream.getvalue()
+
+
+def test_a_compressed_buffer_the_decoder_holds_back_is_not_counted_short(device, caplog):
+    """The decoder gives no image until it has one, and a whole buffer is not a truncated one."""
+    head = FakeFrame(_h264(4)[:64], linux_video.PixelFormat.H264)
+
+    emitted, _ = _driven(device, [head])
+
+    assert emitted.emitted == []
+    assert 'short of a frame' not in caplog.text
+
+
+def test_every_image_of_one_buffer_keeps_its_own_pixels(device):
+    """One buffer decoding to several images must not hand the same adapter, and its pixels, to each."""
+    emitted, _ = _driven(device, [FakeFrame(_h264(4), linux_video.PixelFormat.H264)])
+
+    greys = [adapter.array.mean() for _, adapter in emitted.emitted]
+    assert len(greys) > 1, 'the buffer decoded to a single image, so nothing was shared'
+    assert len({round(grey) for grey in greys}) == len(greys), f'images share their pixels: {greys}'

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -114,6 +114,18 @@ def test_the_device_is_closed_when_the_frames_run_out(device):
     assert opened.closed
 
 
+def test_a_buffer_short_of_a_frame_is_dropped(device, caplog):
+    """A busy bus hands over a buffer with its tail missing, and a run outlives it."""
+    short = FakeFrame(_yuyv(200)[: WIDTH * HEIGHT], linux_video.PixelFormat.YUYV)
+    whole = FakeFrame(_yuyv(200), linux_video.PixelFormat.YUYV)
+
+    emitted, _ = _driven([short, whole, short])
+
+    assert len(emitted.emitted) == 1
+    assert 'short of a frame' in caplog.text
+    assert 'handed over 2 buffers' in caplog.text
+
+
 def test_a_buffer_of_three_bytes_a_pixel_is_taken_as_it_is(device):
     raw = bytes(range(WIDTH * HEIGHT * 3))
 

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -1,0 +1,123 @@
+"""What the Linux video driver puts on its frame port, from the buffers a device hands it."""
+
+import numpy as np
+import pytest
+
+import pimm
+from positronic.drivers.camera import linux_video
+from positronic.tests.testing_coutils import RecordingEmitter
+
+WIDTH, HEIGHT = 4, 2
+
+
+class StopFlag(pimm.SignalReceiver[bool]):
+    """``should_stop`` under the test's control."""
+
+    def __init__(self):
+        self.stopped = False
+
+    def read(self) -> pimm.Message[bool]:
+        return pimm.Message(self.stopped)
+
+
+class FakeFrame:
+    def __init__(self, data: bytes, pixel_format):
+        self.data = data
+        self.pixel_format = pixel_format
+        self.width, self.height = WIDTH, HEIGHT
+
+
+class FakeDevice:
+    """A device that hands over the frames a test gives it, and records what it was set to."""
+
+    to_serve: list['FakeFrame'] = []
+    opened: 'FakeDevice | None' = None
+
+    def __init__(self, path: str):
+        self.path = path
+        self.info = type('Info', (), {'buffers': ['capture']})()
+        self.frames = list(FakeDevice.to_serve)
+        self.format = None
+        self.fps = None
+        self.closed = False
+        FakeDevice.opened = self
+
+    def open(self) -> None:
+        pass
+
+    def set_format(self, buffer, width, height, pixel_format) -> None:
+        self.format = (buffer, width, height, pixel_format)
+
+    def set_fps(self, buffer, fps) -> None:
+        self.fps = (buffer, fps)
+
+    def __iter__(self):
+        return iter(self.frames)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def device(monkeypatch):
+    monkeypatch.setattr(linux_video, 'Device', FakeDevice)
+    return FakeDevice
+
+
+def _driven(frames, **kwargs):
+    """A driver over a device carrying ``frames``, with its port recorded, run to exhaustion."""
+    camera = linux_video.LinuxVideo(
+        device_path='/dev/null', width=WIDTH, height=HEIGHT, fps=30, pixel_format='YUYV', **kwargs
+    )
+    emitted = RecordingEmitter()
+    camera.frame._bind(emitted)
+    FakeDevice.to_serve = frames
+    list(camera.run(StopFlag(), pimm.world.SystemClock()))
+    opened = FakeDevice.opened
+    assert opened is not None, 'the driver opened no device'
+    return emitted, opened
+
+
+def _yuyv(luma: int) -> bytes:
+    """One YUYV buffer of a flat grey, which converts to a flat grey RGB image."""
+    return bytes([luma, 128] * (WIDTH * HEIGHT))
+
+
+def test_a_yuyv_buffer_reaches_the_port_as_an_image(device):
+    emitted, _ = _driven([FakeFrame(_yuyv(200), linux_video.PixelFormat.YUYV)])
+
+    assert len(emitted.emitted) == 1
+    _, adapter = emitted.emitted[0]
+    assert adapter.array.shape == (HEIGHT, WIDTH, 3)
+    assert adapter.array.dtype == np.uint8
+    assert adapter.array.min() > 150  # the grey survives the conversion
+
+
+def test_every_buffer_is_one_frame(device):
+    frames = [FakeFrame(_yuyv(v), linux_video.PixelFormat.YUYV) for v in (50, 120, 200)]
+
+    emitted, _ = _driven(frames)
+
+    assert len(emitted.emitted) == 3
+
+
+def test_the_device_is_set_to_what_the_driver_was_asked_for(device):
+    _, opened = _driven([FakeFrame(_yuyv(100), linux_video.PixelFormat.YUYV)])
+
+    assert opened.format == ('capture', WIDTH, HEIGHT, 'YUYV')
+    assert opened.fps == ('capture', 30)
+
+
+def test_the_device_is_closed_when_the_frames_run_out(device):
+    _, opened = _driven([FakeFrame(_yuyv(100), linux_video.PixelFormat.YUYV)])
+
+    assert opened.closed
+
+
+def test_a_buffer_of_three_bytes_a_pixel_is_taken_as_it_is(device):
+    raw = bytes(range(WIDTH * HEIGHT * 3))
+
+    emitted, _ = _driven([FakeFrame(raw, linux_video.PixelFormat.RGB24)])
+
+    _, adapter = emitted.emitted[0]
+    np.testing.assert_array_equal(adapter.array, np.frombuffer(raw, dtype=np.uint8).reshape(HEIGHT, WIDTH, 3))

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -167,10 +167,16 @@ def test_a_compressed_buffer_the_decoder_holds_back_is_not_counted_misframed(dev
     assert 'not one frame in size' not in caplog.text
 
 
-def test_every_image_of_one_buffer_keeps_its_own_pixels(device):
-    """One buffer decoding to several images must not hand the same adapter, and its pixels, to each."""
+def test_a_buffer_of_several_images_gives_the_newest(device, caplog):
+    """The frame port holds one image, so the older images of a buffer have nowhere to go."""
+    buffer = FakeFrame(_h264(4), linux_video.PixelFormat.H264)
+    driver = linux_video.LinuxVideo(device_path='/dev/null', width=WIDTH, height=HEIGHT, fps=30, pixel_format='YUYV')
+    decoded = driver._images(buffer, lambda name: av.CodecContext.create(name, 'r'))
+    assert decoded is not None and len(decoded) > 1, 'the buffer decoded to a single image'
+
     emitted, _ = _driven(device, [FakeFrame(_h264(4), linux_video.PixelFormat.H264)])
 
-    greys = [adapter.array.mean() for _, adapter in emitted.emitted]
-    assert len(greys) > 1, 'the buffer decoded to a single image, so nothing was shared'
-    assert len({round(grey) for grey in greys}) == len(greys), f'images share their pixels: {greys}'
+    assert len(emitted.emitted) == 1
+    _, adapter = emitted.emitted[0]
+    assert adapter.array.mean() == pytest.approx(decoded[-1].mean())
+    assert f'{len(decoded) - 1} images a newer one' in caplog.text

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -69,11 +69,9 @@ def device(monkeypatch):
     return FakeDevice
 
 
-def _driven(device, frames, **kwargs):
+def _driven(device, frames):
     """A driver over ``device`` carrying ``frames``, with its port recorded, run to exhaustion."""
-    camera = linux_video.LinuxVideo(
-        device_path='/dev/null', width=WIDTH, height=HEIGHT, fps=30, pixel_format='YUYV', **kwargs
-    )
+    camera = linux_video.LinuxVideo(device_path='/dev/null', width=WIDTH, height=HEIGHT, fps=30, pixel_format='YUYV')
     emitted = RecordingEmitter()
     camera.frame._bind(emitted)
     device.to_serve = frames

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -43,10 +43,9 @@ class FakeDevice:
         self.format = None
         self.fps = None
         self.closed = False
-        FakeDevice.opened = self
 
     def open(self) -> None:
-        pass
+        FakeDevice.opened = self
 
     def set_format(self, buffer, width, height, pixel_format) -> None:
         self.format = (buffer, width, height, pixel_format)

--- a/positronic/drivers/camera/tests/test_linux_video.py
+++ b/positronic/drivers/camera/tests/test_linux_video.py
@@ -98,7 +98,7 @@ def test_a_yuyv_buffer_reaches_the_port_as_an_image(device):
     assert adapter.array.min() > 150  # the grey survives the conversion
 
 
-def test_every_buffer_is_one_frame(device):
+def test_every_whole_yuyv_buffer_is_one_frame(device):
     frames = [FakeFrame(_yuyv(v), linux_video.PixelFormat.YUYV) for v in (50, 120, 200)]
 
     emitted, _ = _driven(device, frames)
@@ -119,15 +119,15 @@ def test_the_device_is_closed_when_the_frames_run_out(device):
     assert opened.closed
 
 
-def test_a_buffer_short_of_a_frame_is_dropped(device, caplog):
-    """A busy bus hands over a buffer with its tail missing, and a run outlives it."""
-    short = FakeFrame(_yuyv(200)[: WIDTH * HEIGHT], linux_video.PixelFormat.YUYV)
+def test_a_buffer_that_is_not_one_frame_in_size_is_dropped(device, caplog):
+    """A busy bus hands over a buffer that is not a whole frame, and a run outlives it."""
+    misframed = FakeFrame(_yuyv(200)[: WIDTH * HEIGHT], linux_video.PixelFormat.YUYV)
     whole = FakeFrame(_yuyv(200), linux_video.PixelFormat.YUYV)
 
-    emitted, _ = _driven(device, [short, whole, short])
+    emitted, _ = _driven(device, [misframed, whole, misframed])
 
     assert len(emitted.emitted) == 1
-    assert 'short of a frame' in caplog.text
+    assert 'not one frame in size' in caplog.text
     assert 'handed over 2 buffers' in caplog.text
 
 
@@ -157,14 +157,14 @@ def _h264(count: int) -> bytes:
     return stream.getvalue()
 
 
-def test_a_compressed_buffer_the_decoder_holds_back_is_not_counted_short(device, caplog):
+def test_a_compressed_buffer_the_decoder_holds_back_is_not_counted_misframed(device, caplog):
     """The decoder gives no image until it has one, and a whole buffer is not a truncated one."""
     head = FakeFrame(_h264(4)[:64], linux_video.PixelFormat.H264)
 
     emitted, _ = _driven(device, [head])
 
     assert emitted.emitted == []
-    assert 'short of a frame' not in caplog.text
+    assert 'not one frame in size' not in caplog.text
 
 
 def test_every_image_of_one_buffer_keeps_its_own_pixels(device):


### PR DESCRIPTION
`LinuxVideo` emits a dict of arrays, `{'image': ndarray}`. Every other camera driver emits a
`NumpySMAdapter`, and that is what the recorder reads: `Serializers.camera_images` returns `data.array`.
So a station that records a camera on this driver raises `AttributeError` and writes no episode. The frame
the headset shows takes the same field.

This holds on `main` for the configurations that use the driver today — `main_cfg` names `arducam_left` and
`arducam_right`.

The branch that decodes several frames out of one packet wrote them into a dict that was still `None`, so
it raised `TypeError`. Frames now leave the driver one at a time, each on the port, which is what a
consumer of a single image expects.

## Testing

`positronic/drivers/camera/tests/test_linux_video.py` drives the loop over a device of its own: a YUYV
buffer arrives as an RGB image on the port, three buffers are three frames, the device is set to the
format and rate the driver was asked for, and it is closed when the frames run out. A `conftest` stands in
for `linuxpy`, which ships only in the `hardware` extra, so the tests need neither that extra nor a camera.

On hardware, against a RealSense D405 over UVC (the camera enumerates as a plain UVC device, and its colour
stream is the `-video-index4` node): 640x480 at 27.8 Hz, and a recorded episode of 91 frames that
`load_dataset` opens and decodes.


## Also here

`linuxpy` logs every ioctl, which is several lines per frame per camera: two cameras at 30 Hz bury
everything else a debug run has to say. It joins the libraries whose level `pimm.logging` pins.
