### PR TITLE
Let the episode call carry the session that runs it

### DIFF
--- a/.claude/skills/remote-training/SKILL.md
+++ b/.claude/skills/remote-training/SKILL.md
@@ -228,11 +228,11 @@ nebius ai endpoint list --parent-id "$NEBIUS_PARENT_ID" --format json \
      | .status.public_endpoints[] | select(startswith("https://"))'
 ```
 
-Point the `positronic-inference` CLI at it; `.authed_remote` sends `AUTH_TOKEN`
+Point `positronic eval run` at it; `.authed_remote` sends `AUTH_TOKEN`
 as the bearer token and fails fast if the variable is unset:
 
 ```bash
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.authed_remote --policy.url=https://<managed-url> \
   --output_dir=s3://inference/sim_stack_validation/<run_name>/<vendor>/
 ```
@@ -281,7 +281,7 @@ Run detached with `-d` for a background server; `docker --context <ctx> ps` /
 hostname:
 
 ```bash
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote --policy.url=desktop:8000 \
   --output_dir=<...>
 ```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ After installation, the following command-line scripts will be available:
 - `positronic-data-collection`: Collect demonstrations in simulation or on hardware
 - `positronic-server`: Browse and inspect datasets
 - `lerobot-0_3_3-convert`: Convert datasets to model format
-- `positronic-inference`: Run trained policies in simulation or on hardware
+- `positronic`: Run evals in simulation or on hardware, and read back the ones sent to the platform
+- `positronic-inference`: Run an attended keyboard session on hardware
 
 All commands work both inside an activated virtual environment and with `uv run --locked` prefix (e.g., `uv run --locked positronic-server`). Use `--locked` so the installed environment matches the committed `uv.lock` — uv errors loudly if you edited `pyproject.toml` without re-running `uv lock`.
 
@@ -248,10 +249,10 @@ Progress to OpenPI or GR00T when you need more capable models. See:
 
 ### 4. Run Inference and Iterate
 
-Run trained policies through the [inference script](positronic/inference.py):
+Run trained policies through the [eval runner](positronic/cli/eval/run.py):
 
 ```bash
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
     --policy=@positronic.vendors.lerobot_0_3_3.policy.act_absolute \
     --policy.base.checkpoints_dir=~/checkpoints/lerobot/<run_id> \
     --eval.timeout=60 \
@@ -266,7 +267,7 @@ cd docker && docker compose run --rm --service-ports lerobot-server ee \
     --pipeline.source.checkpoints_dir=~/checkpoints/lerobot/<run_id>
 
 # On the simulator machine:
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
     --policy=.remote \
     --policy.url=<server-ip>:8000
 ```

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -24,7 +24,7 @@ curl http://localhost:8000/api/v1/models
 In a separate terminal, run inference inside the simulation:
 
 ```bash
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote --policy.url=localhost:8000 \
   --output_dir=~/datasets/demo_run
 ```
@@ -228,7 +228,8 @@ If your server sits behind a proxy that caps message size (Modal's is ~2 MB), wr
 Test the server with the same client as the demo:
 
 ```bash
-uv run positronic-inference sim --policy=.remote --policy.url=localhost:8000
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
+  --policy=.remote --policy.url=localhost:8000
 ```
 
 ### Slow-loading or subprocess models

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -46,7 +46,7 @@ uv run positronic eval run --eval=.real.droid.pick_place \
   --output_dir=~/datasets/inference_logs/franka_eval
 ```
 
-`--eval` names what runs: a whole benchmark, a suite, or one task. [Evaluation](evaluation.md) lists the targets and the flags that shape a sweep — `--eval.trial_count`, `--charge_inference_time`, `--timing`. `positronic-inference sim` is the same command with `--eval=.sim.positronic.stack_cubes` fixed, which is the shorthand the vendor quickstarts use.
+`--eval` names what runs: a whole benchmark, a suite, or one task. [Evaluation](evaluation.md) lists the targets and the flags that shape a sweep — `--eval.trial_count`, `--charge_inference_time`, `--timing`. (`positronic-inference sim` is a shorthand for the same command with `--eval=.sim.positronic.stack_cubes` fixed.)
 
 **One URL is the whole endpoint.** `--policy.url` carries the host, port, TLS, model id, and session params, so a server can be handed out as a single string:
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -108,28 +108,31 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller: it decides when an episode starts, and `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. A driver reads what it decides from itself — the keyboard operator reads the terminal in its own loop — so the runner wires nothing of it but that call and `done`.
 
+The driver also brings the policy: each ask carries the session the episode runs on. `open_rollout(task, policy)` opens that session on a runtime of its own, and the harness closes it — the episode it ran, or the ask it refused.
+
 ```python
 import pimm
 from positronic.cli.eval.run import prepare_output_dir, run_world
-from positronic.eval import Task
+from positronic.policy.harness import Rollout, open_rollout
 
 
 class MyConsole(pimm.ControlSystem):
-    """Asks `perform_task` for a `Task` per episode, and emits the episode's terminal on `done`."""
+    """Asks `perform_task` for an episode per `Task`, and emits the episode's terminal on `done`."""
 
-    def __init__(self):
-        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict](self)
+    def __init__(self, policy):
+        self._policy = policy
+        self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict](self)
         self.done = pimm.ControlSystemEmitter[dict](self)
 
     def run(self, should_stop, clock):
-        ...
+        ...  # each episode: `self.perform_task(open_rollout(task, self._policy))`
 
 
 # `prepare_output_dir` syncs a directory and snapshots the sources into it, and it can raise. The
 # policy is yours to close from the moment you first touch it. `None` records nothing.
 try:
-    console = MyConsole()
-    run_world(policy, embodiment, console, prepare_output_dir(output_dir), done=console.done)
+    console = MyConsole(policy)
+    run_world(embodiment, console, prepare_output_dir(output_dir), done=console.done)
 finally:
     policy.close()
 ```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -108,12 +108,12 @@ Something has to say when an episode starts and when it finishes. `positronic-in
 
 Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller: it decides when an episode starts, and `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. A driver reads what it decides from itself — the keyboard operator reads the terminal in its own loop — so the runner wires nothing of it but that call and `done`.
 
-The driver also brings the policy: each ask carries the session the episode runs on. `open_rollout(task, policy)` opens that session on a runtime of its own, and the harness closes it — the episode it ran, or the ask it refused.
+The driver also brings the policy: each ask carries the session the episode runs on. `Rollout(task, policy)` opens that session on a runtime of its own, and the harness closes it — the episode it ran, or the ask it refused.
 
 ```python
 import pimm
 from positronic.cli.eval.run import prepare_output_dir, run_world
-from positronic.policy.harness import Rollout, open_rollout
+from positronic.policy.harness import Rollout
 
 
 class MyConsole(pimm.ControlSystem):
@@ -125,7 +125,7 @@ class MyConsole(pimm.ControlSystem):
         self.done = pimm.ControlSystemEmitter[dict](self)
 
     def run(self, should_stop, clock):
-        ...  # each episode: `self.perform_task(open_rollout(task, self._policy))`
+        ...  # each episode: `self.perform_task(Rollout(task, self._policy))`
 
 
 # `prepare_output_dir` syncs a directory and snapshots the sources into it, and it can raise. The

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -34,50 +34,47 @@ Check server: `curl http://localhost:8000/api/v1/models` returns available model
 **Run inference:**
 ```bash
 # Simulation
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url=localhost:8000 \
   --output_dir=~/datasets/inference_logs/exp_v1
 
-# Hardware
-uv run positronic-inference real \
+# Hardware — the same command against a rig's eval
+uv run positronic eval run --eval=.real.droid.pick_place \
   --policy=.remote \
   --policy.url=gpu-server:8000 \
   --output_dir=~/datasets/inference_logs/franka_eval
 ```
 
+`--eval` names what runs: a whole benchmark, a suite, or one task. [Evaluation](evaluation.md) lists the targets and the flags that shape a sweep — `--eval.trial_count`, `--charge_inference_time`, `--timing`. `positronic-inference sim` is the same command with `--eval=.sim.positronic.stack_cubes` fixed, which is the shorthand the vendor quickstarts use.
+
 **One URL is the whole endpoint.** `--policy.url` carries the host, port, TLS, model id, and session params, so a server can be handed out as a single string:
 
 ```bash
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url='https://gpu-server/api/v1/session/checkpoint-20000?codec.fps=10&local.pad_start=false'
 ```
 
 Accepted forms: `host`, `host:port`, and `https://host[:port][/api/v1/session[/<model_id>]]` (`http`, `ws` and `wss` work too), each with an optional query. `https`/`wss` enable TLS. An omitted port is the scheme's own — 443 for TLS and 80 otherwise — so name the port a server listens on (`:8000` for every vendor server's default). Naming no model id serves the checkpoint the server pinned at startup.
 
