### PR TITLE
Let a run end on an interrupt without naming another cause

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1212,14 +1212,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 99,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 33,
@@ -6896,26 +6888,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -6952,26 +6928,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
                     "lineCount": 1
                 }
             }

--- a/pimm/tests/test_calls.py
+++ b/pimm/tests/test_calls.py
@@ -241,7 +241,8 @@ class TestWorldConnect:
         caller, handler = ControlSystemCaller(Passive()), ControlSystemHandler(Passive())
         with World() as world:
             with pytest.raises(AssertionError):
-                world.connect(caller, handler, emitter_wrapper=lambda e: e)
+                # A call takes no wrapper, so `connect` has no overload for one: the assertion is what says so.
+                world.connect(caller, handler, emitter_wrapper=lambda e: e)  # pyright: ignore[reportArgumentType]
 
     def test_in_process(self):
         client, adder = Client([(1, 2), (-1, 2), (3, 4)]), Adder(defer=2)

--- a/pimm/tests/test_world.py
+++ b/pimm/tests/test_world.py
@@ -100,6 +100,31 @@ class DummySMValue(SMCompliant):
         self.value = struct.unpack('d', buffer[:8])[0]
 
 
+def test_an_interrupt_taken_inside_a_send_is_what_stops_the_process(monkeypatch):
+    """Nothing installs a handler in a process for it: the transport it interrupts is what records it.
+
+    A main-process control system reaches the same transports a background one does, so an interrupt that
+    tears a connection has to be noted where the tearing happens.
+    """
+    monkeypatch.setattr(pimm.world, '_interrupted', False)
+
+    def torn(data, ts):
+        raise KeyboardInterrupt
+
+    with World() as world:
+        emitter, receiver = world.mp_pipes()
+        assert not isinstance(receiver, list)
+        emitter.emit('before', ts=1)
+        assert receiver.read() is not None
+
+        monkeypatch.setattr(emitter, '_emit_queue', torn)
+        with pytest.raises(KeyboardInterrupt):
+            emitter.emit('torn', ts=2)
+
+        assert pimm.world._interrupted, 'the interrupt went unrecorded'
+        assert receiver.read() is None
+
+
 def test_a_process_that_took_an_interrupt_stops_talking_to_the_manager(monkeypatch):
     """An interrupt can land inside a call to the manager, and that connection then holds half a message.
 
@@ -108,6 +133,7 @@ def test_a_process_that_took_an_interrupt_stops_talking_to_the_manager(monkeypat
     """
     with World() as world:
         emitter, receiver = world.mp_pipes()
+        assert not isinstance(receiver, list)
         emitter.emit('before', ts=1)
         assert receiver.read() is not None
 

