### PR TITLE
Let the episode call name where it records

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -7040,14 +7040,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 22,
@@ -7060,22 +7052,6 @@
                 "range": {
                     "startColumn": 39,
                     "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -7116,14 +7092,6 @@
                 "range": {
                     "startColumn": 34,
                     "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1276,74 +1276,10 @@
                 }
             },
             {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 66,
                     "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 76,
                     "lineCount": 1
                 }
             }
@@ -5372,48 +5308,6 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./positronic/replay_record.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1282,6 +1282,22 @@
                     "endColumn": 71,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 83,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 70,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
             }
         ],
         "./positronic/dataset/dataset.py": [
@@ -1298,14 +1314,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 17,
                     "lineCount": 1
                 }
             },

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -101,7 +101,7 @@ Something has to say when an episode starts and when it finishes. There are two 
 
 **Keyboard — `positronic-inference real`:** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, one per press. The default draws a new start pose for every one of them. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
 
-Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller, and it brings the policy and the dataset: each ask carries the session the episode runs on and names where it records. `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. `KeyboardOperator` in [`positronic/inference.py`](../positronic/inference.py) is the worked example, in about thirty lines.
+Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller, and it brings the policy and the output path: each ask carries the session the episode runs on and names where it records. `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. `KeyboardOperator` in [`positronic/inference.py`](../positronic/inference.py) is the worked example, in about thirty lines.
 
 ## Recording and Replay
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -101,7 +101,7 @@ Something has to say when an episode starts and when it finishes. There are two 
 
 **Keyboard — `positronic-inference real`:** press `s` to start an episode, `p` to stop and save, `q` to quit. Headless — it renders nothing — and it takes `--next_task`, `--embodiment`, `--policy` and `--output_dir`. `--next_task` names the config that makes each trial, one per press. The default draws a new start pose for every one of them. Set the goal with `--next_task.instruction="..."`. Manual evaluation and debugging on hardware.
 
-Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller, and it brings the policy: each ask carries the session the episode runs on. `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. `KeyboardOperator` in [`positronic/inference.py`](../positronic/inference.py) is the worked example, in about thirty lines.
+Anything richer — a web console, a foot pedal, a rig UI — is a driver of its own rather than a plug-in. A driver is any control system with a `perform_task` caller, and it brings the policy and the dataset: each ask carries the session the episode runs on and names where it records. `run_world` builds the world around it — the harness, the recorder, the devices, and every wire between them. `KeyboardOperator` in [`positronic/inference.py`](../positronic/inference.py) is the worked example, in about thirty lines.
 
 ## Recording and Replay
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -36,9 +36,9 @@ def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
 
     Returns the local path each episode records into, or ``None`` when the run records nothing.
 
-    TODO(Positronic-Robotics/internal#378): take ``Path | None``. configuronic parses a CLI value with
-    ``ast.literal_eval`` and falls back to ``str``, so ``--output_dir=s3://…`` arrives here as a ``str``
-    whatever this says; narrowing before it coerces would make the annotation lie about what arrives.
+    TODO(Positronic-Robotics/configuronic#40): take ``Path | None``. configuronic builds a CLI value with
+    ``ast.literal_eval`` and keeps a ``str`` when that read fails, so ``--output_dir=s3://…`` arrives here as a
+    ``str`` whatever this says. A narrower annotation disagrees with the value that arrives.
     """
     if output_dir is None:
         return None
@@ -52,20 +52,20 @@ class TaskDriver(pimm.ControlSystem):
     stopping the world — once the last has ended.
 
     It makes the plan on its first turn, not when it is built. It opens a session per task, and asks for the
-    episode that runs it, recording into ``dataset`` — the whole plan lands in one. One task is in flight at
-    a time: the next is asked for only when the previous episode's terminal comes back, so the plan never
+    episode that runs it, recording into ``output_path`` — the whole plan lands in one. One task is in flight
+    at a time: the next is asked for only when the previous episode's terminal comes back, so the plan never
     overlaps two episodes, and each session opens on a model the last episode has let go of.
     """
 
-    def __init__(self, tasks: Callable[[], Iterable[Task]], policy: Policy, dataset: Path | None):
+    def __init__(self, tasks: Callable[[], Iterable[Task]], policy: Policy, output_path: Path | None):
         self._tasks = tasks
         self._policy = policy
-        self._dataset = dataset
+        self._output_path = output_path
         self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
-            answer = self.perform_task(Rollout(task, self._policy, self._dataset))
+            answer = self.perform_task(Rollout(task, self._policy, self._output_path))
             while not answer.done():
                 if should_stop.value:
                     return
@@ -88,7 +88,7 @@ def run_world(
     Every trial runs here, whoever asks for it: the driver is what an attended run and an unattended one
     differ by. A driver is any control system with a ``perform_task`` caller — a plan walked to its end, a
     person at a keyboard, a console of somebody's own — and it reads what it decides from itself, so the
-    runner wires nothing of it but that call. The driver brings the policy and the dataset: it opens the
+    runner wires nothing of it but that call. The driver brings the policy and the output path: it opens the
     session each episode runs on, and names where each episode records. ``record`` off keeps the recorder
     out of the world, so a run that writes nothing costs the producers nothing. ``done`` is what ends an
     episode from outside the policy: the env's terminal in a sim eval, the operator in an attended run.
@@ -208,13 +208,13 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     logger.info('Warming up policy endpoints')
     # The session runs no inference, but a session that serves its model on a runtime needs one to open.
     blocking(policy).new_session().close()
-    dataset = prepare_output_dir(output_dir)
+    output_path = prepare_output_dir(output_dir)
 
     try:
-        with timed_pass(dataset, timing, policy):
+        with timed_pass(output_path, timing, policy):
             for ev in evals:
-                driver = TaskDriver(ev.tasks, policy, dataset)
-                run_world(ev.embodiment, driver, record=dataset is not None, privileged=ev.privileged, done=ev.done)
+                driver = TaskDriver(ev.tasks, policy, output_path)
+                run_world(ev.embodiment, driver, record=output_path is not None, privileged=ev.privileged, done=ev.done)
     finally:
         policy.close()
 

--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -2,7 +2,7 @@ import logging
 import os
 import uuid
 from collections.abc import Callable, Generator, Iterable, Iterator
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
@@ -18,7 +18,6 @@ from positronic import telemetry, telemetry_keys, utils, wire
 from positronic.cfg.eval import placeholder
 from positronic.cli.eval.submit import submit
 from positronic.dataset.ds_writer_agent import TimeMode
-from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.eval import Embodiment, Eval, Observation, Task
 from positronic.policy import Policy
 from positronic.policy.executor import blocking
@@ -35,7 +34,7 @@ _ENV_TELEMETRY_VARS = (ENV_TELEMETRY_DIR, ENV_RUN_ID)
 def prepare_output_dir(output_dir: str | Path | None) -> Path | None:
     """Resolve where a run records: sync the directory and snapshot the sources into it.
 
-    Returns the local path a ``LocalDatasetWriter`` opens, or ``None`` when the run records nothing.
+    Returns the local path each episode records into, or ``None`` when the run records nothing.
 
     TODO(Positronic-Robotics/internal#378): take ``Path | None``. configuronic parses a CLI value with
     ``ast.literal_eval`` and falls back to ``str``, so ``--output_dir=s3://…`` arrives here as a ``str``
@@ -53,19 +52,20 @@ class TaskDriver(pimm.ControlSystem):
     stopping the world — once the last has ended.
 
     It makes the plan on its first turn, not when it is built. It opens a session per task, and asks for the
-    episode that runs it. One task is in flight at a time: the next is asked for only when the previous
-    episode's terminal comes back, so the plan never overlaps two episodes, and each session opens on a model
-    the last episode has let go of.
+    episode that runs it, recording into ``dataset`` — the whole plan lands in one. One task is in flight at
+    a time: the next is asked for only when the previous episode's terminal comes back, so the plan never
+    overlaps two episodes, and each session opens on a model the last episode has let go of.
     """
 
-    def __init__(self, tasks: Callable[[], Iterable[Task]], policy: Policy):
+    def __init__(self, tasks: Callable[[], Iterable[Task]], policy: Policy, dataset: Path | None):
         self._tasks = tasks
         self._policy = policy
+        self._dataset = dataset
         self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
-            answer = self.perform_task(Rollout(task, self._policy))
+            answer = self.perform_task(Rollout(task, self._policy, self._dataset))
             while not answer.done():
                 if should_stop.value:
                     return
@@ -78,8 +78,8 @@ class TaskDriver(pimm.ControlSystem):
 def run_world(
     embodiment: Embodiment,
     driver,
-    output_dir: Path | None,
     *,
+    record: bool = True,
     privileged: dict[str, Observation] | None = None,
     done: pimm.ControlSystemEmitter | None = None,
 ) -> None:
@@ -88,16 +88,16 @@ def run_world(
     Every trial runs here, whoever asks for it: the driver is what an attended run and an unattended one
     differ by. A driver is any control system with a ``perform_task`` caller — a plan walked to its end, a
     person at a keyboard, a console of somebody's own — and it reads what it decides from itself, so the
-    runner wires nothing of it but that call. The driver brings the policy: it opens the session each
-    episode runs on. ``done`` is what ends an episode from outside the policy: the env's terminal in a sim
-    eval, the operator in an attended run.
+    runner wires nothing of it but that call. The driver brings the policy and the dataset: it opens the
+    session each episode runs on, and names where each episode records. ``record`` off keeps the recorder
+    out of the world, so a run that writes nothing costs the producers nothing. ``done`` is what ends an
+    episode from outside the policy: the env's terminal in a sim eval, the operator in an attended run.
     """
     harness = Harness(embodiment)
     time_mode = TimeMode.MESSAGE if embodiment.simulated else TimeMode.CLOCK
-    writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext(None)
-    with writer_cm as dataset_writer, pimm.World(virtual_time=embodiment.simulated) as world:
+    with pimm.World(virtual_time=embodiment.simulated) as world:
         ds_agent = wire.wire_embodiment(
-            world, harness, embodiment, dataset_writer, time_mode, privileged=privileged, done=done
+            world, harness, embodiment, time_mode, record=record, privileged=privileged, done=done
         )
         world.connect(driver.perform_task, harness.perform_task)
         if ds_agent is not None:
@@ -208,13 +208,13 @@ def main(policy, *, evals: list[Eval], output_dir: str | Path | None = None, tim
     logger.info('Warming up policy endpoints')
     # The session runs no inference, but a session that serves its model on a runtime needs one to open.
     blocking(policy).new_session().close()
-    output_dir = prepare_output_dir(output_dir)
+    dataset = prepare_output_dir(output_dir)
 
     try:
-        with timed_pass(output_dir, timing, policy):
+        with timed_pass(dataset, timing, policy):
             for ev in evals:
-                driver = TaskDriver(ev.tasks, policy)
-                run_world(ev.embodiment, driver, output_dir, privileged=ev.privileged, done=ev.done)
+                driver = TaskDriver(ev.tasks, policy, dataset)
+                run_world(ev.embodiment, driver, record=dataset is not None, privileged=ev.privileged, done=ev.done)
     finally:
         policy.close()
 

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -79,7 +79,7 @@ def test_the_driver_asks_for_its_tasks_one_at_a_time():
     answered."""
     tasks = [Task(instruction_source='stack', timeout_sec=0.05, meta={keys.EVAL_TRIAL_INDEX: i}) for i in range(2)]
     stub = _EpisodeStub()
-    driver = TaskDriver(partial(iter, tasks), _IdlePolicy())
+    driver = TaskDriver(partial(iter, tasks), _IdlePolicy(), None)
     with pimm.World(virtual_time=True) as world:
         world.connect(driver.perform_task, stub.perform_task)
         drive_scheduler(world.start([driver, stub]), steps=200)

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -106,12 +106,12 @@ class DataCollectionController(pimm.ControlSystem):
         nominal_joints: Sequence[float] | np.ndarray,
         joints_spread: Sequence[float] | np.ndarray = (),
         *,
-        dataset: Path | None = None,
+        output_path: Path | None = None,
         static_meta: dict | None = None,
         metadata_getter: Callable[[], dict] | None = None,
     ):
         self.operator_position = operator_position
-        self._dataset = dataset
+        self._output_path = output_path
         self._nominal_joints = np.asarray(nominal_joints, dtype=np.float64)
         # A station that measured no jitter sends the arm exactly to its nominal.
         spread = joints_spread if len(joints_spread) else np.zeros_like(self._nominal_joints)
@@ -174,7 +174,7 @@ class DataCollectionController(pimm.ControlSystem):
                         meta = dict(self._static_meta)
                         meta.update(self.robot_meta_in.value)
                         meta.update(self.metadata_getter())
-                        self.ds_agent_commands.emit(DsWriterCommand.START(self._dataset, meta))
+                        self.ds_agent_commands.emit(DsWriterCommand.START(self._output_path, meta))
                         self.sound.emit(start_wav_path)
                     else:
                         self.ds_agent_commands.emit(DsWriterCommand.STOP())
@@ -301,17 +301,17 @@ def main(
         static_meta[keys.TASK] = task
     if robot_arm is not None:
         static_meta.update(wire.ROBOT_STATIC_META)
-    dataset = None
+    output_path = None
     if output_dir is not None:
-        dataset = pos3.sync(output_dir, sync_on_error=True)
-        utils.save_run_metadata(dataset, patterns=['*.py', '*.toml'])
+        output_path = pos3.sync(output_dir, sync_on_error=True)
+        utils.save_run_metadata(output_path, patterns=['*.py', '*.toml'])
     data_collection = DataCollectionController(
-        operator_position.value, nominal_joints, joints_spread, dataset=dataset, static_meta=static_meta
+        operator_position.value, nominal_joints, joints_spread, output_path=output_path, static_meta=static_meta
     )
 
-    new_dataset = partial(LocalDatasetWriter, video_options=video_options) if dataset is not None else None
+    dataset_factory = partial(LocalDatasetWriter, video_options=video_options) if output_path is not None else None
     with pimm.World() as world:
-        ds_agent = wire.wire(world, data_collection, new_dataset, camera_emitters, robot_arm, gripper, None)
+        ds_agent = wire.wire(world, data_collection, dataset_factory, camera_emitters, robot_arm, gripper, None)
         _wire(world, ds_agent, data_collection, webxr, robot_arm, sound)
 
         # SO-101 fills both the arm and gripper slots with one object; a control system runs in exactly one process.
@@ -355,29 +355,29 @@ def main_sim(
     """Runs data collection in simulator."""
 
     sim = MujocoSim(mujoco_model_path, loaders, camera_fps=fps)
-    camera_emitters = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
+    cameras = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
     gui = dpg_ui()
 
     static_meta: dict[str, Any] = dict(wire.ROBOT_STATIC_META)
     if task is not None:
         static_meta[keys.TASK] = task
 
-    dataset = None
+    output_path = None
     if output_dir is not None:
-        dataset = pos3.sync(output_dir, sync_on_error=True)
-        utils.save_run_metadata(dataset, patterns=['*.py', '*.toml'])
+        output_path = pos3.sync(output_dir, sync_on_error=True)
+        utils.save_run_metadata(output_path, patterns=['*.py', '*.toml'])
     data_collection = DataCollectionController(
         operator_position.value,
         sim.initial_joints,
-        dataset=dataset,
+        output_path=output_path,
         static_meta=static_meta,
         metadata_getter=lambda: {k: v.tolist() for k, v in sim.save_state().items()},
     )
 
-    new_dataset = LocalDatasetWriter if dataset is not None else None
+    dataset_factory = LocalDatasetWriter if output_path is not None else None
     with pimm.World(virtual_time=True) as world:
         # The sim carries both the arm and the gripper ports, so it fills both slots.
-        ds_agent = wire.wire(world, data_collection, new_dataset, camera_emitters, sim, sim, gui, TimeMode.MESSAGE)
+        ds_agent = wire.wire(world, data_collection, dataset_factory, cameras, sim, sim, gui, TimeMode.MESSAGE)
         _wire(world, ds_agent, data_collection, webxr, sim, sound)
         world.connect(data_collection.redraw_scene, sim.env_reset)
 

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -1,8 +1,8 @@
 import logging
 import time
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import nullcontext
 from enum import Enum
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -106,10 +106,12 @@ class DataCollectionController(pimm.ControlSystem):
         nominal_joints: Sequence[float] | np.ndarray,
         joints_spread: Sequence[float] | np.ndarray = (),
         *,
+        dataset: Path | None = None,
         static_meta: dict | None = None,
         metadata_getter: Callable[[], dict] | None = None,
     ):
         self.operator_position = operator_position
+        self._dataset = dataset
         self._nominal_joints = np.asarray(nominal_joints, dtype=np.float64)
         # A station that measured no jitter sends the arm exactly to its nominal.
         spread = joints_spread if len(joints_spread) else np.zeros_like(self._nominal_joints)
@@ -172,7 +174,7 @@ class DataCollectionController(pimm.ControlSystem):
                         meta = dict(self._static_meta)
                         meta.update(self.robot_meta_in.value)
                         meta.update(self.metadata_getter())
-                        self.ds_agent_commands.emit(DsWriterCommand.START(meta))
+                        self.ds_agent_commands.emit(DsWriterCommand.START(self._dataset, meta))
                         self.sound.emit(start_wav_path)
                     else:
                         self.ds_agent_commands.emit(DsWriterCommand.STOP())
@@ -299,16 +301,17 @@ def main(
         static_meta[keys.TASK] = task
     if robot_arm is not None:
         static_meta.update(wire.ROBOT_STATIC_META)
+    dataset = None
+    if output_dir is not None:
+        dataset = pos3.sync(output_dir, sync_on_error=True)
+        utils.save_run_metadata(dataset, patterns=['*.py', '*.toml'])
     data_collection = DataCollectionController(
-        operator_position.value, nominal_joints, joints_spread, static_meta=static_meta
+        operator_position.value, nominal_joints, joints_spread, dataset=dataset, static_meta=static_meta
     )
 
-    if output_dir is not None:
-        output_dir = pos3.sync(output_dir, sync_on_error=True)
-        utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])
-    writer_cm = LocalDatasetWriter(output_dir, video_options=video_options) if output_dir is not None else nullcontext()
-    with writer_cm as dataset_writer, pimm.World() as world:
-        ds_agent = wire.wire(world, data_collection, dataset_writer, camera_emitters, robot_arm, gripper, None)
+    new_dataset = partial(LocalDatasetWriter, video_options=video_options) if dataset is not None else None
+    with pimm.World() as world:
+        ds_agent = wire.wire(world, data_collection, new_dataset, camera_emitters, robot_arm, gripper, None)
         _wire(world, ds_agent, data_collection, webxr, robot_arm, sound)
 
         # SO-101 fills both the arm and gripper slots with one object; a control system runs in exactly one process.
@@ -352,27 +355,29 @@ def main_sim(
     """Runs data collection in simulator."""
 
     sim = MujocoSim(mujoco_model_path, loaders, camera_fps=fps)
-    cameras = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
+    camera_emitters = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
     gui = dpg_ui()
 
     static_meta: dict[str, Any] = dict(wire.ROBOT_STATIC_META)
     if task is not None:
         static_meta[keys.TASK] = task
 
+    dataset = None
+    if output_dir is not None:
+        dataset = pos3.sync(output_dir, sync_on_error=True)
+        utils.save_run_metadata(dataset, patterns=['*.py', '*.toml'])
     data_collection = DataCollectionController(
         operator_position.value,
         sim.initial_joints,
+        dataset=dataset,
         static_meta=static_meta,
         metadata_getter=lambda: {k: v.tolist() for k, v in sim.save_state().items()},
     )
 
-    if output_dir is not None:
-        output_dir = pos3.sync(output_dir, sync_on_error=True)
-        utils.save_run_metadata(output_dir, patterns=['*.py', '*.toml'])
-    writer_cm = LocalDatasetWriter(output_dir) if output_dir is not None else nullcontext()
-    with writer_cm as dataset_writer, pimm.World(virtual_time=True) as world:
+    new_dataset = LocalDatasetWriter if dataset is not None else None
+    with pimm.World(virtual_time=True) as world:
         # The sim carries both the arm and the gripper ports, so it fills both slots.
-        ds_agent = wire.wire(world, data_collection, dataset_writer, cameras, sim, sim, gui, TimeMode.MESSAGE)
+        ds_agent = wire.wire(world, data_collection, new_dataset, camera_emitters, sim, sim, gui, TimeMode.MESSAGE)
         _wire(world, ds_agent, data_collection, webxr, sim, sound)
         world.connect(data_collection.redraw_scene, sim.env_reset)
 

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -353,7 +353,7 @@ Each line of `edits.jsonl` is one JSON record carrying its op. `{"op": "set_stat
 
 Key ideas
 - Inputs are registered explicitly through `DsWriterAgent.add_signal(name, serializer=None)`.
-- Each `START_EPISODE` names the path its episode records into. The agent holds no dataset of its own: it opens each named one through the factory it was built with (`DsWriterAgent(LocalDatasetWriter)`), once per name, and closes them all when it stops.
+- Each `START_EPISODE` names the path its episode records into, and `None` names nowhere. The agent holds no dataset of its own: it opens each named one through the factory it was built with (`DsWriterAgent(LocalDatasetWriter)`), once per name, and closes them all when it stops.
 - The agent polls inputs at a configurable rate and appends only on updates.
 - Recording is best effort, and this is a deliberate trade rather than an oversight. Each input arrives over a one-slot `pimm` signal where a new value overwrites one still unread, so a recorder that stalls for longer than the gap between two samples loses the older one — commands exactly as much as camera frames or arm state. An episode is what the recorder managed to observe, not a guaranteed-complete log of what happened; treat a missing sample as possible in any analysis that counts them.
 - A separate `command` channel controls episode lifecycle.
@@ -379,7 +379,8 @@ Built‑in serializers (`positronic.dataset.serializers.Serializers`)
 
 Lifecycle
 - `START_EPISODE`: opens a new episode in the dataset the command names and applies provided static
-  metadata (`DsWriterCommand.START(output_path, static_data)`). A command that names no path opens nothing.
+  metadata (`DsWriterCommand.START(output_path, static_data)`). A command that names no path opens an episode
+  that records nowhere, so the `STOP_EPISODE` that ends it is as ordinary as any other.
 - `STOP_EPISODE`: finalizes the episode (applies static data then closes).
 - `ABORT_EPISODE`: aborts and discards the episode directory.
 

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -353,7 +353,7 @@ Each line of `edits.jsonl` is one JSON record carrying its op. `{"op": "set_stat
 
 Key ideas
 - Inputs are registered explicitly through `DsWriterAgent.add_signal(name, serializer=None)`.
-- Each `START_EPISODE` names the dataset its episode records into. The agent holds no dataset of its own: it opens each named one through the factory it was built with (`DsWriterAgent(LocalDatasetWriter)`), once per name, and closes them all when it stops.
+- Each `START_EPISODE` names the path its episode records into. The agent holds no dataset of its own: it opens each named one through the factory it was built with (`DsWriterAgent(LocalDatasetWriter)`), once per name, and closes them all when it stops.
 - The agent polls inputs at a configurable rate and appends only on updates.
 - Recording is best effort, and this is a deliberate trade rather than an oversight. Each input arrives over a one-slot `pimm` signal where a new value overwrites one still unread, so a recorder that stalls for longer than the gap between two samples loses the older one — commands exactly as much as camera frames or arm state. An episode is what the recorder managed to observe, not a guaranteed-complete log of what happened; treat a missing sample as possible in any analysis that counts them.
 - A separate `command` channel controls episode lifecycle.
@@ -379,7 +379,7 @@ Built‑in serializers (`positronic.dataset.serializers.Serializers`)
 
 Lifecycle
 - `START_EPISODE`: opens a new episode in the dataset the command names and applies provided static
-  metadata (`DsWriterCommand.START(dataset, static_data)`). A command that names no dataset opens nothing.
+  metadata (`DsWriterCommand.START(output_path, static_data)`). A command that names no path opens nothing.
 - `STOP_EPISODE`: finalizes the episode (applies static data then closes).
 - `ABORT_EPISODE`: aborts and discards the episode directory.
 

--- a/positronic/dataset/README.md
+++ b/positronic/dataset/README.md
@@ -353,6 +353,7 @@ Each line of `edits.jsonl` is one JSON record carrying its op. `{"op": "set_stat
 
 Key ideas
 - Inputs are registered explicitly through `DsWriterAgent.add_signal(name, serializer=None)`.
+- Each `START_EPISODE` names the dataset its episode records into. The agent holds no dataset of its own: it opens each named one through the factory it was built with (`DsWriterAgent(LocalDatasetWriter)`), once per name, and closes them all when it stops.
 - The agent polls inputs at a configurable rate and appends only on updates.
 - Recording is best effort, and this is a deliberate trade rather than an oversight. Each input arrives over a one-slot `pimm` signal where a new value overwrites one still unread, so a recorder that stalls for longer than the gap between two samples loses the older one — commands exactly as much as camera frames or arm state. An episode is what the recorder managed to observe, not a guaranteed-complete log of what happened; treat a missing sample as possible in any analysis that counts them.
 - A separate `command` channel controls episode lifecycle.
@@ -377,8 +378,8 @@ Built‑in serializers (`positronic.dataset.serializers.Serializers`)
   - `JointPosition(positions)` -> `{'.joints': positions}`
 
 Lifecycle
-- `START_EPISODE`: allocates a new episode writer and applies provided static
-  metadata (`DsWriterCommand(static_data=...)`).
+- `START_EPISODE`: opens a new episode in the dataset the command names and applies provided static
+  metadata (`DsWriterCommand.START(dataset, static_data)`). A command that names no dataset opens nothing.
 - `STOP_EPISODE`: finalizes the episode (applies static data then closes).
 - `ABORT_EPISODE`: aborts and discards the episode directory.
 

--- a/positronic/dataset/dataset.py
+++ b/positronic/dataset/dataset.py
@@ -94,11 +94,9 @@ class CachedDataset(Dataset):
         return len(self._dataset)
 
     def _get_episode(self, index: int) -> Episode:
-        ep = self._cache.get(index)
-        if ep is None:
-            ep = self._dataset[index]
-            self._cache[index] = ep
-        return ep
+        if index not in self._cache:
+            self._cache[index] = self._dataset[index]
+        return self._cache[index]
 
     @property
     def meta(self) -> dict[str, Any]:

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager, ExitStack, nullcontext
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from pathlib import Path
@@ -10,7 +10,7 @@ import pimm
 from positronic.utils import frozen_keys_dict
 
 from .dataset import DatasetWriter
-from .episode import EpisodeWriter
+from .episode import META_PATH, EpisodeWriter
 from .serializers import Serializer, StatefulSerializer, _PureSerializer, expand_suffixed
 
 logger = logging.getLogger(__name__)
@@ -85,11 +85,12 @@ class _Recording:
         self._dataset_factory = dataset_factory
         self._serializers = serializers
         self._datasets: dict[Path, DatasetWriter] = {}
-        self._open = False
+        self._open_datasets = ExitStack()
+        self._episode_open = False
         self.writer: EpisodeWriter | None = None
 
     def handle(self, cmd: DsWriterCommand) -> None:
-        match cmd.type, self._open:
+        match cmd.type, self._episode_open:
             case DsWriterCommandType.START_EPISODE, False:
                 self._start(cmd)
             case DsWriterCommandType.START_EPISODE, True:
@@ -104,25 +105,25 @@ class _Recording:
     def close(self) -> None:
         """Discard an episode still open, and close every dataset this recording opened."""
         self._abort()
-        for ds_writer in self._datasets.values():
-            ds_writer.__exit__(None, None, None)
+        self._open_datasets.close()
 
     def _start(self, cmd: DsWriterCommand) -> None:
         """Open an episode in the dataset the command names, stamped with its static data."""
-        self._open = True
+        self._episode_open = True
         if cmd.output_path is None:
             return
         for ser in self._serializers.values():
             ser.reset()
         if cmd.output_path not in self._datasets:  # a dataset numbers its episodes, off the disk it holds
-            self._datasets[cmd.output_path] = self._dataset_factory(cmd.output_path)
+            ds_writer = self._dataset_factory(cmd.output_path)
+            self._datasets[cmd.output_path] = self._open_datasets.enter_context(ds_writer)
         self.writer = self._datasets[cmd.output_path].new_episode()
         self._set_statics(self.writer, cmd.static_data)
         logger.info(f'DsWriterAgent: [START] {self._episode_path(self.writer)}')
 
     def _stop(self, static_data: dict[str, Any]) -> None:
         """Finish the open episode, stamped with the command's static data."""
-        self._open = False
+        self._episode_open = False
         if (writer := self.writer) is None:
             return
         self._set_statics(writer, static_data)
@@ -132,7 +133,7 @@ class _Recording:
 
     def _abort(self) -> None:
         """Discard the open episode."""
-        self._open = False
+        self._episode_open = False
         if (writer := self.writer) is None:
             return
         try:
@@ -150,7 +151,7 @@ class _Recording:
     @staticmethod
     def _episode_path(writer: EpisodeWriter) -> str:
         """Where the episode is written, as its own writer reports it."""
-        return writer.meta.get('path', 'unknown')
+        return writer.meta.get(META_PATH, 'unknown')
 
 
 class DsWriterAgent(pimm.ControlSystem):

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
+from pathlib import Path
 from typing import Any, TypeAlias
 
 import pimm
@@ -39,20 +40,22 @@ class DsWriterCommand:
 
     Args:
         type: Desired episode action (start/stop/abort).
+        dataset: Which dataset `START_EPISODE` records into; the other actions name none.
         static_data: Optional static key/value pairs to set on the episode
             when starting or right before stopping.
     """
 
     type: DsWriterCommandType
+    dataset: Path | None = None
     static_data: dict[str, Any] = field(default_factory=dict)
 
     @staticmethod
-    def START(static_data: dict[str, Any] | None = None):
-        return DsWriterCommand(DsWriterCommandType.START_EPISODE, static_data or {})
+    def START(dataset: Path | None, static_data: dict[str, Any] | None = None):
+        return DsWriterCommand(DsWriterCommandType.START_EPISODE, dataset, static_data or {})
 
     @staticmethod
     def STOP(static_data: dict[str, Any] | None = None):
-        return DsWriterCommand(DsWriterCommandType.STOP_EPISODE, static_data or {})
+        return DsWriterCommand(DsWriterCommandType.STOP_EPISODE, static_data=static_data or {})
 
     @staticmethod
     def ABORT():
@@ -72,8 +75,8 @@ class DsWriterAgent(pimm.ControlSystem):
     Listens on `command` for `DsWriterCommand` messages controlling the
     episode lifecycle.
 
-    On `START_EPISODE`, opens a new `EpisodeWriter` from the provided
-    `DatasetWriter` and applies `static_data`. The opening turn records what each
+    On `START_EPISODE`, opens a new `EpisodeWriter` in the dataset the command names — ``new_dataset``
+    opens that dataset, once per name — and applies `static_data`. The opening turn records what each
     input holds, whenever that value was produced. While open, each updated input
     signal (from `inputs`) is appended with the current timestamp from `clock`.
     `STOP_EPISODE` and `ABORT_EPISODE` are handled after that turn's inputs, so
@@ -91,7 +94,7 @@ class DsWriterAgent(pimm.ControlSystem):
 
     def __init__(
         self,
-        ds_writer: DatasetWriter,
+        new_dataset: Callable[[Path], DatasetWriter],
         poll_hz: float = 1000.0,
         time_mode: TimeMode = TimeMode.CLOCK,
         virtual_time: bool = False,
@@ -99,7 +102,10 @@ class DsWriterAgent(pimm.ControlSystem):
         # a context of unsaid purpose. It generalises when a second kind of caller arrives.
         telemetry_span: ContextFactory = nullcontext,
     ):
-        self.ds_writer = ds_writer
+        # A picklable factory, never a lambda: the recorder may be spawned as a background process, and it
+        # opens its datasets there.
+        self._new_dataset = new_dataset
+        self._datasets: dict[Path, DatasetWriter] = {}
         self._poll_hz = float(poll_hz)
         self._time_mode = time_mode
         self._virtual_time = virtual_time
@@ -110,6 +116,14 @@ class DsWriterAgent(pimm.ControlSystem):
 
         self._inputs: dict[str, pimm.ControlSystemReceiver[Any]] = {}
         self._serializers: dict[str, StatefulSerializer] = {}
+
+    def _dataset(self, path: Path) -> DatasetWriter:
+        """The dataset at ``path``, opened once and kept: a dataset numbers the episodes it takes, and a
+        writer opened afresh reads that number off the disk again."""
+        writer = self._datasets.get(path)
+        if writer is None:
+            writer = self._datasets[path] = self._new_dataset(path)
+        return writer
 
     def add_signal(self, name: str, serializer: Serializer | StatefulSerializer | None = None):
         self._inputs[name] = pimm.ControlSystemReceiver[Any](self)
@@ -179,6 +193,11 @@ class DsWriterAgent(pimm.ControlSystem):
 
                 yield pace()
         finally:
+            self._shutdown(ep_writer, ep_counter)
+
+    def _shutdown(self, ep_writer: EpisodeWriter | None, ep_counter: int) -> None:
+        """Take the last command, discard an episode still open, and close every dataset opened here."""
+        try:
             cmd = pimm.read_updated(self.command)
             if cmd is not None:
                 ep_writer, ep_counter = self._handle_command(cmd.data, ep_writer, ep_counter)
@@ -189,24 +208,33 @@ class DsWriterAgent(pimm.ControlSystem):
                 finally:
                     ep_writer.__exit__(None, None, None)
                     logger.info(f'DsWriterAgent: [ABORT] Episode {ep_counter}')
+        finally:
+            for ds_writer in self._datasets.values():
+                ds_writer.__exit__(None, None, None)
+            self._datasets.clear()
+
+    @staticmethod
+    def _set_statics(ep_writer: EpisodeWriter, static_data: dict[str, Any]) -> None:
+        for k, v in static_data.items():
+            ep_writer.set_static(k, v)
 
     def _handle_command(self, cmd: DsWriterCommand, ep_writer: EpisodeWriter | None, ep_counter: int):
         match cmd.type:
             case DsWriterCommandType.START_EPISODE:
-                if ep_writer is None:
+                if ep_writer is not None:
+                    logger.warning('Episode already started, ignoring start command')
+                elif cmd.dataset is None:
+                    logger.warning('Start command names no dataset, ignoring start command')
+                else:
                     ep_counter += 1
-                    logger.info(f'DsWriterAgent: [START] Episode {ep_counter}')
+                    logger.info(f'DsWriterAgent: [START] Episode {ep_counter} in {cmd.dataset}')
                     for ser in self._serializers.values():
                         ser.reset()
-                    ep_writer = self.ds_writer.new_episode()
-                    for k, v in cmd.static_data.items():
-                        ep_writer.set_static(k, v)
-                else:
-                    logger.warning('Episode already started, ignoring start command')
+                    ep_writer = self._dataset(cmd.dataset).new_episode()
+                    self._set_statics(ep_writer, cmd.static_data)
             case DsWriterCommandType.STOP_EPISODE:
                 if ep_writer is not None:
-                    for k, v in cmd.static_data.items():
-                        ep_writer.set_static(k, v)
+                    self._set_statics(ep_writer, cmd.static_data)
                     ep_writer.__exit__(None, None, None)
                     logger.info(f'DsWriterAgent: [STOP] Episode {ep_counter} {ep_writer.meta.get("path", "unknown")}')
                     ep_writer = None

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -19,6 +19,9 @@ logger.setLevel(logging.INFO)
 # A factory of context managers the caller brackets each record-flush I/O section with (default inert).
 ContextFactory: TypeAlias = Callable[[], AbstractContextManager[Any]]
 
+# A factory of dataset writers, one per path a command names.
+DatasetFactory: TypeAlias = Callable[[Path], DatasetWriter]
+
 
 class DsWriterCommandType(Enum):
     """Episode lifecycle commands for the dataset writer.
@@ -40,18 +43,18 @@ class DsWriterCommand:
 
     Args:
         type: Desired episode action (start/stop/abort).
-        dataset: Which dataset `START_EPISODE` records into; the other actions name none.
+        output_path: Which dataset `START_EPISODE` records into; the other actions name none.
         static_data: Optional static key/value pairs to set on the episode
             when starting or right before stopping.
     """
 
     type: DsWriterCommandType
-    dataset: Path | None = None
+    output_path: Path | None = None
     static_data: dict[str, Any] = field(default_factory=dict)
 
     @staticmethod
-    def START(dataset: Path | None, static_data: dict[str, Any] | None = None):
-        return DsWriterCommand(DsWriterCommandType.START_EPISODE, dataset, static_data or {})
+    def START(output_path: Path | None, static_data: dict[str, Any] | None = None):
+        return DsWriterCommand(DsWriterCommandType.START_EPISODE, output_path, static_data or {})
 
     @staticmethod
     def STOP(static_data: dict[str, Any] | None = None):
@@ -69,13 +72,86 @@ class TimeMode(IntEnum):
     MESSAGE = 1
 
 
+class _Recording:
+    """The episode a run has open, and the datasets it opened to hold them.
+
+    One command moves it: a START opens an episode, a STOP finishes it, an ABORT discards it. A command that
+    does not fit the state it finds is ignored with a log message.
+    """
+
+    def __init__(self, dataset_factory: DatasetFactory, serializers: dict[str, StatefulSerializer]):
+        self._dataset_factory = dataset_factory
+        self._serializers = serializers
+        self._datasets: dict[Path, DatasetWriter] = {}
+        self.writer: EpisodeWriter | None = None
+
+    def handle(self, cmd: DsWriterCommand) -> None:
+        match cmd.type, self.writer:
+            case DsWriterCommandType.START_EPISODE, None:
+                self._start(cmd)
+            case DsWriterCommandType.START_EPISODE, _:
+                logger.warning('Episode already started, ignoring start command')
+            case _, None:
+                logger.warning(f'Episode not started, ignoring {cmd.type.value} command')
+            case DsWriterCommandType.STOP_EPISODE, writer:
+                self._stop(writer, cmd.static_data)
+            case _, writer:
+                self._abort(writer)
+
+    def close(self) -> None:
+        """Discard an episode still open, and close every dataset this recording opened."""
+        if self.writer is not None:
+            self._abort(self.writer)
+        for ds_writer in self._datasets.values():
+            ds_writer.__exit__(None, None, None)
+
+    def _start(self, cmd: DsWriterCommand) -> None:
+        """Open an episode in the dataset the command names, stamped with its static data."""
+        if cmd.output_path is None:
+            logger.warning('Start command names no dataset, ignoring start command')
+            return
+        for ser in self._serializers.values():
+            ser.reset()
+        if cmd.output_path not in self._datasets:  # a dataset numbers its episodes, off the disk it holds
+            self._datasets[cmd.output_path] = self._dataset_factory(cmd.output_path)
+        self.writer = self._datasets[cmd.output_path].new_episode()
+        self._set_statics(self.writer, cmd.static_data)
+        logger.info(f'DsWriterAgent: [START] {self._episode_path(self.writer)}')
+
+    def _stop(self, writer: EpisodeWriter, static_data: dict[str, Any]) -> None:
+        """Finish the open episode, stamped with the command's static data."""
+        self._set_statics(writer, static_data)
+        writer.__exit__(None, None, None)
+        logger.info(f'DsWriterAgent: [STOP] {self._episode_path(writer)}')
+        self.writer = None
+
+    def _abort(self, writer: EpisodeWriter) -> None:
+        """Discard the open episode."""
+        try:
+            writer.abort()
+        finally:  # the writer holds a file handle per signal; release them even if the discard fails
+            writer.__exit__(None, None, None)
+        logger.info(f'DsWriterAgent: [ABORT] {self._episode_path(writer)}')
+        self.writer = None
+
+    @staticmethod
+    def _set_statics(writer: EpisodeWriter, static_data: dict[str, Any]) -> None:
+        for k, v in static_data.items():
+            writer.set_static(k, v)
+
+    @staticmethod
+    def _episode_path(writer: EpisodeWriter) -> str:
+        """Where the episode is written, as its own writer reports it."""
+        return writer.meta.get('path', 'unknown')
+
+
 class DsWriterAgent(pimm.ControlSystem):
     """Streams input signals into episodes based on control commands.
 
     Listens on `command` for `DsWriterCommand` messages controlling the
     episode lifecycle.
 
-    On `START_EPISODE`, opens a new `EpisodeWriter` in the dataset the command names — ``new_dataset``
+    On `START_EPISODE`, opens a new `EpisodeWriter` in the dataset the command names — ``dataset_factory``
     opens that dataset, once per name — and applies `static_data`. The opening turn records what each
     input holds, whenever that value was produced. While open, each updated input
     signal (from `inputs`) is appended with the current timestamp from `clock`.
@@ -94,7 +170,7 @@ class DsWriterAgent(pimm.ControlSystem):
 
     def __init__(
         self,
-        new_dataset: Callable[[Path], DatasetWriter],
+        dataset_factory: DatasetFactory,
         poll_hz: float = 1000.0,
         time_mode: TimeMode = TimeMode.CLOCK,
         virtual_time: bool = False,
@@ -104,8 +180,7 @@ class DsWriterAgent(pimm.ControlSystem):
     ):
         # A picklable factory, never a lambda: the recorder may be spawned as a background process, and it
         # opens its datasets there.
-        self._new_dataset = new_dataset
-        self._datasets: dict[Path, DatasetWriter] = {}
+        self._dataset_factory = dataset_factory
         self._poll_hz = float(poll_hz)
         self._time_mode = time_mode
         self._virtual_time = virtual_time
@@ -116,14 +191,6 @@ class DsWriterAgent(pimm.ControlSystem):
 
         self._inputs: dict[str, pimm.ControlSystemReceiver[Any]] = {}
         self._serializers: dict[str, StatefulSerializer] = {}
-
-    def _dataset(self, path: Path) -> DatasetWriter:
-        """The dataset at ``path``, opened once and kept: a dataset numbers the episodes it takes, and a
-        writer opened afresh reads that number off the disk again."""
-        writer = self._datasets.get(path)
-        if writer is None:
-            writer = self._datasets[path] = self._new_dataset(path)
-        return writer
 
     def add_signal(self, name: str, serializer: Serializer | StatefulSerializer | None = None):
         self._inputs[name] = pimm.ControlSystemReceiver[Any](self)
@@ -170,82 +237,30 @@ class DsWriterAgent(pimm.ControlSystem):
         """Main loop: process commands and append updated inputs to the episode."""
         limiter = pimm.utils.RateLimiter(clock, hz=self._poll_hz)
         pace = (lambda: pimm.Yield()) if self._virtual_time else limiter.wait
-        ep_writer: EpisodeWriter | None = None
-        ep_counter = 0
+        recording = _Recording(self._dataset_factory, self._serializers)
+        sampled: EpisodeWriter | None = None  # the writer this loop last took a window for
 
         try:
             while not should_stop.value:
                 cmd = pimm.read_updated(self.command)
-                stop_at, stop_cmd, opening = None, None, False
+                stop = None
                 if cmd is not None:
                     if cmd.data.type == DsWriterCommandType.START_EPISODE:
-                        was_open = ep_writer is not None
-                        ep_writer, ep_counter = self._handle_command(cmd.data, ep_writer, ep_counter)
-                        opening = ep_writer is not None and not was_open
+                        recording.handle(cmd.data)
                     else:
-                        stop_at, stop_cmd = cmd.ts, cmd.data
+                        stop = cmd
 
-                if ep_writer is not None:
-                    self._record_window(ep_writer, clock, stop_at, opening)
+                if recording.writer is not None:
+                    before = stop.ts if stop is not None else None
+                    self._record_window(recording.writer, clock, before, recording.writer is not sampled)
+                    sampled = recording.writer
 
-                if stop_cmd is not None:
-                    ep_writer, ep_counter = self._handle_command(stop_cmd, ep_writer, ep_counter)
+                if stop is not None:
+                    recording.handle(stop.data)
 
                 yield pace()
+
+            if (cmd := pimm.read_updated(self.command)) is not None:
+                recording.handle(cmd.data)
         finally:
-            self._shutdown(ep_writer, ep_counter)
-
-    def _shutdown(self, ep_writer: EpisodeWriter | None, ep_counter: int) -> None:
-        """Take the last command, discard an episode still open, and close every dataset opened here."""
-        try:
-            cmd = pimm.read_updated(self.command)
-            if cmd is not None:
-                ep_writer, ep_counter = self._handle_command(cmd.data, ep_writer, ep_counter)
-
-            if ep_writer is not None:
-                try:
-                    ep_writer.abort()
-                finally:
-                    ep_writer.__exit__(None, None, None)
-                    logger.info(f'DsWriterAgent: [ABORT] Episode {ep_counter}')
-        finally:
-            for ds_writer in self._datasets.values():
-                ds_writer.__exit__(None, None, None)
-            self._datasets.clear()
-
-    @staticmethod
-    def _set_statics(ep_writer: EpisodeWriter, static_data: dict[str, Any]) -> None:
-        for k, v in static_data.items():
-            ep_writer.set_static(k, v)
-
-    def _handle_command(self, cmd: DsWriterCommand, ep_writer: EpisodeWriter | None, ep_counter: int):
-        match cmd.type:
-            case DsWriterCommandType.START_EPISODE:
-                if ep_writer is not None:
-                    logger.warning('Episode already started, ignoring start command')
-                elif cmd.dataset is None:
-                    logger.warning('Start command names no dataset, ignoring start command')
-                else:
-                    ep_counter += 1
-                    logger.info(f'DsWriterAgent: [START] Episode {ep_counter} in {cmd.dataset}')
-                    for ser in self._serializers.values():
-                        ser.reset()
-                    ep_writer = self._dataset(cmd.dataset).new_episode()
-                    self._set_statics(ep_writer, cmd.static_data)
-            case DsWriterCommandType.STOP_EPISODE:
-                if ep_writer is not None:
-                    self._set_statics(ep_writer, cmd.static_data)
-                    ep_writer.__exit__(None, None, None)
-                    logger.info(f'DsWriterAgent: [STOP] Episode {ep_counter} {ep_writer.meta.get("path", "unknown")}')
-                    ep_writer = None
-                else:
-                    logger.warning('Episode not started, ignoring stop command')
-            case DsWriterCommandType.ABORT_EPISODE:
-                if ep_writer is not None:
-                    ep_writer.abort()
-                    ep_writer.__exit__(None, None, None)
-                    logger.info(f'DsWriterAgent: [ABORT] Episode {ep_counter}')
-                    ep_writer = None
-                else:
-                    logger.warning('Episode not started, ignoring abort command')
-        return ep_writer, ep_counter
+            recording.close()

--- a/positronic/dataset/ds_writer_agent.py
+++ b/positronic/dataset/ds_writer_agent.py
@@ -43,7 +43,8 @@ class DsWriterCommand:
 
     Args:
         type: Desired episode action (start/stop/abort).
-        output_path: Which dataset `START_EPISODE` records into; the other actions name none.
+        output_path: Which dataset `START_EPISODE` records into. `None` records nowhere: the episode runs
+            and nothing is written. The other actions name no dataset.
         static_data: Optional static key/value pairs to set on the episode
             when starting or right before stopping.
     """
@@ -75,40 +76,41 @@ class TimeMode(IntEnum):
 class _Recording:
     """The episode a run has open, and the datasets it opened to hold them.
 
-    One command moves it: a START opens an episode, a STOP finishes it, an ABORT discards it. A command that
-    does not fit the state it finds is ignored with a log message.
+    One command moves it: a START opens an episode, a STOP finishes it, an ABORT discards it. An episode a
+    START named no dataset for records nowhere, and its ``writer`` stays ``None``. A command that does not fit
+    the state it finds is ignored with a log message.
     """
 
     def __init__(self, dataset_factory: DatasetFactory, serializers: dict[str, StatefulSerializer]):
         self._dataset_factory = dataset_factory
         self._serializers = serializers
         self._datasets: dict[Path, DatasetWriter] = {}
+        self._open = False
         self.writer: EpisodeWriter | None = None
 
     def handle(self, cmd: DsWriterCommand) -> None:
-        match cmd.type, self.writer:
-            case DsWriterCommandType.START_EPISODE, None:
+        match cmd.type, self._open:
+            case DsWriterCommandType.START_EPISODE, False:
                 self._start(cmd)
-            case DsWriterCommandType.START_EPISODE, _:
+            case DsWriterCommandType.START_EPISODE, True:
                 logger.warning('Episode already started, ignoring start command')
-            case _, None:
+            case _, False:
                 logger.warning(f'Episode not started, ignoring {cmd.type.value} command')
-            case DsWriterCommandType.STOP_EPISODE, writer:
-                self._stop(writer, cmd.static_data)
-            case _, writer:
-                self._abort(writer)
+            case DsWriterCommandType.STOP_EPISODE, True:
+                self._stop(cmd.static_data)
+            case _, True:
+                self._abort()
 
     def close(self) -> None:
         """Discard an episode still open, and close every dataset this recording opened."""
-        if self.writer is not None:
-            self._abort(self.writer)
+        self._abort()
         for ds_writer in self._datasets.values():
             ds_writer.__exit__(None, None, None)
 
     def _start(self, cmd: DsWriterCommand) -> None:
         """Open an episode in the dataset the command names, stamped with its static data."""
+        self._open = True
         if cmd.output_path is None:
-            logger.warning('Start command names no dataset, ignoring start command')
             return
         for ser in self._serializers.values():
             ser.reset()
@@ -118,15 +120,21 @@ class _Recording:
         self._set_statics(self.writer, cmd.static_data)
         logger.info(f'DsWriterAgent: [START] {self._episode_path(self.writer)}')
 
-    def _stop(self, writer: EpisodeWriter, static_data: dict[str, Any]) -> None:
+    def _stop(self, static_data: dict[str, Any]) -> None:
         """Finish the open episode, stamped with the command's static data."""
+        self._open = False
+        if (writer := self.writer) is None:
+            return
         self._set_statics(writer, static_data)
         writer.__exit__(None, None, None)
         logger.info(f'DsWriterAgent: [STOP] {self._episode_path(writer)}')
         self.writer = None
 
-    def _abort(self, writer: EpisodeWriter) -> None:
+    def _abort(self) -> None:
         """Discard the open episode."""
+        self._open = False
+        if (writer := self.writer) is None:
+            return
         try:
             writer.abort()
         finally:  # the writer holds a file handle per signal; release them even if the discard fails
@@ -152,7 +160,8 @@ class DsWriterAgent(pimm.ControlSystem):
     episode lifecycle.
 
     On `START_EPISODE`, opens a new `EpisodeWriter` in the dataset the command names — ``dataset_factory``
-    opens that dataset, once per name — and applies `static_data`. The opening turn records what each
+    opens that dataset, once per name — and applies `static_data`. A `START_EPISODE` that names no dataset
+    opens an episode that records nowhere. The opening turn records what each
     input holds, whenever that value was produced. While open, each updated input
     signal (from `inputs`) is appended with the current timestamp from `clock`.
     `STOP_EPISODE` and `ABORT_EPISODE` are handled after that turn's inputs, so

--- a/positronic/dataset/episode.py
+++ b/positronic/dataset/episode.py
@@ -10,6 +10,8 @@ import numpy as np
 from .signal import Signal
 
 EPISODE_SCHEMA_VERSION = 1
+# Where the episode is written, in the meta of both the episode and the writer that made it.
+META_PATH = 'path'
 T = TypeVar('T')
 SIGNAL_FACTORY_T = Callable[[], Signal[Any]]
 

--- a/positronic/dataset/local_dataset.py
+++ b/positronic/dataset/local_dataset.py
@@ -24,6 +24,7 @@ from .dataset import ConcatDataset, Dataset, DatasetWriter
 from .edits import EditedDataset
 from .episode import (
     EPISODE_SCHEMA_VERSION,
+    META_PATH,
     SIGNAL_FACTORY_T,
     Episode,
     EpisodeWriter,
@@ -122,7 +123,7 @@ class DiskEpisodeWriter(EpisodeWriter):
         }
         self._meta['writer'] = _cached_env_writer_info()
         self._meta['writer']['name'] = f'{self.__class__.__module__}.{self.__class__.__qualname__}'
-        self._meta['path'] = str(self._path.resolve(strict=True))
+        self._meta[META_PATH] = str(self._path.resolve(strict=True))
 
     @property
     def path(self) -> Path:
@@ -413,7 +414,7 @@ class DiskEpisode(Episode):
             if 'uid' not in meta and 'created_ts_ns' in meta:
                 meta['uid'] = f'ts-{meta["created_ts_ns"]}'
 
-            meta['path'] = str(self._dir.expanduser().resolve(strict=False))
+            meta[META_PATH] = str(self._dir.expanduser().resolve(strict=False))
 
             lazy_getters: dict[str, Any] = {}
             if 'size_mb' not in meta:

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -1,5 +1,4 @@
 import pickle
-from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -11,7 +10,7 @@ import pytest
 import pimm
 from positronic import geom, keys, telemetry, telemetry_keys
 from positronic.dataset import DatasetWriter, EpisodeWriter
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, TimeMode
+from positronic.dataset.ds_writer_agent import DatasetFactory, DsWriterAgent, DsWriterCommand, TimeMode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus
@@ -19,8 +18,8 @@ from positronic.drivers.roboarm import command as rcmd
 from positronic.drivers.roboarm.tests.fakes import FakeRobotState
 from positronic.tests.testing_coutils import run_scripted_agent
 
-# The dataset a scripted episode names; a fake opens the same one whatever the path.
-DATASET = Path('dataset')
+# Where a scripted episode records; a fake dataset opens the same one whatever the path.
+OUTPUT_PATH = Path('dataset')
 
 
 @pytest.fixture
@@ -55,7 +54,7 @@ class FakeDatasetWriter(DatasetWriter):
     def __init__(self) -> None:
         self.created: list[FakeEpisodeWriter] = []
 
-    def __call__(self, path: Path) -> 'FakeDatasetWriter':
+    def __call__(self, output_path: Path) -> 'FakeDatasetWriter':
         return self
 
     def new_episode(self) -> FakeEpisodeWriter:
@@ -69,7 +68,7 @@ class FakeDatasetWriter(DatasetWriter):
 
 def build_agent_with_pipes(
     signals_spec: dict[str, Any],
-    new_dataset: Callable[[Path], DatasetWriter],
+    dataset_factory: DatasetFactory,
     world: pimm.World,
     *,
     time_mode: TimeMode = TimeMode.CLOCK,
@@ -83,7 +82,7 @@ def build_agent_with_pipes(
         * return None to drop the sample (not recorded at all).
     Returns (agent, cmd_emitter, emitters_by_name).
     """
-    agent = DsWriterAgent(new_dataset, time_mode=time_mode)
+    agent = DsWriterAgent(dataset_factory, time_mode=time_mode)
     for name, serializer in signals_spec.items():
         agent.add_signal(name, serializer)
     emitters: dict[str, pimm.SignalEmitter[Any]] = {name: world.pair(agent.inputs[name]) for name in signals_spec}
@@ -98,7 +97,7 @@ def test_start_stop_happy_path(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None, 'b': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET, {'user': 'alice'})), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH, {'user': 'alice'})), 0.001),
         (partial(emitters['a'].emit, 1), 0.001),
         (partial(emitters['b'].emit, 2), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.STOP({'done': True})), 0.001),
@@ -118,7 +117,10 @@ def test_episode_finalizes_when_run_stops(world):
     ds = FakeDatasetWriter()
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 
-    script = [(partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001), (partial(emitters['a'].emit, 42), 0.001)]
+    script = [
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
+        (partial(emitters['a'].emit, 42), 0.001),
+    ]
 
     run_scripted_agent(agent, script, world=world)
 
@@ -134,8 +136,8 @@ def test_ignore_duplicate_commands_and_empty_stop(world):
 
     script = [
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
 
@@ -151,10 +153,10 @@ def test_abort_flow_then_restart(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'s': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['s'].emit, 10), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.ABORT()), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['s'].emit, 11), 0.001),
     ]
 
@@ -171,7 +173,7 @@ def test_appends_only_on_updates_and_timestamps_from_clock(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['a'].emit, 1), 0.001),
         (None, 0.001),
         (partial(emitters['a'].emit, 2), 0.001),
@@ -192,7 +194,7 @@ def test_records_what_the_inputs_hold_when_the_episode_opens(world):
 
     script = [
         (partial(emitters['a'].emit, 99), 0.001),  # latched on the channel before the episode opens
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['a'].emit, 7), 0.001),  # the first value that arrives in-episode
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
@@ -211,7 +213,7 @@ def test_time_mode_message_uses_signal_timestamp(world):
     ts_second = 456_000_000
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['a'].emit, 1, ts=ts_first), 0.001),
         (partial(emitters['a'].emit, 2, ts=ts_second), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
@@ -316,7 +318,7 @@ def test_serializer_scalar_transform(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'x': double}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['x'].emit, 3), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
@@ -339,7 +341,7 @@ def test_serializer_dict_expansion(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'img': expand}, ds, world)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (lambda: emitters['img'].emit(10), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
@@ -362,7 +364,7 @@ def test_serializer_none_drops_sample(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'x': drop_negative}, ds, world)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (lambda: emitters['x'].emit(3), 0.001),
         (lambda: emitters['x'].emit(-1), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
@@ -384,7 +386,7 @@ def test_transform_3d_serializer(world):
     pose = geom.Transform3D(translation=t, rotation=q)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (lambda: emitters['pose'].emit(pose), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
@@ -408,7 +410,7 @@ def test_robot_state_serializer_records_a_busy_arm_beside_its_pose(world):
     pose = geom.Transform3D(translation=t, rotation=geom.Rotation.identity)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (lambda: emitters[keys.ROBOT_STATE].emit(FakeRobotState(q, dq, pose, RobotStatus.BUSY)), 0.001),
         (lambda: emitters[keys.ROBOT_STATE].emit(FakeRobotState(q, dq, pose, RobotStatus.AVAILABLE)), 0.001),
         (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
@@ -439,7 +441,7 @@ def test_robot_command_serializer_variants(world):
     impedance = rcmd.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianPosition(pose)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianDelta(delta, delta_frame)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints)), 0.001),
@@ -474,7 +476,7 @@ def test_multiple_timelines_recorded(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['a'].emit, 42), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
@@ -531,7 +533,7 @@ def test_serializer_plain_list_value(world):
 
     agent, cmd_em, emitters = build_agent_with_pipes({'v': to_list}, ds, world)
     script = [
-        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001),
         (partial(emitters['v'].emit, 0), 0.001),
         (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -1,5 +1,7 @@
 import pickle
+from collections.abc import Callable
 from functools import partial
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -9,13 +11,16 @@ import pytest
 import pimm
 from positronic import geom, keys, telemetry, telemetry_keys
 from positronic.dataset import DatasetWriter, EpisodeWriter
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType, TimeMode
+from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, TimeMode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm import command as rcmd
 from positronic.drivers.roboarm.tests.fakes import FakeRobotState
 from positronic.tests.testing_coutils import run_scripted_agent
+
+# The dataset a scripted episode names; a fake opens the same one whatever the path.
+DATASET = Path('dataset')
 
 
 @pytest.fixture
@@ -45,8 +50,13 @@ class FakeEpisodeWriter(EpisodeWriter[Any]):
 
 
 class FakeDatasetWriter(DatasetWriter):
+    """One in-memory dataset, and the factory that opens it: it answers every path with itself."""
+
     def __init__(self) -> None:
         self.created: list[FakeEpisodeWriter] = []
+
+    def __call__(self, path: Path) -> 'FakeDatasetWriter':
+        return self
 
     def new_episode(self) -> FakeEpisodeWriter:
         w = FakeEpisodeWriter()
@@ -58,7 +68,11 @@ class FakeDatasetWriter(DatasetWriter):
 
 
 def build_agent_with_pipes(
-    signals_spec: dict[str, Any], ds_writer: DatasetWriter, world: pimm.World, *, time_mode: TimeMode = TimeMode.CLOCK
+    signals_spec: dict[str, Any],
+    new_dataset: Callable[[Path], DatasetWriter],
+    world: pimm.World,
+    *,
+    time_mode: TimeMode = TimeMode.CLOCK,
 ):
     """Build agent with given signals spec and wire it using ``world.pair``.
 
@@ -69,7 +83,7 @@ def build_agent_with_pipes(
         * return None to drop the sample (not recorded at all).
     Returns (agent, cmd_emitter, emitters_by_name).
     """
-    agent = DsWriterAgent(ds_writer, time_mode=time_mode)
+    agent = DsWriterAgent(new_dataset, time_mode=time_mode)
     for name, serializer in signals_spec.items():
         agent.add_signal(name, serializer)
     emitters: dict[str, pimm.SignalEmitter[Any]] = {name: world.pair(agent.inputs[name]) for name in signals_spec}
@@ -84,10 +98,10 @@ def test_start_stop_happy_path(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None, 'b': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE, {'user': 'alice'})), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET, {'user': 'alice'})), 0.001),
         (partial(emitters['a'].emit, 1), 0.001),
         (partial(emitters['b'].emit, 2), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE, {'done': True})), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP({'done': True})), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -104,10 +118,7 @@ def test_episode_finalizes_when_run_stops(world):
     ds = FakeDatasetWriter()
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 
-    script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
-        (partial(emitters['a'].emit, 42), 0.001),
-    ]
+    script = [(partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001), (partial(emitters['a'].emit, 42), 0.001)]
 
     run_scripted_agent(agent, script, world=world)
 
@@ -122,10 +133,10 @@ def test_ignore_duplicate_commands_and_empty_stop(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'x': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -140,10 +151,10 @@ def test_abort_flow_then_restart(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'s': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['s'].emit, 10), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.ABORT_EPISODE)), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.ABORT()), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['s'].emit, 11), 0.001),
     ]
 
@@ -160,7 +171,7 @@ def test_appends_only_on_updates_and_timestamps_from_clock(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['a'].emit, 1), 0.001),
         (None, 0.001),
         (partial(emitters['a'].emit, 2), 0.001),
@@ -181,9 +192,9 @@ def test_records_what_the_inputs_hold_when_the_episode_opens(world):
 
     script = [
         (partial(emitters['a'].emit, 99), 0.001),  # latched on the channel before the episode opens
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['a'].emit, 7), 0.001),  # the first value that arrives in-episode
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -200,10 +211,10 @@ def test_time_mode_message_uses_signal_timestamp(world):
     ts_second = 456_000_000
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['a'].emit, 1, ts=ts_first), 0.001),
         (partial(emitters['a'].emit, 2, ts=ts_second), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -214,17 +225,16 @@ def test_time_mode_message_uses_signal_timestamp(world):
 
 
 def test_integration_with_local_dataset_writer(tmp_path, world):
-    with LocalDatasetWriter(tmp_path) as writer:
-        agent, cmd_em, emitters = build_agent_with_pipes({'a': None, 'b': None}, writer, world)
+    agent, cmd_em, emitters = build_agent_with_pipes({'a': None, 'b': None}, LocalDatasetWriter, world)
 
-        script = [
-            (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE, {'task': 'unit'})), 0.001),
-            (partial(emitters['a'].emit, 10), 0.001),
-            (partial(emitters['b'].emit, 20), 0.001),
-            (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE, {'ok': True})), 0.001),
-        ]
+    script = [
+        (partial(cmd_em.emit, DsWriterCommand.START(tmp_path, {'task': 'unit'})), 0.001),
+        (partial(emitters['a'].emit, 10), 0.001),
+        (partial(emitters['b'].emit, 20), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP({'ok': True})), 0.001),
+    ]
 
-        run_scripted_agent(agent, script, world=world)
+    run_scripted_agent(agent, script, world=world)
 
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
@@ -240,6 +250,44 @@ def test_integration_with_local_dataset_writer(tmp_path, world):
     assert 'ts_ns.message' in table_a.column_names
     assert 'ts_ns.system' in table_a.column_names
     assert 'ts_ns.world' in table_a.column_names
+
+
+def test_each_episode_records_into_the_dataset_its_start_names(tmp_path, world):
+    """Each START names where its episode records, so one run writes into as many datasets as it names."""
+    agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, LocalDatasetWriter, world)
+    first, second = tmp_path / 'first', tmp_path / 'second'
+
+    script = [
+        (partial(cmd_em.emit, DsWriterCommand.START(first)), 0.001),
+        (partial(emitters['a'].emit, 10), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(second)), 0.001),
+        (partial(emitters['a'].emit, 20), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
+    ]
+
+    run_scripted_agent(agent, script, world=world)
+
+    (first_ep,) = LocalDataset(first)
+    (second_ep,) = LocalDataset(second)
+    assert first_ep['a'][-1][0] == 10
+    assert second_ep['a'][-1][0] == 20
+
+
+def test_a_start_that_names_no_dataset_opens_no_episode(world):
+    """There is nowhere to record, and the STOP that follows finds nothing open."""
+    ds = FakeDatasetWriter()
+    agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
+
+    script = [
+        (partial(cmd_em.emit, DsWriterCommand.START(None)), 0.001),
+        (partial(emitters['a'].emit, 10), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
+    ]
+
+    run_scripted_agent(agent, script, world=world)
+
+    assert ds.created == []
 
 
 def test_inputs_mapping_is_immutable(world):
@@ -268,9 +316,9 @@ def test_serializer_scalar_transform(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'x': double}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['x'].emit, 3), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -291,9 +339,9 @@ def test_serializer_dict_expansion(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'img': expand}, ds, world)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
         (lambda: emitters['img'].emit(10), 0.001),
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -314,10 +362,10 @@ def test_serializer_none_drops_sample(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'x': drop_negative}, ds, world)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
         (lambda: emitters['x'].emit(3), 0.001),
         (lambda: emitters['x'].emit(-1), 0.001),
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -336,9 +384,9 @@ def test_transform_3d_serializer(world):
     pose = geom.Transform3D(translation=t, rotation=q)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
         (lambda: emitters['pose'].emit(pose), 0.001),
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -360,10 +408,10 @@ def test_robot_state_serializer_records_a_busy_arm_beside_its_pose(world):
     pose = geom.Transform3D(translation=t, rotation=geom.Rotation.identity)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
         (lambda: emitters[keys.ROBOT_STATE].emit(FakeRobotState(q, dq, pose, RobotStatus.BUSY)), 0.001),
         (lambda: emitters[keys.ROBOT_STATE].emit(FakeRobotState(q, dq, pose, RobotStatus.AVAILABLE)), 0.001),
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -391,14 +439,14 @@ def test_robot_command_serializer_variants(world):
     impedance = rcmd.Impedance(kq=(40.0,) * 7, kqd=(4.0,) * 7, kx=(750.0,) * 6, kxd=(37.0,) * 6)
 
     script = [
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.START(DATASET)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianPosition(pose)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.CartesianDelta(delta, delta_frame)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=impedance)), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=rcmd.PositionControl())), 0.001),
         (lambda: emitters['cmd'].emit(rcmd.JointPosition(joints, mode=rcmd.PositionControl((100.0,) * 7))), 0.001),
-        (lambda: cmd_em.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (lambda: cmd_em.emit(DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -426,9 +474,9 @@ def test_multiple_timelines_recorded(world):
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['a'].emit, 42), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
 
     run_scripted_agent(agent, script, world=world)
@@ -483,9 +531,9 @@ def test_serializer_plain_list_value(world):
 
     agent, cmd_em, emitters = build_agent_with_pipes({'v': to_list}, ds, world)
     script = [
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.START_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.START(DATASET)), 0.001),
         (partial(emitters['v'].emit, 0), 0.001),
-        (partial(cmd_em.emit, DsWriterCommand(DsWriterCommandType.STOP_EPISODE)), 0.001),
+        (partial(cmd_em.emit, DsWriterCommand.STOP()), 0.001),
     ]
     run_scripted_agent(agent, script, world=world)
 

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -277,7 +277,7 @@ def test_each_episode_records_into_the_dataset_its_start_names(tmp_path, world):
 
 
 def test_a_start_that_names_no_dataset_opens_no_episode(world):
-    """There is nowhere to record, and the STOP that follows finds nothing open."""
+    """The episode runs, and the STOP that ends it finishes an episode that recorded nowhere."""
     ds = FakeDatasetWriter()
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)
 

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -53,16 +53,23 @@ class FakeDatasetWriter(DatasetWriter):
 
     def __init__(self) -> None:
         self.created: list[FakeEpisodeWriter] = []
+        self.lifecycle: list[str] = []  # 'enter', 'new_episode' and 'exit', in the order they arrive
 
     def __call__(self, output_path: Path) -> 'FakeDatasetWriter':
         return self
 
+    def __enter__(self) -> 'FakeDatasetWriter':
+        self.lifecycle.append('enter')
+        return self
+
     def new_episode(self) -> FakeEpisodeWriter:
+        self.lifecycle.append('new_episode')
         w = FakeEpisodeWriter()
         self.created.append(w)
         return w
 
     def __exit__(self, exc_type, exc, tb) -> None:
+        self.lifecycle.append('exit')
         return False
 
 
@@ -274,6 +281,19 @@ def test_each_episode_records_into_the_dataset_its_start_names(tmp_path, world):
     (second_ep,) = LocalDataset(second)
     assert first_ep['a'][-1][0] == 10
     assert second_ep['a'][-1][0] == 20
+
+
+def test_the_dataset_a_start_names_is_entered_before_it_writes(world):
+    """A backend whose setup is in ``__enter__`` gets that call before its first episode, and the ``__exit__``
+    that matches it when the run ends."""
+    ds = FakeDatasetWriter()
+    agent, cmd_em, _ = build_agent_with_pipes({'a': None}, ds, world)
+
+    script = [(partial(cmd_em.emit, DsWriterCommand.START(OUTPUT_PATH)), 0.001)]
+
+    run_scripted_agent(agent, script, world=world)
+
+    assert ds.lifecycle == ['enter', 'new_episode', 'exit']
 
 
 def test_a_start_that_names_no_dataset_writes_no_episode(world):

--- a/positronic/dataset/tests/test_ds_writer_agent.py
+++ b/positronic/dataset/tests/test_ds_writer_agent.py
@@ -276,7 +276,7 @@ def test_each_episode_records_into_the_dataset_its_start_names(tmp_path, world):
     assert second_ep['a'][-1][0] == 20
 
 
-def test_a_start_that_names_no_dataset_opens_no_episode(world):
+def test_a_start_that_names_no_dataset_writes_no_episode(world):
     """The episode runs, and the STOP that ends it finishes an episode that recorded nowhere."""
     ds = FakeDatasetWriter()
     agent, cmd_em, emitters = build_agent_with_pipes({'a': None}, ds, world)

--- a/positronic/dataset/transforms/episode.py
+++ b/positronic/dataset/transforms/episode.py
@@ -127,10 +127,8 @@ class _LazyMergedEpisode(Episode):
 
     def __getitem__(self, name: str) -> Any:
         for ep in self._episodes:
-            try:
+            if name in ep:
                 return ep[name]
-            except KeyError:
-                continue
         raise KeyError(name)
 
     @property

--- a/positronic/dataset/transforms/episode.py
+++ b/positronic/dataset/transforms/episode.py
@@ -127,8 +127,10 @@ class _LazyMergedEpisode(Episode):
 
     def __getitem__(self, name: str) -> Any:
         for ep in self._episodes:
-            if name in ep:
+            try:  # `name in ep` is `ep[name]` under `Mapping`, so a membership test costs the lookup twice
                 return ep[name]
+            except KeyError:
+                pass
         raise KeyError(name)
 
     @property

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -100,7 +100,7 @@ class Task:
 # [✓] One runner builds the world for both.
 # [✓] A session reports the model's meta, so a policy holds none.
 # [✓] The episode call carries the session that runs it, so the Harness holds no policy.
-# [ ] The episode call names where it records, so the Harness holds no dataset.
+# [✓] The episode call names where it records, so the Harness holds no dataset.
 # [ ] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.
 # [ ] A task carries its instruction as data, so no trial reads it after the reset.
 # [ ] A sim eval config names a selection, and a spec flag narrows it to one task.

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -4,6 +4,7 @@ aliases over ``cli.eval.run``."""
 import logging
 from collections import Counter
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import configuronic as cfn
@@ -33,13 +34,14 @@ class KeyboardOperator(KeyboardControl):
     One episode is in flight at a time: a press while one runs is declined here, with a warning. It holds
     the pending answer because that is where the episode's terminal — or a refused ask — arrives, and it
     logs that as it lands. ``next_task`` makes the trial and the policy opens its session, once per accepted
-    press.
+    press. Every episode records into ``dataset``, and none records when that is ``None``.
     """
 
-    def __init__(self, next_task: Callable[[], Task], policy: Policy):
+    def __init__(self, next_task: Callable[[], Task], policy: Policy, dataset: Path | None):
         super().__init__(quit_key='q')
         self._next_task = next_task
         self._policy = policy
+        self._dataset = dataset
         self._pending: pimm.calls.Answer[dict[str, Any]] | None = None
         self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
@@ -59,7 +61,7 @@ class KeyboardOperator(KeyboardControl):
                 # A model that will not open a session ends the episode, not the run: the operator hears it
                 # and presses again.
                 try:  # rules-allow: swallowed-error — the operator is who this failure is for
-                    self._pending = self.perform_task(Rollout(self._next_task(), self._policy))
+                    self._pending = self.perform_task(Rollout(self._next_task(), self._policy, self._dataset))
                 except Exception as e:
                     logger.error(f'Episode failed to open: {e}')
             case 'p':
@@ -78,12 +80,13 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
         raise ValueError('the keyboard path drives hardware in real time; run a simulated embodiment as `sim`')
 
     # The policy is this function's to close from here on, and everything below can raise:
-    # `prepare_output_dir` syncs a directory and snapshots sources into it, and `run_world` opens the
-    # dataset it is given.
+    # `prepare_output_dir` syncs a directory and snapshots sources into it, and `run_world` builds the
+    # world the rig runs in.
     try:
-        operator = KeyboardOperator(next_task, policy)
+        dataset = prepare_output_dir(output_dir)
+        operator = KeyboardOperator(next_task, policy, dataset)
         logger.info('Keyboard controls: [s]tart, sto[p], [q]uit')
-        run_world(embodiment, operator, prepare_output_dir(output_dir), done=operator.done)
+        run_world(embodiment, operator, record=dataset is not None, done=operator.done)
     finally:
         policy.close()
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -34,14 +34,14 @@ class KeyboardOperator(KeyboardControl):
     One episode is in flight at a time: a press while one runs is declined here, with a warning. It holds
     the pending answer because that is where the episode's terminal — or a refused ask — arrives, and it
     logs that as it lands. ``next_task`` makes the trial and the policy opens its session, once per accepted
-    press. Every episode records into ``dataset``, and none records when that is ``None``.
+    press. Every episode records into ``output_path``, and none records when that is ``None``.
     """
 
-    def __init__(self, next_task: Callable[[], Task], policy: Policy, dataset: Path | None):
+    def __init__(self, next_task: Callable[[], Task], policy: Policy, output_path: Path | None):
         super().__init__(quit_key='q')
         self._next_task = next_task
         self._policy = policy
-        self._dataset = dataset
+        self._output_path = output_path
         self._pending: pimm.calls.Answer[dict[str, Any]] | None = None
         self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
@@ -61,7 +61,7 @@ class KeyboardOperator(KeyboardControl):
                 # A model that will not open a session ends the episode, not the run: the operator hears it
                 # and presses again.
                 try:  # rules-allow: swallowed-error — the operator is who this failure is for
-                    self._pending = self.perform_task(Rollout(self._next_task(), self._policy, self._dataset))
+                    self._pending = self.perform_task(Rollout(self._next_task(), self._policy, self._output_path))
                 except Exception as e:
                     logger.error(f'Episode failed to open: {e}')
             case 'p':
@@ -83,10 +83,10 @@ def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_d
     # `prepare_output_dir` syncs a directory and snapshots sources into it, and `run_world` builds the
     # world the rig runs in.
     try:
-        dataset = prepare_output_dir(output_dir)
-        operator = KeyboardOperator(next_task, policy, dataset)
+        output_path = prepare_output_dir(output_dir)
+        operator = KeyboardOperator(next_task, policy, output_path)
         logger.info('Keyboard controls: [s]tart, sto[p], [q]uit')
-        run_world(embodiment, operator, record=dataset is not None, done=operator.done)
+        run_world(embodiment, operator, record=output_path is not None, done=operator.done)
     finally:
         policy.close()
 

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -28,15 +28,15 @@ POLL_PERIOD_SEC = 0.01
 
 class Rollout:
     """What one ``perform_task`` call asks for: the trial to run, the session that runs it, the runtime that
-    serves the policy's functions to that session, and the dataset the episode records into.
+    serves the policy's functions to that session, and the path the episode records into.
 
-    Whoever asks opens it, and so decides which model runs the trial and where the recording lands. A
-    ``dataset`` of ``None`` records nothing. The Harness closes it: the episode it ran, or the ask it refused.
+    Whoever asks opens it, and so decides which model runs the trial and where the recording lands. An
+    ``output_path`` of ``None`` records nothing. The Harness closes it: the episode it ran, or the ask it refused.
     """
 
-    def __init__(self, task: Task, policy: Policy, dataset: Path | None):
+    def __init__(self, task: Task, policy: Policy, output_path: Path | None):
         self.task = task
-        self.dataset = dataset
+        self.output_path = output_path
         # The Harness closes this runtime before the session, and charges the trial for the model's time
         # through it. TODO(#661): the framework takes over closing the chain, and only the charge keeps a
         # runtime here.
@@ -220,11 +220,11 @@ class Harness(pimm.ControlSystem):
         return self._call.request.task
 
     @property
-    def _dataset(self) -> Path | None:
-        """Where the live episode records. The call that asked for it names the dataset, and ``None`` names
+    def _output_path(self) -> Path | None:
+        """Where the live episode records. The call that asked for it names the path, and ``None`` names
         nowhere: that trial runs, and the recorder hears nothing of it."""
         assert self._call is not None, 'only a live episode records'
-        return self._call.request.dataset
+        return self._call.request.output_path
 
     @property
     def _charges_wall_time(self) -> bool:
@@ -291,7 +291,7 @@ class Harness(pimm.ControlSystem):
         """Commit the live episode: cancel the in-flight chunk, stop the recorder — stamping the
         episode's full static meta (plus any terminal payload) — then close its span."""
         self._set_deadline(None)
-        if self._dataset is not None:
+        if self._output_path is not None:
             # Stamped before the inference is retired: the meta overlays what its session reports.
             self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})}))
         for schedule in self._schedules.values():  # devices hold their last commanded position