-**Credentials stay out of the URL**, which is meant to be safe to paste around: they ride headers instead. A server gated on a bearer token — whether it checks the token itself, as every endpoint [`workflows/nebius/serve.sh`](../workflows/nebius/README.md) creates does, or sits behind a proxy that checks it — is reached with `.authed_remote`, which reads the token from `AUTH_TOKEN` and raises if it is unset. For any other scheme, write the headers as a JSON object in a file and name the file: `.file_authed_remote` with `--policy.headers.path=~/.config/endpoint/headers.json`.
+**Credentials stay out of the URL, and out of the command line.** The URL is meant to be safe to paste around, so a token rides a header instead. It stays off the command line too: `save_run_metadata()` writes `sys.argv` beside the run's episodes. Three policy configs build the header:
+
+- `.authed_remote` — a bearer token read from `AUTH_TOKEN`, which it raises about when that is unset. Every endpoint [`workflows/nebius/serve.sh`](../workflows/nebius/README.md) creates is gated this way, whether the server checks the token itself or a proxy in front of it does.
+- `.nebius_remote` — the same header, with the Nebius token fetched for you (see [the Nebius workflow README](../workflows/nebius/README.md#authenticated-inference)).
+- `.file_authed_remote` — any header set, read from the JSON object in the file at `--policy.headers.path`.
 
 ```bash
-uv run positronic-inference sim \
-  --policy=.authed_remote \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
+  --policy=.file_authed_remote \
   --policy.url=https://<endpoint-managed-url> \
+  --policy.headers.path=~/.config/endpoint/headers.json \
   --output_dir=~/datasets/inference_logs/exp_v1
 ```
 
 **Session parameters** are the URL's query string: the server applies them as overrides to its pipeline config, so you can tune the served pipeline without restarting the server. Keys are dotted paths into that config and values are JSON literals, forwarded verbatim so they arrive exactly as written (`fps=10`, `pad=false`, `name="s3"`).
 
 The model source (`checkpoints_dir`, `checkpoint`, device...) is fixed at server launch — `source.*` params are rejected; name a checkpoint in the URL path instead. Bad params fail at connect with a clear server error. Full rules in the [Offboard README](../positronic/offboard/README.md).
-
-**Credentials stay out of the URL, and out of the command line.** `.file_authed_remote` reads a fronted endpoint's auth headers from the JSON file at `--policy.headers.path`, so neither the URL nor `sys.argv` carries one — and `save_run_metadata()` writes `sys.argv` beside the run's episodes. Against a Nebius endpoint use `.authed_remote` or `.nebius_remote`, which build the bearer header for you (see [the Nebius workflow README](../workflows/nebius/README.md#authenticated-inference)).
-
-```bash
-uv run positronic-inference sim \
-  --policy=.file_authed_remote \
-  --policy.url=https://<endpoint-managed-url> \
-  --policy.headers.path=~/.config/endpoint/headers.json \
-  --output_dir=~/datasets/inference_logs/exp_v1
-```
 
 **What crosses the wire is the server's call, not the client's.** A server that wants smaller frames declares `RestrictImageSize` in its rig-side stack (640x640 by default); one behind a proxy with a message-size cap declares `remote(compress_images=True)` and the rig JPEG-encodes frames before sending. A server whose checkpoint speaks a different end-effector frame declares `ChangeEEFrame` with the transform placing that frame relative to the rig's `default`, and the rig converts poses (see [End-effector frames](codecs.md#end-effector-frames)). The client builds whatever the handshake declares, and only that — connecting to a server that declares no stack fails with an error naming the version it runs. What the declared stack must achieve is checked where it matters: the harness refuses to emit an action scheduled further than `MAX_ACTION_SKEW_SEC` from now, which is what a stack that never anchored its chunk to the rig's clock produces.
 
@@ -88,7 +85,7 @@ uv run positronic-inference sim \
 Load model directly on robot/simulator machine. Only ACT is supported locally (GR00T and OpenPI use remote inference).
 
 ```bash
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=@positronic.vendors.lerobot_0_3_3.policy.act_absolute \
   --policy.base.checkpoints_dir=~/checkpoints/lerobot/experiment_v1/ \
   --policy.base.checkpoint=10000
@@ -98,50 +95,13 @@ Use local when latency is critical (<50ms), robot has built-in GPU, or offline o
 
 ## Who Decides Episode Boundaries
 
-Something has to say when an episode starts and when it finishes. `positronic-inference` ships two commands, one per answer (see [`positronic/inference.py`](../positronic/inference.py)):
+Something has to say when an episode starts and when it finishes. There are two answers, one command each:
 
-**Unattended (`sim`):** a driver walks the eval's tasks — `--eval.trial_count=10` episodes back-to-back, each ending when its task's `timeout` expires (override with `--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
+**Unattended — `positronic eval run`:** a driver walks the eval's tasks, `--eval.trial_count=10` episodes back-to-back. Each ends when its benchmark reports the task done, or when the task's timeout expires (`--eval.timeout=60`, seconds per episode). Batch evaluation with nobody in the loop.
 
-**Keyboard (`real`):** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, one per press. The default draws a new start pose for every one of them. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
+**Keyboard — `positronic-inference real`:** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, one per press. The default draws a new start pose for every one of them. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
 
-### A console of your own
-
-Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller: it decides when an episode starts, and `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. A driver reads what it decides from itself — the keyboard operator reads the terminal in its own loop — so the runner wires nothing of it but that call and `done`.
-
-The driver also brings the policy: each ask carries the session the episode runs on. `Rollout(task, policy)` opens that session on a runtime of its own, and the harness closes it — the episode it ran, or the ask it refused.
-
-```python
-import pimm
-from positronic.cli.eval.run import prepare_output_dir, run_world
-from positronic.policy.harness import Rollout
-
-
-class MyConsole(pimm.ControlSystem):
-    """Asks `perform_task` for an episode per `Task`, and emits the episode's terminal on `done`."""
-
-    def __init__(self, policy):
-        self._policy = policy
-        self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict](self)
-        self.done = pimm.ControlSystemEmitter[dict](self)
-
-    def run(self, should_stop, clock):
-        ...  # each episode: `self.perform_task(Rollout(task, self._policy))`
-
-
-# `prepare_output_dir` syncs a directory and snapshots the sources into it, and it can raise. The
-# policy is yours to close from the moment you first touch it. `None` records nothing.
-try:
-    console = MyConsole(policy)
-    run_world(embodiment, console, prepare_output_dir(output_dir), done=console.done)
-finally:
-    policy.close()
-```
-
-The same runner takes a **simulated** embodiment: it reads `embodiment.simulated`, and gives a sim world virtual time, message-stamped recording and foreground producers. One scheduler round is then one control period. The world stops when any of its control systems returns, so the console ends the run by returning from its loop.
-
-A surface that brings a control system of its own — a camera viewer, a pedal on a socket — composes its own world instead, because only whoever builds a world can wire what runs in it. `run_world` is the shape to copy. To show the cameras, connect every observation named with the `positronic.keys.IMAGE_PREFIX` convention into a viewer's `cameras`; `positronic.gui.dpg_ui()` is one. To let the operator jog the arm between episodes, emit robot commands into `harness.manual_command`, which the harness applies only while it is idle.
-
-To count down an episode's remaining time, read `harness.deadline_ns`: it carries the instant on the world's clock the live episode ends at, so the time left is that value minus your own `clock.now_ns()`. An episode publishes its deadline once the rig is ready — after the task's prepare handlers answer, so the reset costs the episode nothing. It is `None` whenever no deadline stands — no episode running, or one whose task has no `timeout_sec`.
+Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller, and it brings the policy: each ask carries the session the episode runs on. `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. `KeyboardOperator` in [`positronic/inference.py`](../positronic/inference.py) is the worked example, in about thirty lines.
 
 ## Recording and Replay
 

--- a/docs/training-workflow.md
+++ b/docs/training-workflow.md
@@ -268,7 +268,7 @@ cd docker && docker compose run --rm lerobot-train expert_only \
 cd docker && docker compose run --rm --service-ports lerobot-server ee \
   --pipeline.source.checkpoints_dir=~/checkpoints/lerobot/baseline_v1/ &
 
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --output_dir=~/datasets/inference_logs/baseline_v1
 ```

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -22,7 +22,7 @@ from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.eval import Embodiment, Eval, Observation, Task
 from positronic.policy import Policy
 from positronic.policy.executor import blocking
-from positronic.policy.harness import Harness, Rollout, open_rollout
+from positronic.policy.harness import Harness, Rollout
 from positronic.simulator.env_server.telemetry import ATTR_RUN_ID, ENV_RUN_ID, ENV_TELEMETRY_DIR
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ class TaskDriver(pimm.ControlSystem):
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
-            answer = self.perform_task(open_rollout(task, self._policy))
+            answer = self.perform_task(Rollout(task, self._policy))
             while not answer.done():
                 if should_stop.value:
                     return

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -20,8 +20,9 @@ from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.eval import Embodiment, Eval, Observation, Task
+from positronic.policy import Policy
 from positronic.policy.executor import blocking
-from positronic.policy.harness import Harness
+from positronic.policy.harness import Harness, Rollout, open_rollout
 from positronic.simulator.env_server.telemetry import ATTR_RUN_ID, ENV_RUN_ID, ENV_TELEMETRY_DIR
 
 logger = logging.getLogger(__name__)
@@ -51,17 +52,20 @@ class TaskDriver(pimm.ControlSystem):
     """Walks a plan of tasks, asking for each as an episode through ``perform_task``, and returns —
     stopping the world — once the last has ended.
 
-    It makes the plan on its first turn, not when it is built. One task is in flight at a time: the next is
-    asked for only when the previous episode's terminal comes back, so the plan never overlaps two episodes.
+    It makes the plan on its first turn, not when it is built. It opens a session per task, and asks for the
+    episode that runs it. One task is in flight at a time: the next is asked for only when the previous
+    episode's terminal comes back, so the plan never overlaps two episodes, and each session opens on a model
+    the last episode has let go of.
     """
 
-    def __init__(self, tasks: Callable[[], Iterable[Task]]):
+    def __init__(self, tasks: Callable[[], Iterable[Task]], policy: Policy):
         self._tasks = tasks
-        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
+        self._policy = policy
+        self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
-            answer = self.perform_task(task)
+            answer = self.perform_task(open_rollout(task, self._policy))
             while not answer.done():
                 if should_stop.value:
                     return
@@ -72,7 +76,6 @@ class TaskDriver(pimm.ControlSystem):
 
 
 def run_world(
-    policy,
     embodiment: Embodiment,
     driver,
     output_dir: Path | None,
@@ -85,11 +88,11 @@ def run_world(
     Every trial runs here, whoever asks for it: the driver is what an attended run and an unattended one
     differ by. A driver is any control system with a ``perform_task`` caller — a plan walked to its end, a
     person at a keyboard, a console of somebody's own — and it reads what it decides from itself, so the
-    runner wires nothing of it but that call. ``done`` is what ends an episode from outside the policy: the
-    env's terminal in a sim eval, the operator in an attended run. The ``policy``'s lifetime stays with the
-    caller.
+    runner wires nothing of it but that call. The driver brings the policy: it opens the session each
+    episode runs on. ``done`` is what ends an episode from outside the policy: the env's terminal in a sim
+    eval, the operator in an attended run.
     """
-    harness = Harness(policy, embodiment)
+    harness = Harness(embodiment)
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
     writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
     with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
@@ -210,8 +213,8 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     try:
         with timed_pass(output_dir, timing, policy):
             for ev in evals:
-                driver = TaskDriver(ev.tasks)
-                run_world(policy, ev.embodiment, driver, output_dir, privileged=ev.privileged, done=ev.done)
+                driver = TaskDriver(ev.tasks, policy)
+                run_world(ev.embodiment, driver, output_dir, privileged=ev.privileged, done=ev.done)
     finally:
         policy.close()
 

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -11,6 +11,7 @@ from positronic import keys, telemetry, telemetry_keys
 from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
 from positronic.eval import Embodiment, Eval, Task
 from positronic.policy import Policy, Session
+from positronic.policy.harness import Rollout
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler
 
 
@@ -54,18 +55,20 @@ def test_an_exhausted_trial_plan_ends_the_sweep():
 
 
 class _EpisodeStub(pimm.ControlSystem):
-    """Stands in for the harness: records the task it was asked for and answers a round later."""
+    """Stands in for the harness: records the task it was asked for, closes the session that came with it,
+    and answers a round later."""
 
     def __init__(self):
         self.asked: list[Task] = []
-        self.perform_task = pimm.calls.ControlSystemHandler[Task, dict](self)
+        self.perform_task = pimm.calls.ControlSystemHandler[Rollout, dict](self)
 
     def run(self, should_stop, clock):
         while not should_stop.value:
             for call in self.perform_task.incoming():
-                self.asked.append(call.request)
+                self.asked.append(call.request.task)
                 yield pimm.Sleep(0.01)  # an episode takes a round to run
                 assert not list(self.perform_task.incoming()), 'a task was asked for while one was running'
+                call.request.close()
                 call.set_result({})
             yield pimm.Sleep(0.01)
 
@@ -76,7 +79,7 @@ def test_the_driver_asks_for_its_tasks_one_at_a_time():
     answered."""
     tasks = [Task(instruction_source='stack', timeout_sec=0.05, meta={keys.EVAL_TRIAL_INDEX: i}) for i in range(2)]
     stub = _EpisodeStub()
-    driver = TaskDriver(partial(iter, tasks))
+    driver = TaskDriver(partial(iter, tasks), _IdlePolicy())
     with pimm.World(virtual_time=True) as world:
         world.connect(driver.perform_task, stub.perform_task)
         drive_scheduler(world.start([driver, stub]), steps=200)

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -99,7 +99,7 @@ class Task:
 # [✓] A task source makes the plan when the world starts.
 # [✓] One runner builds the world for both.
 # [✓] A session reports the model's meta, so a policy holds none.
-# [ ] The episode call carries the session that runs it, so the Harness holds no policy.
+# [✓] The episode call carries the session that runs it, so the Harness holds no policy.
 # [ ] The episode call names where it records, so the Harness holds no dataset.
 # [ ] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.
 # [ ] A task carries its instruction as data, so no trial reads it after the reset.

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -56,7 +56,12 @@ class KeyboardOperator(KeyboardControl):
             case 's' if self._pending is not None:
                 logger.warning('An episode is already running: press [p] to stop it')
             case 's':
-                self._pending = self.perform_task(Rollout(self._next_task(), self._policy))
+                # A model that will not open a session ends the episode, not the run: the operator hears it
+                # and presses again.
+                try:  # rules-allow: swallowed-error — the operator is who this failure is for
+                    self._pending = self.perform_task(Rollout(self._next_task(), self._policy))
+                except Exception as e:
+                    logger.error(f'Episode failed to open: {e}')
             case 'p':
                 self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -21,7 +21,7 @@ from positronic.dataset.local_dataset import load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
 from positronic.eval import Embodiment, Task
 from positronic.policy import Policy
-from positronic.policy.harness import Rollout, open_rollout
+from positronic.policy.harness import Rollout
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class KeyboardOperator(KeyboardControl):
             case 's' if self._pending is not None:
                 logger.warning('An episode is already running: press [p] to stop it')
             case 's':
-                self._pending = self.perform_task(open_rollout(self._next_task(), self._policy))
+                self._pending = self.perform_task(Rollout(self._next_task(), self._policy))
             case 'p':
                 self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -20,6 +20,8 @@ from positronic.cli.eval.run import prepare_output_dir, run, run_world
 from positronic.dataset.local_dataset import load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
 from positronic.eval import Embodiment, Task
+from positronic.policy import Policy
+from positronic.policy.harness import Rollout, open_rollout
 
 logger = logging.getLogger(__name__)
 
@@ -30,14 +32,16 @@ class KeyboardOperator(KeyboardControl):
 
     One episode is in flight at a time: a press while one runs is declined here, with a warning. It holds
     the pending answer because that is where the episode's terminal — or a refused ask — arrives, and it
-    logs that as it lands. ``next_task`` is called once per accepted press.
+    logs that as it lands. ``next_task`` makes the trial and the policy opens its session, once per accepted
+    press.
     """
 
-    def __init__(self, next_task: Callable[[], Task]):
+    def __init__(self, next_task: Callable[[], Task], policy: Policy):
         super().__init__(quit_key='q')
         self._next_task = next_task
+        self._policy = policy
         self._pending: pimm.calls.Answer[dict[str, Any]] | None = None
-        self.perform_task = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](self)
+        self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
     def _each_round(self, key: str | None) -> None:
@@ -52,7 +56,7 @@ class KeyboardOperator(KeyboardControl):
             case 's' if self._pending is not None:
                 logger.warning('An episode is already running: press [p] to stop it')
             case 's':
-                self._pending = self.perform_task(self._next_task())
+                self._pending = self.perform_task(open_rollout(self._next_task(), self._policy))
             case 'p':
                 self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
 
@@ -72,9 +76,9 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `run_world` opens the
     # dataset it is given.
     try:
-        operator = KeyboardOperator(next_task)
+        operator = KeyboardOperator(next_task, policy)
         logger.info('Keyboard controls: [s]tart, sto[p], [q]uit')
-        run_world(policy, embodiment, operator, prepare_output_dir(output_dir), done=operator.done)
+        run_world(embodiment, operator, prepare_output_dir(output_dir), done=operator.done)
     finally:
         policy.close()
 

--- a/positronic/offboard/README.md
+++ b/positronic/offboard/README.md
@@ -193,7 +193,7 @@ cd docker && docker compose run --rm --service-ports groot-server ee_rot6d_joint
   --pipeline.source.checkpoints_dir=~/checkpoints/groot/exp_v1
 
 # Client connects the same way
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url=localhost:8000
 ```

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,7 +1,6 @@
 import time
 from collections import deque
 from collections.abc import Generator, Iterator
-from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -13,7 +12,7 @@ from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.drivers.roboarm.ik import assert_default_frame
 from positronic.eval import Embodiment, Task
-from positronic.policy.base import Policy, Session
+from positronic.policy.base import Policy
 from positronic.policy.executor import Executor
 from positronic.utils import flatten_dict, frozen_view
 
@@ -26,18 +25,22 @@ MAX_ACTION_SKEW_SEC = 60.0
 POLL_PERIOD_SEC = 0.01
 
 
-@dataclass
 class Rollout:
     """What one ``perform_task`` call asks for: the trial to run, the session that runs it, and the runtime
-    serving that session.
+    that serves the policy's functions to that session.
 
-    Whoever asks opens the session, and so decides which model runs the trial. The Harness closes it: the
-    episode it ran, or the ask it refused.
+    Whoever asks opens it, and so decides which model runs the trial. The Harness closes it: the episode it
+    ran, or the ask it refused.
     """
 
-    task: Task
-    session: Session
-    rt: Executor
+    def __init__(self, task: Task, policy: Policy):
+        self.task = task
+        self.rt = Executor(policy.functions)
+        try:
+            self.session = policy.new_session(rt=self.rt)
+        except BaseException:
+            self.rt.close()
+            raise
 
     def close(self) -> None:
         """Close the runtime, then the session it was serving.
@@ -46,16 +49,6 @@ class Rollout:
         """
         self.rt.close()
         self.session.close()
-
-
-def open_rollout(task: Task, policy: Policy) -> Rollout:
-    """Open a session to run ``task``, on a runtime that serves ``policy``'s functions to it."""
-    rt = Executor(policy.functions)
-    try:
-        return Rollout(task, policy.new_session(rt=rt), rt)
-    except BaseException:
-        rt.close()
-        raise
 
 
 class _EpisodeInference:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -35,8 +35,9 @@ class Rollout:
 
     def __init__(self, task: Task, policy: Policy):
         self.task = task
-        # TODO(#661): rung 8 gives the session chain and its close order to the framework. Only the charge —
-        # ``in_flight`` and ``wait`` — keeps a runtime here after that, if anything does.
+        # The Harness closes this runtime before the session, and charges the trial for the model's time
+        # through it. TODO(#661): the framework takes over closing the chain, and only the charge keeps a
+        # runtime here.
         self.rt = Executor(policy.functions)
         try:
             self.session = policy.new_session(rt=self.rt)

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -467,6 +467,11 @@ class Harness(pimm.ControlSystem):
             self._set_deadline(None)
             self._retire_inference()
             self._reap_inference()
+            # An ask this loop never reached still carries a live session, and the Harness closes what it is
+            # handed. The world answers what is left queued, so these calls are answered here as well.
+            for call in self.perform_task.incoming():
+                call.request.close()
+                call.set_exception(pimm.calls.HandlerStopped())
 
     def _run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         while not should_stop.value:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,6 +1,7 @@
 import time
 from collections import deque
 from collections.abc import Generator, Iterator
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -12,7 +13,7 @@ from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.drivers.roboarm.ik import assert_default_frame
 from positronic.eval import Embodiment, Task
-from positronic.policy.base import Policy
+from positronic.policy.base import Policy, Session
 from positronic.policy.executor import Executor
 from positronic.utils import flatten_dict, frozen_view
 
@@ -25,24 +26,51 @@ MAX_ACTION_SKEW_SEC = 60.0
 POLL_PERIOD_SEC = 0.01
 
 
-class _EpisodeInference:
-    """One episode's policy session, and the runtime that serves the policy's functions to it."""
+@dataclass
+class Rollout:
+    """What one ``perform_task`` call asks for: the trial to run, the session that runs it, and the runtime
+    serving that session.
 
-    def __init__(self, policy: Policy, context: dict[str, Any], charges_wall_time: bool, clock: pimm.Clock) -> None:
+    Whoever asks opens the session, and so decides which model runs the trial. The Harness closes it: the
+    episode it ran, or the ask it refused.
+    """
+
+    task: Task
+    session: Session
+    rt: Executor
+
+    def close(self) -> None:
+        """Close the runtime, then the session it was serving.
+
+        Until ``Executor.close`` returns, the function in flight still holds the session's websocket or model.
+        """
+        self.rt.close()
+        self.session.close()
+
+
+def open_rollout(task: Task, policy: Policy) -> Rollout:
+    """Open a session to run ``task``, on a runtime that serves ``policy``'s functions to it."""
+    rt = Executor(policy.functions)
+    try:
+        return Rollout(task, policy.new_session(rt=rt), rt)
+    except BaseException:
+        rt.close()
+        raise
+
+
+class _EpisodeInference:
+    """One episode's rollout, charged the way its trial asks and anchored on the world's clock."""
+
+    def __init__(self, rollout: Rollout, charges_wall_time: bool, clock: pimm.Clock) -> None:
+        self._rollout = rollout
         self._charges_wall_time = charges_wall_time
         self._clock = clock
         # One instant on two clocks, so ``wait`` adds a wall duration to a world instant.
         self._t0_ns, self._wall_t0 = clock.now_ns(), time.monotonic()
-        self._runtime = Executor(policy.functions)
-        try:
-            self._session = policy.new_session(context, self._runtime)
-        except BaseException:
-            self._runtime.close()
-            raise
 
     @property
     def meta(self) -> dict[str, Any]:
-        return self._session.meta
+        return self._rollout.session.meta
 
     @staticmethod
     def _owned(obs: dict[str, Any]) -> dict[str, Any]:
@@ -56,29 +84,24 @@ class _EpisodeInference:
     def __call__(self, obs: dict[str, Any]) -> list[dict[str, Any]] | None:
         now_ns = self._clock.now_ns()
         # A call that joins work already in flight keeps its anchor, so the trial pays for that work one time.
-        if not self._runtime.in_flight:
+        if not self._rollout.rt.in_flight:
             self._t0_ns, self._wall_t0 = now_ns, time.monotonic()
-        return self._session(frozen_view(self._owned(obs)), now_ns)
+        return self._rollout.session(frozen_view(self._owned(obs)), now_ns)
 
     def wait(self, should_stop: pimm.SignalReceiver[bool]) -> None:
         """Wait for the function in flight, for as long as the trial charges the loop for it."""
         if self._charges_wall_time:
             # Wall time cannot be held still, so the loop waits out only the time the world is already ahead by.
             paid_through = self._t0_ns / 1e9 + (time.monotonic() - self._wall_t0)
-            self._runtime.wait(max(self._clock.now() - paid_through, 0.0))
+            self._rollout.rt.wait(max(self._clock.now() - paid_through, 0.0))
             return
         # A trial that pays nothing waits the function out. It waits in steps, because a model that never
         # answers must not also keep the world from coming down.
-        while self._runtime.in_flight and not should_stop.value:
-            self._runtime.wait(POLL_PERIOD_SEC)
+        while self._rollout.rt.in_flight and not should_stop.value:
+            self._rollout.rt.wait(POLL_PERIOD_SEC)
 
     def close(self) -> None:
-        """Close the runtime, then the session it was serving.
-
-        Until ``Executor.close`` returns, the function in flight still holds the session's websocket or model.
-        """
-        self._runtime.close()
-        self._session.close()
+        self._rollout.close()
 
 
 class _EpisodeTelemetry:
@@ -151,20 +174,20 @@ class Harness(pimm.ControlSystem):
     so playing continues while the model runs. That work costs the trial either the wall time it took or
     nothing, with the world held still for it.
 
-    An episode runs one ``Task``, asked for by a ``perform_task`` call and answered with the terminal
-    payload it ended on. The task's ``timeout_sec`` bounds it and a truthy ``done`` within budget ends it
-    early — ``eval.terminated`` records which; a task without one ends on ``done`` alone. Which tasks run,
-    and in what order, belongs to whoever makes the calls.
+    An episode runs one ``Rollout``, asked for by a ``perform_task`` call and answered with the terminal
+    payload it ended on. The rollout's task ``timeout_sec`` bounds it and a truthy ``done`` within budget
+    ends it early — ``eval.terminated`` records which; a task without one ends on ``done`` alone. Which
+    tasks run, in what order, and on which model, belongs to whoever makes the calls.
     """
 
-    def __init__(self, policy: Policy, embodiment: Embodiment, *, static_meta: dict[str, Any] | None = None):
+    def __init__(self, embodiment: Embodiment, *, static_meta: dict[str, Any] | None = None):
         self._embodiment = embodiment
-        self.policy: Policy = policy
         self._static_meta = static_meta or {}
-        # This episode's session and the runtime serving it. ``None`` while no episode is live.
+        # This episode's rollout, on the clock and under the charge its trial asks for. ``None`` while no
+        # episode is live.
         self._inference: _EpisodeInference | None = None
         # The call this episode answers when it ends.
-        self._call: pimm.calls.Call[Task, dict[str, Any]] | None = None
+        self._call: pimm.calls.Call[Rollout, dict[str, Any]] | None = None
         # An inference let go of with a function still running.
         self._retired: _EpisodeInference | None = None
         # ``task.timeout_sec``, armed per episode; a task without one has no deadline and ends on ``done`` alone.
@@ -179,7 +202,7 @@ class Harness(pimm.ControlSystem):
         self._schedules: dict[str, deque[tuple[int, Any]]] = {name: deque() for name in embodiment.commands}
 
         # One episode per call, answered with the terminal payload it ended on.
-        self.perform_task = pimm.calls.ControlSystemHandler[Task, dict[str, Any]](self)
+        self.perform_task = pimm.calls.ControlSystemHandler[Rollout, dict[str, Any]](self)
         self.manual_command = pimm.ControlSystemReceiver(self)
         self.ds_command = pimm.ControlSystemEmitter[DsWriterCommand](self)
         # The instant on the world's clock the live episode ends at, ``None`` while no deadline stands.
@@ -196,7 +219,7 @@ class Harness(pimm.ControlSystem):
     def _task(self) -> Task:
         """The live episode's task. An episode runs for the call that asked for it, so the call carries it."""
         assert self._call is not None, 'only a live episode has a task'
-        return self._call.request
+        return self._call.request.task
 
     @property
     def _charges_wall_time(self) -> bool:
@@ -247,8 +270,8 @@ class Harness(pimm.ControlSystem):
         return pimm.Sleep(min(POLL_PERIOD_SEC, max(due - clock.now_ns(), 1) / 1e9))
 
     def _retire_inference(self) -> None:
-        """Let go of this episode's inference, keeping it for ``_reap_inference``: ending an episode must not
-        wait for a model that hangs."""
+        """Let go of this episode's inference, keeping it for ``_reap_inference``: the recording stops and the
+        rig goes back without waiting for a model that hangs."""
         if self._inference is not None:
             self._retired, self._inference = self._inference, None
 
@@ -284,25 +307,18 @@ class Harness(pimm.ControlSystem):
         self.deadline_ns.emit(deadline_ns)
 
     def _begin_episode(
-        self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, call: pimm.calls.Call[Task, dict[str, Any]]
+        self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, call: pimm.calls.Call[Rollout, dict[str, Any]]
     ) -> Generator[pimm.Command, None, None]:
-        """Open a fresh episode: ready the rig and the scene, read the instruction, open the session, the
-        recording and the first inference."""
-        # Before anything that can raise, so an episode that fails to open still answers whoever asked for it.
+        """Open a fresh episode: take the rollout, ready the rig and the scene, open the recording and the
+        first inference."""
+        # Before anything that can raise, so an episode that fails to open still answers whoever asked for
+        # it, and still closes the session it was handed.
         self._call = call
+        self._inference = _EpisodeInference(call.request, self._charges_wall_time, clock)
         # The episode span opens first, so the prepare and the rollout's other phase spans parent to it.
         self._telemetry.begin(self._task.meta)
         with telemetry.span(telemetry_keys.SPAN_RESET):
             yield from self._ready(should_stop, self._task.prepare_args)
-        # The reap waits out the function the last episode left running. It runs after the rig is readied, so
-        # a model that hangs does not leave the devices at the policy's last setpoint, and before the session
-        # below, because an in-process policy is one model across every episode.
-        self._reap_inference()
-        # Read after the reset: an embodiment that learns its task from the scene reports it only once the
-        # scene is set up.
-        self._inference = _EpisodeInference(
-            self.policy, {keys.TASK: self._task.instruction}, self._charges_wall_time, clock
-        )
         budget = self._task.timeout_sec
         self._set_deadline(clock.now_ns() + round(budget * 1e9) if budget is not None else None)
         self._telemetry.start_rollout(clock.now())
@@ -313,11 +329,11 @@ class Harness(pimm.ControlSystem):
     def _end_episode(
         self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]
     ) -> Generator[pimm.Command, None, None]:
-        """Close the live episode: finalize the recording, put the rig back, retire the session, hand the
+        """Close the live episode: finalize the recording, put the rig back, close the session, and hand the
         terminal back to whoever asked for the episode.
 
-        The inference is retired rather than closed here, so a ``RemoteSession``'s websocket outlives the
-        function still using it.
+        The session is closed after the rig has moved, so a model still inside its function costs the
+        recording and the move nothing.
         """
         yield from self._finalize_recording(clock, payload)
         # A powered arm holds the policy's last setpoint until the next trial, so each device the trial placed
@@ -325,6 +341,10 @@ class Harness(pimm.ControlSystem):
         # up, and is not asked again. The terminal waits on the move: a scene the next trial draws rebuilds
         # the model an unfinished one is still travelling under, which nothing but its timeout would end.
         yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != keys.SCENE})
+        # The answer waits until the model is out of this episode's function. An in-process policy is one
+        # model across every episode, so the session that the next ask opens must not overtake it. The move
+        # back above gives the function that time.
+        self._reap_inference()
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None
@@ -464,6 +484,7 @@ class Harness(pimm.ControlSystem):
             done = pimm.read_updated(self.done)
             if self._inference is not None:
                 if call is not None:  # the live episode is the one that finishes; a second ask is refused
+                    call.request.close()  # the session came with the ask, and nothing here will run it
                     call.set_exception(RuntimeError('An episode is already running'))
                 yield from self._advance_episode(self._inference, done, clock, should_stop)
             elif call is not None:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -35,6 +35,8 @@ class Rollout:
 
     def __init__(self, task: Task, policy: Policy):
         self.task = task
+        # TODO(#661): rung 8 gives the session chain and its close order to the framework. Only the charge —
+        # ``in_flight`` and ``wait`` — keeps a runtime here after that, if anything does.
         self.rt = Executor(policy.functions)
         try:
             self.session = policy.new_session(rt=self.rt)

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -45,7 +45,7 @@ from positronic.policy.base import DelegatingPolicy, DelegatingSession, Policy, 
 from positronic.policy.codec import ActionTiming
 from positronic.policy.harness import Harness
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
-from positronic.tests.testing_coutils import ManualDriver, drive_scheduler
+from positronic.tests.testing_coutils import ManualDriver, drive_scheduler, episode_caller
 
 GOLDEN_FILE = Path(__file__).parent / 'golden_pipeline.json.gz'
 
@@ -207,12 +207,11 @@ def _run_pipeline(tmp_path: Path) -> dict:
             # runs in.
             simulated=True,
         )
-        harness = Harness(
-            _SimulatedLatency((StopOnFault() | ChunkedSchedule()).wrap(policy), INFERENCE_LATENCY_S), embodiment
-        )
+        served = _SimulatedLatency((StopOnFault() | ChunkedSchedule()).wrap(policy), INFERENCE_LATENCY_S)
+        harness = Harness(embodiment)
         ds_agent = wire.wire_embodiment(world, harness, embodiment, ds_writer, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
-        perform_task = world.pair(harness.perform_task)
+        perform_task = episode_caller(world, harness, served)
         done_em = world.pair(harness.done)
 
         # Robot/gripper emit state every tick, so the script only drives the

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -207,11 +207,11 @@ def _run_pipeline(tmp_path: Path) -> dict:
             # runs in.
             simulated=True,
         )
-        served = _SimulatedLatency((StopOnFault() | ChunkedSchedule()).wrap(policy), INFERENCE_LATENCY_S)
+        wrapped = _SimulatedLatency((StopOnFault() | ChunkedSchedule()).wrap(policy), INFERENCE_LATENCY_S)
         harness = Harness(embodiment)
         ds_agent = wire.wire_embodiment(world, harness, embodiment, ds_writer, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
-        perform_task = episode_caller(world, harness, served)
+        perform_task = episode_caller(world, harness, wrapped)
         done_em = world.pair(harness.done)
 
         # Robot/gripper emit state every tick, so the script only drives the

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -23,7 +23,7 @@ from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import DelegatingSession, Layer, Policy, Session
 from positronic.policy.codec import ActionTimestamp
-from positronic.policy.harness import POLL_PERIOD_SEC, Harness, Rollout, _EpisodeInference, open_rollout
+from positronic.policy.harness import POLL_PERIOD_SEC, Harness, Rollout, _EpisodeInference
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.remote import INFER, RemoteSession, round_trip
 from positronic.tests.testing_coutils import (
@@ -667,7 +667,7 @@ def test_an_uncharged_wait_ends_when_the_world_comes_down(world):
         def functions(self):
             return {INFER: never_answers.wait}
 
-    rollout = open_rollout(Task(instruction_source='t', timeout_sec=None), _HangingPolicy())
+    rollout = Rollout(Task(instruction_source='t', timeout_sec=None), _HangingPolicy())
     inference = _EpisodeInference(rollout, charges_wall_time=False, clock=world.clock)
     try:
         inference({})  # starts the function, which never answers
@@ -1683,7 +1683,7 @@ def _ask(world: pimm.World, harness: Harness, policy: Policy, task: Task) -> Non
     """Deliver one ``perform_task``, for a test that drives the harness's generator rather than a World."""
     caller = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](harness)
     wire_call(world, caller, harness.perform_task)
-    caller(open_rollout(task, policy))
+    caller(Rollout(task, policy))
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -102,10 +102,8 @@ class SpyPolicy(Policy):
         self.command = command
         self.target_grip = float(target_grip)
         self.last_obs: dict[str, Any] | None = None
-        self.reset_calls: int = 0
 
     def new_session(self, context=None, rt=None):
-        self.reset_calls += 1
         return _SpySession(self)
 
 
@@ -143,12 +141,12 @@ class StubPolicy(Policy):
         self.target_grip = float(target_grip)
         self.last_obs: dict[str, Any] | None = None
         self.observations: list[dict[str, Any]] = []
-        self.reset_calls = 0
+        self.opened_sessions = 0
         self.closed_sessions = 0
         self._meta: dict[str, object] = meta or {}
 
     def new_session(self, context=None, rt=None) -> Session:
-        self.reset_calls += 1
+        self.opened_sessions += 1
         return _StubSession(self)
 
 
@@ -177,7 +175,7 @@ class ChunkPolicy(StubPolicy):
         self.counter = 0
 
     def new_session(self, context=None, rt=None):
-        self.reset_calls += 1
+        self.opened_sessions += 1
         return _ChunkSession(self)
 
 
@@ -297,8 +295,8 @@ class _Scene(pimm.ControlSystem):
 
 
 def _pair_all(world, harness, policy):
-    """Pair all harness signals and return a dict of test handles. ``perform_task`` asks for a task the way
-    a driver does, on a session opened from ``policy``."""
+    """Pair all harness signals and return a dict of test handles. ``perform_task`` opens a session from
+    ``policy`` and asks for the episode, the way a driver does."""
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     deadline_recorder = RecordingEmitter()
@@ -1296,7 +1294,7 @@ def test_a_call_arriving_mid_episode_is_refused(world):
         refused.result()
     assert not live.done()
     assert _ds_types(p).count(DsWriterCommandType.START_EPISODE) == 1
-    assert policy.reset_calls == 2, 'each ask opens its own session'
+    assert policy.opened_sessions == 2, 'each ask opens its own session'
     assert policy.closed_sessions == 1, 'the refused ask left its session open'
 
 
@@ -1380,17 +1378,16 @@ def test_an_episode_answers_only_once_the_call_it_abandoned_has(world):
     p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     emit_obs = partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
-    answers = []
 
     driver = ManualDriver([
-        (lambda: answers.append(p['perform_task'](Task(instruction_source='ep1', timeout_sec=None))), 0.0),
         (emit_obs, 0.01),  # the observation that starts the function
         (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),  # while that function is still running
         (None, 0.02),
     ])
 
     scheduler = world.start([harness, driver])
-    drive_until(scheduler, lambda: answers and answers[0].done(), max_steps=400)
+    answer = p['perform_task'](Task(instruction_source='ep1', timeout_sec=None))
+    drive_until(scheduler, answer.done, max_steps=400)
 
     assert policy.events == ['open', 'answered'], f'the episode answered mid-function: {policy.events}'
 
@@ -1435,8 +1432,7 @@ class _LabeledRecorder(pimm.SignalEmitter):
 def test_finish_stops_playing_the_live_chunk(world):
     """Finishing drops the schedule the harness is playing: the chunk's remaining waypoints never reach the
     devices, so nothing is emitted past the recorder's STOP."""
-    policy = ChunkPolicy()
-    wrapped = ActionTimestamp(fps=5.0).wrap(policy)  # 1.8 s chunk — won't drain before the episode ends
+    policy = ActionTimestamp(fps=5.0).wrap(ChunkPolicy())  # 1.8 s chunk — won't drain before the episode ends
     harness = Harness(make_embodiment())
     events: list[tuple[str, object]] = []
     harness.commands[keys.ROBOT_COMMAND]._bind(_LabeledRecorder(keys.ROBOT_COMMAND, events))
@@ -1446,7 +1442,7 @@ def test_finish_stops_playing_the_live_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, wrapped)
+    perform_task = episode_caller(world, harness, policy)
     done_em = world.pair(harness.done)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -1637,7 +1633,7 @@ def test_shutdown_stops_playing_the_live_chunk(world):
     """Shutdown while recording drops the schedule too: the unplayed tail of the live chunk never reaches
     the devices after the recorder's STOP."""
     events: list[tuple[str, object]] = []