--- a/pimm/tests/test_world.py
+++ b/pimm/tests/test_world.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import pimm.world
 from pimm.core import (
     ControlSystem,
     ControlSystemEmitter,
@@ -97,6 +98,23 @@ class DummySMValue(SMCompliant):
 
     def read_from_buffer(self, buffer: memoryview | bytes) -> None:
         self.value = struct.unpack('d', buffer[:8])[0]
+
+
+def test_a_process_that_took_an_interrupt_stops_talking_to_the_manager(monkeypatch):
+    """An interrupt can land inside a call to the manager, and that connection then holds half a message.
+
+    Reading it again returns what another call asked for, so a reader takes a value off a channel it never
+    subscribed to. A process that has taken one neither reads nor sends after it.
+    """
+    with World() as world:
+        emitter, receiver = world.mp_pipes()
+        emitter.emit('before', ts=1)
+        assert receiver.read() is not None
+
+        monkeypatch.setattr(pimm.world, '_interrupted', True)
+
+        emitter.emit('after', ts=2)  # dropped, not sent
+        assert receiver.read() is None
 
 
 class TestQueueEmitter:

--- a/pimm/tests/test_world.py
+++ b/pimm/tests/test_world.py
@@ -27,7 +27,15 @@ from pimm.core import (
 from pimm.logging import LOG_LEVEL_ENV
 from pimm.shared_memory import SMCompliant
 from pimm.tests.testing import MockClock
-from pimm.world import EventReceiver, LocalQueueEmitter, QueueEmitter, SystemClock, VirtualClock, World
+from pimm.world import (
+    EventReceiver,
+    LocalQueueEmitter,
+    MultiprocessReceiver,
+    QueueEmitter,
+    SystemClock,
+    VirtualClock,
+    World,
+)
 
 
 def dummy_process(stop_reader, clock):
@@ -148,7 +156,7 @@ def test_a_queue_that_answers_with_anything_but_a_message_says_the_connection_is
     the incident that named this produced a float. Reading `.data` off it would hide the interrupt."""
     with World() as world:
         emitter, receiver = world.mp_pipes()
-        assert not isinstance(receiver, list)
+        assert isinstance(receiver, MultiprocessReceiver)
         emitter.emit('before', ts=1)  # settles the channel on the queue transport
         assert receiver.read() is not None
         receiver._queue.put(0.5)  # what the torn connection hands back

--- a/pimm/tests/test_world.py
+++ b/pimm/tests/test_world.py
@@ -152,8 +152,8 @@ def test_a_process_that_took_an_interrupt_stops_talking_to_the_manager(monkeypat
 
 
 def test_a_queue_that_answers_with_anything_but_a_message_says_the_connection_is_torn():
-    """A connection torn by an interrupt answers with what another call asked for, of whatever type it was:
-    the incident that named this produced a float. Reading `.data` off it would hide the interrupt."""
+    """A connection torn by an interrupt answers with what another call asked for, of whatever type that
+    call wanted -- a float as readily as nothing. Reading `.data` off it would hide the interrupt."""
     with World() as world:
         emitter, receiver = world.mp_pipes()
         assert isinstance(receiver, MultiprocessReceiver)

--- a/pimm/tests/test_world.py
+++ b/pimm/tests/test_world.py
@@ -143,6 +143,20 @@ def test_a_process_that_took_an_interrupt_stops_talking_to_the_manager(monkeypat
         assert receiver.read() is None
 
 
+def test_a_queue_that_answers_with_anything_but_a_message_says_the_connection_is_torn():
+    """A connection torn by an interrupt answers with what another call asked for, of whatever type it was:
+    the incident that named this produced a float. Reading `.data` off it would hide the interrupt."""
+    with World() as world:
+        emitter, receiver = world.mp_pipes()
+        assert not isinstance(receiver, list)
+        emitter.emit('before', ts=1)  # settles the channel on the queue transport
+        assert receiver.read() is not None
+        receiver._queue.put(0.5)  # what the torn connection hands back
+
+        with pytest.raises(ConnectionError, match='tore its connection'):
+            receiver.read()
+
+
 class TestQueueEmitter:
     """Test the QueueEmitter class."""
 

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -6,12 +6,12 @@ import logging
 import multiprocessing as mp
 import multiprocessing.shared_memory
 import os
-import signal
 import sys
 import time
 import traceback
 from collections import Counter, defaultdict, deque
 from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
 from enum import IntEnum
 from multiprocessing import resource_tracker
 from multiprocessing.managers import ValueProxy
@@ -143,8 +143,6 @@ class MultiprocessEmitter(SignalEmitter[T]):
         return self._mode
 
     def _emit_queue(self, data: T, ts: int) -> bool:
-        if _interrupted:
-            return False
         msg = Message(data, ts)
         success = False
 
@@ -193,16 +191,19 @@ class MultiprocessEmitter(SignalEmitter[T]):
         return True
 
     def emit(self, data: T, ts: int = -1):
-        ts = ts if ts >= 0 else self._clock.now_ns()
-        mode = self._ensure_mode(data)
-
-        if mode is TransportMode.SHARED_MEMORY:
-            if not isinstance(data, SMCompliant):
-                raise TypeError('Shared memory transport selected; data must implement SMCompliant')
-            self._emit_shared_memory(data, ts)
+        if _interrupted:
             return
+        with _noting_interrupt():
+            ts = ts if ts >= 0 else self._clock.now_ns()
+            mode = self._ensure_mode(data)  # itself a call to the manager, so it sits inside the guard
 
-        self._emit_queue(data, ts)
+            if mode is TransportMode.SHARED_MEMORY:
+                if not isinstance(data, SMCompliant):
+                    raise TypeError('Shared memory transport selected; data must implement SMCompliant')
+                self._emit_shared_memory(data, ts)
+                return
+
+            self._emit_queue(data, ts)
 
     def close(self) -> None:
         if self._closed:
@@ -230,10 +231,20 @@ class MultiprocessEmitter(SignalEmitter[T]):
 _interrupted = False
 
 
-def _note_interrupt(signum, frame):
+@contextmanager
+def _noting_interrupt() -> Iterator[None]:
+    """Record an interrupt taken inside the block, and let it go on.
+
+    A connection is torn by an interrupt that lands in the middle of a call over it, so every process that
+    reaches a transport records its own -- there is nowhere else the tearing can happen, and no process has
+    to have had a handler installed for it.
+    """
     global _interrupted
-    _interrupted = True
-    raise KeyboardInterrupt
+    try:
+        yield
+    except KeyboardInterrupt:
+        _interrupted = True
+        raise
 
 
 class MultiprocessReceiver(SignalReceiver[T]):
@@ -286,8 +297,6 @@ class MultiprocessReceiver(SignalReceiver[T]):
         return self.transport_mode is TransportMode.SHARED_MEMORY
 
     def _read_queue(self) -> Message[T] | None:
-        if _interrupted:
-            return None
         try:
             message = self._queue.get_nowait()
         except Empty:
@@ -355,19 +364,22 @@ class MultiprocessReceiver(SignalReceiver[T]):
             return Message(data=self._out_value, ts=self._ts_value.value, updated=updated)  # instead of True
 
     def read(self) -> Message[T] | None:
-        mode = self.transport_mode
-
-        if mode is TransportMode.SHARED_MEMORY:
-            return self._read_shared_memory()
-
-        message = self._read_queue()
-        if message is not None:
-            return message
-
-        if mode is TransportMode.UNDECIDED:
-            # No data yet; underlying transport still undecided.
+        if _interrupted:
             return None
-        return None
+        with _noting_interrupt():
+            mode = self.transport_mode  # itself a call to the manager, so it sits inside the guard
+
+            if mode is TransportMode.SHARED_MEMORY:
+                return self._read_shared_memory()
+
+            message = self._read_queue()
+            if message is not None:
+                return message
+
+            if mode is TransportMode.UNDECIDED:
+                # No data yet; underlying transport still undecided.
+                return None
+            return None
 
     def close(self) -> None:
         if self._closed:
@@ -488,7 +500,6 @@ class _CallAnsweringLoop:
 def _bg_wrapper(
     run_func: ControlLoop, stop_event: EventClass, clock: Clock, name: str, parent_component_levels: Mapping[str, int]
 ):
-    signal.signal(signal.SIGINT, _note_interrupt)
     try:
         # A freshly spawned subprocess carries no logging configuration, so set one up. It is inside
         # the `try` because a failure here must still reach the `finally` that stops the World.
@@ -665,6 +676,28 @@ class World:
             self._advance_to(target_ns)
             yield Sleep(wait_ns / 1e9) if wait_ns else Yield()
 
+    @overload
+    def connect(self, source: ControlSystemCaller[Req, Res], target: ControlSystemHandler[Req, Res]) -> None: ...
+
+    @overload
+    def connect(
+        self,
+        source: ControlSystemEmitter[T],
+        target: ControlSystemReceiver[T],
+        *,
+        emitter_wrapper: Callable[[SignalEmitter[T]], SignalEmitter[T]] = ...,
+    ) -> None: ...
+
+    @overload
+    def connect(
+        self,
+        source: ControlSystemEmitter[T],
+        target: ControlSystemReceiver[U],
+        *,
+        emitter_wrapper: Callable[[SignalEmitter[T]], SignalEmitter[T]] = ...,
+        receiver_wrapper: Callable[[SignalReceiver[T]], SignalReceiver[U]],
+    ) -> None: ...
+
     def connect(
         self,
         source: ControlSystemEmitter[T] | ControlSystemCaller[Req, Res],
@@ -686,7 +719,8 @@ class World:
             emitter_wrapper: Optional function to wrap the underlying SignalEmitter
                            before binding. Defaults to identity function.
             receiver_wrapper: Optional function to wrap the underlying SignalReceiver
-                            before binding. Defaults to identity function.
+                            before binding. Defaults to identity function. It is the only way the
+                            receiver may carry a type other than the emitter's.
 
         The wrapper functions allow for transformation or decoration of the
         underlying signal transport mechanisms, such as adding logging,

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -43,6 +43,7 @@ from .utils import identity
 logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
+U = TypeVar('U')
 Req = TypeVar('Req')
 Res = TypeVar('Res')
 
@@ -667,10 +668,10 @@ class World:
     def connect(
         self,
         source: ControlSystemEmitter[T] | ControlSystemCaller[Req, Res],
-        target: ControlSystemReceiver[T] | ControlSystemHandler[Req, Res],
+        target: ControlSystemReceiver[U] | ControlSystemHandler[Req, Res],
         *,
         emitter_wrapper: Callable[[SignalEmitter[T]], SignalEmitter[T]] = identity,
-        receiver_wrapper: Callable[[SignalReceiver[T]], SignalReceiver[T]] = identity,
+        receiver_wrapper: Callable[[SignalReceiver[T]], SignalReceiver[U]] = identity,
     ) -> None:
         """Declare a logical connection: an Emitter feeding a Receiver, or a Caller invoking a Handler.
 

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -275,6 +275,10 @@ class MultiprocessReceiver(SignalReceiver[T]):
         except Empty:
             message = None
         else:
+            if message is None:
+                # An interrupt that lands inside a manager call leaves that connection holding half a
+                # message, and every read after it comes back as something the queue never carried.
+                raise ConnectionError('the queue was read after an interrupt tore its connection')
             self._last_queue_message = Message(message.data, message.ts, True)
             if self._mode is TransportMode.UNDECIDED:
                 self._mode = TransportMode.QUEUE

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -6,6 +6,7 @@ import logging
 import multiprocessing as mp
 import multiprocessing.shared_memory
 import os
+import signal
 import sys
 import time
 import traceback
@@ -141,6 +142,8 @@ class MultiprocessEmitter(SignalEmitter[T]):
         return self._mode
 
     def _emit_queue(self, data: T, ts: int) -> bool:
+        if _interrupted:
+            return False
         msg = Message(data, ts)
         success = False
 
@@ -220,6 +223,18 @@ class MultiprocessEmitter(SignalEmitter[T]):
         self.close()
 
 
+# Set in a process that has taken an interrupt. An interrupt can land inside a call to the manager, and
+# that connection then holds half a message: the next call over it returns what another one asked for, so
+# a reader takes a value from a channel it never subscribed to. Nothing may be sent or read after it.
+_interrupted = False
+
+
+def _note_interrupt(signum, frame):
+    global _interrupted
+    _interrupted = True
+    raise KeyboardInterrupt
+
+
 class MultiprocessReceiver(SignalReceiver[T]):
     """Signal receiver companion for :class:`MultiprocessEmitter`.
 
@@ -270,6 +285,8 @@ class MultiprocessReceiver(SignalReceiver[T]):
         return self.transport_mode is TransportMode.SHARED_MEMORY
 
     def _read_queue(self) -> Message[T] | None:
+        if _interrupted:
+            return None
         try:
             message = self._queue.get_nowait()
         except Empty:
@@ -470,6 +487,7 @@ class _CallAnsweringLoop:
 def _bg_wrapper(
     run_func: ControlLoop, stop_event: EventClass, clock: Clock, name: str, parent_component_levels: Mapping[str, int]
 ):
+    signal.signal(signal.SIGINT, _note_interrupt)
     try:
         # A freshly spawned subprocess carries no logging configuration, so set one up. It is inside
         # the `try` because a failure here must still reach the `finally` that stops the World.

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -77,6 +77,28 @@ class QueueEmitter(SignalEmitter[T]):
                 pass
 
 
+# Set in a process that has taken an interrupt. An interrupt can land inside a call to the manager, and
+# that connection then holds half a message: the next call over it returns what another one asked for, so
+# a reader takes a value from a channel it never subscribed to. Nothing may be sent or read after it.
+_interrupted = False
+
+
+@contextmanager
+def _noting_interrupt() -> Iterator[None]:
+    """Record an interrupt taken inside the block, and let it go on.
+
+    A connection is torn by an interrupt that lands in the middle of a call over it, so every process that
+    reaches a transport records its own -- there is nowhere else the tearing can happen, and no process has
+    to have had a handler installed for it.
+    """
+    global _interrupted
+    try:
+        yield
+    except KeyboardInterrupt:
+        _interrupted = True
+        raise
+
+
 class MultiprocessEmitter(SignalEmitter[T]):
     """Signal emitter that transparently bridges processes.
 
@@ -190,20 +212,20 @@ class MultiprocessEmitter(SignalEmitter[T]):
 
         return True
 
+    @_noting_interrupt()
     def emit(self, data: T, ts: int = -1):
         if _interrupted:
             return
-        with _noting_interrupt():
-            ts = ts if ts >= 0 else self._clock.now_ns()
-            mode = self._ensure_mode(data)  # itself a call to the manager, so it sits inside the guard
+        ts = ts if ts >= 0 else self._clock.now_ns()
+        mode = self._ensure_mode(data)  # itself a call to the manager, so it sits inside the guard
 
-            if mode is TransportMode.SHARED_MEMORY:
-                if not isinstance(data, SMCompliant):
-                    raise TypeError('Shared memory transport selected; data must implement SMCompliant')
-                self._emit_shared_memory(data, ts)
-                return
+        if mode is TransportMode.SHARED_MEMORY:
+            if not isinstance(data, SMCompliant):
+                raise TypeError('Shared memory transport selected; data must implement SMCompliant')
+            self._emit_shared_memory(data, ts)
+            return
 
-            self._emit_queue(data, ts)
+        self._emit_queue(data, ts)
 
     def close(self) -> None:
         if self._closed:
@@ -223,28 +245,6 @@ class MultiprocessEmitter(SignalEmitter[T]):
     def __del__(self):
         # Last-resort cleanup when user code forgets to close the emitter.
         self.close()
-
-
-# Set in a process that has taken an interrupt. An interrupt can land inside a call to the manager, and
-# that connection then holds half a message: the next call over it returns what another one asked for, so
-# a reader takes a value from a channel it never subscribed to. Nothing may be sent or read after it.
-_interrupted = False
-
-
-@contextmanager
-def _noting_interrupt() -> Iterator[None]:
-    """Record an interrupt taken inside the block, and let it go on.
-
-    A connection is torn by an interrupt that lands in the middle of a call over it, so every process that
-    reaches a transport records its own -- there is nowhere else the tearing can happen, and no process has
-    to have had a handler installed for it.
-    """
-    global _interrupted
-    try:
-        yield
-    except KeyboardInterrupt:
-        _interrupted = True
-        raise
 
 
 class MultiprocessReceiver(SignalReceiver[T]):
@@ -363,23 +363,23 @@ class MultiprocessReceiver(SignalReceiver[T]):
             self._up_value.value = False
             return Message(data=self._out_value, ts=self._ts_value.value, updated=updated)  # instead of True
 
+    @_noting_interrupt()
     def read(self) -> Message[T] | None:
         if _interrupted:
             return None
-        with _noting_interrupt():
-            mode = self.transport_mode  # itself a call to the manager, so it sits inside the guard
+        mode = self.transport_mode  # itself a call to the manager, so it sits inside the guard
 
-            if mode is TransportMode.SHARED_MEMORY:
-                return self._read_shared_memory()
+        if mode is TransportMode.SHARED_MEMORY:
+            return self._read_shared_memory()
 
-            message = self._read_queue()
-            if message is not None:
-                return message
+        message = self._read_queue()
+        if message is not None:
+            return message
 
-            if mode is TransportMode.UNDECIDED:
-                # No data yet; underlying transport still undecided.
-                return None
+        if mode is TransportMode.UNDECIDED:
+            # No data yet; underlying transport still undecided.
             return None
+        return None
 
     def close(self) -> None:
         if self._closed:

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -302,10 +302,10 @@ class MultiprocessReceiver(SignalReceiver[T]):
         except Empty:
             message = None
         else:
-            if message is None:
+            if not isinstance(message, Message):
                 # An interrupt that lands inside a manager call leaves that connection holding half a
-                # message, and every read after it comes back as something the queue never carried.
-                raise ConnectionError('the queue was read after an interrupt tore its connection')
+                # message, and every read after it comes back as whatever another call asked for.
+                raise ConnectionError(f'the queue was read after an interrupt tore its connection: {message!r}')
             self._last_queue_message = Message(message.data, message.ts, True)
             if self._mode is TransportMode.UNDECIDED:
                 self._mode = TransportMode.QUEUE

--- a/pimm/world.py
+++ b/pimm/world.py
@@ -142,7 +142,8 @@ class MultiprocessEmitter(SignalEmitter[T]):
     @property
     def transport_mode(self) -> TransportMode:
         if self._mode is TransportMode.UNDECIDED:
-            self._mode = TransportMode(self._mode_value.value)
+            with _noting_interrupt():  # reading the manager is where a connection is torn
+                self._mode = TransportMode(self._mode_value.value)
         return self._mode
 
     @property
@@ -289,7 +290,8 @@ class MultiprocessReceiver(SignalReceiver[T]):
     @property
     def transport_mode(self) -> TransportMode:
         if self._mode is TransportMode.UNDECIDED:
-            self._mode = TransportMode(self._mode_value.value)
+            with _noting_interrupt():  # reading the manager is where a connection is torn
+                self._mode = TransportMode(self._mode_value.value)
         return self._mode
 
     @property

--- a/positronic/tests/test_components.py
+++ b/positronic/tests/test_components.py
@@ -12,7 +12,9 @@ from pimm.core import ControlSystem
 def _optional_import(module: str, symbol: str) -> Any | None:
     try:
         return getattr(import_module(module), symbol)
-    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    # A vendor that is installed but cannot load — its own native library is missing — leaves this station
+    # without the component just as an absent package does.
+    except ImportError:  # pragma: no cover - optional dependency
         return None
 
 

--- a/positronic/tests/test_components.py
+++ b/positronic/tests/test_components.py
@@ -1,3 +1,4 @@
+import logging
 import pickle
 from collections.abc import Callable
 from importlib import import_module
@@ -8,13 +9,24 @@ import pytest
 import pimm
 from pimm.core import ControlSystem
 
+logger = logging.getLogger(__name__)
+
+_OURS = ('positronic', 'pimm')
+
 
 def _optional_import(module: str, symbol: str) -> Any | None:
+    """``symbol``, or ``None`` where the vendor package it needs is not usable on this machine.
+
+    A vendor that is installed but cannot load — its own native library is missing — leaves this station
+    without the component just as an absent package does. A project module that fails to import is a broken
+    build rather than a missing vendor, and is not one of those.
+    """
     try:
         return getattr(import_module(module), symbol)
-    # A vendor that is installed but cannot load — its own native library is missing — leaves this station
-    # without the component just as an absent package does.
-    except ImportError:  # pragma: no cover - optional dependency
+    except ImportError as e:  # pragma: no cover - optional dependency
+        if (e.name or '').split('.')[0] in _OURS:
+            raise
+        logger.error('%s is not available: %s', module, e)
         return None
 
 

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -16,7 +16,7 @@ def wire(  # noqa: C901
     world: pimm.World,
     harness: pimm.ControlSystem,
     dataset_factory: DatasetFactory | None,
-    cameras: Mapping[str, pimm.SignalEmitter],
+    cameras: Mapping[str, pimm.ControlSystemEmitter],
     robot_arm: pimm.ControlSystem | None,
     gripper: pimm.ControlSystem | None,
     gui: pimm.ControlSystem | None,
@@ -101,7 +101,7 @@ def wire_embodiment(
     *,
     record: bool = True,
     privileged: dict[str, Observation] | None = None,
-    done: pimm.SignalEmitter | None = None,
+    done: pimm.ControlSystemEmitter | None = None,
 ):
     """Wire an embodiment to the Harness for the inference path.
 


### PR DESCRIPTION
Four things a run needs to survive its own ending, and one an environment needs to survive a vendor it
does not have. Found while running a teleoperation station: every `Ctrl+C` ended with a traceback that
named something other than the interrupt.

## An interrupt lands in every process at once

It can land inside a call to the manager, and that connection then holds half a message. Every call over
it afterwards returns what another one asked for.

Two of them were seen on a station with an arm, two cameras and a recorder:

- `fail_queued` read a grip value where a request envelope belongs, and raised `AttributeError`.
- The recorder read a grip value off the channel that carries its commands, and raised
  `AttributeError: 'float' object has no attribute 'type'` — over the real reason the run ended.

A process that has taken an interrupt now neither sends nor reads: whatever it would carry is going
nowhere, because every other process is stopping too. Where a torn connection still answers with
something that is not a message, the reader says so by name rather than dereferencing it.

## A vendor that is installed but cannot load

`_optional_import` caught a missing package. A package that is present while its own native library is not
— `pyzed` on a host without the ZED SDK — raises plain `ImportError`, and that ended the collection of
the whole test module. A station without the component is in the same place either way.

## A wrapper that changes what a signal carries

`pimm.map` maps a `SignalReceiver[T]` to a `SignalReceiver[U]`; its docstring says so, and data collection
uses it to hand a headset the array inside a camera frame. `World.connect` typed the wrapper as
type-preserving, so that call read as an error as soon as the camera port carried a type of its own.

## Testing

`uv run --locked pytest` is green. The interrupt guard and the torn-connection reader each carry a test
that fails without them.