@@ -327,8 +327,8 @@ class Harness(pimm.ControlSystem):
         budget = self._task.timeout_sec
         self._set_deadline(clock.now_ns() + round(budget * 1e9) if budget is not None else None)
         self._telemetry.start_rollout(clock.now())
-        if self._dataset is not None:
-            self.ds_command.emit(DsWriterCommand.START(self._dataset))
+        if self._output_path is not None:
+            self.ds_command.emit(DsWriterCommand.START(self._output_path))
         # The fresh data is here, later round would read a frame the recording did not open on.
         self._infer(self._inference, clock, should_stop)
 

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -220,13 +220,6 @@ class Harness(pimm.ControlSystem):
         return self._call.request.task
 
     @property
-    def _output_path(self) -> Path | None:
-        """Where the live episode records. The call that asked for it names the path, and ``None`` names
-        nowhere: that trial runs, and the recorder hears nothing of it."""
-        assert self._call is not None, 'only a live episode records'
-        return self._call.request.output_path
-
-    @property
     def _charges_wall_time(self) -> bool:
         """Whether each model call costs the trial the wall time it took. A real rig has no other option."""
         return self._task.charge_inference_time or not self._embodiment.simulated
@@ -291,9 +284,8 @@ class Harness(pimm.ControlSystem):
         """Commit the live episode: cancel the in-flight chunk, stop the recorder — stamping the
         episode's full static meta (plus any terminal payload) — then close its span."""
         self._set_deadline(None)
