### PR TITLE
Say what to_joints actually checks

### DIFF
--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -236,11 +236,8 @@ class _Arm(DriverRun[command.CommandType]):
         """The joints ``cmd`` asks for, not applied yet.
 
         Solved here so that a malformed command raises before anything changes; ``command_target``
-        is what applies the result.
-
-        Width and finiteness are the whole of the check. ``_ik`` holds a Cartesian command inside
-        the joint position limits; nothing bounds a joint-space one, so a policy can walk a joint
-        out of its range one legal step at a time.
+        applies the result. ``_ik`` keeps a Cartesian command inside the joint limits; a joint-space
+        one is unbounded.
         """
         match cmd:
             case command.CartesianPosition(pose):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -235,8 +235,12 @@ class _Arm(DriverRun[command.CommandType]):
     def to_joints(self, cmd: command.CommandType) -> np.ndarray:
         """The joints ``cmd`` asks for, not applied yet.
 
-        Solved here so that a command the arm cannot hold raises before anything changes; ``command_target``
+        Solved here so that a malformed command raises before anything changes; ``command_target``
         is what applies the result.
+
+        FOOTGUN: width and finiteness are the whole of the check. ``_ik`` holds a Cartesian command
+        inside the joint position limits, and no joint-space command is bounded at all, so a policy
+        walks a joint out of its range one legal step at a time (internal#887).
         """
         match cmd:
             case command.CartesianPosition(pose):

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -238,9 +238,9 @@ class _Arm(DriverRun[command.CommandType]):
         Solved here so that a malformed command raises before anything changes; ``command_target``
         is what applies the result.
 
-        FOOTGUN: width and finiteness are the whole of the check. ``_ik`` holds a Cartesian command
-        inside the joint position limits, and no joint-space command is bounded at all, so a policy
-        walks a joint out of its range one legal step at a time (internal#887).
+        Width and finiteness are the whole of the check. ``_ik`` holds a Cartesian command inside
+        the joint position limits; nothing bounds a joint-space one, so a policy can walk a joint
+        out of its range one legal step at a time.
         """
         match cmd:
             case command.CartesianPosition(pose):


### PR DESCRIPTION
`_Arm.to_joints` promised that "a command the arm cannot hold raises before anything changes". Width and finiteness are the whole of the check, so the sentence is false for the case that matters most — a joint position outside the arm's range — and it is what makes a reader stop looking.

Docstring only. No behaviour changes.

## What is actually true

- `CartesianPosition` and `CartesianDelta` go through `_ik`, which is `inverse_kinematics_with_limits`. Its Python port in `drivers/roboarm/ik.py:403-456` box-constrains every Newton step to the joint limits and clips the iterate, so a Cartesian target is inside the limits by construction.
- `JointPosition` (`franka.py:247`) is a verbatim pass-through, and `JointDelta` (`franka.py:249`) is `state.q + delta`. Neither is bounded anywhere.
- The codec bounds a STEP, never a position: `JointDeltaAction` caps a delta at `MAX_JOINT_DELTA = 0.2` rad (`policy/action.py:150,163-166`), so N full-scale steps walk 0.2N rad with nothing capping where the arm ends up. `AbsoluteJointsAction._decode_single` (`policy/action.py:68-75`) has no bound at all.
- The `# The robot raises on a bad target` comment at `franka.py:252` is about a malformed vector, not a range — its pre-rewrite wording in `725832aa` said so, and the test named for it pushes NaN.

So a policy walks a joint out of its range one legal step at a time, and the arm then refuses every move: the reflex aborts each commanded motion, the driver recovers it every control cycle, and the round dies with the gripper still working.

## Why only a docstring

Closing the gap is a clamp or a raise on the live command path of a machine that moves, and the two behave differently under a running policy — a clamp keeps the arm usable and silently changes what the policy asked for; a raise matches the existing contract but is swallowed into a warning on the async path. That is a decision for a named human, tracked as internal#887 with the evidence, the recommended home (`to_joints`, the one funnel every joint target passes through, which can read the limits from `robot.get_robot_model()` it already parses for joint names) and the note that the URDF's unused `safety_controller` soft limits are the natural clamp target, since the hard limit leaves zero margin.

Detection ships separately on the platform side: the round report now flags an episode that left a joint outside its limit, and the runbook carries the tell.

Ticket: Positronic-Robotics/internal#887

<!-- opened-by: posi-agent -->