-    wrapped = ActionTimestamp(fps=5.0).wrap(ChunkPolicy())  # 1.8 s chunk — won't drain before shutdown
+    policy = ActionTimestamp(fps=5.0).wrap(ChunkPolicy())  # 1.8 s chunk — won't drain before shutdown
     harness = Harness(make_embodiment())
     harness.commands[keys.ROBOT_COMMAND]._bind(_LabeledRecorder(keys.ROBOT_COMMAND, events))
     harness.commands[keys.TARGET_GRIP]._bind(_LabeledRecorder(keys.TARGET_GRIP, events))
@@ -1646,7 +1642,7 @@ def test_shutdown_stops_playing_the_live_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, wrapped)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A call + a complete obs schedules a chunk; the driver then ends, which makes the
@@ -2388,8 +2384,7 @@ def test_manual_commands_are_emitted_as_plain_values(world):
 def test_finishing_discards_a_call_that_is_still_in_flight(world):
     """Finishing while the model is still inside its call throws that answer away: the trajectory it carries
     never reaches the devices."""
-    policy = RemoteStubPolicy(wall_sec=1.0, chunk=slow_chunk())
-    wrapped = ChunkedSchedule().wrap(policy)
+    policy = ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=1.0, chunk=slow_chunk()))
     harness = Harness(make_embodiment(simulated=True))
     cmd_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -2399,7 +2394,7 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, wrapped)