-        if self._output_path is not None:
-            # Stamped before the inference is retired: the meta overlays what its session reports.
-            self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})}))
+        # Stamped before the inference is retired: the meta overlays what its session reports.
+        self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})}))
         for schedule in self._schedules.values():  # devices hold their last commanded position
             schedule.clear()
         self._retire_inference()
@@ -327,8 +319,7 @@ class Harness(pimm.ControlSystem):
         budget = self._task.timeout_sec
         self._set_deadline(clock.now_ns() + round(budget * 1e9) if budget is not None else None)
         self._telemetry.start_rollout(clock.now())
-        if self._output_path is not None:
-            self.ds_command.emit(DsWriterCommand.START(self._output_path))
+        self.ds_command.emit(DsWriterCommand.START(call.request.output_path))
         # The fresh data is here, later round would read a frame the recording did not open on.
         self._infer(self._inference, clock, should_stop)
 

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -1,6 +1,7 @@
 import time
 from collections import deque
 from collections.abc import Generator, Iterator
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -26,15 +27,16 @@ POLL_PERIOD_SEC = 0.01
 
 
 class Rollout:
-    """What one ``perform_task`` call asks for: the trial to run, the session that runs it, and the runtime
-    that serves the policy's functions to that session.
+    """What one ``perform_task`` call asks for: the trial to run, the session that runs it, the runtime that
+    serves the policy's functions to that session, and the dataset the episode records into.
 
