### PR TITLE
Accept null as a static episode value

### DIFF
--- a/positronic/dataset/episode.py
+++ b/positronic/dataset/episode.py
@@ -32,7 +32,7 @@ def _static_decode_hook(obj: dict) -> Any:
 
 
 def _is_valid_static_value(value: Any) -> bool:
-    if isinstance(value, str | int | float | bool | bytes):
+    if value is None or isinstance(value, str | int | float | bool | bytes):
         return True
     if isinstance(value, list | tuple):
         return all(_is_valid_static_value(v) for v in value)

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -184,7 +184,8 @@ class DiskEpisodeWriter(EpisodeWriter):
         # Validate restricted JSON structure
         if not _is_valid_static_value(data):
             raise ValueError(
-                f'Static item must be JSON-serializable: dict/list over numbers and strings, but got {name}\n{data=!r}'
+                f'Static item must be JSON-serializable: null, or dict/list over numbers and strings, '
+                f'but got {name}\n{data=!r}'
             )
         self._static_items[name] = data
 

--- a/positronic/dataset/tests/test_episode.py
+++ b/positronic/dataset/tests/test_episode.py
@@ -201,11 +201,22 @@ def test_episode_static_accepts_tuple_but_rejects_set(tmp_path):
     assert ep['coords'] == [1, 2]
 
 
-def test_episode_static_rejects_none(tmp_path):
+def test_episode_static_round_trips_none(tmp_path):
     ep_dir = tmp_path / 'ep_static_none'
+    payload = {
+        'maybe': None,
+        'server': {'base_frame_prefix': None, 'serve_mode': 'chunked'},
+        'mixed': [None, 1, 'a', {'k': None}],
+    }
     with DiskEpisodeWriter(ep_dir) as w:
-        with np.testing.assert_raises_regex(ValueError, 'JSON-serializable'):
-            w.set_static('maybe', None)
+        for k, v in payload.items():
+            w.set_static(k, v)
+
+    static = DiskEpisode(ep_dir).static
+    assert static == payload
+    assert static['maybe'] is None
+    assert static['server']['base_frame_prefix'] is None
+    assert static['mixed'][0] is None
 
 
 def test_episode_writer_abort_cleans_up_and_blocks_further_use(tmp_path):

--- a/positronic/dataset/tests/test_local_dataset.py
+++ b/positronic/dataset/tests/test_local_dataset.py
@@ -602,16 +602,6 @@ def test_unsupported_edit_record_raises(tmp_path):
         load_dataset(root)
 
 
-def test_edit_record_with_invalid_static_values_raises(tmp_path):
-    root = tmp_path / 'ds'
-    build_dataset_with_signal(root, [0])
-    (root / edits.EDITS_FILE).write_text(
-        '{"op": "set_static", "v": 1, "ep": "x", "data": {"maybe": null}}\n', encoding='utf-8'
-    )
-    with pytest.raises(ValueError, match='Invalid static values'):
-        load_dataset(root)
-
-
 def test_load_all_datasets_propagates_corrupt_edit_log(tmp_path):
     build_dataset_with_signal(tmp_path / 'ds1', [0, 1])
     build_dataset_with_signal(tmp_path / 'ds2', [2])


### PR DESCRIPTION
## What it fixes

`_is_valid_static_value` rejected `None`, while the error text promised "JSON-serializable". `null` is valid JSON.

A served policy reports an optional config field as `None` — `inference.policy.server.serve_mode.base_frame_prefix`. That value reaches `set_static`, and the recorder refused the whole episode. A run reached the operator, she pressed Start, and it died writing episode one.

The fix accepts `None` at every level the recursion reaches: bare, inside a dict, inside a list.

## The read path already carries it

`json.dump` writes `null`, `json.load` returns `None`, and every reader keys on membership rather than truthiness, so the key stays present in `Episode.static`.

I verified that in the rig's own installed venv, not only locally: write `None` and a nested `{'base_frame_prefix': None, 'chunk': 24}`, read back `None` and the nested dict unchanged. A test pins the round trip through `static.json` — bare, in a dict, in a list.

## It has run in production

The rig serves this change as positronic `7d810555f49321912730147240a599be22aae827`. A customer round completed 15 episodes across 5 tasks on it, recorded and verified in the bucket.

## Why the rig's revision differs from main

`7d810555` sits on `08b08698`, the revision `rollouts/console` pins. It carries this same `positronic/dataset/` change and nothing else.

`main` cannot go on the rig as it stands: the policy protocol moved after `08b08698`. `Executor.new_session` lost its `now` parameter and `Session.__call__` gained `time_ns`, so the console's calls no longer match. This PR touches no file under `positronic/policy/` and does not move the console's pin — that decision is live in platform#291.

`positronic/dataset/` is identical between `08b08698` and `main`, so the same patch applies to both.

## For the reviewer: a guard that can no longer fire

`_load_edits` in `positronic/dataset/edits.py` validates each parsed edit record with `_is_valid_static_value`. Once `None` is accepted, every value `json.loads` can produce becomes valid — `str`, `int`, `float`, `bool`, `None`, `list`, `dict` with string keys, plus `bytes` through `_static_decode_hook`. That guard is therefore unreachable.

I deleted only its test (`test_edit_record_with_invalid_static_values_raises`, which asserted `null` is rejected) and left the guard standing. Removing a check at a trust boundary is your call rather than mine.

## Checks

- 210 dataset tests pass.
- basedpyright: 0 errors, baseline unchanged.
- `check-rules`: 13 rules, 0 findings.

<!-- opened-by: posi-agent -->