+    perform_task = episode_caller(world, harness, policy)
     done_em = world.pair(harness.done)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1298,6 +1298,25 @@ def test_a_call_arriving_mid_episode_is_refused(world):
     assert policy.closed_sessions == 1, 'the refused ask left its session open'
 
 
+@pytest.mark.timeout(3.0)
+def test_an_ask_the_world_stops_before_is_closed(world):
+    """A queued ask still carries a live session, so the Harness closes it on the way down rather than
+    leaving the model open for the rest of the process."""
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
+
+    scheduler = world.start([harness])
+    answer = p['perform_task'](Task(instruction_source='never-runs', timeout_sec=None))
+    world.request_stop()
+    drive_scheduler(scheduler, steps=5)
+
+    assert policy.opened_sessions == 1
+    assert policy.closed_sessions == 1, 'the ask went down with its session open'
+    with pytest.raises(RuntimeError):
+        answer.result()
+
+
 class _FrameWatchingSession(_FakeInferenceSession):
     """Reads its camera frame at both ends of a slow function, so a rewrite underneath it shows up as a
     difference."""

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -23,10 +23,16 @@ from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import DelegatingSession, Layer, Policy, Session
 from positronic.policy.codec import ActionTimestamp
-from positronic.policy.harness import POLL_PERIOD_SEC, Harness, _EpisodeInference
+from positronic.policy.harness import POLL_PERIOD_SEC, Harness, Rollout, _EpisodeInference, open_rollout
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.remote import INFER, RemoteSession, round_trip
-from positronic.tests.testing_coutils import ManualDriver, RecordingEmitter, drive_scheduler
+from positronic.tests.testing_coutils import (
+    ManualDriver,
+    RecordingEmitter,
+    drive_scheduler,
+    drive_until,
+    episode_caller,
+)
 
 POLL_PERIOD_NS = round(POLL_PERIOD_SEC * 1e9)
 