-    Whoever asks opens it, and so decides which model runs the trial. The Harness closes it: the episode it
-    ran, or the ask it refused.
+    Whoever asks opens it, and so decides which model runs the trial and where the recording lands. A
+    ``dataset`` of ``None`` records nothing. The Harness closes it: the episode it ran, or the ask it refused.
     """
 
-    def __init__(self, task: Task, policy: Policy):
+    def __init__(self, task: Task, policy: Policy, dataset: Path | None):
         self.task = task
+        self.dataset = dataset
         # The Harness closes this runtime before the session, and charges the trial for the model's time
         # through it. TODO(#661): the framework takes over closing the chain, and only the charge keeps a
         # runtime here.
@@ -218,6 +220,13 @@ class Harness(pimm.ControlSystem):
         return self._call.request.task
 
     @property
+    def _dataset(self) -> Path | None:
+        """Where the live episode records. The call that asked for it names the dataset, and ``None`` names
+        nowhere: that trial runs, and the recorder hears nothing of it."""
+        assert self._call is not None, 'only a live episode records'
+        return self._call.request.dataset
+
+    @property
     def _charges_wall_time(self) -> bool:
         """Whether each model call costs the trial the wall time it took. A real rig has no other option."""
         return self._task.charge_inference_time or not self._embodiment.simulated
@@ -282,12 +291,12 @@ class Harness(pimm.ControlSystem):
         """Commit the live episode: cancel the in-flight chunk, stop the recorder — stamping the
         episode's full static meta (plus any terminal payload) — then close its span."""
         self._set_deadline(None)
