### PR TITLE
Refuse a trial that names no prepare on a rig that readies

### DIFF
--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -296,6 +296,13 @@ class Harness(pimm.ControlSystem):
         # The episode span opens first, so the prepare and the rollout's other phase spans parent to it.
         self._telemetry.begin(self._task.meta)
         with telemetry.span(telemetry_keys.SPAN_RESET):
+            # An empty ask answers at once, so the episode would open on a rig that no device moved.
+            if self.prepare and not self._task.prepare_args:
+                rig = self._embodiment.descriptor or 'this rig'
+                raise ValueError(
+                    f'The trial readies nothing on {rig}, which readies {sorted(self.prepare)}; '
+                    'name at least one of them in prepare_args'
+                )
             yield from self._ready(should_stop, clock, self._task.prepare_args)
         budget = self._task.timeout_sec
         self._set_deadline(clock.now_ns() + round(budget * 1e9) if budget is not None else None)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -1197,6 +1197,46 @@ def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
 
 
 @pytest.mark.timeout(3.0)
+def test_a_trial_naming_no_prepare_on_a_rig_that_readies_fails_loudly(world):
+    """Only the handlers a task names are asked, so a task that names none asks nobody, and an empty ask
+    answers at once. The episode is refused instead of opening on a rig no device moved."""
+    moved = []
+    arm = _Scene(moved.append)
+    embodiment = make_embodiment(descriptor='yam', prepare_handlers={eval_keys.ARM: arm.env_reset})
+    policy = StubPolicy()
+    harness = Harness(embodiment)
+    p = _pair_all(world, harness, policy)
+    wire_call(world, harness.prepare[eval_keys.ARM], arm.env_reset)
+
+    scheduler = world.start([harness, arm])
+    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05))
+
+    named = r"readies nothing on yam, which readies \['arm'\]"
+    with pytest.raises(ValueError, match=named):
+        drive_scheduler(scheduler, steps=50)
+    with pytest.raises(ValueError):
+        answer.result()  # whoever asked for the trial hears it too
+    assert moved == [], 'the rig was asked to ready something the trial never named'
+    assert DsWriterCommandType.START_EPISODE not in _ds_types(p), 'the episode opened on a rig nothing readied'
+
+
+@pytest.mark.timeout(3.0)
+def test_a_trial_naming_no_prepare_on_a_rig_that_readies_nothing_opens(world):
+    """A rig with nothing to ready is ready as it stands, so a task that names no prepare opens its episode
+    and runs it."""
+    policy = StubPolicy()
+    harness = Harness(make_embodiment(prepare_handlers={}))
+    p = _pair_all(world, harness, policy)
+
+    scheduler = world.start([harness, _Pacer()])
+    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05))
+    drive_scheduler(scheduler, steps=2000)
+
+    assert DsWriterCommandType.START_EPISODE in _ds_types(p), 'the episode never opened'
+    assert answer.done(), 'the episode never ended'
+
+
+@pytest.mark.timeout(3.0)
 def test_trial_seed_reaches_task_reset_and_meta(world):
     """A trial's params draw its scene and identify it: the scene prepare is asked with them, and they land
     in episode meta beside the instruction. A real rig records that it charged inference time, whatever the


### PR DESCRIPTION
## The hole

#657 made the caller name where the arm goes, and changed how the harness asks:

```python
# before — iterated the EMBODIMENT's handlers; an absent arg became None, meaning "the home"
ready = all_of([ask(task.prepare_args.get(name)) for name, ask in self.prepare.items()])
# after  — iterates the TASK's args; an empty dict asks nobody at all
ready = all_of([self.prepare[name](arg) for name, arg in args.items()])
```

`all_of([])` is `done()` at once and its `.result()` raises nothing. So a caller that was never updated for #657 gets a reset that is a **silent no-op**: no device moves, and nothing fails. A reset that failed and a reset that had nothing to do are currently indistinguishable.

This is not hypothetical. The rollouts console still built a bare `Task`, and a customer round recorded episodes against a Franka that never reset between them — each opening at the pose the last one ended in, with a clean log and no error anywhere. It was found by reading joint positions out of the recording, which is the only place it showed.

## The change

`_begin_episode` refuses when the embodiment declares prepare handlers and the trial names none:

```python
# An empty ask answers at once, so the episode would open on a rig that no device moved.
if self.prepare and not self._task.prepare_args:
    rig = self._embodiment.descriptor or 'this rig'
    raise ValueError(
        f'The trial readies nothing on {rig}, which readies {sorted(self.prepare)}; '
        'name at least one of them in prepare_args'
    )
```

It extends an invariant `_ready` already states for its other failure — *"An episode must not open on a rig that never got ready, and its asker must hear that rather than wait"* — to the case where nobody was asked at all.

Deliberately **not** in `_ready`, and not in `_end_episode`: a trial that readies only a scene legitimately reaches `_ready` with an empty dict at episode close, because `_end_episode` filters `eval_keys.SCENE` out. Putting the check there would break that.

## Blast radius

Nothing in this repository is caught by the gate. Every non-test `Task` construction was checked:

- `cfg/eval/sim/{libero,positronic,robolab}.py` build bare `Task`s but pass them through `build_tasks`/`number_trials`, which injects `{keys.SCENE: p}` per trial.
- `cfg/eval/real/droid.py` names `{ARM, GRIPPER}` explicitly.
- `cli/eval/run.py` builds no `Task`.
- `yam` and `yam_bimanual` declare handlers but have no in-repo eval config building tasks for them.
- `tests/test_inference_integration.py` builds a bare `Task` against a scene-readying embodiment, but all three tests route it through `number_trials` first.

An embodiment declaring no handlers keeps working with a bare `Task`, which is what most of the existing harness tests rely on.

## Tests

Both in `tests/test_harness.py`, beside the sibling failure case, and both verified by mutation:

- `test_a_trial_naming_no_prepare_on_a_rig_that_readies_fails_loudly` — remove the gate and it reports `DID NOT RAISE ValueError`.
- `test_a_trial_naming_no_prepare_on_a_rig_that_readies_nothing_opens` — widen the gate to drop the handler check and it fails, so the boundary is genuinely pinned.

`81 passed` in `test_harness.py`; `263 passed` across `positronic/policy` + `positronic/cfg`; `ruff` and the basedpyright ratchet clean with the baseline unmodified.

Ticket: Positronic-Robotics/internal#892

<!-- opened-by: posi-agent -->