@@ -97,11 +103,9 @@ class SpyPolicy(Policy):
         self.target_grip = float(target_grip)
         self.last_obs: dict[str, Any] | None = None
         self.reset_calls: int = 0
-        self.last_reset_context = None
 
     def new_session(self, context=None, rt=None):
         self.reset_calls += 1
-        self.last_reset_context = context
         return _SpySession(self)
 
 
@@ -118,6 +122,9 @@ class _StubSession(Session):
     @property
     def meta(self):
         return self._meta
+
+    def close(self):
+        self._policy.closed_sessions += 1
 
 
 class StubPolicy(Policy):
@@ -137,12 +144,11 @@ class StubPolicy(Policy):
         self.last_obs: dict[str, Any] | None = None
         self.observations: list[dict[str, Any]] = []
         self.reset_calls = 0
-        self.last_reset_context: dict[str, Any] | None = None
+        self.closed_sessions = 0
         self._meta: dict[str, object] = meta or {}
 
     def new_session(self, context=None, rt=None) -> Session:
         self.reset_calls += 1
-        self.last_reset_context = context
         return _StubSession(self)
 
 
@@ -172,7 +178,6 @@ class ChunkPolicy(StubPolicy):
 
     def new_session(self, context=None, rt=None):
         self.reset_calls += 1
-        self.last_reset_context = context
         return _ChunkSession(self)
 
 
@@ -291,8 +296,9 @@ class _Scene(pimm.ControlSystem):
             yield pimm.Sleep(0.001)
 
 
-def _pair_all(world, harness):
-    """Pair all harness signals and return a dict of test handles."""
+def _pair_all(world, harness, policy):
+    """Pair all harness signals and return a dict of test handles. ``perform_task`` asks for a task the way
+    a driver does, on a session opened from ``policy``."""
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     deadline_recorder = RecordingEmitter()
@@ -301,7 +307,7 @@ def _pair_all(world, harness):
         'frame_em': world.pair(harness.observations[CAM]),
         'robot_em': world.pair(harness.observations[keys.ROBOT_STATE]),
         'grip_em': world.pair(harness.observations[keys.GRIP]),
-        'perform_task': world.pair(harness.perform_task),
+        'perform_task': episode_caller(world, harness, policy),
         'done_em': world.pair(harness.done),
         'command_rx': world.pair(harness.commands[keys.ROBOT_COMMAND]),
         'grip_rx': world.pair(harness.commands['target_grip']),
@@ -352,7 +358,7 @@ def _emitted_grips(recorder):
 def test_harness_emits_cartesian_move(world):
     pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
     policy = SpyPolicy(command=CartesianPosition(pose=pose), target_grip=0.33)
-    harness = Harness(policy, make_embodiment())
+    harness = Harness(make_embodiment())
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -362,7 +368,7 @@ def test_harness_emits_cartesian_move(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
@@ -413,7 +419,7 @@ def test_harness_emits_cartesian_move(world):
 def test_harness_passes_descriptor_to_policy(world):
     """The embodiment descriptor reaches the policy on every call (stateless policy)."""
     policy = SpyPolicy()
-    harness = Harness(policy, make_embodiment(descriptor='mujoco.franka'))
+    harness = Harness(make_embodiment(descriptor='mujoco.franka'))
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands['target_grip']._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
@@ -421,7 +427,7 @@ def test_harness_passes_descriptor_to_policy(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -443,7 +449,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     policy = SpyPolicy()
     model = bundled_franka_model()
     statics = {keys.URDF: model[keys.URDF], keys.CONTROL_FRAME: model[keys.CONTROL_FRAME]}
-    harness = Harness(policy, make_embodiment(static_meta=statics))
+    harness = Harness(make_embodiment(static_meta=statics))
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands['target_grip']._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
@@ -451,7 +457,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations['grip'])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -470,11 +476,12 @@ def test_robot_model_stays_out_of_the_observation(world):
 @pytest.mark.timeout(3.0)
 def _run_with_model(world, model, static_meta=None):
     """Drive one episode with ``model`` published on ``robot_meta_in``, or baked into embodiment statics."""
-    harness = Harness(SpyPolicy(), make_embodiment(static_meta=static_meta))
+    policy = SpyPolicy()
+    harness = Harness(make_embodiment(static_meta=static_meta))
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands['target_grip']._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
     meta_em = world.pair(harness.robot_meta_in)
 
     steps = [(partial(perform_task, Task(instruction_source='t', timeout_sec=None)), 0.0)]
@@ -512,7 +519,7 @@ def test_rejects_a_control_frame_a_late_model_declares(world):
 def test_harness_waits_for_complete_inputs(world):
     pose = Transform3D(translation=np.array([0.4, 0.5, 0.6], dtype=np.float32), rotation=Rotation.identity)
     policy = SpyPolicy(command=CartesianPosition(pose=pose), target_grip=0.33)
-    harness = Harness(policy, make_embodiment())
+    harness = Harness(make_embodiment())
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -522,7 +529,7 @@ def test_harness_waits_for_complete_inputs(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     assert CAM in harness.observations
 
@@ -559,8 +566,8 @@ def test_harness_waits_for_complete_inputs(world):
 @pytest.mark.timeout(3.0)
 def test_episode_meta_stamped_at_finalize(world):
     policy = StubPolicy(meta={'type': 'stub', 'checkpoint': 'v1'})
-    harness = Harness(policy, make_embodiment(), static_meta={keys.JOINT_SIGNALS: [keys.JOINTS]})
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment(), static_meta={keys.JOINT_SIGNALS: [keys.JOINTS]})
+    p = _pair_all(world, harness, policy)
 
     driver = ManualDriver([
         (partial(p['meta_em'].emit, {keys.URDF: '<robot/>', keys.JOINT_NAMES: ['j1']}), 0.0),
@@ -586,8 +593,8 @@ def test_episode_meta_stamped_at_finalize(world):
 @pytest.mark.timeout(3.0)
 def test_finish_emits_ds_stop_with_data(world):
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     driver = ManualDriver([
         (partial(p['perform_task'], Task(instruction_source='test', timeout_sec=None)), 0.0),
@@ -607,8 +614,9 @@ def test_finish_emits_ds_stop_with_data(world):
 @pytest.mark.timeout(3.0)
 def test_the_call_is_answered_with_the_terminal_the_episode_ended_on(world):
     """A task with no timeout ends on ``done`` alone, and its caller gets what it ended on."""
-    harness = Harness(StubPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     scheduler = world.start([harness])
     answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
@@ -624,8 +632,9 @@ def test_the_call_is_answered_with_the_terminal_the_episode_ended_on(world):
 @pytest.mark.timeout(3.0)
 def test_the_world_stopping_under_a_live_episode_fails_the_call(world):
     """The caller hears that its episode will never answer, rather than holding a handle that never completes."""
-    harness = Harness(StubPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     scheduler = world.start([harness, ManualDriver([(None, 0.02)])])
     answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
@@ -658,7 +667,8 @@ def test_an_uncharged_wait_ends_when_the_world_comes_down(world):
         def functions(self):
             return {INFER: never_answers.wait}
 
-    inference = _EpisodeInference(_HangingPolicy(), {}, charges_wall_time=False, clock=world.clock)
+    rollout = open_rollout(Task(instruction_source='t', timeout_sec=None), _HangingPolicy())
+    inference = _EpisodeInference(rollout, charges_wall_time=False, clock=world.clock)
     try:
         inference({})  # starts the function, which never answers
         world.request_stop()
@@ -680,8 +690,9 @@ def test_a_session_that_raises_fails_the_call_that_asked_for_the_episode(world):
         def new_session(self, context=None, rt=None):
             return _RaisingSession()
 
-    harness = Harness(_RaisingPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = _RaisingPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.01),
@@ -701,8 +712,8 @@ def test_a_session_that_raises_fails_the_call_that_asked_for_the_episode(world):
 def test_trial_ends_at_its_timeout(world):
     """Nothing ever lands on ``done``, yet the trial still ends at ``task.timeout_sec``: terminated=False."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     scheduler = world.start([harness])
     p['perform_task'](Task(instruction_source='test', timeout_sec=0.05))
@@ -719,8 +730,9 @@ def test_trial_budget_starts_when_the_rig_is_ready(world):
     """The 0.05 budget is measured from the end of the prepare, not from the ask: the 0.2 the scene takes to
     draw is not the trial's to spend."""
     scene = _Scene(lambda _: None, draw_s=0.2)
-    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene, _Pacer()])
@@ -736,8 +748,8 @@ def test_trial_budget_starts_when_the_rig_is_ready(world):
 def test_trial_stop_signal_terminates(world):
     """Delivering the privileged ``done`` ends a trial early: terminated=True, payload recorded."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     scheduler = world.start([harness])
     # Timeout far in the future so the stop-signal, not the clock, ends the trial.
@@ -762,8 +774,8 @@ def test_stale_done_does_not_terminate_next_trial(world):
     latched value is ignored — no producer ``reset`` clears it here (``reset`` is ``None``, as on a real
     embodiment). A falsy payload never terminates; trial 1 runs until its own fresh terminal lands."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     task = Task(instruction_source='t', timeout_sec=100.0)
 
     def stop_count():
@@ -833,8 +845,8 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
         simulated=True,
     )
     policy = StubPolicy()
-    harness = Harness(policy, embodiment)
-    perform_task = world.pair(harness.perform_task)
+    harness = Harness(embodiment)
+    perform_task = episode_caller(world, harness, policy)
     wire.wire_embodiment(world, harness, embodiment, None)
 
     scheduler = world.start([harness, device])
@@ -877,10 +889,11 @@ def test_task_done_terminates_through_wire_embodiment(world):
     )
     # Termination is independent of the policy layers; the minimal embodiment has no
     # ``robot_state``, so run the stub policy bare.
-    harness = Harness(StubPolicy(), embodiment)
+    policy = StubPolicy()
+    harness = Harness(embodiment)
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
     wire.wire_embodiment(world, harness, embodiment, None, done=device.done)
 
     scheduler = world.start([harness, device])
@@ -898,8 +911,8 @@ def test_done_after_deadline_is_a_timeout(world):
     """The deadline is hard: a ``done`` delivered past it records as a timeout — ``eval.terminated`` False,
     payload dropped — not a late stop-signal success."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # The 0.05s deadline lapses first; done lands at ~0.1s, after the trial has already timed out.
@@ -924,8 +937,9 @@ def test_a_handler_the_trial_does_not_name_is_left_alone(world):
     drawn, moved = [], []
     scene, arm = _Scene(drawn.append), _Scene(moved.append)
     handlers = {keys.SCENE: scene.env_reset, keys.ARM: arm.env_reset}
-    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers=handlers))
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers=handlers))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
     wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
 
@@ -946,8 +960,9 @@ def test_every_rig_is_put_back_where_the_trial_placed_it(world, simulated):
     placed = []
     arm = _Scene(placed.append)
     handlers = {keys.ARM: arm.env_reset}
-    harness = Harness(StubPolicy(), make_embodiment(simulated=simulated, prepare_handlers=handlers))
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(simulated=simulated, prepare_handlers=handlers))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
 
     start = JointPosition(np.arange(7, dtype=np.float64))