-        # Stamped before the inference is retired: the meta overlays what its session reports.
-        stop = DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})})
+        if self._dataset is not None:
+            # Stamped before the inference is retired: the meta overlays what its session reports.
+            self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})}))
         for schedule in self._schedules.values():  # devices hold their last commanded position
             schedule.clear()
         self._retire_inference()
-        self.ds_command.emit(stop)
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
         # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
         # last-value-wins would drop one) and before the next trial's prepare, so the moves it asks for stay
@@ -318,7 +327,8 @@ class Harness(pimm.ControlSystem):
         budget = self._task.timeout_sec
         self._set_deadline(clock.now_ns() + round(budget * 1e9) if budget is not None else None)
         self._telemetry.start_rollout(clock.now())
-        self.ds_command.emit(DsWriterCommand.START())
+        if self._dataset is not None:
+            self.ds_command.emit(DsWriterCommand.START(self._dataset))
         # The fresh data is here, later round would read a frame the recording did not open on.
         self._infer(self._inference, clock, should_stop)
 

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -34,7 +34,7 @@ import pytest
 import pimm
 from positronic import keys, wire
 from positronic.dataset.ds_writer_agent import TimeMode
-from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
+from positronic.dataset.local_dataset import LocalDataset
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import CartesianPosition, CommandType
@@ -189,7 +189,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
     robot = FakeRobot()
     gripper = FakeGripper()
 
-    with LocalDatasetWriter(tmp_path) as ds_writer, pimm.World(virtual_time=True) as world:
+    with pimm.World(virtual_time=True) as world:
         embodiment = Embodiment(
             descriptor='',
             observations={
@@ -209,9 +209,9 @@ def _run_pipeline(tmp_path: Path) -> dict:
         )
         wrapped = _SimulatedLatency((StopOnFault() | ChunkedSchedule()).wrap(policy), INFERENCE_LATENCY_S)
         harness = Harness(embodiment)
-        ds_agent = wire.wire_embodiment(world, harness, embodiment, ds_writer, TimeMode.MESSAGE)
+        ds_agent = wire.wire_embodiment(world, harness, embodiment, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
-        perform_task = episode_caller(world, harness, wrapped)
+        perform_task = episode_caller(world, harness, wrapped, tmp_path)
         done_em = world.pair(harness.done)
 
         # Robot/gripper emit state every tick, so the script only drives the

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -2,6 +2,7 @@ import threading
 import time
 from contextlib import contextmanager
 from functools import partial
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -294,9 +295,9 @@ class _Scene(pimm.ControlSystem):
             yield pimm.Sleep(0.001)
 
 
-def _pair_all(world, harness, policy):
+def _pair_all(world, harness, policy, dataset: Path | None = Path('dataset')):
     """Pair all harness signals and return a dict of test handles. ``perform_task`` opens a session from
-    ``policy`` and asks for the episode, the way a driver does."""
+    ``policy``, names ``dataset`` as where the episode records, and asks for it, the way a driver does."""
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     deadline_recorder = RecordingEmitter()
@@ -305,7 +306,7 @@ def _pair_all(world, harness, policy):
         'frame_em': world.pair(harness.observations[CAM]),
         'robot_em': world.pair(harness.observations[keys.ROBOT_STATE]),
         'grip_em': world.pair(harness.observations[keys.GRIP]),
-        'perform_task': episode_caller(world, harness, policy),
+        'perform_task': episode_caller(world, harness, policy, dataset),
         'done_em': world.pair(harness.done),
         'command_rx': world.pair(harness.commands[keys.ROBOT_COMMAND]),
         'grip_rx': world.pair(harness.commands['target_grip']),
@@ -610,6 +611,45 @@ def test_finish_emits_ds_stop_with_data(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_the_episode_records_into_the_dataset_its_call_named(world, tmp_path):
+    """The call names where the episode records, so the recorder's START carries that dataset."""
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy, dataset=tmp_path / 'trials')
+
+    driver = ManualDriver([
+        (partial(p['perform_task'], Task(instruction_source='test', timeout_sec=None)), 0.0),
+        (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),
+        (None, 0.02),
+    ])
+
+    scheduler = world.start([harness, driver])
+    drive_scheduler(scheduler, steps=20)
+
+    starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
+    assert [c.dataset for c in starts] == [tmp_path / 'trials']
+
+
+@pytest.mark.timeout(3.0)
+def test_a_call_that_names_no_dataset_runs_the_trial_and_records_nothing(world):
+    """A trial the caller wants unrecorded still runs and still answers; the recorder hears nothing of it."""
+    policy = StubPolicy()
+    harness = Harness(make_embodiment())
+    p = _pair_all(world, harness, policy, dataset=None)
+
+    scheduler = world.start([harness])
+    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
+    emit_ready_payload(p['frame_em'], p['robot_em'], p['grip_em'], make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]))
+    drive_scheduler(scheduler, steps=5)
+    p['done_em'].emit({keys.EVAL_SUCCESS: True})
+    drive_scheduler(scheduler, steps=10)
+
+    assert answer.result() == {keys.EVAL_SUCCESS: True, keys.EVAL_TERMINATED: True}
+    assert policy.observations, 'the trial never reached the policy'
+    assert not _ds_commands(p)
+
+
+@pytest.mark.timeout(3.0)
 def test_the_call_is_answered_with_the_terminal_the_episode_ended_on(world):
     """A task with no timeout ends on ``done`` alone, and its caller gets what it ended on."""
     policy = StubPolicy()
@@ -665,7 +705,7 @@ def test_an_uncharged_wait_ends_when_the_world_comes_down(world):
         def functions(self):
             return {INFER: never_answers.wait}
 
-    rollout = Rollout(Task(instruction_source='t', timeout_sec=None), _HangingPolicy())
+    rollout = Rollout(Task(instruction_source='t', timeout_sec=None), _HangingPolicy(), None)
     inference = _EpisodeInference(rollout, charges_wall_time=False, clock=world.clock)
     try:
         inference({})  # starts the function, which never answers
@@ -845,7 +885,7 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
     policy = StubPolicy()
     harness = Harness(embodiment)
     perform_task = episode_caller(world, harness, policy)
-    wire.wire_embodiment(world, harness, embodiment, None)
+    wire.wire_embodiment(world, harness, embodiment, record=False)
 
     scheduler = world.start([harness, device])
     perform_task(Task(instruction_source='t', timeout_sec=100.0, prepare_args={keys.SCENE: {}}))
@@ -892,7 +932,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     perform_task = episode_caller(world, harness, policy)
-    wire.wire_embodiment(world, harness, embodiment, None, done=device.done)
+    wire.wire_embodiment(world, harness, embodiment, record=False, done=device.done)
 
     scheduler = world.start([harness, device])
     perform_task(Task(instruction_source='t', timeout_sec=100.0))
@@ -1698,7 +1738,7 @@ def _ask(world: pimm.World, harness: Harness, policy: Policy, task: Task) -> Non
     """Deliver one ``perform_task``, for a test that drives the harness's generator rather than a World."""
     caller = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](harness)
     wire_call(world, caller, harness.perform_task)
-    caller(Rollout(task, policy))
+    caller(Rollout(task, policy, Path('dataset')))
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -295,9 +295,9 @@ class _Scene(pimm.ControlSystem):
             yield pimm.Sleep(0.001)
 
 
-def _pair_all(world, harness, policy, dataset: Path | None = Path('dataset')):
+def _pair_all(world, harness, policy, output_path: Path | None = Path('dataset')):
     """Pair all harness signals and return a dict of test handles. ``perform_task`` opens a session from
-    ``policy``, names ``dataset`` as where the episode records, and asks for it, the way a driver does."""
+    ``policy``, names ``output_path`` as where the episode records, and asks for it, the way a driver does."""
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     deadline_recorder = RecordingEmitter()
@@ -306,7 +306,7 @@ def _pair_all(world, harness, policy, dataset: Path | None = Path('dataset')):
         'frame_em': world.pair(harness.observations[CAM]),
         'robot_em': world.pair(harness.observations[keys.ROBOT_STATE]),
         'grip_em': world.pair(harness.observations[keys.GRIP]),
-        'perform_task': episode_caller(world, harness, policy, dataset),
+        'perform_task': episode_caller(world, harness, policy, output_path),
         'done_em': world.pair(harness.done),
         'command_rx': world.pair(harness.commands[keys.ROBOT_COMMAND]),
         'grip_rx': world.pair(harness.commands['target_grip']),
@@ -615,7 +615,7 @@ def test_the_episode_records_into_the_dataset_its_call_named(world, tmp_path):
     """The call names where the episode records, so the recorder's START carries that dataset."""
     policy = StubPolicy()
     harness = Harness(make_embodiment())
