### PR TITLE
Fix the Static Data button when the stored sidebar state is unusable

### DIFF
--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -612,7 +612,7 @@ function initSidebar() {
   }
 
   function setSidebarWidth(width) {
-    sidebarState.sidebarWidth = Math.max(100, width);
+    sidebarState.sidebarWidth = clampSidebarWidth(width);
     sidebar.style.width = `${sidebarState.sidebarWidth}px`;
   }
 
@@ -632,10 +632,38 @@ function initSidebar() {
   }
 }
 
+const SIDEBAR_STATE_DEFAULTS = { isExpanded: false, sidebarWidth: 300, keyColumnWidth: 150, scrollTop: 0 };
+const MIN_SIDEBAR_WIDTH = 100;
+
+// Keep a stored measurement only when it is a real number. `${NaN}px` is invalid CSS, so the
+// browser drops the declaration and the sidebar keeps the 0px width the stylesheet gives it.
+function storedNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function clampSidebarWidth(width) {
+  return Math.max(MIN_SIDEBAR_WIDTH, storedNumber(width, SIDEBAR_STATE_DEFAULTS.sidebarWidth));
+}
+
+// The sidebar reads back whatever an earlier session left in localStorage, so that string is input.
 function loadSidebarState() {
-  const defaults = { isExpanded: false, sidebarWidth: 300, keyColumnWidth: 150, scrollTop: 0 };
-  const saved = JSON.parse(localStorage.getItem('sidebarState'));
-  return { ...defaults, ...saved };
+  let saved = null;
+  try {
+    saved = JSON.parse(localStorage.getItem('sidebarState'));
+  } catch (error) {
+    // Unreadable text, or a browser that blocks storage. Both mean the same here: no usable
+    // preference, and the sidebar must still open.
+    console.error('Discarding the stored sidebar state:', error);
+    saved = null;
+  }
+  const state = { ...SIDEBAR_STATE_DEFAULTS, ...(typeof saved === 'object' ? saved : null) };
+  return {
+    isExpanded: Boolean(state.isExpanded),
+    sidebarWidth: clampSidebarWidth(state.sidebarWidth),
+    keyColumnWidth: storedNumber(state.keyColumnWidth, SIDEBAR_STATE_DEFAULTS.keyColumnWidth),
+    scrollTop: storedNumber(state.scrollTop, SIDEBAR_STATE_DEFAULTS.scrollTop),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -563,6 +563,7 @@ document.addEventListener('DOMContentLoaded', () => {
 const SIDEBAR_STATE_DEFAULTS = { isExpanded: false, sidebarWidth: 300, keyColumnWidth: 150, scrollTop: 0 };
 const MIN_SIDEBAR_WIDTH = 100;
 const MIN_KEY_COLUMN_WIDTH = 50;
+const SIDEBAR_STATE_STORAGE_KEY = 'sidebarState';
 
 // Keep a measurement only when it is a real number. `${NaN}px` is invalid CSS, so the
 // browser drops the declaration and the sidebar keeps the 0px width the stylesheet gives it.
@@ -648,7 +649,7 @@ function initSidebar() {
   }
 
   function save() {
-    localStorage.setItem('sidebarState', JSON.stringify(sidebarState));
+    localStorage.setItem(SIDEBAR_STATE_STORAGE_KEY, JSON.stringify(sidebarState));
   }
 }
 
@@ -656,7 +657,7 @@ function initSidebar() {
 function loadSidebarState() {
   let saved = null;
   try {
-    saved = JSON.parse(localStorage.getItem('sidebarState'));
+    saved = JSON.parse(localStorage.getItem(SIDEBAR_STATE_STORAGE_KEY));
   } catch (error) {
     // Unreadable text, or a browser that blocks storage. Both mean the same here: no usable
     // preference, and the sidebar must still open.

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -560,6 +560,20 @@ document.addEventListener('DOMContentLoaded', () => {
 // Sidebar (episode detail page)
 // ---------------------------------------------------------------------------
 
+const SIDEBAR_STATE_DEFAULTS = { isExpanded: false, sidebarWidth: 300, keyColumnWidth: 150, scrollTop: 0 };
+const MIN_SIDEBAR_WIDTH = 100;
+
+// Keep a measurement only when it is a real number. `${NaN}px` is invalid CSS, so the
+// browser drops the declaration and the sidebar keeps the 0px width the stylesheet gives it.
+function finiteNumberOr(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function clampSidebarWidth(width) {
+  return Math.max(MIN_SIDEBAR_WIDTH, finiteNumberOr(width, SIDEBAR_STATE_DEFAULTS.sidebarWidth));
+}
+
 function initSidebar() {
   const sidebar = document.querySelector('.sidebar');
   if (!sidebar) return;
@@ -632,20 +646,6 @@ function initSidebar() {
   }
 }
 
-const SIDEBAR_STATE_DEFAULTS = { isExpanded: false, sidebarWidth: 300, keyColumnWidth: 150, scrollTop: 0 };
-const MIN_SIDEBAR_WIDTH = 100;
-
-// Keep a stored measurement only when it is a real number. `${NaN}px` is invalid CSS, so the
-// browser drops the declaration and the sidebar keeps the 0px width the stylesheet gives it.
-function storedNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : fallback;
-}
-
-function clampSidebarWidth(width) {
-  return Math.max(MIN_SIDEBAR_WIDTH, storedNumber(width, SIDEBAR_STATE_DEFAULTS.sidebarWidth));
-}
-
 // The sidebar reads back whatever an earlier session left in localStorage, so that string is input.
 function loadSidebarState() {
   let saved = null;
@@ -661,8 +661,8 @@ function loadSidebarState() {
   return {
     isExpanded: Boolean(state.isExpanded),
     sidebarWidth: clampSidebarWidth(state.sidebarWidth),
-    keyColumnWidth: storedNumber(state.keyColumnWidth, SIDEBAR_STATE_DEFAULTS.keyColumnWidth),
-    scrollTop: storedNumber(state.scrollTop, SIDEBAR_STATE_DEFAULTS.scrollTop),
+    keyColumnWidth: finiteNumberOr(state.keyColumnWidth, SIDEBAR_STATE_DEFAULTS.keyColumnWidth),
+    scrollTop: finiteNumberOr(state.scrollTop, SIDEBAR_STATE_DEFAULTS.scrollTop),
   };
 }
 

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -562,6 +562,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 const SIDEBAR_STATE_DEFAULTS = { isExpanded: false, sidebarWidth: 300, keyColumnWidth: 150, scrollTop: 0 };
 const MIN_SIDEBAR_WIDTH = 100;
+const MIN_KEY_COLUMN_WIDTH = 50;
 
 // Keep a measurement only when it is a real number. `${NaN}px` is invalid CSS, so the
 // browser drops the declaration and the sidebar keeps the 0px width the stylesheet gives it.
@@ -572,6 +573,11 @@ function finiteNumberOr(value, fallback) {
 
 function clampSidebarWidth(width) {
   return Math.max(MIN_SIDEBAR_WIDTH, finiteNumberOr(width, SIDEBAR_STATE_DEFAULTS.sidebarWidth));
+}
+
+// A 0px key column hides every metadata key, and `Number(null)` is 0.
+function clampKeyColumnWidth(width) {
+  return Math.max(MIN_KEY_COLUMN_WIDTH, finiteNumberOr(width, SIDEBAR_STATE_DEFAULTS.keyColumnWidth));
 }
 
 function initSidebar() {
@@ -601,7 +607,7 @@ function initSidebar() {
   });
   setupResizer(keyColumnResizer, (e) => {
     const offsetX = sidebarState.sidebarWidth - (document.body.clientWidth - e.clientX);
-    setKeyColumnWidth(Math.min(Math.max(50, offsetX), sidebarState.sidebarWidth - 50));
+    setKeyColumnWidth(Math.min(clampKeyColumnWidth(offsetX), sidebarState.sidebarWidth - MIN_KEY_COLUMN_WIDTH));
     save();
   });
 
@@ -661,7 +667,7 @@ function loadSidebarState() {
   return {
     isExpanded: Boolean(state.isExpanded),
     sidebarWidth: clampSidebarWidth(state.sidebarWidth),
-    keyColumnWidth: finiteNumberOr(state.keyColumnWidth, SIDEBAR_STATE_DEFAULTS.keyColumnWidth),
+    keyColumnWidth: clampKeyColumnWidth(state.keyColumnWidth),
     scrollTop: finiteNumberOr(state.scrollTop, SIDEBAR_STATE_DEFAULTS.scrollTop),
   };
 }

--- a/positronic/server/tests/test_sidebar_state.py
+++ b/positronic/server/tests/test_sidebar_state.py
@@ -1,0 +1,124 @@
+"""`loadSidebarState` in the viewer's app.js, driven through node.
+
+The sidebar remembers its width and its open state in localStorage, so every load reads back
+whatever an earlier session wrote. A value the browser cannot use must not disable the sidebar.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+APP_JS = Path(__file__).resolve().parents[1] / 'static' / 'app.js'
+
+# app.js registers listeners when it loads, so the context needs a document. Nothing here runs;
+# the harness calls one function and prints what it returns.
+_HARNESS = """
+const fs = require('fs');
+const vm = require('vm');
+
+const stored = JSON.parse(process.argv[1]);
+const noop = () => {};
+const context = {
+  JSON,
+  Number,
+  Math,
+  Object,
+  console,
+  localStorage: {getItem: () => stored, setItem: noop},
+  document: {
+    addEventListener: noop,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+  },
+};
+vm.createContext(context);
+vm.runInContext(fs.readFileSync(process.argv[2], 'utf8'), context);
+process.stdout.write(JSON.stringify(context.loadSidebarState()));
+"""
+
+DEFAULTS = {'isExpanded': False, 'sidebarWidth': 300, 'keyColumnWidth': 150, 'scrollTop': 0}
+
+
+def load_sidebar_state(stored: str | None) -> dict:
+    """Return what app.js reads back from a localStorage holding `stored`."""
+    node = shutil.which('node')
+    if node is None:
+        pytest.skip('node is required to run the viewer JavaScript')
+    result = subprocess.run(
+        [node, '-e', _HARNESS, json.dumps(stored), str(APP_JS)], capture_output=True, text=True, timeout=60, check=False
+    )
+    assert result.returncode == 0, f'app.js raised on stored state {stored!r}:\n{result.stderr}'
+    return json.loads(result.stdout)
+
+
+# --- a value the browser cannot use must not disable the sidebar ------------------------------
+# Each stored value below is unusable, either as JSON or as a width. `loadSidebarState` returns a
+# usable state rather than raising, and the width it returns is a real number: a `style.width` of
+# "NaNpx" is invalid CSS, so the browser drops it and the sidebar keeps the 0px width from the
+# stylesheet.
+
+
+@pytest.mark.parametrize(
+    'stored',
+    [
+        pytest.param('not-json{', id='unparseable'),
+        pytest.param('', id='empty'),
+        pytest.param('{"sidebarWidth": "300px"}', id='width-carries-a-unit'),
+        pytest.param('{"sidebarWidth": {}}', id='width-is-an-object'),
+        pytest.param('{"sidebarWidth": "wide"}', id='width-is-a-word'),
+    ],
+)
+def test_an_unusable_stored_state_falls_back_to_the_defaults(stored):
+    assert load_sidebar_state(stored) == DEFAULTS
+
+
+@pytest.mark.parametrize(
+    'stored',
+    [
+        pytest.param('not-json{', id='unparseable'),
+        pytest.param('{"sidebarWidth": "300px"}', id='width-carries-a-unit'),
+        pytest.param('{"sidebarWidth": {}}', id='width-is-an-object'),
+    ],
+)
+def test_an_unusable_stored_width_still_opens_the_sidebar(stored):
+    """A width the sidebar opens to must be a real number, or `${width}px` is invalid CSS."""
+    width = load_sidebar_state(stored)['sidebarWidth']
+    assert isinstance(width, int | float)
+    assert width >= 100
+
+
+# --- the boundary: a usable stored state survives ----------------------------------------------
+# The guard above must reject only what the browser cannot use. A state an earlier session
+# legitimately wrote is restored unchanged.
+
+
+def test_a_usable_stored_state_is_restored_unchanged():
+    stored = '{"isExpanded": true, "sidebarWidth": 450, "keyColumnWidth": 220, "scrollTop": 90}'
+    assert load_sidebar_state(stored) == {
+        'isExpanded': True,
+        'sidebarWidth': 450,
+        'keyColumnWidth': 220,
+        'scrollTop': 90,
+    }
+
+
+def test_a_stored_width_below_the_minimum_clamps_rather_than_resets():
+    """0 and -500 are numbers the sidebar can use, so they clamp — they do not fall back to 300."""
+    assert load_sidebar_state('{"sidebarWidth": 0}')['sidebarWidth'] == 100
+    assert load_sidebar_state('{"sidebarWidth": -500}')['sidebarWidth'] == 100
+
+
+def test_a_numeric_string_width_still_counts_as_a_number():
+    assert load_sidebar_state('{"sidebarWidth": "450"}')['sidebarWidth'] == 450
+
+
+def test_nothing_stored_gives_the_defaults():
+    assert load_sidebar_state(None) == DEFAULTS
+
+
+def test_a_partial_stored_state_keeps_the_defaults_for_what_it_omits():
+    assert load_sidebar_state('{"isExpanded": true}') == {**DEFAULTS, 'isExpanded': True}

--- a/positronic/server/tests/test_sidebar_state.py
+++ b/positronic/server/tests/test_sidebar_state.py
@@ -55,11 +55,8 @@ def load_sidebar_state(stored: str | None) -> dict:
     return json.loads(result.stdout)
 
 
-# --- a value the browser cannot use must not disable the sidebar ------------------------------
-# Each stored value below is unusable, either as JSON or as a width. `loadSidebarState` returns a
-# usable state rather than raising, and the width it returns is a real number: a `style.width` of
-# "NaNpx" is invalid CSS, so the browser drops it and the sidebar keeps the 0px width from the
-# stylesheet.
+# `style.width = "NaNpx"` is invalid CSS, so the browser drops the declaration and the sidebar
+# keeps the stylesheet's 0px. A width that is not a number therefore closes the sidebar for good.
 
 
 @pytest.mark.parametrize(

--- a/positronic/server/tests/test_sidebar_state.py
+++ b/positronic/server/tests/test_sidebar_state.py
@@ -119,3 +119,13 @@ def test_nothing_stored_gives_the_defaults():
 
 def test_a_partial_stored_state_keeps_the_defaults_for_what_it_omits():
     assert load_sidebar_state('{"isExpanded": true}') == {**DEFAULTS, 'isExpanded': True}
+
+
+def test_a_stored_key_column_width_that_is_not_a_number_falls_back():
+    assert load_sidebar_state('{"keyColumnWidth": "wide"}')['keyColumnWidth'] == 150
+
+
+def test_a_stored_key_column_width_below_the_minimum_clamps_rather_than_resets():
+    """`Number(null)` is 0, and a 0px key column hides every metadata key; the resizer's floor holds it."""
+    assert load_sidebar_state('{"keyColumnWidth": null}')['keyColumnWidth'] == 50
+    assert load_sidebar_state('{"keyColumnWidth": 0}')['keyColumnWidth'] == 50


### PR DESCRIPTION
The sidebar keeps its width and its open state in `localStorage`. Every page load reads that value back, so the stored string is input. `loadSidebarState` trusted it.

## What breaks

- Text that is not JSON. `JSON.parse` raises, `initSidebar` stops, and the toggler never gets its click listener. The Static Data button then does nothing at all.
- A width that is not a number, for example `"300px"`. `Math.max(100, "300px")` gives `NaN`, and `toggleSidebar` writes `NaNpx` to `style.width`. The browser drops the invalid declaration, so the sidebar keeps the 0px width from the stylesheet. The class changes to `expanded` and the panel stays closed.

`localStorage` holds the value, so a reload repeats the fault. Only clearing the site data restores the button.

## The change

`loadSidebarState` validates what it reads. It catches the parse error, and it keeps a measurement only when `Number` gives a finite value. `setSidebarWidth` shares the same clamp, so the resizer cannot store a width the next load rejects.

A usable state stays unchanged: a stored `450` opens the sidebar at 450, a stored `"450"` still counts as a number, and a stored `0` still clamps to 100.

The key-column width takes the same treatment with the resizer's 50px floor: `Number(null)` is 0, and a 0px key column hides every metadata key.

## Why the reader validates, not only the writer

A clamp at `setSidebarWidth` alone protects only the values this build writes. The stored value outlives a build in the browser profile, so a state written by an older version, by a hand edit, or by another tool still reaches the reader. Every path passes through the reader.

## Test

`positronic/server/tests/test_sidebar_state.py` runs the real `app.js` in node against a stub `localStorage`: 15 cases, 11 of which fail before the fix. It covers both faults and the boundary the guard must not cross. The test skips when node is absent.

The four state keys stay literal in the test. They are the `localStorage` schema `app.js` owns, and the test exists to assert that wire shape; a Python constant cannot import from the JavaScript that defines it, and asserting one against itself proves nothing.

## Caveat

The reported symptom did not reproduce on a fresh browser profile — the button works there at every viewport and on all 10 episodes. The cause above is a persisted-state fault, and it is unproven that it is the reporter's state. The one-line check is `localStorage.removeItem('sidebarState')` then reload. If that does not restore the button, something else is wrong and this change does not address it.

<!-- opened-by: posi-agent -->