@@ -982,8 +997,9 @@ def test_a_trial_does_not_end_until_the_rig_is_back_where_it_started(world):
     """The terminal waits on the return move. Handed back sooner, the next trial's scene draw goes ahead of a
     move still travelling and rebuilds the model under it, leaving nothing but its timeout to end it."""
     arm = _PlacesOnce()
-    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
 
     scheduler = world.start([harness, arm, _Pacer()])
@@ -999,8 +1015,9 @@ def test_the_deadline_is_published_once_the_rig_is_ready(world):
     """An idle harness publishes nothing: ``deadline_ns`` states the instant the harness will stop at, and
     between episodes there is none to state. The first one goes out when the episode's prepare has
     answered — this embodiment readies nothing, so that is the round the task is taken."""
-    harness = Harness(StubPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     driver = ManualDriver([(None, 100.0)])  # outlives the pumping, so the world stays up between phases
     scheduler = world.start([harness, driver])
@@ -1039,8 +1056,9 @@ def test_no_deadline_is_published_while_the_rig_is_still_readying(world):
                 yield pimm.Sleep(0.001)
 
     scene = _SlowScene()
-    harness = Harness(StubPolicy(), make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
@@ -1057,8 +1075,9 @@ def test_no_deadline_is_published_while_the_rig_is_still_readying(world):
 def test_the_deadline_clears_when_the_episode_ends(world):
     """``None`` at the close is what tells a display the countdown is over, and it is published only
     there: cleared mid-episode it would stop a countdown the harness is still enforcing."""
-    harness = Harness(StubPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     driver = ManualDriver([
@@ -1078,8 +1097,9 @@ def test_the_deadline_clears_when_the_episode_ends(world):
 def test_an_episode_with_no_timeout_publishes_no_deadline(world):
     """A task with no ``timeout_sec`` publishes ``None``, which corrects a reader still holding the
     previous episode's deadline. Silence would leave it counting down against one that has lapsed."""
-    harness = Harness(StubPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     driver = ManualDriver([
@@ -1096,8 +1116,9 @@ def test_an_episode_with_no_timeout_publishes_no_deadline(world):
 def test_a_world_stopping_mid_episode_withdraws_the_deadline(world):
     """A run that ends with an episode still live withdraws its deadline like any other close: a receiver
     latches what it last got, and there is no later episode to correct it."""
-    harness = Harness(StubPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     # The script runs out while the episode is live; a control system returning is what stops the world.
@@ -1123,8 +1144,9 @@ def test_an_episode_abandoned_by_a_raise_withdraws_the_deadline(world):
         def new_session(self, context=None, rt=None):
             return _BoomSession()
 
-    harness = Harness(_BoomPolicy(), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = _BoomPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     driver = ManualDriver([
@@ -1145,8 +1167,9 @@ def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     trial would open on a rig nothing readied."""
     scene = _Scene(lambda _params: None)
     embodiment = make_embodiment(descriptor='yam', prepare_handlers={keys.SCENE: scene.env_reset})
-    harness = Harness(StubPolicy(), embodiment)
-    p = _pair_all(world, harness)
+    policy = StubPolicy()
+    harness = Harness(embodiment)
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
@@ -1174,8 +1197,8 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
     scene = _Scene(reset)
-    harness = Harness(policy, make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
@@ -1195,7 +1218,6 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
     assert all(s.static_data[keys.EVAL_EMBODIMENT] == '' for s in stops)
     assert all(s.static_data[keys.EVAL_TIMEOUT] == 0.05 for s in stops)
     assert all(s.static_data[keys.EVAL_CHARGE_INFERENCE_TIME] is True for s in stops)
-    assert policy.reset_calls == 2
 
 
 @pytest.mark.timeout(3.0)
@@ -1203,11 +1225,9 @@ def test_timeout_during_inference_drops_the_chunk(world):
     """A trial whose deadline lapses while the model is still inside its function ends with that function in
     flight: the trajectory it eventually returns is discarded, never emitted past the advertised termination
     point."""
-    harness = Harness(
-        # the function runs well past the deadline
-        ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3, chunk=slow_chunk())),
-        make_embodiment(simulated=True),
-    )
+    # the function runs well past the deadline
+    policy = ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3, chunk=slow_chunk()))
+    harness = Harness(make_embodiment(simulated=True))
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     ds_recorder = RecordingEmitter()
@@ -1218,7 +1238,7 @@ def test_timeout_during_inference_drops_the_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
@@ -1240,8 +1260,8 @@ def test_timeout_during_inference_drops_the_chunk(world):
 def test_a_terminal_landing_while_idle_does_not_end_the_next_episode(world):
     """A finish pressed with nothing running belongs to no episode, so the one asked for next runs on."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -1260,10 +1280,11 @@ def test_a_terminal_landing_while_idle_does_not_end_the_next_episode(world):
 
 @pytest.mark.timeout(3.0)
 def test_a_call_arriving_mid_episode_is_refused(world):
-    """The live episode runs on and the second caller is told why, rather than its ask being dropped."""
+    """The live episode runs on and the second caller is told why, rather than its ask being dropped. The
+    session that ask carried is closed: it came with the ask, and nothing will run it."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     scheduler = world.start([harness])
     live = p['perform_task'](Task(instruction_source='ep1', timeout_sec=None))
@@ -1275,7 +1296,8 @@ def test_a_call_arriving_mid_episode_is_refused(world):
         refused.result()
     assert not live.done()
     assert _ds_types(p).count(DsWriterCommandType.START_EPISODE) == 1
-    assert policy.reset_calls == 1
+    assert policy.reset_calls == 2, 'each ask opens its own session'
+    assert policy.closed_sessions == 1, 'the refused ask left its session open'
 
 
 class _FrameWatchingSession(_FakeInferenceSession):
@@ -1298,8 +1320,9 @@ def test_a_producer_reusing_its_buffer_cannot_rewrite_a_pending_observation(worl
     """A camera renders into the array behind the adapter it re-emits, and a wall-charged trial keeps the loop
     stepping while the function runs — so the observation handed to that function has to be its own copy."""
     watcher = _FrameWatchingSession(wall_sec=0.3)
-    harness = Harness(ServedPolicy(watcher), make_embodiment())
-    p = _pair_all(world, harness)
+    policy = ServedPolicy(watcher)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     frame = pimm.shared_memory.NumpySMAdapter((2, 2, 3), np.dtype(np.uint8))
 
@@ -1348,53 +1371,34 @@ class _AbandonedCallPolicy(ServedPolicy):
 
 
 @pytest.mark.timeout(10.0)
-def test_a_new_episode_waits_out_the_call_the_last_one_abandoned(world):
-    """An in-process policy is one model across episodes, so opening a session must not overtake a function
-    still inside the previous one — ``new_session`` resets the object that function is using."""
+def test_an_episode_answers_only_once_the_call_it_abandoned_has(world):
+    """An in-process policy is one model across episodes, so the session the next ask opens must not overtake
+    a function still inside this one. The terminal comes back after that function answers, so a driver that
+    waits for it opens the next session on a free model."""
     policy = _AbandonedCallPolicy(wall_sec=0.4)
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     emit_obs = partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
+    answers = []
 
     driver = ManualDriver([
-        (partial(p['perform_task'], Task(instruction_source='ep1', timeout_sec=None)), 0.0),
+        (lambda: answers.append(p['perform_task'](Task(instruction_source='ep1', timeout_sec=None))), 0.0),
         (emit_obs, 0.01),  # the observation that starts the function
         (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),  # while that function is still running
-        (partial(p['perform_task'], Task(instruction_source='ep2', timeout_sec=None)), 0.02),
         (None, 0.02),
     ])
 
     scheduler = world.start([harness, driver])
-    drive_scheduler(scheduler, steps=40)
+    drive_until(scheduler, lambda: answers and answers[0].done(), max_steps=400)
 
-    assert policy.events[:3] == ['open', 'answered', 'open'], (
-        f'the second session opened before the abandoned function answered: {policy.events}'
-    )
+    assert policy.events == ['open', 'answered'], f'the episode answered mid-function: {policy.events}'
 
 
 @pytest.mark.timeout(3.0)
-def test_run_calls_policy_reset_with_context(world):
-    policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
-
-    driver = ManualDriver([
-        (partial(p['perform_task'], Task(instruction_source='test-task', timeout_sec=None)), 0.0),
-        (None, 0.01),
-    ])
-
-    scheduler = world.start([harness, driver])
-    drive_scheduler(scheduler, steps=5)
-
-    assert policy.reset_calls == 1
-    assert policy.last_reset_context == {keys.TASK: 'test-task'}
-
-
-@pytest.mark.timeout(3.0)
-def test_task_instruction_reaches_session_context_after_reset(world):
-    """A task eval resets the scene before opening the session, so an instruction resolvable only on reset
-    (as a remote env reports its task) still reaches ``new_session`` — task-grouped sampling/counting needs it."""
+def test_a_task_the_reset_resolves_reaches_the_policy(world):
+    """A task eval resets the scene before the episode opens, so an instruction that only the reset resolves
+    (as a remote env reports its task) still reaches the policy: every observation carries it."""
     policy = StubPolicy()
     scene = {}
 
@@ -1402,16 +1406,18 @@ def test_task_instruction_reaches_session_context_after_reset(world):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
     drawing = _Scene(reset)
-    harness = Harness(policy, make_embodiment(prepare_handlers={keys.SCENE: drawing.env_reset}))
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: drawing.env_reset}))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], drawing.env_reset)
+    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     scheduler = world.start([harness, drawing])
     p['perform_task'](Task(instruction_source=lambda: scene['task'], timeout_sec=0.05, prepare_args={keys.SCENE: {}}))
+    emit_ready_payload(p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
     drive_scheduler(scheduler, steps=200)
 
-    assert policy.last_reset_context is not None
-    assert policy.last_reset_context[keys.TASK] == 'resolved-on-reset'
+    assert policy.last_obs is not None
+    assert policy.last_obs[keys.TASK] == 'resolved-on-reset'
 
 
 class _LabeledRecorder(pimm.SignalEmitter):
@@ -1431,7 +1437,7 @@ def test_finish_stops_playing_the_live_chunk(world):
     devices, so nothing is emitted past the recorder's STOP."""
     policy = ChunkPolicy()
     wrapped = ActionTimestamp(fps=5.0).wrap(policy)  # 1.8 s chunk — won't drain before the episode ends
-    harness = Harness(wrapped, make_embodiment())
+    harness = Harness(make_embodiment())
     events: list[tuple[str, object]] = []
     harness.commands[keys.ROBOT_COMMAND]._bind(_LabeledRecorder(keys.ROBOT_COMMAND, events))
     harness.commands['target_grip']._bind(_LabeledRecorder('target_grip', events))
@@ -1440,7 +1446,7 @@ def test_finish_stops_playing_the_live_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, wrapped)
     done_em = world.pair(harness.done)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -1473,7 +1479,8 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
         def new_session(self, context=None, rt=None):
             return _EmptyChunkSession()
 
-    harness = Harness(EmptyChunkPolicy(), make_embodiment())
+    policy = EmptyChunkPolicy()
+    harness = Harness(make_embodiment())
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -1483,7 +1490,7 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     script = [
@@ -1501,8 +1508,8 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
 @pytest.mark.timeout(3.0)
 def test_harness_clears_trajectory_on_finish(world):
     policy = ChunkPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     scheduler = world.start([harness])
@@ -1528,8 +1535,8 @@ def test_harness_clears_trajectory_on_finish(world):
 @pytest.mark.timeout(3.0)
 def test_harness_clears_trajectory_on_run(world):
     policy = ChunkPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     scheduler = world.start([harness])
@@ -1559,8 +1566,9 @@ def test_the_stack_keeps_the_model_away_from_an_unavailable_arm(world, unavailab
     asked again, on a fresh
     chunk."""
     policy = ChunkPolicy()
-    harness = Harness((StopOnFault() | ChunkedSchedule()).wrap(policy), make_embodiment())
-    p = _pair_all(world, harness)
+    wrapped = (StopOnFault() | ChunkedSchedule()).wrap(policy)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, wrapped)
 
     state_ok = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6], status=RobotStatus.AVAILABLE)
     state_unavailable = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6], status=unavailable)
@@ -1630,7 +1638,7 @@ def test_shutdown_stops_playing_the_live_chunk(world):
     the devices after the recorder's STOP."""
     events: list[tuple[str, object]] = []
     wrapped = ActionTimestamp(fps=5.0).wrap(ChunkPolicy())  # 1.8 s chunk — won't drain before shutdown
-    harness = Harness(wrapped, make_embodiment())
+    harness = Harness(make_embodiment())
     harness.commands[keys.ROBOT_COMMAND]._bind(_LabeledRecorder(keys.ROBOT_COMMAND, events))
     harness.commands[keys.TARGET_GRIP]._bind(_LabeledRecorder(keys.TARGET_GRIP, events))
     harness.ds_command._bind(_LabeledRecorder('ds_command', events))
@@ -1638,7 +1646,7 @@ def test_shutdown_stops_playing_the_live_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, wrapped)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A call + a complete obs schedules a chunk; the driver then ends, which makes the
@@ -1671,11 +1679,11 @@ class _ManualClock:
         return int(self.now() * 1e9)
 
 
-def _ask(world: pimm.World, harness: Harness, task: Task) -> None:
+def _ask(world: pimm.World, harness: Harness, policy: Policy, task: Task) -> None:
     """Deliver one ``perform_task``, for a test that drives the harness's generator rather than a World."""
-    caller = pimm.calls.ControlSystemCaller[Task, dict[str, Any]](harness)
+    caller = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](harness)
     wire_call(world, caller, harness.perform_task)
-    caller(task)
+    caller(open_rollout(task, policy))
 
 
 @pytest.mark.timeout(3.0)
@@ -1685,11 +1693,11 @@ def test_stop_mid_episode_keeps_episode_open_for_recorder_flush(world, tmp_path)
     shutdown-flush ``record.io`` span parents to the episode, not the pass. Driven straight through the
     generator protocol: the yield after the queued STOP is the recorder's flush slot."""
     policy = StubPolicy()
-    harness = Harness(policy, make_embodiment())
+    harness = Harness(make_embodiment())
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     # Never ends within the drive: the stop, not the deadline, is what winds this episode down.
-    _ask(world, harness, Task(instruction_source='stack', timeout_sec=10.0, meta={keys.EVAL_TRIAL_INDEX: 0}))
+    _ask(world, harness, policy, Task(instruction_source='stack', timeout_sec=10.0, meta={keys.EVAL_TRIAL_INDEX: 0}))
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
 
@@ -1730,8 +1738,8 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
     ``policy.infer`` span is recorded at the remote inference boundary, so the terminal is a ``RemoteStubPolicy``
     (a real ``RemoteSession`` over a fake inference session)."""
     policy = ChunkedSchedule().wrap(RemoteStubPolicy())
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A latched observation set makes the inference of every step run, because the harness reads the latest
     # value. The world ends when the script runs out, so the script covers the rounds one inference takes:
@@ -1775,11 +1783,9 @@ def test_an_inference_outliving_its_episode_parents_to_it(world, tmp_path):
     ``policy.infer`` span is recorded off the loop thread after the episode span closed. It still parents to
     the episode that asked for it rather than to the pass: charging wall time is the mode that measures real
     inference cost, so that span is the one a reader most wants attributed."""
-    harness = Harness(
-        ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3)),  # the call runs well past the deadline
-        make_embodiment(simulated=True),
-    )
-    p = _pair_all(world, harness)
+    policy = ChunkedSchedule().wrap(RemoteStubPolicy(wall_sec=0.3))  # the call runs well past the deadline
+    harness = Harness(make_embodiment(simulated=True))
+    p = _pair_all(world, harness, policy)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     producer = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.01),
@@ -1810,13 +1816,13 @@ def test_failed_pass_seals_open_episode_span(world, tmp_path):
 
     policy = StubPolicy()
     scene = pimm.calls.ControlSystemHandler[Any, None](Passive())
-    harness = Harness(policy, make_embodiment(prepare_handlers={keys.SCENE: scene}))
+    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene}))
     wire_call(world, harness.prepare[keys.SCENE], scene)
     harness.ds_command._bind(RecordingEmitter())
     task = Task(
         instruction_source='stack', timeout_sec=10.0, prepare_args={keys.SCENE: {}}, meta={keys.EVAL_TRIAL_INDEX: 0}
     )
-    _ask(world, harness, task)
+    _ask(world, harness, policy, task)
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
 
@@ -1852,8 +1858,9 @@ def test_episode_virtual_duration_starts_when_the_rig_is_ready(world, tmp_path):
     The rollout's virtual duration measures from the end of the prepare, so that stretch stays reset work
     instead of inflating the real-time factor the report derives from it."""
     scene = _Scene(lambda _: None, draw_s=0.2)
-    harness = Harness(ChunkPolicy(), make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
-    p = _pair_all(world, harness)
+    policy = ChunkPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    p = _pair_all(world, harness, policy)
     wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
@@ -1902,7 +1909,7 @@ def test_anchored_chunk_passes():
 def test_a_reply_is_scheduled_only_while_the_trial_still_has_budget(world, expired, scheduled):
     """A trial advertises the instant it stops at. A chunk answered after the world passed that instant is
     dropped instead of placed, and ``_run`` finishes the trial on the next round."""
-    harness = Harness(StubPolicy(), make_embodiment())
+    harness = Harness(make_embodiment())
     now_ns = world.clock.now_ns()
     harness._deadline_ns = now_ns - 1_000_000_000 if expired else now_ns + 1_000_000_000
 
@@ -1955,7 +1962,8 @@ def _run_episode(
 ) -> list[tuple[float, Any]]:
     """One trial run with ``charge_inference_time``; returns the grip commands with the world time each went
     out at. A sim trial runs against a pacer, the sole time-master a real rig doesn't need."""
-    harness = Harness(layer.wrap(policy), make_embodiment(simulated=simulated))
+    wrapped = layer.wrap(policy)
+    harness = Harness(make_embodiment(simulated=simulated))
     grip_recorder = _TimedRecorder(world.clock)
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
@@ -1964,7 +1972,7 @@ def _run_episode(
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, wrapped)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -2076,8 +2084,8 @@ def test_an_unavailable_arm_reaches_the_policy_with_its_pose(world, unavailable)
     """An unavailable arm is not swallowed as "no observation": its measurements reach the policy beside the status.
     The harness here runs no ``StopOnFault``, so nothing filters it on the way."""
     policy = SpyPolicy()
-    harness = Harness(policy, make_embodiment())
-    p = _pair_all(world, harness)
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy)
 
     driver = ManualDriver([
         (partial(p['perform_task'], Task(instruction_source='test', timeout_sec=None)), 0.0),
@@ -2120,13 +2128,13 @@ def test_every_arm_of_a_bimanual_rig_reports_its_own_status(world):
         pimm.ControlSystemEmitter(Passive()),
     )
     policy = SpyPolicy()
-    harness = Harness(policy, embodiment)
+    harness = Harness(embodiment)
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
     left_em = world.pair(harness.observations[left])
     right_em = world.pair(harness.observations[right])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     def emit_states():
         left_em.emit(make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6], status=RobotStatus.BUSY))
@@ -2151,7 +2159,8 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
     """A stop has no waypoints to place: an arm that faults mid-chunk stops in the round its fault is seen."""
     fault_at, period = 0.5, 0.005
     stack = StopOnFault() | ChunkedSchedule()
-    harness = Harness(stack.wrap(RemoteStubPolicy(chunk=slow_chunk(1.0, 50))), make_embodiment(simulated=True))
+    policy = stack.wrap(RemoteStubPolicy(chunk=slow_chunk(1.0, 50)))
+    harness = Harness(make_embodiment(simulated=True))
     grip_recorder = _TimedRecorder(world.clock)
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
@@ -2160,7 +2169,7 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     pose, joints = [0.1, 0.2, 0.3], [0.4, 0.5, 0.6]
     driver = ManualDriver([
@@ -2192,7 +2201,8 @@ def test_finish_does_not_wait_for_the_call_in_flight():
             raise RuntimeError('inference boom')
 
     with pimm.World() as world:
-        harness = Harness(ServedPolicy(_HangingInfer([], hang_sec)), make_embodiment())
+        policy = ServedPolicy(_HangingInfer([], hang_sec))
+        harness = Harness(make_embodiment())
         cmd_recorder = RecordingEmitter()
         ds_recorder = _TimedRecorder(world.clock)
         harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -2202,7 +2212,7 @@ def test_finish_does_not_wait_for_the_call_in_flight():
         frame_em = world.pair(harness.observations[CAM])
         robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
         grip_em = world.pair(harness.observations[keys.GRIP])
-        perform_task = world.pair(harness.perform_task)
+        perform_task = episode_caller(world, harness, policy)
         done_em = world.pair(harness.done)
 
         robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -2234,7 +2244,8 @@ def test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy():
             return answer
 
     with pimm.World() as world:
-        harness = Harness(ServedPolicy(_HangingInfer([], hang_sec)), make_embodiment())
+        policy = ServedPolicy(_HangingInfer([], hang_sec))
+        harness = Harness(make_embodiment())
         harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
         harness.commands[keys.TARGET_GRIP]._bind(RecordingEmitter())
         harness.ds_command._bind(RecordingEmitter())
@@ -2242,7 +2253,7 @@ def test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy():
         frame_em = world.pair(harness.observations[CAM])
         robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
         grip_em = world.pair(harness.observations[keys.GRIP])
-        perform_task = world.pair(harness.perform_task)
+        perform_task = episode_caller(world, harness, policy)
         done_em = world.pair(harness.done)
 
         robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -2279,7 +2290,8 @@ def test_the_session_is_closed_only_once_its_call_has_left_it():
             inside_at_close.append(self.inside)
 
     with pimm.World() as world:
-        harness = Harness(ServedPolicy(_HangingInfer()), make_embodiment())
+        policy = ServedPolicy(_HangingInfer())
+        harness = Harness(make_embodiment())
         harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
         harness.commands[keys.TARGET_GRIP]._bind(RecordingEmitter())
         harness.ds_command._bind(RecordingEmitter())
@@ -2287,7 +2299,7 @@ def test_the_session_is_closed_only_once_its_call_has_left_it():
         frame_em = world.pair(harness.observations[CAM])
         robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
         grip_em = world.pair(harness.observations[keys.GRIP])
-        perform_task = world.pair(harness.perform_task)
+        perform_task = episode_caller(world, harness, policy)
         done_em = world.pair(harness.done)
 
         robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -2328,7 +2340,8 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
         def new_session(self, context=None, rt=None):
             return _GripThenArm()
 
-    harness = Harness(ChunkedSchedule().wrap(_GripThenArmPolicy()), make_embodiment())
+    policy = ChunkedSchedule().wrap(_GripThenArmPolicy())
+    harness = Harness(make_embodiment())
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands[keys.TARGET_GRIP]._bind(grip_recorder)
@@ -2337,7 +2350,7 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -2354,7 +2367,7 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
 @pytest.mark.timeout(3.0)
 def test_manual_commands_are_emitted_as_plain_values(world):
     """An operator's command bypasses the schedule: it is the command, not a plan to play."""
-    harness = Harness(StubPolicy(), make_embodiment())
+    harness = Harness(make_embodiment())
     cmd_recorder = RecordingEmitter()
     grip_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
@@ -2376,7 +2389,8 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
     """Finishing while the model is still inside its call throws that answer away: the trajectory it carries
     never reaches the devices."""
     policy = RemoteStubPolicy(wall_sec=1.0, chunk=slow_chunk())
-    harness = Harness(ChunkedSchedule().wrap(policy), make_embodiment(simulated=True))
+    wrapped = ChunkedSchedule().wrap(policy)
+    harness = Harness(make_embodiment(simulated=True))
     cmd_recorder = RecordingEmitter()
     harness.commands[keys.ROBOT_COMMAND]._bind(cmd_recorder)
     harness.commands[keys.TARGET_GRIP]._bind(RecordingEmitter())
@@ -2385,7 +2399,7 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = world.pair(harness.perform_task)
+    perform_task = episode_caller(world, harness, wrapped)
     done_em = world.pair(harness.done)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -134,6 +134,25 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, caplog):
     assert policy.closed
 
 
+def test_a_press_that_cannot_open_a_session_keeps_the_run(monkeypatch, caplog):
+    """A model that refuses a session ends the press, not the run: the operator hears it and the rig stays
+    up for the next one."""
+
+    class _RefusingPolicy(Policy):
+        def new_session(self, *_args, **_kwargs):
+            raise RuntimeError('endpoint down')
+
+    presses = iter(['s'])
+    monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
+    operator = KeyboardOperator(lambda: Task(instruction_source='pick', timeout_sec=None), _RefusingPolicy())
+    with pimm.World(virtual_time=True) as world:
+        world.pair(operator.perform_task)
+        with caplog.at_level(logging.ERROR):
+            drive_scheduler(world.start([operator, scripted_driver((None, 0.05), (None, 0.05))]))
+
+    assert 'endpoint down' in caplog.text
+
+
 def test_the_operator_declines_a_press_while_an_episode_runs(monkeypatch, caplog):
     """One episode at a time is the operator's own rule: the second press never reaches the harness."""
     task = Task(instruction_source='pick', timeout_sec=None)

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -139,14 +139,14 @@ def test_the_operator_declines_a_press_while_an_episode_runs(monkeypatch, caplog
     task = Task(instruction_source='pick', timeout_sec=None)
     presses = iter(['s', 's'])
     monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
-    operator = KeyboardOperator(lambda: task)
+    operator = KeyboardOperator(lambda: task, _IdlePolicy())
     with pimm.World(virtual_time=True) as world:
         harness = world.pair(operator.perform_task)
         received = []
 
         def hold_the_ask():
             """Stand in for a harness running the episode it was asked for: take the call, answer nothing."""
-            received.extend(call.request for call in harness.incoming())
+            received.extend(call.request.task for call in harness.incoming())
 
         driver = scripted_driver((hold_the_ask, 0.05), (hold_the_ask, 0.05))
         drive_scheduler(world.start([operator, driver]))

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -9,7 +9,7 @@ from typing import Any, TypeVar
 import pimm
 from positronic.eval import Task
 from positronic.policy import Policy, Session
-from positronic.policy.harness import Harness, open_rollout
+from positronic.policy.harness import Harness, Rollout
 
 # The driver runs a step for its effect, so a step that hands something back — a call's answer — is one too.
 ScriptStep = tuple[Callable[[], object] | None, float]
@@ -62,7 +62,7 @@ def episode_caller(world: pimm.World, harness: Harness, policy: Policy) -> Calla
     perform_task = world.pair(harness.perform_task)
 
     def ask(task: Task) -> pimm.calls.Answer[dict[str, Any]]:
-        return perform_task(open_rollout(task, policy))
+        return perform_task(Rollout(task, policy))
 
     return ask
 

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -57,11 +57,13 @@ def scripted_driver(*steps: ScriptStep) -> ManualDriver:
     return ManualDriver(script=steps)
 
 
-def episode_caller(world: pimm.World, harness: Harness, policy: Policy) -> Callable[[Task], pimm.calls.Answer]:
+def episode_caller(
+    world: pimm.World, harness: Harness, policy: Policy
+) -> Callable[[Task], pimm.calls.Answer[dict[str, Any]]]:
     """A caller that asks ``harness`` for a task the way a driver does: it opens the session that runs it."""
     perform_task = world.pair(harness.perform_task)
 
-    def ask(task: Task) -> pimm.calls.Answer[dict[str, Any]]:
+    def ask(task: Task):
         return perform_task(Rollout(task, policy))
 
     return ask

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import pimm
-from positronic.policy import Session
+from positronic.eval import Task
+from positronic.policy import Policy, Session
+from positronic.policy.harness import Harness, open_rollout
 
 # The driver runs a step for its effect, so a step that hands something back — a call's answer — is one too.
 ScriptStep = tuple[Callable[[], object] | None, float]
@@ -53,6 +55,16 @@ class ManualDriver(pimm.ControlSystem):
 def scripted_driver(*steps: ScriptStep) -> ManualDriver:
     """Convenience factory mirroring ``ManualDriver`` construction."""
     return ManualDriver(script=steps)
+
+
+def episode_caller(world: pimm.World, harness: Harness, policy: Policy) -> Callable[[Task], pimm.calls.Answer]:
+    """A caller that asks ``harness`` for a task the way a driver does: it opens the session that runs it."""
+    perform_task = world.pair(harness.perform_task)
+
+    def ask(task: Task) -> pimm.calls.Answer[dict[str, Any]]:
+        return perform_task(open_rollout(task, policy))
+
+    return ask
 
 
 class RecordingEmitter(pimm.SignalEmitter[T]):

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -31,7 +31,7 @@ serverless alternative is in the [Appendix](#appendix-nebius-serverless).)
 
 ## Zero-shot inference (wan2.1 DROID checkpoint)
 
-To try the pretrained DROID model with no training. `positronic-inference` comes from `uv sync` (see
+To try the pretrained DROID model with no training. `positronic` comes from `uv sync` (see
 [Installation](../../../README.md#installation)). Replace `<user>` with your username on the H100 box —
 `CACHE_ROOT` is that box's home, where the mounted `~/.cache` and `~/.aws` live (more in
 [Prerequisites](#full-pipeline-fine-tune-your-own-checkpoint) below).
@@ -43,7 +43,7 @@ cd docker
 CACHE_ROOT=/home/<user> docker --context <h100> compose run --rm --service-ports dreamzero-server droid
 
 # Run sim inference locally (only inference is remote; MuJoCo runs on your machine).
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote --policy.url=<h100-host>:8000 \
   --eval.trial_count=2
 ```
@@ -147,7 +147,7 @@ Sanity-check once warm: `curl http://<h100-host>:8000/api/v1/models` → `{"mode
 ### 4. Run sim inference
 
 ```bash
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote --policy.url=<h100-host>:8000 \
   --eval.trial_count=<N> --output_dir=<dir-or-s3-path>
 ```
@@ -188,12 +188,12 @@ checkpoints; the `droid` pipeline pairs the pretrained DROID model with its requ
 
 A client can tune the serving pipeline per connection: session query params become dotted overrides into the
 pipeline config, applied server-side (values are literals; the model checkpoint and backbone are fixed at
-launch). With `positronic-inference`, pass them through the remote policy:
+launch). With `positronic eval run`, pass them through the remote policy:
 
 ```bash
 # At episode start, send only the observed history (a growing frame stack) instead of
 # padding the window with the current frame repeated.
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote --policy.url='<h100-host>:8000?local.pad_start=false' \
   --eval.trial_count=2
 ```

--- a/positronic/vendors/gr00t/README.md
+++ b/positronic/vendors/gr00t/README.md
@@ -42,7 +42,7 @@ cd docker && docker compose run --rm --service-ports groot-server ee_rot6d_joint
   --pipeline.source.checkpoints_dir=~/checkpoints/groot/my_task_v1/
 
 # 4. Run inference
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url=localhost:8000
 ```

--- a/positronic/vendors/lerobot/README.md
+++ b/positronic/vendors/lerobot/README.md
@@ -43,7 +43,7 @@ cd docker && docker compose run --rm --service-ports lerobot-server ee \
   --pipeline.source.checkpoints_dir=~/checkpoints/lerobot/my_task_v1/
 
 # 4. Run inference
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url=localhost:8000
 ```

--- a/positronic/vendors/lerobot_0_3_3/README.md
+++ b/positronic/vendors/lerobot_0_3_3/README.md
@@ -38,7 +38,7 @@ cd docker && docker compose run --rm --service-ports lerobot-0_3_3-server ee \
   --pipeline.source.checkpoints_dir=~/checkpoints/lerobot/my_task_v1/
 
 # 4. Run inference
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url=localhost:8000
 ```

--- a/positronic/vendors/molmoact2/README.md
+++ b/positronic/vendors/molmoact2/README.md
@@ -47,7 +47,7 @@ curl http://localhost:8000/api/v1/models
 Point the unified `.remote` client at the server (same client as every other vendor):
 
 ```bash
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote --policy.url=localhost:8000 \
   --output_dir=~/datasets/molmoact2_run
 ```

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -212,7 +212,7 @@ To evaluate the policy, run the inference client locally using the unified `.rem
 
 **Command:**
 ```bash
-uv run --locked positronic-inference sim \
+uv run --locked positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.remote \
   --policy.url=vm-h100:8000 \
   --eval.timeout=20 \

--- a/workflows/nebius/README.md
+++ b/workflows/nebius/README.md
@@ -265,11 +265,11 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://<endpoint-managed-url>/api/v
 # → {"models": ["050000"]}
 ```
 
-Run inference from your laptop or robot host using the existing `positronic-inference` CLI
+Run inference from your laptop or robot host with `positronic eval run`
 ([docs/inference.md](../../docs/inference.md)); `.authed_remote` attaches the token:
 
 ```bash
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.authed_remote \
   --policy.url=https://<endpoint-managed-url> \
   --output_dir=.data/inference/<run-name>/
@@ -309,7 +309,7 @@ SECRET_ID=$(nebius mysterybox secret get-by-name --parent-id "$PARENT_ID" \
 export AUTH_TOKEN=$(nebius mysterybox payload get-by-key \
   --secret-id "$SECRET_ID" --key "$AUTH_TOKEN_KEY" --format json | jq -r '.data.string_value')
 
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.authed_remote \
   --policy.url=https://<endpoint-managed-url> \
   --output_dir=.data/inference/<run-name>/
@@ -331,7 +331,7 @@ cold checkpoint's first inference, so the client holds sessions open with pings 
 [rotated](#rotating-the-token) token is picked up on the next run:
 
 ```bash
-uv run positronic-inference sim \
+uv run positronic eval run --eval=.sim.positronic.stack_cubes \
   --policy=.nebius_remote \
   --policy.url=https://<endpoint-managed-url> \
   --output_dir=.data/inference/<run-name>/


### PR DESCRIPTION
## Summary

The `perform_task` call now carries a `Rollout` — the task, the session that runs it, and the runtime serving that session — so the `Harness` holds no policy at all.

- Whoever asks opens the session: `TaskDriver` and `KeyboardOperator` take the policy and pass `Rollout(task, policy)`.
- `Harness(embodiment)` and `run_world(embodiment, driver, ...)` lose their policy argument.
- The Harness closes every session handed to it: the episode it ran, or the ask it refused while one was live.
- An episode answers only once the model has left the function it abandoned. The wait moved from "before the next session opens" to "before the terminal comes back", because the caller now opens that session. The rig's move back is the time the function gets.
- The session opens before the scene reset, so it no longer gets the instruction as `new_session` context. The instruction still reaches the policy in every observation and the episode meta, both read after the reset.

Roadmap box ticked in `positronic/eval.py`.

## Test plan

`uv run --locked pytest` — 1690 passed, 8 skipped. `basedpyright` — 0 errors.