-    p = _pair_all(world, harness, policy, dataset=tmp_path / 'trials')
+    p = _pair_all(world, harness, policy, output_path=tmp_path / 'trials')
 
     driver = ManualDriver([
         (partial(p['perform_task'], Task(instruction_source='test', timeout_sec=None)), 0.0),
@@ -627,7 +627,7 @@ def test_the_episode_records_into_the_dataset_its_call_named(world, tmp_path):
     drive_scheduler(scheduler, steps=20)
 
     starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
-    assert [c.dataset for c in starts] == [tmp_path / 'trials']
+    assert [c.output_path for c in starts] == [tmp_path / 'trials']
 
 
 @pytest.mark.timeout(3.0)
@@ -635,7 +635,7 @@ def test_a_call_that_names_no_dataset_runs_the_trial_and_records_nothing(world):
     """A trial the caller wants unrecorded still runs and still answers; the recorder hears nothing of it."""
     policy = StubPolicy()
     harness = Harness(make_embodiment())
-    p = _pair_all(world, harness, policy, dataset=None)
+    p = _pair_all(world, harness, policy, output_path=None)
 
     scheduler = world.start([harness])
     answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -632,7 +632,7 @@ def test_the_episode_records_into_the_dataset_its_call_named(world, tmp_path):
 
 @pytest.mark.timeout(3.0)
 def test_a_call_that_names_no_dataset_runs_the_trial_and_records_nothing(world):
-    """A trial the caller wants unrecorded still runs and still answers; the recorder hears nothing of it."""
+    """A trial the caller wants unrecorded still runs and still answers; its START names no dataset."""
     policy = StubPolicy()
     harness = Harness(make_embodiment())
     p = _pair_all(world, harness, policy, output_path=None)
@@ -646,7 +646,8 @@ def test_a_call_that_names_no_dataset_runs_the_trial_and_records_nothing(world):
 
     assert answer.result() == {keys.EVAL_SUCCESS: True, keys.EVAL_TERMINATED: True}
     assert policy.observations, 'the trial never reached the policy'
-    assert not _ds_commands(p)
+    starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
+    assert [c.output_path for c in starts] == [None]
 
 
 @pytest.mark.timeout(3.0)

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -125,7 +125,6 @@ def main(
 
     output_path = Path(output_dir) if output_dir is not None else None
     dataset_factory = LocalDatasetWriter if output_path is not None else None
-    # Process each episode
     for ep_index in indices:
         episode = dataset[ep_index]
         assert isinstance(episode, Episode), 'an integer index names one episode'

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -123,8 +123,8 @@ def main(
     # Apply dataset transform once
     dataset = transforms.TransformedDataset(dataset, Group(RestoreCommand(), Identity()))
 
-    dataset_dir = Path(output_dir) if output_dir is not None else None
-    new_dataset = LocalDatasetWriter if dataset_dir is not None else None
+    output_path = Path(output_dir) if output_dir is not None else None
+    dataset_factory = LocalDatasetWriter if output_path is not None else None
     # Process each episode
     for ep_index in indices:
         episode = dataset[ep_index]
@@ -139,7 +139,7 @@ def main(
 
         with pimm.World(virtual_time=True) as world:
             # The sim carries both the arm and the gripper ports, so it fills both slots.
-            ds_agent = wire.wire(world, replay, new_dataset, cameras_mapped, sim, sim, gui, TimeMode.MESSAGE)
+            ds_agent = wire.wire(world, replay, dataset_factory, cameras_mapped, sim, sim, gui, TimeMode.MESSAGE)
             player_cmd = world.pair(replay.command)
 
             ds_cmd = pimm.NoOpEmitter()
@@ -156,7 +156,7 @@ def main(
             _ = world.pair(replay.finished, emitter_wrapper=pimm.map(call_stop))
 
             sim_iter = world.start([sim, replay, ds_agent], gui)
-            ds_cmd.emit(DsWriterCommand.START(dataset_dir, episode.static))
+            ds_cmd.emit(DsWriterCommand.START(output_path, episode.static))
             player_cmd.emit(DsPlayerStartCommand(episode))
 
             p_bar = tqdm.tqdm(total=round(episode.duration_ns / 1e9, 1), unit='s')

--- a/positronic/replay_record.py
+++ b/positronic/replay_record.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -124,47 +123,47 @@ def main(
     # Apply dataset transform once
     dataset = transforms.TransformedDataset(dataset, Group(RestoreCommand(), Identity()))
 
-    # Create writer context outside the loop so it persists across episodes
-    writer_cm = LocalDatasetWriter(Path(output_dir)) if output_dir is not None else nullcontext(None)
-    with writer_cm as dataset_writer:
-        # Process each episode
-        for ep_index in indices:
-            episode = dataset[ep_index]
+    dataset_dir = Path(output_dir) if output_dir is not None else None
+    new_dataset = LocalDatasetWriter if dataset_dir is not None else None
+    # Process each episode
+    for ep_index in indices:
+        episode = dataset[ep_index]
+        assert isinstance(episode, Episode), 'an integer index names one episode'
 
-            sim = MujocoSim(mujoco_model_path, loaders, camera_fps=fps)
-            sim.load_state(episode.static)
-            cameras_mapped = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
-            gui = dpg_ui() if show_gui else None
+        sim = MujocoSim(mujoco_model_path, loaders, camera_fps=fps)
+        sim.load_state(episode.static)
+        cameras_mapped = {name: sim.cameras[orig_name] for name, orig_name in cameras.items()}
+        gui = dpg_ui() if show_gui else None
 
-            replay = Replay()
+        replay = Replay()
 
-            with pimm.World(virtual_time=True) as world:
-                # The sim carries both the arm and the gripper ports, so it fills both slots.
-                ds_agent = wire.wire(world, replay, dataset_writer, cameras_mapped, sim, sim, gui, TimeMode.MESSAGE)
-                player_cmd = world.pair(replay.command)
+        with pimm.World(virtual_time=True) as world:
+            # The sim carries both the arm and the gripper ports, so it fills both slots.
+            ds_agent = wire.wire(world, replay, new_dataset, cameras_mapped, sim, sim, gui, TimeMode.MESSAGE)
+            player_cmd = world.pair(replay.command)
 
-                ds_cmd = pimm.NoOpEmitter()
-                if ds_agent is not None:
-                    ds_cmd = world.pair(ds_agent.command)
+            ds_cmd = pimm.NoOpEmitter()
+            if ds_agent is not None:
+                ds_cmd = world.pair(ds_agent.command)
 
-                # This is extremely hacky, but it works. The problem to connect them directly
-                # is that any emitter can be connected only to one receiver.
-                def call_stop(_finished, ds_cmd=ds_cmd, world=world):
-                    ds_cmd.emit(DsWriterCommand.STOP())
-                    world.request_stop()
-                    return True
+            # This is extremely hacky, but it works. The problem to connect them directly
+            # is that any emitter can be connected only to one receiver.
+            def call_stop(_finished, ds_cmd=ds_cmd, world=world):
+                ds_cmd.emit(DsWriterCommand.STOP())
+                world.request_stop()
+                return True
 
-                _ = world.pair(replay.finished, emitter_wrapper=pimm.map(call_stop))
+            _ = world.pair(replay.finished, emitter_wrapper=pimm.map(call_stop))
 
-                sim_iter = world.start([sim, replay, ds_agent], gui)
-                ds_cmd.emit(DsWriterCommand.START(episode.static))
-                player_cmd.emit(DsPlayerStartCommand(episode))
+            sim_iter = world.start([sim, replay, ds_agent], gui)
+            ds_cmd.emit(DsWriterCommand.START(dataset_dir, episode.static))
+            player_cmd.emit(DsPlayerStartCommand(episode))
 
-                p_bar = tqdm.tqdm(total=round(episode.duration_ns / 1e9, 1), unit='s')
+            p_bar = tqdm.tqdm(total=round(episode.duration_ns / 1e9, 1), unit='s')
 
-                for _ in sim_iter:
-                    p_bar.n = round(world.clock.now(), 1)
-                    p_bar.refresh()
+            for _ in sim_iter:
+                p_bar.n = round(world.clock.now(), 1)
+                p_bar.refresh()
 
 
 if __name__ == '__main__':

--- a/positronic/telemetry.py
+++ b/positronic/telemetry.py
@@ -515,11 +515,10 @@ class StatsSampler:
         cpu_pct = 0.0
         rss = 0
         for proc in processes:
-            cached = self._proc_cache.get(proc.pid)
-            if cached is None:
-                cached = proc
-                self._proc_cache[proc.pid] = cached
-                cached.cpu_percent(interval=None)  # prime; the first read is meaningless
+            if proc.pid not in self._proc_cache:
+                self._proc_cache[proc.pid] = proc
+                proc.cpu_percent(interval=None)  # prime; the first read is meaningless
+            cached = self._proc_cache[proc.pid]
             try:
                 cpu_pct += cached.cpu_percent(interval=None)
                 rss += cached.memory_info().rss

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -50,7 +50,7 @@ class DummyRobot(pimm.ControlSystem):
 
 def build_collection(world, out_dir: Path, *, metadata_getter: Callable[[], dict[str, object]] | None = None):
     dc = DataCollectionController(
-        operator_position=None, nominal_joints=(), dataset=out_dir, metadata_getter=metadata_getter
+        operator_position=None, nominal_joints=(), output_path=out_dir, metadata_getter=metadata_getter
     )
     robot = DummyRobot()
 
@@ -312,7 +312,7 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
     # Virtual time: the sim advances the world clock as physics steps
     with pimm.World(virtual_time=True) as world:
         dc = DataCollectionController(
-            operator_position=OperatorPosition.FRONT.value, nominal_joints=sim.initial_joints, dataset=tmp_path
+            operator_position=OperatorPosition.FRONT.value, nominal_joints=sim.initial_joints, output_path=tmp_path
         )
 
         agent = DsWriterAgent(LocalDatasetWriter)

--- a/positronic/tests/test_data_collection.py
+++ b/positronic/tests/test_data_collection.py
@@ -7,7 +7,7 @@ import pytest
 import pimm
 from positronic import data_collection, keys, wire
 from positronic.data_collection import DataCollectionController, OperatorPosition, controller_positions_serializer
-from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, DsWriterCommandType
+from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand
 from positronic.dataset.episode import Episode
 from positronic.dataset.local_dataset import LocalDataset, LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
@@ -49,12 +49,12 @@ class DummyRobot(pimm.ControlSystem):
 
 
 def build_collection(world, out_dir: Path, *, metadata_getter: Callable[[], dict[str, object]] | None = None):
-    dc = DataCollectionController(operator_position=None, nominal_joints=(), metadata_getter=metadata_getter)
+    dc = DataCollectionController(
+        operator_position=None, nominal_joints=(), dataset=out_dir, metadata_getter=metadata_getter
+    )
     robot = DummyRobot()
 
-    writer_cm = LocalDatasetWriter(out_dir)
-    writer = writer_cm.__enter__()
-    ds_agent = wire.wire(world, dc, writer, {}, robot, None, None)
+    ds_agent = wire.wire(world, dc, LocalDatasetWriter, {}, robot, None, None)
     assert ds_agent is not None
     ds_agent.add_signal('controller_positions', controller_positions_serializer)
 
@@ -64,7 +64,7 @@ def build_collection(world, out_dir: Path, *, metadata_getter: Callable[[], dict
     ctrl_em_agent = world.pair(ds_agent.inputs['controller_positions'])
     buttons_em = world.pair(dc.buttons_receiver)
 
-    return dc, ds_agent, ctrl_em_dc, ctrl_em_agent, buttons_em, writer_cm, robot
+    return dc, ds_agent, ctrl_em_dc, ctrl_em_agent, buttons_em, robot
 
 
 def test_data_collection_records_task_metadata(tmp_path, world):
@@ -75,7 +75,7 @@ def test_data_collection_records_task_metadata(tmp_path, world):
         call_count += 1
         return {keys.TASK: 'stack-blocks'}
 
-    (dc, agent, ctrl_em_dc, ctrl_em_agent, buttons_em, writer_cm, robot) = build_collection(
+    (dc, agent, ctrl_em_dc, ctrl_em_agent, buttons_em, robot) = build_collection(
         world, tmp_path, metadata_getter=metadata_getter
     )
 
@@ -98,9 +98,8 @@ def test_data_collection_records_task_metadata(tmp_path, world):
         (None, 0.005),
     ])
 
-    with writer_cm:
-        scheduler = world.start([dc, agent, robot, driver])
-        drive_scheduler(scheduler, steps=400)
+    scheduler = world.start([dc, agent, robot, driver])
+    drive_scheduler(scheduler, steps=400)
 
     assert call_count == 1
 
@@ -112,7 +111,7 @@ def test_data_collection_records_task_metadata(tmp_path, world):
 
 
 def test_data_collection_basic_recording(tmp_path, world):
-    dc, agent, ctrl_em_dc, ctrl_em_agent, buttons_em, writer_cm, robot = build_collection(world, tmp_path)
+    dc, agent, ctrl_em_dc, ctrl_em_agent, buttons_em, robot = build_collection(world, tmp_path)
 
     # A simple right-hand pose and button frames
     right_pose = Transform3D(translation=np.array([0.1, 0.2, 0.3]), rotation=Rotation.identity)
@@ -120,7 +119,7 @@ def test_data_collection_basic_recording(tmp_path, world):
     payload = {'left': None, 'right': right_pose}
 
     def start_episode():
-        dc.ds_agent_commands.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE))
+        dc.ds_agent_commands.emit(DsWriterCommand.START(tmp_path))
         buttons_em.emit(make_buttons(trigger=0.7, B=False))
 
     def emit_signals():
@@ -128,13 +127,12 @@ def test_data_collection_basic_recording(tmp_path, world):
         ctrl_em_agent.emit(payload)
 
     def stop_episode():
-        dc.ds_agent_commands.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE))
+        dc.ds_agent_commands.emit(DsWriterCommand.STOP())
 
     driver = ManualDriver([(start_episode, 0.001), (emit_signals, 0.001), (stop_episode, 0.001)])
 
-    with writer_cm:
-        scheduler = world.start([dc, agent, robot, driver])
-        drive_scheduler(scheduler)
+    scheduler = world.start([dc, agent, robot, driver])
+    drive_scheduler(scheduler)
 
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
@@ -313,10 +311,11 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
 
     # Virtual time: the sim advances the world clock as physics steps
     with pimm.World(virtual_time=True) as world:
-        dc = DataCollectionController(operator_position=OperatorPosition.FRONT.value, nominal_joints=sim.initial_joints)
+        dc = DataCollectionController(
+            operator_position=OperatorPosition.FRONT.value, nominal_joints=sim.initial_joints, dataset=tmp_path
+        )
 
-        writer_cm = LocalDatasetWriter(tmp_path)
-        agent = DsWriterAgent(writer_cm.__enter__())
+        agent = DsWriterAgent(LocalDatasetWriter)
         agent.add_signal(keys.TARGET_GRIP)
         agent.add_signal(keys.ROBOT_COMMAND, Serializers.robot_command)
         agent.add_signal('controller_positions', controller_positions_serializer)
@@ -337,7 +336,7 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
         buttons_em = world.pair(dc.buttons_receiver)
 
         def start_episode():
-            dc.ds_agent_commands.emit(DsWriterCommand(DsWriterCommandType.START_EPISODE))
+            dc.ds_agent_commands.emit(DsWriterCommand.START(tmp_path))
             buttons_em.emit(make_buttons(trigger=0.5))
 
         def enable_tracking():
@@ -349,7 +348,7 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
             ctrl_em_agent.emit(payload)
 
         def stop_episode():
-            dc.ds_agent_commands.emit(DsWriterCommand(DsWriterCommandType.STOP_EPISODE))
+            dc.ds_agent_commands.emit(DsWriterCommand.STOP())
 
         driver = ManualDriver([
             (start_episode, 0.01),
@@ -358,9 +357,8 @@ def test_data_collection_with_mujoco_robot_gripper(tmp_path):
             (stop_episode, 0.005),
         ])
 
-        with writer_cm:
-            scheduler = world.start([sim, dc, agent, driver])
-            drive_scheduler(scheduler, steps=400)
+        scheduler = world.start([sim, dc, agent, driver])
+        drive_scheduler(scheduler, steps=400)
 
     # Validate dataset contents
     ds = LocalDataset(tmp_path)

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -144,7 +144,7 @@ def test_a_press_that_cannot_open_a_session_keeps_the_run(monkeypatch, caplog):
 
     presses = iter(['s'])
     monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
-    operator = KeyboardOperator(lambda: Task(instruction_source='pick', timeout_sec=None), _RefusingPolicy())
+    operator = KeyboardOperator(lambda: Task(instruction_source='pick', timeout_sec=None), _RefusingPolicy(), None)
     with pimm.World(virtual_time=True) as world:
         world.pair(operator.perform_task)
         with caplog.at_level(logging.ERROR):
@@ -158,7 +158,7 @@ def test_the_operator_declines_a_press_while_an_episode_runs(monkeypatch, caplog
     task = Task(instruction_source='pick', timeout_sec=None)
     presses = iter(['s', 's'])
     monkeypatch.setattr(keyboard, 'key_reader', partial(nullcontext, lambda: next(presses, None)))
-    operator = KeyboardOperator(lambda: task, _IdlePolicy())
+    operator = KeyboardOperator(lambda: task, _IdlePolicy(), None)
     with pimm.World(virtual_time=True) as world:
         harness = world.pair(operator.perform_task)
         received = []

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -59,14 +59,14 @@ def scripted_driver(*steps: ScriptStep) -> ManualDriver:
 
 
 def episode_caller(
-    world: pimm.World, harness: Harness, policy: Policy, dataset: Path | None = Path('dataset')
+    world: pimm.World, harness: Harness, policy: Policy, output_path: Path | None = Path('dataset')
 ) -> Callable[[Task], pimm.calls.Answer[dict[str, Any]]]:
     """A caller that asks ``harness`` for a task the way a driver does: it opens the session that runs it and
-    names the dataset it records into. Nothing writes there unless the test runs a recorder of its own."""
+    names the path it records into. Nothing writes there unless the test runs a recorder of its own."""
     perform_task = world.pair(harness.perform_task)
 
     def ask(task: Task):
-        return perform_task(Rollout(task, policy, dataset))
+        return perform_task(Rollout(task, policy, output_path))
 
     return ask
 

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, TypeVar
 
 import pimm
@@ -58,13 +59,14 @@ def scripted_driver(*steps: ScriptStep) -> ManualDriver:
 
 
 def episode_caller(
-    world: pimm.World, harness: Harness, policy: Policy
+    world: pimm.World, harness: Harness, policy: Policy, dataset: Path | None = Path('dataset')
 ) -> Callable[[Task], pimm.calls.Answer[dict[str, Any]]]:
-    """A caller that asks ``harness`` for a task the way a driver does: it opens the session that runs it."""
+    """A caller that asks ``harness`` for a task the way a driver does: it opens the session that runs it and
+    names the dataset it records into. Nothing writes there unless the test runs a recorder of its own."""
     perform_task = world.pair(harness.perform_task)
 
     def ask(task: Task):
-        return perform_task(Rollout(task, policy))
+        return perform_task(Rollout(task, policy, dataset))
 
     return ask
 

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -16,7 +16,7 @@ def wire(  # noqa: C901
     world: pimm.World,
     harness: pimm.ControlSystem,
     dataset_factory: DatasetFactory | None,
-    cameras: Mapping[str, pimm.SignalEmitter] | None,
+    cameras: Mapping[str, pimm.SignalEmitter],
     robot_arm: pimm.ControlSystem | None,
     gripper: pimm.ControlSystem | None,
     gui: pimm.ControlSystem | None,

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -1,9 +1,12 @@
 import functools
+from collections.abc import Callable, Mapping
+from pathlib import Path
 
 import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset import DatasetWriter
 from positronic.dataset.ds_writer_agent import DsWriterAgent, TimeMode
+from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.dataset.serializers import Serializers, StatefulSerializer
 from positronic.eval import ROBOT_STATIC_META, Embodiment, Observation
 from positronic.policy.harness import Harness
@@ -14,8 +17,8 @@ __all__ = ['ROBOT_STATIC_META', 'wire', 'wire_embodiment']
 def wire(  # noqa: C901
     world: pimm.World,
     harness: pimm.ControlSystem,
-    dataset_writer: DatasetWriter | None,
-    cameras: dict[str, pimm.SignalEmitter] | None,
+    new_dataset: Callable[[Path], DatasetWriter] | None,
+    cameras: Mapping[str, pimm.SignalEmitter] | None,
     robot_arm: pimm.ControlSystem | None,
     gripper: pimm.ControlSystem | None,
     gui: pimm.ControlSystem | None,
@@ -34,11 +37,11 @@ def wire(  # noqa: C901
         world.connect(emitter, harness.frames[signal_name])
 
     ds_agent = None
-    if dataset_writer is not None:
+    if new_dataset is not None:
         # A partial, never a lambda: the recorder may be spawned as a background process, and `World`
         # pickles a background control system whole.
         ds_agent = DsWriterAgent(
-            dataset_writer,
+            new_dataset,
             time_mode=time_mode,
             telemetry_span=functools.partial(telemetry.span, telemetry_keys.SPAN_RECORD_IO),
         )
@@ -68,16 +71,12 @@ def wire(  # noqa: C901
 
 
 def _recorder(
-    world: pimm.World,
-    harness: Harness,
-    embodiment: Embodiment,
-    dataset_writer: DatasetWriter,
-    time_mode: TimeMode,
-    privileged: dict[str, Observation],
+    world: pimm.World, harness: Harness, embodiment: Embodiment, time_mode: TimeMode, privileged: dict[str, Observation]
 ) -> DsWriterAgent:
-    """An embodiment's observations, command chunks and privileged ground-truth, recorded into a dataset."""
+    """An embodiment's observations, command chunks and privileged ground-truth, recorded into the dataset
+    each episode names."""
     ds_agent = DsWriterAgent(
-        dataset_writer,
+        LocalDatasetWriter,
         time_mode=time_mode,
         virtual_time=embodiment.simulated,
         telemetry_span=functools.partial(telemetry.span, telemetry_keys.SPAN_RECORD_IO),
@@ -100,8 +99,9 @@ def wire_embodiment(
     world: pimm.World,
     harness: Harness,
     embodiment: Embodiment,
-    dataset_writer: DatasetWriter | None,
     time_mode: TimeMode = TimeMode.CLOCK,
+    *,
+    record: bool = True,
     privileged: dict[str, Observation] | None = None,
     done: pimm.SignalEmitter | None = None,
 ):
@@ -109,9 +109,10 @@ def wire_embodiment(
 
     Connects device observation sources -> ``harness.observations``, ``harness.commands`` -> device
     receivers, ``harness.prepare`` -> everything a trial readies, and records observations, command chunks,
-    and the eval's privileged ground-truth into the dataset. The ``done`` terminating signal, when present,
-    is connected to ``harness.done``. GUI camera wiring stays with the caller — it is a presentation
-    concern, not part of the embodiment contract.
+    and the eval's privileged ground-truth into the dataset each episode names. ``record`` off leaves the
+    recorder out, so the episode commands reach nobody and the producers keep one consumer each. The ``done``
+    terminating signal, when present, is connected to ``harness.done``. GUI camera wiring stays with the
+    caller — it is a presentation concern, not part of the embodiment contract.
     """
     privileged = privileged or {}
     for name, obs in embodiment.observations.items():
@@ -125,6 +126,6 @@ def wire_embodiment(
     if done is not None:
         world.connect(done, harness.done)
 
-    if dataset_writer is None:
+    if not record:
         return None
-    return _recorder(world, harness, embodiment, dataset_writer, time_mode, privileged)
+    return _recorder(world, harness, embodiment, time_mode, privileged)

--- a/positronic/wire.py
+++ b/positronic/wire.py
@@ -1,11 +1,9 @@
 import functools
-from collections.abc import Callable, Mapping
-from pathlib import Path
+from collections.abc import Mapping
 
 import pimm
 from positronic import keys, telemetry, telemetry_keys
-from positronic.dataset import DatasetWriter
-from positronic.dataset.ds_writer_agent import DsWriterAgent, TimeMode
+from positronic.dataset.ds_writer_agent import DatasetFactory, DsWriterAgent, TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.dataset.serializers import Serializers, StatefulSerializer
 from positronic.eval import ROBOT_STATIC_META, Embodiment, Observation
@@ -17,7 +15,7 @@ __all__ = ['ROBOT_STATIC_META', 'wire', 'wire_embodiment']
 def wire(  # noqa: C901
     world: pimm.World,
     harness: pimm.ControlSystem,
-    new_dataset: Callable[[Path], DatasetWriter] | None,
+    dataset_factory: DatasetFactory | None,
     cameras: Mapping[str, pimm.SignalEmitter] | None,
     robot_arm: pimm.ControlSystem | None,
     gripper: pimm.ControlSystem | None,
@@ -37,11 +35,11 @@ def wire(  # noqa: C901
         world.connect(emitter, harness.frames[signal_name])
 
     ds_agent = None
-    if new_dataset is not None:
+    if dataset_factory is not None:
         # A partial, never a lambda: the recorder may be spawned as a background process, and `World`
         # pickles a background control system whole.
         ds_agent = DsWriterAgent(
-            new_dataset,
+            dataset_factory,
             time_mode=time_mode,
             telemetry_span=functools.partial(telemetry.span, telemetry_keys.SPAN_RECORD_IO),
         )

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -1,4 +1,5 @@
 import random
+from pathlib import Path
 
 import configuronic as cfn
 import numpy as np
@@ -68,6 +69,7 @@ FAILURE_OUTCOME_WEIGHTS = (0.25, 0.20, 0.10, 0.10)
 class FakeGenerator(pimm.ControlSystem):
     def __init__(
         self,
+        dataset: Path,
         num_episodes: int,
         fps: int,
         avg_run_per_item: float,
@@ -77,6 +79,7 @@ class FakeGenerator(pimm.ControlSystem):
         max_items: int,
         cap_per_item: int = 30,
     ):
+        self.dataset = dataset
         self.num_episodes = num_episodes
         self.fps = fps
         self.avg_run_per_item = avg_run_per_item
@@ -146,7 +149,7 @@ class FakeGenerator(pimm.ControlSystem):
                 f'Starting episode {i + 1}/{self.num_episodes}: {task} (Items: {total_items},'
                 f' Duration: {episode_duration:.2f}s, Outcome: {outcome})'
             )
-            self.command.emit(DsWriterCommand.START(static_data))
+            self.command.emit(DsWriterCommand.START(self.dataset, static_data))
 
             # --- Episode Loop ---
             start_time = clock.now()
@@ -213,11 +216,13 @@ def main(
     meta = META_MAP[policy]
     print(f'Generating {num_episodes} episodes to {output_dir} mimicking {policy}...')
 
-    writer = LocalDatasetWriter(pos3.upload(output_dir, sync_on_error=True, interval=None))
+    dataset = pos3.upload(output_dir, sync_on_error=True, interval=None)
 
     with pimm.World() as world:
-        agent = DsWriterAgent(writer, time_mode=TimeMode.CLOCK)
-        generator = FakeGenerator(num_episodes, fps, avg_run_per_item, meta, success_rate, min_items, max_items)
+        agent = DsWriterAgent(LocalDatasetWriter, time_mode=TimeMode.CLOCK)
+        generator = FakeGenerator(
+            dataset, num_episodes, fps, avg_run_per_item, meta, success_rate, min_items, max_items
+        )
 
         # Wire generator to agent
         agent.add_signal(keys.WRIST_IMAGE, Serializers.camera_images)

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -69,7 +69,7 @@ FAILURE_OUTCOME_WEIGHTS = (0.25, 0.20, 0.10, 0.10)
 class FakeGenerator(pimm.ControlSystem):
     def __init__(
         self,
-        dataset: Path,
+        output_path: Path,
         num_episodes: int,
         fps: int,
         avg_run_per_item: float,
@@ -79,7 +79,7 @@ class FakeGenerator(pimm.ControlSystem):
         max_items: int,
         cap_per_item: int = 30,
     ):
-        self.dataset = dataset
+        self.output_path = output_path
         self.num_episodes = num_episodes
         self.fps = fps
         self.avg_run_per_item = avg_run_per_item
@@ -149,7 +149,7 @@ class FakeGenerator(pimm.ControlSystem):
                 f'Starting episode {i + 1}/{self.num_episodes}: {task} (Items: {total_items},'
                 f' Duration: {episode_duration:.2f}s, Outcome: {outcome})'
             )
-            self.command.emit(DsWriterCommand.START(self.dataset, static_data))
+            self.command.emit(DsWriterCommand.START(self.output_path, static_data))
 
             # --- Episode Loop ---
             start_time = clock.now()
@@ -216,12 +216,12 @@ def main(
     meta = META_MAP[policy]
     print(f'Generating {num_episodes} episodes to {output_dir} mimicking {policy}...')
 
-    dataset = pos3.upload(output_dir, sync_on_error=True, interval=None)
+    output_path = pos3.upload(output_dir, sync_on_error=True, interval=None)
 
     with pimm.World() as world:
         agent = DsWriterAgent(LocalDatasetWriter, time_mode=TimeMode.CLOCK)
         generator = FakeGenerator(
-            dataset, num_episodes, fps, avg_run_per_item, meta, success_rate, min_items, max_items
+            output_path, num_episodes, fps, avg_run_per_item, meta, success_rate, min_items, max_items
         )
 
         # Wire generator to agent


### PR DESCRIPTION
## Summary

The `perform_task` call now carries the path its episode records into, so the `Harness` holds no dataset and one recorder can serve many destinations.

- `Rollout(task, policy, output_path)`. `DsWriterCommand.START` carries that path, and the Harness passes it straight through.
- `DsWriterAgent` takes a `dataset_factory` (`Callable[[Path], DatasetWriter]`) instead of a live writer, and opens each named dataset once. A live writer could not travel in a command: the recorder may run in a spawned process, and a pickled `LocalDatasetWriter` carries a stale episode counter.
- `_Recording` holds what a command changes — the episode a run has open, and the datasets it opened. `run` keeps the turn and the sampling.
- An `output_path` of `None` means the trial records nothing. The recorder owns that case: it opens an episode that writes nowhere, so the STOP that ends it is ordinary and nothing is serialized.
- `run_world(..., record=False)` keeps the recorder out of the world entirely, for a run that writes nothing at all.
- Every argument naming a recording destination is `output_path`.

Also here:
- The `prepare_output_dir` TODO points at Positronic-Robotics/configuronic#40, which carries the configuronic half of that work.
- Three get-or-create caches are written as a membership test.
- The basedpyright baseline loses 21 entries in `data_collection`, `dataset`, `test_policy_io` and `replay_record`; nothing is added.

## Test plan

- `uv run --locked pytest` — 1696 passed, 8 skipped
- `uv run --locked ruff check .` clean, `uv run --locked basedpyright` 0 errors
- New tests: each episode records into the dataset its START names (two datasets in one run); a START that names no dataset writes no episode; the harness START carries the path the call named; a call that names no dataset still runs and answers.
