### PR TITLE
Let a benchmark answer `tasks(spec)`, so positronic holds no task table

### DIFF
--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -13,6 +13,17 @@ from positronic.cfg.ds import internal
 from positronic.cfg.eval.real import tasks
 from positronic.dataset.episode import META_CREATED_TS_NS, Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Group, Identity
+from positronic.policy.base import (
+    CHECKPOINT_ID,
+    CHECKPOINT_PATH,
+    CONFIG_NAME,
+    EXPERIMENT_NAME,
+    HOST,
+    POLICY_META,
+    PORT,
+    SERVER_META,
+    TYPE,
+)
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import GroupTableConfig, RendererConfig, SortConfig
 from positronic.server.positronic_server import main as server_main
@@ -45,17 +56,17 @@ def _model_label_from_path(model_type: str, checkpoint_path: str) -> str | None:
 
 
 def model(ep: Episode) -> str:
-    policy_type = ep.get(f'{keys.POLICY_META}.{keys.TYPE}', '')
+    policy_type = ep.get(f'{POLICY_META}.{TYPE}', '')
 
     if policy_type == 'remote':
-        server_type = ep.get(f'{keys.SERVER_META}.{keys.TYPE}', '')
-        path_label = _model_label_from_path(server_type, ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_PATH}', ''))
+        server_type = ep.get(f'{SERVER_META}.{TYPE}', '')
+        path_label = _model_label_from_path(server_type, ep.get(f'{SERVER_META}.{CHECKPOINT_PATH}', ''))
         if path_label:
             return path_label
         return server_type or ''
 
     if policy_type:
-        path_label = _model_label_from_path(policy_type, ep.get(f'{keys.POLICY_META}.{keys.CHECKPOINT_PATH}', ''))
+        path_label = _model_label_from_path(policy_type, ep.get(f'{POLICY_META}.{CHECKPOINT_PATH}', ''))
         if path_label:
             return path_label
         return policy_type
@@ -68,7 +79,7 @@ def _split_path(path: str) -> list[str]:
 
 
 def _ckpt_act(ep: Episode) -> str:
-    raw_path = ep[f'{keys.POLICY_META}.{keys.CHECKPOINT_PATH}']
+    raw_path = ep[f'{POLICY_META}.{CHECKPOINT_PATH}']
     parts = _split_path(raw_path)
     chkpt_idxs = [i for i, p in enumerate(parts) if p == 'checkpoints']
     if chkpt_idxs:
@@ -79,10 +90,10 @@ def _ckpt_act(ep: Episode) -> str:
 
 
 def _ckpt_remote(ep: Episode) -> str:
-    checkpoint_id = ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}', '')
+    checkpoint_id = ep.get(f'{SERVER_META}.{CHECKPOINT_ID}', '')
     if checkpoint_id:
         return str(checkpoint_id)
-    raw_path = ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_PATH}', '')
+    raw_path = ep.get(f'{SERVER_META}.{CHECKPOINT_PATH}', '')
     if raw_path:
         parts = _split_path(raw_path)
         if parts[-1] == 'pretrained_model' and len(parts) >= 2:
@@ -93,7 +104,7 @@ def _ckpt_remote(ep: Episode) -> str:
 
 def ckpt(ep: Episode) -> str | None:
     try:
-        match ep.get(f'{keys.POLICY_META}.{keys.TYPE}', ''):
+        match ep.get(f'{POLICY_META}.{TYPE}', ''):
             case 'act':
                 return _ckpt_act(ep)
             case 'remote':
@@ -572,7 +583,7 @@ PHAIL_OUTCOME_BADGE = RendererConfig(
 
 
 def phail_model(ep: Episode) -> str:
-    return PHAIL_MODEL_DISPLAY.get(ep.get(f'{keys.SERVER_META}.{keys.TYPE}', ''), '')
+    return PHAIL_MODEL_DISPLAY.get(ep.get(f'{SERVER_META}.{TYPE}', ''), '')
 
 
 def phail_status(ep: Episode) -> str:
@@ -605,8 +616,8 @@ def phail_uph(ep: Episode) -> float | None:
 
 
 def phail_variant(ep: Episode) -> str:
-    exp = ep.get(f'{keys.SERVER_META}.{keys.EXPERIMENT_NAME}', '')
-    ckpt = ep.get(f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}', '')
+    exp = ep.get(f'{SERVER_META}.{EXPERIMENT_NAME}', '')
+    ckpt = ep.get(f'{SERVER_META}.{CHECKPOINT_ID}', '')
     if exp and ckpt:
         return f'{exp}:{ckpt}'
     if exp:
@@ -639,13 +650,13 @@ phail_inference = base_cfg.transform.override(
                     'robot_commands.reset',
                     'robot_command.reset',
                     'eval.object',
-                    f'{keys.POLICY_META}.{keys.PORT}',
-                    f'{keys.POLICY_META}.{keys.HOST}',
-                    f'{keys.SERVER_META}.{keys.CHECKPOINT_ID}',
-                    f'{keys.SERVER_META}.{keys.CONFIG_NAME}',
-                    f'{keys.SERVER_META}.{keys.EXPERIMENT_NAME}',
-                    f'{keys.SERVER_META}.{keys.TYPE}',
-                    f'{keys.POLICY_META}.{keys.TYPE}',
+                    f'{POLICY_META}.{PORT}',
+                    f'{POLICY_META}.{HOST}',
+                    f'{SERVER_META}.{CHECKPOINT_ID}',
+                    f'{SERVER_META}.{CONFIG_NAME}',
+                    f'{SERVER_META}.{EXPERIMENT_NAME}',
+                    f'{SERVER_META}.{TYPE}',
+                    f'{POLICY_META}.{TYPE}',
                 ]
             ),
             # NOTE: _phail_derives reads inference.policy.server.type from the original episode,
@@ -728,7 +739,7 @@ phail_episodes = base_cfg.concat_ds.override(datasets=[phail_inference, phail_hu
 
 
 def _raw_model(ep: Episode) -> str:
-    return ep.get(f'{keys.SERVER_META}.{keys.TYPE}', '')
+    return ep.get(f'{SERVER_META}.{TYPE}', '')
 
 
 phail_inference_release = base_cfg.transform.override(
@@ -744,9 +755,9 @@ phail_inference_release = base_cfg.transform.override(
                 remove=[
                     'robot_commands.reset',
                     'robot_command.reset',
-                    f'{keys.POLICY_META}.{keys.PORT}',
-                    f'{keys.POLICY_META}.{keys.HOST}',
-                    f'{keys.POLICY_META}.{keys.TYPE}',
+                    f'{POLICY_META}.{PORT}',
+                    f'{POLICY_META}.{HOST}',
+                    f'{POLICY_META}.{TYPE}',
                 ]
             ),
             Derive(model=_raw_model, variant=phail_variant),

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -13,17 +13,8 @@ from positronic.cfg.ds import internal
 from positronic.cfg.eval.real import tasks
 from positronic.dataset.episode import META_CREATED_TS_NS, Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Group, Identity
-from positronic.policy.base import (
-    CHECKPOINT_ID,
-    CHECKPOINT_PATH,
-    CONFIG_NAME,
-    EXPERIMENT_NAME,
-    HOST,
-    POLICY_META,
-    PORT,
-    SERVER_META,
-    TYPE,
-)
+from positronic.offboard.protocol import CHECKPOINT_ID, HOST, PORT
+from positronic.policy.base import CHECKPOINT_PATH, CONFIG_NAME, EXPERIMENT_NAME, POLICY_META, SERVER_META, TYPE
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import GroupTableConfig, RendererConfig, SortConfig
 from positronic.server.positronic_server import main as server_main

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -13,8 +13,8 @@ from positronic.cfg.ds import internal
 from positronic.cfg.eval.real import tasks
 from positronic.dataset.episode import META_CREATED_TS_NS, Episode
 from positronic.dataset.transforms.episode import Derive, FromValue, Group, Identity
-from positronic.offboard.protocol import CHECKPOINT_ID, HOST, PORT
-from positronic.policy.base import CHECKPOINT_PATH, CONFIG_NAME, EXPERIMENT_NAME, POLICY_META, SERVER_META, TYPE
+from positronic.offboard import keys as offboard_keys
+from positronic.policy import keys as policy_keys
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import GroupTableConfig, RendererConfig, SortConfig
 from positronic.server.positronic_server import main as server_main
@@ -47,17 +47,21 @@ def _model_label_from_path(model_type: str, checkpoint_path: str) -> str | None:
 
 
 def model(ep: Episode) -> str:
-    policy_type = ep.get(f'{POLICY_META}.{TYPE}', '')
+    policy_type = ep.get(f'{policy_keys.POLICY_META}.{policy_keys.TYPE}', '')
 
     if policy_type == 'remote':
-        server_type = ep.get(f'{SERVER_META}.{TYPE}', '')
-        path_label = _model_label_from_path(server_type, ep.get(f'{SERVER_META}.{CHECKPOINT_PATH}', ''))
+        server_type = ep.get(f'{policy_keys.SERVER_META}.{policy_keys.TYPE}', '')
+        path_label = _model_label_from_path(
+            server_type, ep.get(f'{policy_keys.SERVER_META}.{policy_keys.CHECKPOINT_PATH}', '')
+        )
         if path_label:
             return path_label
         return server_type or ''
 
     if policy_type:
-        path_label = _model_label_from_path(policy_type, ep.get(f'{POLICY_META}.{CHECKPOINT_PATH}', ''))
+        path_label = _model_label_from_path(
+            policy_type, ep.get(f'{policy_keys.POLICY_META}.{policy_keys.CHECKPOINT_PATH}', '')
+        )
         if path_label:
             return path_label
         return policy_type
@@ -70,7 +74,7 @@ def _split_path(path: str) -> list[str]:
 
 
 def _ckpt_act(ep: Episode) -> str:
-    raw_path = ep[f'{POLICY_META}.{CHECKPOINT_PATH}']
+    raw_path = ep[f'{policy_keys.POLICY_META}.{policy_keys.CHECKPOINT_PATH}']
     parts = _split_path(raw_path)
     chkpt_idxs = [i for i, p in enumerate(parts) if p == 'checkpoints']
     if chkpt_idxs:
@@ -81,10 +85,10 @@ def _ckpt_act(ep: Episode) -> str:
 
 
 def _ckpt_remote(ep: Episode) -> str:
-    checkpoint_id = ep.get(f'{SERVER_META}.{CHECKPOINT_ID}', '')
+    checkpoint_id = ep.get(f'{policy_keys.SERVER_META}.{offboard_keys.CHECKPOINT_ID}', '')
     if checkpoint_id:
         return str(checkpoint_id)
-    raw_path = ep.get(f'{SERVER_META}.{CHECKPOINT_PATH}', '')
+    raw_path = ep.get(f'{policy_keys.SERVER_META}.{policy_keys.CHECKPOINT_PATH}', '')
     if raw_path:
         parts = _split_path(raw_path)
         if parts[-1] == 'pretrained_model' and len(parts) >= 2:
@@ -95,7 +99,7 @@ def _ckpt_remote(ep: Episode) -> str:
 
 def ckpt(ep: Episode) -> str | None:
     try:
-        match ep.get(f'{POLICY_META}.{TYPE}', ''):
+        match ep.get(f'{policy_keys.POLICY_META}.{policy_keys.TYPE}', ''):
             case 'act':
                 return _ckpt_act(ep)
             case 'remote':
@@ -574,7 +578,7 @@ PHAIL_OUTCOME_BADGE = RendererConfig(
 
 
 def phail_model(ep: Episode) -> str:
-    return PHAIL_MODEL_DISPLAY.get(ep.get(f'{SERVER_META}.{TYPE}', ''), '')
+    return PHAIL_MODEL_DISPLAY.get(ep.get(f'{policy_keys.SERVER_META}.{policy_keys.TYPE}', ''), '')
 
 
 def phail_status(ep: Episode) -> str:
@@ -607,8 +611,8 @@ def phail_uph(ep: Episode) -> float | None:
 
 
 def phail_variant(ep: Episode) -> str:
-    exp = ep.get(f'{SERVER_META}.{EXPERIMENT_NAME}', '')
-    ckpt = ep.get(f'{SERVER_META}.{CHECKPOINT_ID}', '')
+    exp = ep.get(f'{policy_keys.SERVER_META}.{policy_keys.EXPERIMENT_NAME}', '')
+    ckpt = ep.get(f'{policy_keys.SERVER_META}.{offboard_keys.CHECKPOINT_ID}', '')
     if exp and ckpt:
         return f'{exp}:{ckpt}'
     if exp:
@@ -641,13 +645,13 @@ phail_inference = base_cfg.transform.override(
                     'robot_commands.reset',
                     'robot_command.reset',
                     'eval.object',
-                    f'{POLICY_META}.{PORT}',
-                    f'{POLICY_META}.{HOST}',
-                    f'{SERVER_META}.{CHECKPOINT_ID}',
-                    f'{SERVER_META}.{CONFIG_NAME}',
-                    f'{SERVER_META}.{EXPERIMENT_NAME}',
-                    f'{SERVER_META}.{TYPE}',
-                    f'{POLICY_META}.{TYPE}',
+                    f'{policy_keys.POLICY_META}.{offboard_keys.PORT}',
+                    f'{policy_keys.POLICY_META}.{offboard_keys.HOST}',
+                    f'{policy_keys.SERVER_META}.{offboard_keys.CHECKPOINT_ID}',
+                    f'{policy_keys.SERVER_META}.{policy_keys.CONFIG_NAME}',
+                    f'{policy_keys.SERVER_META}.{policy_keys.EXPERIMENT_NAME}',
+                    f'{policy_keys.SERVER_META}.{policy_keys.TYPE}',
+                    f'{policy_keys.POLICY_META}.{policy_keys.TYPE}',
                 ]
             ),
             # NOTE: _phail_derives reads inference.policy.server.type from the original episode,
@@ -730,7 +734,7 @@ phail_episodes = base_cfg.concat_ds.override(datasets=[phail_inference, phail_hu
 
 
 def _raw_model(ep: Episode) -> str:
-    return ep.get(f'{SERVER_META}.{TYPE}', '')
+    return ep.get(f'{policy_keys.SERVER_META}.{policy_keys.TYPE}', '')
 
 
 phail_inference_release = base_cfg.transform.override(
@@ -746,9 +750,9 @@ phail_inference_release = base_cfg.transform.override(
                 remove=[
                     'robot_commands.reset',
                     'robot_command.reset',
-                    f'{POLICY_META}.{PORT}',
-                    f'{POLICY_META}.{HOST}',
-                    f'{POLICY_META}.{TYPE}',
+                    f'{policy_keys.POLICY_META}.{offboard_keys.PORT}',
+                    f'{policy_keys.POLICY_META}.{offboard_keys.HOST}',
+                    f'{policy_keys.POLICY_META}.{policy_keys.TYPE}',
                 ]
             ),
             Derive(model=_raw_model, variant=phail_variant),

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -24,7 +24,7 @@ from positronic.dataset.transforms import Elementwise, TransformedDataset, agg_f
 from positronic.dataset.transforms.episode import Concat, Derive, FromValue, Get, Group, Identity, Rename
 from positronic.dataset.transforms.quality import cmd_lag, cmd_velocity, idle_mask, jerk
 from positronic.drivers.roboarm.models import bundled_franka_model, bundled_panda_model
-from positronic.eval import JOINT_SIGNALS, POSE_SIGNALS
+from positronic.eval import keys as eval_keys
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import main as server_main
 
@@ -39,8 +39,8 @@ _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
 # transform, so the transform always supplies them — overriding any stale value a recording baked
 # into static (pre-rename recordings carry `robot_commands.pose` in their `pose_signals`).
 _POINTER_VALUES: dict[str, Any] = {
-    JOINT_SIGNALS: FromValue([keys.JOINTS]),
-    POSE_SIGNALS: FromValue([keys.EE_POSE, keys.TARGET_EE_POSE]),
+    eval_keys.JOINT_SIGNALS: FromValue([keys.JOINTS]),
+    eval_keys.POSE_SIGNALS: FromValue([keys.EE_POSE, keys.TARGET_EE_POSE]),
 }
 ROBOT_SIGNAL_POINTERS = Derive(**_POINTER_VALUES)
 

--- a/positronic/cfg/ds/internal.py
+++ b/positronic/cfg/ds/internal.py
@@ -24,6 +24,7 @@ from positronic.dataset.transforms import Elementwise, TransformedDataset, agg_f
 from positronic.dataset.transforms.episode import Concat, Derive, FromValue, Get, Group, Identity, Rename
 from positronic.dataset.transforms.quality import cmd_lag, cmd_velocity, idle_mask, jerk
 from positronic.drivers.roboarm.models import bundled_franka_model, bundled_panda_model
+from positronic.eval import JOINT_SIGNALS, POSE_SIGNALS
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import main as server_main
 
@@ -38,8 +39,8 @@ _REMOVE_SIGNALS = ['controller_positions.right', 'robot_commands.pose']
 # transform, so the transform always supplies them — overriding any stale value a recording baked
 # into static (pre-rename recordings carry `robot_commands.pose` in their `pose_signals`).
 _POINTER_VALUES: dict[str, Any] = {
-    keys.JOINT_SIGNALS: FromValue([keys.JOINTS]),
-    keys.POSE_SIGNALS: FromValue([keys.EE_POSE, keys.TARGET_EE_POSE]),
+    JOINT_SIGNALS: FromValue([keys.JOINTS]),
+    POSE_SIGNALS: FromValue([keys.EE_POSE, keys.TARGET_EE_POSE]),
 }
 ROBOT_SIGNAL_POINTERS = Derive(**_POINTER_VALUES)
 

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -5,7 +5,18 @@ import positronic.cfg.hardware.gripper
 import positronic.cfg.hardware.roboarm
 from positronic import keys
 from positronic.dataset.serializers import Serializers
-from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation
+from positronic.eval import (
+    ARM,
+    GRIPPER,
+    JOINT_SIGNALS,
+    MOUNTS,
+    POSE_SIGNALS,
+    ROBOT_STATIC_META,
+    SCENE,
+    Command,
+    Embodiment,
+    Observation,
+)
 
 
 @cfn.config(
@@ -35,7 +46,7 @@ def droid(robot_arm, gripper, cameras):
         descriptor='',
         observations=observations,
         commands=commands,
-        prepare_handlers={keys.ARM: robot_arm.sync_move, keys.GRIPPER: gripper.sync_move},
+        prepare_handlers={ARM: robot_arm.sync_move, GRIPPER: gripper.sync_move},
         static_meta=dict(ROBOT_STATIC_META),
         meta_source=robot_arm.robot_meta,
         control_systems=(*cameras.values(), robot_arm, gripper),
@@ -60,7 +71,7 @@ def yam(robot_arm, cameras):
         observations=observations,
         commands=commands,
         # One driver, one handler: the YAM chain carries its own fingers
-        prepare_handlers={keys.ARM: robot_arm.sync_move},
+        prepare_handlers={ARM: robot_arm.sync_move},
         static_meta=dict(ROBOT_STATIC_META),
         meta_source=robot_arm.robot_meta,
         control_systems=(*cameras.values(), robot_arm),
@@ -107,16 +118,16 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
     }
     joint_signals = {side: f'{keys.ROBOT_STATE}.{side}.q' for side in arms}
     static_meta = {
-        keys.JOINT_SIGNALS: list(joint_signals.values()),
-        keys.POSE_SIGNALS: [f'{keys.ROBOT_STATE}.{s}.ee_pose' for s in arms]
+        JOINT_SIGNALS: list(joint_signals.values()),
+        POSE_SIGNALS: [f'{keys.ROBOT_STATE}.{s}.ee_pose' for s in arms]
         + [f'{keys.ROBOT_COMMAND}.{s}.pose' for s in arms],
-        keys.MOUNTS: {sig: mounts[side] for side, sig in joint_signals.items()},
+        MOUNTS: {sig: mounts[side] for side, sig in joint_signals.items()},
     }
     return Embodiment(
         descriptor='yam_bimanual',
         observations=observations,
         commands=commands,
-        prepare_handlers={f'{keys.ARM}.{s}': arm.sync_move for s, arm in arms.items()},
+        prepare_handlers={f'{ARM}.{s}': arm.sync_move for s, arm in arms.items()},
         static_meta=static_meta,
         # Both drivers emit the identical per-arm meta; record one copy.
         meta_source=arms['left'].robot_meta,
@@ -147,7 +158,7 @@ def mujoco_franka(sim, camera_dict):
         commands=commands,
         # Two handlers on one sim: the draw places the objects and leaves the arm at the pose the scene
         # itself starts from; the move is what a trial names to put the arm somewhere else.
-        prepare_handlers={keys.SCENE: sim.env_reset, keys.ARM: sim.sync_move},
+        prepare_handlers={SCENE: sim.env_reset, ARM: sim.sync_move},
         static_meta={**ROBOT_STATIC_META, 'simulation.mujoco_model_path': sim.mujoco_model_path},
         meta_source=sim.robot_meta,
         control_systems=(sim,),

--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -5,18 +5,8 @@ import positronic.cfg.hardware.gripper
 import positronic.cfg.hardware.roboarm
 from positronic import keys
 from positronic.dataset.serializers import Serializers
-from positronic.eval import (
-    ARM,
-    GRIPPER,
-    JOINT_SIGNALS,
-    MOUNTS,
-    POSE_SIGNALS,
-    ROBOT_STATIC_META,
-    SCENE,
-    Command,
-    Embodiment,
-    Observation,
-)
+from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation
+from positronic.eval import keys as eval_keys
 
 
 @cfn.config(
@@ -46,7 +36,7 @@ def droid(robot_arm, gripper, cameras):
         descriptor='',
         observations=observations,
         commands=commands,
-        prepare_handlers={ARM: robot_arm.sync_move, GRIPPER: gripper.sync_move},
+        prepare_handlers={eval_keys.ARM: robot_arm.sync_move, eval_keys.GRIPPER: gripper.sync_move},
         static_meta=dict(ROBOT_STATIC_META),
         meta_source=robot_arm.robot_meta,
         control_systems=(*cameras.values(), robot_arm, gripper),
@@ -71,7 +61,7 @@ def yam(robot_arm, cameras):
         observations=observations,
         commands=commands,
         # One driver, one handler: the YAM chain carries its own fingers
-        prepare_handlers={ARM: robot_arm.sync_move},
+        prepare_handlers={eval_keys.ARM: robot_arm.sync_move},
         static_meta=dict(ROBOT_STATIC_META),
         meta_source=robot_arm.robot_meta,
         control_systems=(*cameras.values(), robot_arm),
@@ -118,16 +108,16 @@ def yam_bimanual(left_channel: str, right_channel: str, mounts: dict[str, list[f
     }
     joint_signals = {side: f'{keys.ROBOT_STATE}.{side}.q' for side in arms}
     static_meta = {
-        JOINT_SIGNALS: list(joint_signals.values()),
-        POSE_SIGNALS: [f'{keys.ROBOT_STATE}.{s}.ee_pose' for s in arms]
+        eval_keys.JOINT_SIGNALS: list(joint_signals.values()),
+        eval_keys.POSE_SIGNALS: [f'{keys.ROBOT_STATE}.{s}.ee_pose' for s in arms]
         + [f'{keys.ROBOT_COMMAND}.{s}.pose' for s in arms],
-        MOUNTS: {sig: mounts[side] for side, sig in joint_signals.items()},
+        eval_keys.MOUNTS: {sig: mounts[side] for side, sig in joint_signals.items()},
     }
     return Embodiment(
         descriptor='yam_bimanual',
         observations=observations,
         commands=commands,
-        prepare_handlers={f'{ARM}.{s}': arm.sync_move for s, arm in arms.items()},
+        prepare_handlers={f'{eval_keys.ARM}.{s}': arm.sync_move for s, arm in arms.items()},
         static_meta=static_meta,
         # Both drivers emit the identical per-arm meta; record one copy.
         meta_source=arms['left'].robot_meta,
@@ -158,7 +148,7 @@ def mujoco_franka(sim, camera_dict):
         commands=commands,
         # Two handlers on one sim: the draw places the objects and leaves the arm at the pose the scene
         # itself starts from; the move is what a trial names to put the arm somewhere else.
-        prepare_handlers={SCENE: sim.env_reset, ARM: sim.sync_move},
+        prepare_handlers={eval_keys.SCENE: sim.env_reset, eval_keys.ARM: sim.sync_move},
         static_meta={**ROBOT_STATIC_META, 'simulation.mujoco_model_path': sim.mujoco_model_path},
         meta_source=sim.robot_meta,
         control_systems=(sim,),

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -1,5 +1,6 @@
 import random
 from dataclasses import replace
+from typing import Any
 
 import configuronic as cfn
 
@@ -14,6 +15,15 @@ def placeholder():
         '--eval is required: a config to run here (--eval=.sim.positronic.stack_cubes), '
         'or the name of one the platform offers (--eval=robolab.public_subset, with --policy-image)'
     )
+
+
+def spec(**selection) -> dict[str, Any]:
+    """The selection arguments an eval binds, as the spec its env resolves.
+
+    An argument the eval leaves unbound is ``None``, and it is absent from the spec, so the env does not
+    narrow that axis.
+    """
+    return {name: value for name, value in selection.items() if value is not None}
 
 
 def number_trials(trials: list[tuple[Task, dict]]) -> list[Task]:

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -18,17 +18,13 @@ def placeholder():
 
 
 def spec(**selection) -> dict[str, Any]:
-    """The selection arguments an eval binds, as the spec its env resolves.
-
-    An argument the eval leaves unbound is ``None``, and it is absent from the spec, so the env does not
-    narrow that axis.
-    """
+    """The spec an env resolves: the selection arguments an eval binds, an unbound (``None``) one absent."""
     return {name: value for name, value in selection.items() if value is not None}
 
 
 def number_trials(trials: list[tuple[Task, dict]]) -> list[Task]:
-    """One trial per ``(task, params)`` pair: each task's scene prepare is asked with its own params, and its
-    episode records them beside the trial's place in the whole sweep."""
+    """One trial per ``(task, params)`` pair: its scene prepare is asked with the params, and its episode records
+    them beside the trial's place in the sweep."""
     return [
         replace(
             task,

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -16,16 +16,16 @@ def placeholder():
     )
 
 
-def number_trials(task: Task, params: list[dict]) -> list[Task]:
-    """One copy of ``task`` per entry in ``params``: its scene prepare is asked with them, and its episode
-    records them beside the trial's place in the sweep."""
+def number_trials(trials: list[tuple[Task, dict]]) -> list[Task]:
+    """One trial per ``(task, params)`` pair: each task's scene prepare is asked with its own params, and its
+    episode records them beside the trial's place in the whole sweep."""
     return [
         replace(
             task,
-            prepare_args={**task.prepare_args, keys.SCENE: p},
-            meta={**task.meta, **p, keys.EVAL_TRIAL_INDEX: i, keys.EVAL_TRIAL_COUNT: len(params)},
+            prepare_args={**task.prepare_args, keys.SCENE: params},
+            meta={**task.meta, **params, keys.EVAL_TRIAL_INDEX: i, keys.EVAL_TRIAL_COUNT: len(trials)},
         )
-        for i, p in enumerate(params)
+        for i, (task, params) in enumerate(trials)
     ]
 
 
@@ -36,11 +36,8 @@ def build_tasks(task: Task, seed: int | None, trial_count: int, scenes: list[dic
     ``None`` sweeps the seed alone (an eval with no scene axis). ``seed`` ``None`` draws an independent
     random seed per trial; an int runs ``seed .. seed + trial_count - 1`` for every scene.
     """
-    return number_trials(
-        task,
-        [
-            {**scene, keys.EVAL_SEED: seed + s if seed is not None else random.randrange(2**31)}
-            for scene in (scenes if scenes is not None else [{}])
-            for s in range(trial_count)
-        ],
-    )
+    return number_trials([
+        (task, {**scene, keys.EVAL_SEED: seed + s if seed is not None else random.randrange(2**31)})
+        for scene in (scenes if scenes is not None else [{}])
+        for s in range(trial_count)
+    ])

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -4,7 +4,8 @@ from typing import Any
 
 import configuronic as cfn
 
-from positronic.eval import EVAL_SEED, EVAL_TRIAL_COUNT, EVAL_TRIAL_INDEX, SCENE, Task
+from positronic.eval import Task
+from positronic.eval import keys as eval_keys
 
 
 @cfn.config()
@@ -27,8 +28,8 @@ def number_trials(trials: list[tuple[Task, dict]]) -> list[Task]:
     return [
         replace(
             task,
-            prepare_args={**task.prepare_args, SCENE: params},
-            meta={**task.meta, **params, EVAL_TRIAL_INDEX: i, EVAL_TRIAL_COUNT: len(trials)},
+            prepare_args={**task.prepare_args, eval_keys.SCENE: params},
+            meta={**task.meta, **params, eval_keys.TRIAL_INDEX: i, eval_keys.TRIAL_COUNT: len(trials)},
         )
         for i, (task, params) in enumerate(trials)
     ]
@@ -42,7 +43,7 @@ def build_tasks(task: Task, seed: int | None, trial_count: int, scenes: list[dic
     random seed per trial; an int runs ``seed .. seed + trial_count - 1`` for every scene.
     """
     return number_trials([
-        (task, {**scene, EVAL_SEED: seed + s if seed is not None else random.randrange(2**31)})
+        (task, {**scene, eval_keys.SEED: seed + s if seed is not None else random.randrange(2**31)})
         for scene in (scenes if scenes is not None else [{}])
         for s in range(trial_count)
     ])

--- a/positronic/cfg/eval/__init__.py
+++ b/positronic/cfg/eval/__init__.py
@@ -4,8 +4,7 @@ from typing import Any
 
 import configuronic as cfn
 
-from positronic import keys
-from positronic.eval import Task
+from positronic.eval import EVAL_SEED, EVAL_TRIAL_COUNT, EVAL_TRIAL_INDEX, SCENE, Task
 
 
 @cfn.config()
@@ -28,8 +27,8 @@ def number_trials(trials: list[tuple[Task, dict]]) -> list[Task]:
     return [
         replace(
             task,
-            prepare_args={**task.prepare_args, keys.SCENE: params},
-            meta={**task.meta, **params, keys.EVAL_TRIAL_INDEX: i, keys.EVAL_TRIAL_COUNT: len(trials)},
+            prepare_args={**task.prepare_args, SCENE: params},
+            meta={**task.meta, **params, EVAL_TRIAL_INDEX: i, EVAL_TRIAL_COUNT: len(trials)},
         )
         for i, (task, params) in enumerate(trials)
     ]
@@ -43,7 +42,7 @@ def build_tasks(task: Task, seed: int | None, trial_count: int, scenes: list[dic
     random seed per trial; an int runs ``seed .. seed + trial_count - 1`` for every scene.
     """
     return number_trials([
-        (task, {**scene, keys.EVAL_SEED: seed + s if seed is not None else random.randrange(2**31)})
+        (task, {**scene, EVAL_SEED: seed + s if seed is not None else random.randrange(2**31)})
         for scene in (scenes if scenes is not None else [{}])
         for s in range(trial_count)
     ])

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -7,7 +7,8 @@ import configuronic as cfn
 from positronic.cfg.embodiment import droid
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
 from positronic.cfg.hardware.roboarm import droid_start_pose
-from positronic.eval import ARM, EVAL_TRIAL_COUNT, EVAL_TRIAL_INDEX, GRIPPER, Eval, Task
+from positronic.eval import Eval, Task
+from positronic.eval import keys as eval_keys
 
 
 def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] | None = None) -> Task:
@@ -15,7 +16,7 @@ def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] |
     return Task(
         instruction_source=instruction,
         timeout_sec=timeout,
-        prepare_args={ARM: droid_start_pose(), GRIPPER: 0.0},
+        prepare_args={eval_keys.ARM: droid_start_pose(), eval_keys.GRIPPER: 0.0},
         meta=meta or {},
     )
 
@@ -29,7 +30,7 @@ def attended_trials(instruction: str, timeout: float | None) -> Callable[[], Tas
 
 def _planned_trials(instruction: str, timeout: float | None, trial_count: int) -> list[Task]:
     return [
-        _droid_trial(instruction, timeout, {EVAL_TRIAL_INDEX: trial, EVAL_TRIAL_COUNT: trial_count})
+        _droid_trial(instruction, timeout, {eval_keys.TRIAL_INDEX: trial, eval_keys.TRIAL_COUNT: trial_count})
         for trial in range(trial_count)
     ]
 

--- a/positronic/cfg/eval/real/droid.py
+++ b/positronic/cfg/eval/real/droid.py
@@ -4,11 +4,10 @@ from typing import Any
 
 import configuronic as cfn
 
-from positronic import keys
 from positronic.cfg.embodiment import droid
 from positronic.cfg.eval.real.tasks import BATTERIES_TASK, SCISSORS_TASK, SPOONS_TASK, TOWELS_TASK, UNIFIED_TASK
 from positronic.cfg.hardware.roboarm import droid_start_pose
-from positronic.eval import Eval, Task
+from positronic.eval import ARM, EVAL_TRIAL_COUNT, EVAL_TRIAL_INDEX, GRIPPER, Eval, Task
 
 
 def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] | None = None) -> Task:
@@ -16,7 +15,7 @@ def _droid_trial(instruction: str, timeout: float | None, meta: dict[str, Any] |
     return Task(
         instruction_source=instruction,
         timeout_sec=timeout,
-        prepare_args={keys.ARM: droid_start_pose(), keys.GRIPPER: 0.0},
+        prepare_args={ARM: droid_start_pose(), GRIPPER: 0.0},
         meta=meta or {},
     )
 
@@ -30,7 +29,7 @@ def attended_trials(instruction: str, timeout: float | None) -> Callable[[], Tas
 
 def _planned_trials(instruction: str, timeout: float | None, trial_count: int) -> list[Task]:
     return [
-        _droid_trial(instruction, timeout, {keys.EVAL_TRIAL_INDEX: trial, keys.EVAL_TRIAL_COUNT: trial_count})
+        _droid_trial(instruction, timeout, {EVAL_TRIAL_INDEX: trial, EVAL_TRIAL_COUNT: trial_count})
         for trial in range(trial_count)
     ]
 

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -35,10 +35,9 @@ def _libero_eval(
 
     ``_libero_eval`` leaves ``suite`` unbound; each named config below is a ``.override`` binding it — to one
     suite, or to a list (``all``) swept in one run. An unbound ``task_id`` sweeps every task of each bound suite;
-    ``--eval.task_id`` pins one. The env resolves that selection when the run starts, so a suite or a
-    ``task_id`` LIBERO does not hold stops the run after the server boots. The instruction is never pinned: the
-    task reads its language live from the env, which reports it (with ``suite`` and ``task_id``) in every
-    reset's meta.
+    ``--eval.task_id`` pins one. The env resolves that selection when the run starts. The instruction is never
+    pinned: the task reads its language live from the env, which reports it (with ``suite`` and ``task_id``) in
+    every reset's meta.
 
     positronic launches a single task-agnostic env server in its own 3.10 interpreter; the proxy drives it over
     the socket and the whole scene spec — suite, task_id, camera_resolution, control_mode, settle_steps — rides

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -5,7 +5,12 @@ from positronic.cfg.eval import build_tasks, spec
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
-from positronic.simulator.libero.adapter import LiberoAdapter
+from positronic.simulator.libero.adapter import (
+    EVAL_CAMERA_RESOLUTION,
+    EVAL_CONTROL_MODE,
+    EVAL_SETTLE_STEPS,
+    LiberoAdapter,
+)
 from positronic.simulator.libero.launcher import serve_libero
 
 
@@ -61,9 +66,9 @@ def _libero_eval(
         scenes = [
             {
                 **params,
-                keys.EVAL_CAMERA_RESOLUTION: camera_resolution,
-                keys.EVAL_CONTROL_MODE: control_mode,
-                keys.EVAL_SETTLE_STEPS: settle_steps,
+                EVAL_CAMERA_RESOLUTION: camera_resolution,
+                EVAL_CONTROL_MODE: control_mode,
+                EVAL_SETTLE_STEPS: settle_steps,
             }
             for params in proxy.tasks(spec(suite=suite, task_id=task_id))
         ]

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -5,12 +5,8 @@ from positronic.cfg.eval import build_tasks, spec
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
-from positronic.simulator.libero.adapter import (
-    EVAL_CAMERA_RESOLUTION,
-    EVAL_CONTROL_MODE,
-    EVAL_SETTLE_STEPS,
-    LiberoAdapter,
-)
+from positronic.simulator.libero import keys as libero_keys
+from positronic.simulator.libero.adapter import LiberoAdapter
 from positronic.simulator.libero.launcher import serve_libero
 
 
@@ -66,9 +62,9 @@ def _libero_eval(
         scenes = [
             {
                 **params,
-                EVAL_CAMERA_RESOLUTION: camera_resolution,
-                EVAL_CONTROL_MODE: control_mode,
-                EVAL_SETTLE_STEPS: settle_steps,
+                libero_keys.CAMERA_RESOLUTION: camera_resolution,
+                libero_keys.CONTROL_MODE: control_mode,
+                libero_keys.SETTLE_STEPS: settle_steps,
             }
             for params in proxy.tasks(spec(suite=suite, task_id=task_id))
         ]

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -1,7 +1,7 @@
 import configuronic as cfn
 
 from positronic import keys
-from positronic.cfg.eval import build_tasks
+from positronic.cfg.eval import build_tasks, spec
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
@@ -66,7 +66,7 @@ def _libero_eval(
                 keys.EVAL_CONTROL_MODE: control_mode,
                 keys.EVAL_SETTLE_STEPS: settle_steps,
             }
-            for params in proxy.tasks({keys.EVAL_SUITE: suite, keys.EVAL_TASK_ID: task_id})
+            for params in proxy.tasks(spec(suite=suite, task_id=task_id))
         ]
         return build_tasks(task, seed, trial_count, scenes)
 

--- a/positronic/cfg/eval/sim/libero.py
+++ b/positronic/cfg/eval/sim/libero.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 import configuronic as cfn
 
 from positronic import keys
@@ -9,10 +7,6 @@ from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.libero.adapter import LiberoAdapter
 from positronic.simulator.libero.launcher import serve_libero
-
-# Task count per LIBERO suite — the config expands an unbound ``task_id`` over ``range(num_tasks)``. positronic
-# cannot import LIBERO (it lives in the 3.10 env server), so the counts are pinned here against the pinned commit.
-_SUITE_NUM_TASKS = {'libero_spatial': 10, 'libero_object': 10, 'libero_goal': 10, 'libero_10': 10, 'libero_90': 90}
 
 
 @cfn.config(
@@ -33,16 +27,18 @@ def _libero_eval(
     A LIBERO *suite* is a set of related manipulation tasks; ``task_id`` selects one within it — a fixed scene and
     language goal (see https://github.com/Lifelong-Robot-Learning/LIBERO). The suites bound below:
 
-      - ``spatial`` (libero_spatial, 10 tasks) — same object and goal, varied placement (spatial generalization)
-      - ``object`` (libero_object, 10 tasks) — different objects, same pick-and-place (object generalization)
-      - ``goal`` (libero_goal, 10 tasks) — same objects, different goals (goal/procedure generalization)
-      - ``libero_10`` (libero_10 / LIBERO-LONG, 10 tasks) — long-horizon, entangled tasks across diverse scenes
-      - ``libero_90`` (libero_90, 90 tasks) — the large short-horizon pool; with libero_10 it forms LIBERO-100
+      - ``spatial`` (libero_spatial) — same object and goal, varied placement (spatial generalization)
+      - ``object`` (libero_object) — different objects, same pick-and-place (object generalization)
+      - ``goal`` (libero_goal) — same objects, different goals (goal/procedure generalization)
+      - ``libero_10`` (libero_10 / LIBERO-LONG) — long-horizon, entangled tasks across diverse scenes
+      - ``libero_90`` (libero_90) — the large short-horizon pool; with libero_10 it forms LIBERO-100
 
     ``_libero_eval`` leaves ``suite`` unbound; each named config below is a ``.override`` binding it — to one
     suite, or to a list (``all``) swept in one run. An unbound ``task_id`` sweeps every task of each bound suite;
-    ``--eval.task_id`` pins one. The instruction is never pinned: the task reads its language live from the env,
-    which reports it (with ``suite`` and ``task_id``) in every reset's meta.
+    ``--eval.task_id`` pins one. The env resolves that selection when the run starts, so a suite or a
+    ``task_id`` LIBERO does not hold stops the run after the server boots. The instruction is never pinned: the
+    task reads its language live from the env, which reports it (with ``suite`` and ``task_id``) in every
+    reset's meta.
 
     positronic launches a single task-agnostic env server in its own 3.10 interpreter; the proxy drives it over
     the socket and the whole scene spec — suite, task_id, camera_resolution, control_mode, settle_steps — rides
@@ -59,53 +55,32 @@ def _libero_eval(
         proxy, camera_dict, descriptor='remote.libero.franka', static_meta=bundled_panda_model()
     )
     privileged = {'sim_state': Observation(proxy.privileged['sim_state'], None)}
-    # One scene per (suite, task) pair: an unbound ``task_id`` sweeps each suite, a pinned one runs that task
-    # in every bound suite. The scene spec rides each trial's reset token, so the single task-agnostic env
-    # server serves every trial.
-    scenes = [
-        {
-            keys.EVAL_SUITE: s,
-            keys.EVAL_TASK_ID: t,
-            keys.EVAL_CAMERA_RESOLUTION: camera_resolution,
-            keys.EVAL_CONTROL_MODE: control_mode,
-            keys.EVAL_SETTLE_STEPS: settle_steps,
-        }
-        for s in ([suite] if isinstance(suite, str) else suite)
-        for t in ([task_id] if task_id is not None else range(_SUITE_NUM_TASKS[s]))
-    ]
-    return Eval(
-        embodiment,
-        # rules-allow: hardcoded-keys — the env names this reset-meta field; it is not positronic's ``keys.TASK``
-        partial(
-            build_tasks,
-            Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=timeout),
-            seed,
-            trial_count,
-            scenes,
-        ),
-        privileged=privileged,
-        done=proxy.done,
-    )
+    # rules-allow: hardcoded-keys — the env names this reset-meta field; it is not positronic's ``keys.TASK``
+    task = Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=timeout)
+
+    def tasks() -> list[Task]:
+        scenes = [
+            {
+                **params,
+                keys.EVAL_CAMERA_RESOLUTION: camera_resolution,
+                keys.EVAL_CONTROL_MODE: control_mode,
+                keys.EVAL_SETTLE_STEPS: settle_steps,
+            }
+            for params in proxy.tasks({keys.EVAL_SUITE: suite, keys.EVAL_TASK_ID: task_id})
+        ]
+        return build_tasks(task, seed, trial_count, scenes)
+
+    return Eval(embodiment, tasks, privileged=privileged, done=proxy.done)
 
 
 # Each suite binds only its LIBERO ``suite``; an unbound ``task_id`` sweeps the whole suite, ``--eval.task_id``
 # pins one. The instruction is not pinned — the task reads it live from the env's reset meta.
-
-# libero_spatial — 10 tasks
 spatial = _libero_eval.override(suite='libero_spatial')
-
-# libero_object — 10 tasks
 object = _libero_eval.override(suite='libero_object')
-
-# libero_goal — 10 tasks
 goal = _libero_eval.override(suite='libero_goal')
-
-# libero_10 (LIBERO-LONG) — 10 tasks
 libero_10 = _libero_eval.override(suite='libero_10')
-
-# libero_90 — 90 tasks
 libero_90 = _libero_eval.override(suite='libero_90')
 
-# The four-suite LIBERO benchmark (40 tasks) in one run — the set papers report as "LIBERO average".
-# libero_90 stays out: it is the LIBERO-100 pretraining pool, not a standard eval target.
+# The four-suite LIBERO benchmark in one run — the set papers report as "LIBERO average". libero_90 stays out:
+# it is the LIBERO-100 pretraining pool, not a standard eval target.
 all = _libero_eval.override(suite=['libero_spatial', 'libero_object', 'libero_goal', 'libero_10'])

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -1,7 +1,7 @@
 import configuronic as cfn
 
 from positronic import keys
-from positronic.cfg.eval import number_trials
+from positronic.cfg.eval import number_trials, spec
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.robolab.adapter import RobolabAdapter
@@ -24,7 +24,7 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     ``procedural`` — and one task can sit on several axes, so the three category sweeps overlap.
 
     ``_robolab_eval`` leaves ``task`` unbound; each named config below is a ``.override`` binding it — to a
-    single task name, a category, or ``all``. A list of names also works. The env resolves that selection when
+    single task name, a category, or ``None`` for every task. A list of names also works. The env resolves it when
     the run starts, so a task name RoboLab does not hold stops the run after the server boots. The instruction
     is never pinned: the task reads its language live from the env, which reports the resolved instruction in
     every reset's meta.
@@ -48,7 +48,7 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
         # RoboLab truncates an episode at its own budget, so the harness deadline sits above it and the env's
         # verdict is what ends a trial. ``--eval.timeout`` replaces it with one deadline for the whole sweep.
         trials = []
-        for params in proxy.tasks(task):
+        for params in proxy.tasks(spec(task=task)):
             deadline = timeout if timeout is not None else params[keys.EVAL_EPISODE_LENGTH] + 10.0
             trial = Task(instruction_source=instruction, timeout_sec=deadline)
             trials += [(trial, {**params, keys.EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
@@ -59,8 +59,8 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     )
 
 
-# Every task the benchmark holds, in one run.
-benchmark = _robolab_eval.override(task='all')
+# Every task the benchmark holds, in one run: a spec that names no task narrows nothing.
+benchmark = _robolab_eval.override(task=None)
 
 # One category each — the three axes RoboLab reports scores on.
 visual = _robolab_eval.override(task='visual')

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -4,7 +4,8 @@ from positronic import keys
 from positronic.cfg.eval import number_trials, spec
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
-from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, EVAL_INSTRUCTION_TYPE, RobolabAdapter
+from positronic.simulator.robolab import keys as robolab_keys
+from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 
@@ -44,10 +45,10 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
         for params in proxy.tasks(spec(task=task)):
             # RoboLab truncates an episode at its own budget, so the deadline sits above it and the env's verdict
             # ends a trial.
-            deadline = timeout if timeout is not None else params[EVAL_EPISODE_LENGTH] + 10.0
+            deadline = timeout if timeout is not None else params[robolab_keys.EPISODE_LENGTH] + 10.0
             # rules-allow: hardcoded-keys — the env names this reset-meta field; it is not positronic's ``keys.TASK``
             trial = Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=deadline)
-            trials += [(trial, {**params, EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
+            trials += [(trial, {**params, robolab_keys.INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
         return number_trials(trials)
 
     return Eval(

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -4,7 +4,7 @@ from positronic import keys
 from positronic.cfg.eval import number_trials, spec
 from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
-from positronic.simulator.robolab.adapter import RobolabAdapter
+from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, EVAL_INSTRUCTION_TYPE, RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 
@@ -44,10 +44,10 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
         for params in proxy.tasks(spec(task=task)):
             # RoboLab truncates an episode at its own budget, so the deadline sits above it and the env's verdict
             # ends a trial.
-            deadline = timeout if timeout is not None else params[keys.EVAL_EPISODE_LENGTH] + 10.0
+            deadline = timeout if timeout is not None else params[EVAL_EPISODE_LENGTH] + 10.0
             # rules-allow: hardcoded-keys — the env names this reset-meta field; it is not positronic's ``keys.TASK``
             trial = Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=deadline)
-            trials += [(trial, {**params, keys.EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
+            trials += [(trial, {**params, EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
         return number_trials(trials)
 
     return Eval(

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 import configuronic as cfn
 
 from positronic import keys
@@ -8,146 +6,6 @@ from positronic.eval import Eval, Observation, Task
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
-
-# The 120 benchmark tasks: name -> (categories, episode_length_s). positronic cannot import robolab (it lives in
-# the Isaac Lab env server), so the table is pinned here against the launcher's commit (7d45d749), generated
-# from robolab/tasks/_metadata/task_metadata.json. The categories are the task's attributes mapped through
-# RoboLab's BENCHMARK_TASK_CATEGORIES (attribute -> visual/relational/procedural); a task can sit on several
-# axes (84/42/34 memberships across the 120 tasks, matching the benchmark's reported splits), and the empty
-# tuple marks the three tasks the metadata leaves untagged — they run only by name or in ``all``.
-_TASKS = {
-    'AnimalsInBinTask': (('visual',), 90),
-    'AppleAndYogurtInBowlTask': (('procedural',), 120),
-    'BBQSauceInBinTask': (('visual',), 90),
-    'BagelsOnPlateTask': (('visual',), 60),
-    'BananaInBowlTask': (('visual',), 50),
-    'BananaOnPlateTask': ((), 40),
-    'BananaThenRubiksCubeTask': (('relational',), 60),
-    'BananasInBinOneMoreTask': (('relational', 'visual'), 60),
-    'BananasInBinThreeTotalTask': (('relational', 'visual'), 60),
-    'BananasInCrateTask': (('relational',), 60),
-    'BananasOutOfBinTask': (('relational', 'visual'), 90),
-    'BigPumpkinInBinTask': (('visual',), 60),
-    'BlackItemsInBinTask': (('procedural', 'visual'), 120),
-    'BlockStackingOrderAgnosticTask': (('procedural',), 90),
-    'BlockStackingSpecifiedOrderTask': (('procedural', 'visual'), 90),
-    'BlocksInBinTask': (('procedural',), 150),
-    'BowlInBinTask': ((), 60),
-    'BowlStackingLeftOnRightTask': (('relational',), 20),
-    'BowlStackingRightOnLeftTask': (('relational',), 20),
-    'ButterAboveRaisinTask': (('relational',), 40),
-    'CannedFoodInBinTask': (('visual',), 60),
-    'ClampInRightBinTask': (('relational', 'visual'), 60),
-    'CleanUpToysTask': (('procedural', 'visual'), 300),
-    'ClearOrganicObjectsTask': (('visual',), 240),
-    'ClutterPlasticTask': (('visual',), 180),
-    'ClutterPumpkinTask': (('visual',), 90),
-    'CoffeePotInBinTask': (('visual',), 60),
-    'CondimentsInBinTask': (('procedural', 'visual'), 180),
-    'CookingClearPlateTask': (('procedural', 'visual'), 180),
-    'CookingPickPastaToolTask': (('relational', 'visual'), 60),
-    'CubesAndBlocksInBinTask': (('procedural', 'relational'), 240),
-    'DishesInBinTask': (('visual',), 180),
-    'ElectronicsInBinTask': (('procedural', 'visual'), 180),
-    'FoodPacking1BoxesTask': (('visual',), 60),
-    'FoodPacking1CansTask': (('visual',), 60),
-    'FoodPacking2BoxesTask': (('visual',), 180),
-    'FoodPacking2CansTask': (('visual',), 180),
-    'FoodPacking3BoxesTask': (('visual',), 240),
-    'FoodPacking3CansTask': (('visual',), 240),
-    'FoodPackingByColorTask': (('procedural', 'relational', 'visual'), 120),
-    'FruitsGreenLimesOnPlateTask': (('visual',), 90),
-    'FruitsMovingOrangeOrLimeTask': (('relational',), 60),
-    'FruitsMovingTask': (('visual',), 60),
-    'FruitsOnPlate3Task': (('relational', 'visual'), 200),
-    'FruitsOnPlateTask': (('visual',), 300),
-    'FruitsOnionTask': (('visual',), 60),
-    'FruitsOnionToPlateTask': (('visual',), 60),
-    'FruitsOrangesOnPlateTask': (('relational', 'visual'), 90),
-    'GrabABagelTask': (('visual',), 30),
-    'GrabAFruitTask': (('visual',), 30),
-    'GreenSpoonsInPotTask': (('procedural', 'visual'), 180),
-    'HammersInLeftBinTask': (('relational', 'visual'), 180),
-    'JugsOnShelfTask': (('visual',), 120),
-    'KeyboardOutOfBinTask': (('relational',), 60),
-    'LargerObjectRaisinBoxInBinTask': (('visual',), 30),
-    'MarkerInMugTask': (('procedural',), 40),
-    'MouseOnKeyboardTask': (('visual',), 60),
-    'MoveBananaToBagelPlateTask': (('visual',), 90),
-    'MustardAboveRaisinTask': (('relational',), 40),
-    'MustardInLeftBinTask': (('relational',), 30),
-    'MustardInRightBinTask': (('relational',), 30),
-    'NonHammerToolsInRightBinTask': (('procedural', 'relational', 'visual'), 180),
-    'OneBottleInSquarePailTask': (('visual',), 60),
-    'OneBottleOnShelfTask': (('visual',), 60),
-    'PhoneOrRemoteInBinTask': (('relational',), 60),
-    'PickDrillTask': (('visual',), 40),
-    'PickGlassesTask': (('visual',), 30),
-    'PickOrangeObjectTask': (('visual',), 60),
-    'PickUpBluePitcherTask': (('procedural', 'visual'), 30),
-    'PickUpGreenObjectTask': (('visual',), 30),
-    'PinkSpoonInPotTask': (('procedural', 'visual'), 60),
-    'PlasticBottlesInSquarePailTask': (('procedural', 'visual'), 180),
-    'PutBowlOnShelfTopTask': (('relational',), 60),
-    'PutMugsOnShelfTask': (('procedural', 'relational'), 180),
-    'PutTwoMugsOnShelfTask': (('procedural', 'relational'), 180),
-    'RecycleCartonTask': (('visual',), 90),
-    'RecycleCartonsOnBoxTask': (('visual',), 90),
-    'RecycleCartonsVerticalCrateTask': (('relational', 'visual'), 90),
-    'RedDishesInBinTask': (('visual',), 60),
-    'RedItemsInBinTask': (('procedural', 'visual'), 60),
-    'ReorientAllMugsTask': (('procedural',), 90),
-    'ReorientJugTask': (('procedural', 'visual'), 60),
-    'ReorientRedMugTask': (('procedural', 'visual'), 60),
-    'ReorientWhiteMugsTask': (('procedural', 'visual'), 60),
-    'RubiksCubeAndBananaTask': (('relational',), 60),
-    'RubiksCubeBehindBowlTask': (('relational',), 30),
-    'RubiksCubeInFrontOfBowlTask': (('relational',), 30),
-    'RubiksCubeLeftOfBowlTask': (('relational',), 30),
-    'RubiksCubeOrBananaTask': (('relational',), 30),
-    'RubiksCubeRightOfBowlTask': (('relational',), 30),
-    'RubiksCubeTask': ((), 40),
-    'RubiksCubeThenBananaTask': (('relational',), 60),
-    'RubiksCubesInBinTask': (('procedural',), 120),
-    'SauceBottlesCrateTask': (('visual',), 40),
-    'SmallPumpkinInBinTask': (('visual',), 60),
-    'SmallerObjectButterInBinTask': (('visual',), 30),
-    'SmartphoneInBinTask': (('visual',), 60),
-    'SpoonInMugTask': (('procedural', 'relational'), 60),
-    'SpoonsInPotTask': (('procedural', 'visual'), 180),
-    'Stack3RubiksCubeTask': (('procedural',), 60),
-    'StackWhiteMugsTask': (('procedural', 'visual'), 60),
-    'StackYellowOnRedTask': (('procedural',), 60),
-    'TakeMeasuringSpoonOutTask': (('visual',), 40),
-    'TakeMugsOffOfShelfTask': (('procedural', 'visual'), 180),
-    'TakeSpatulaOffShelfTask': (('procedural', 'relational'), 60),
-    'ThrowAwayAppleTask': (('visual',), 60),
-    'ThrowAwaySnacksTask': (('visual',), 120),
-    'ToolOrganizationBothTask': (('relational', 'visual'), 180),
-    'ToolOrganizationTask': (('relational', 'visual'), 180),
-    'ToolsPickingAllHammersTask': (('relational', 'visual'), 240),
-    'ToolsPickingDrillTask': (('relational', 'visual'), 60),
-    'ToolsPickingHammerTask': (('relational', 'visual'), 60),
-    'ToyInBinTask': (('visual',), 60),
-    'UnstackRubiksCubeTask': (('procedural',), 90),
-    'UtensilsInMugTask': (('procedural', 'visual'), 90),
-    'WhiteMugInCenterOfTableTask': (('relational', 'visual'), 30),
-    'WhiteMugsInBinTask': (('visual',), 60),
-    'WoodSpatulaToBowlTask': (('visual',), 60),
-    'YellowAndWhiteObjectsInBinTask': (('relational', 'visual'), 60),
-    'YogurtInBowlTask': (('visual',), 40),
-}
-
-_CATEGORIES = ('visual', 'relational', 'procedural')
-
-
-def _resolve_tasks(task) -> list[str]:
-    """A task name, a list of names, a category, or ``'all'`` -> the benchmark task names to run."""
-    if task == 'all':
-        return list(_TASKS)
-    if task in _CATEGORIES:
-        return [name for name, (categories, _) in _TASKS.items() if task in categories]
-    return [task] if isinstance(task, str) else list(task)
 
 
 @cfn.config(
@@ -159,17 +17,17 @@ def _resolve_tasks(task) -> list[str]:
 def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     """A RoboLab eval: the embodiment proxies a remote RoboLab env, the task carries the scenario.
 
-    RoboLab (https://github.com/NVLabs/RoboLab) is NVIDIA's Isaac Lab benchmark: 120 tabletop manipulation
+    RoboLab (https://github.com/NVLabs/RoboLab) is NVIDIA's Isaac Lab benchmark: tabletop manipulation
     tasks on the DROID rig (Franka arm + Robotiq 2F-85), each with a fixed scene, a language instruction in
-    three phrasings (``instruction_type`` ``default``/``vague``/``specific``), and a scripted success check.
-    Tasks carry categories — ``visual`` (color/size/semantics), ``relational`` (spatial/conjunction/counting),
-    ``procedural`` (stacking/sorting/reorientation/affordance) — and one task can sit on several axes, so the
-    three category sweeps overlap.
+    three phrasings (``instruction_type`` ``default``/``vague``/``specific``), a time budget of its own and a
+    scripted success check. RoboLab scores three task categories — ``visual``, ``relational`` and
+    ``procedural`` — and one task can sit on several axes, so the three category sweeps overlap.
 
     ``_robolab_eval`` leaves ``task`` unbound; each named config below is a ``.override`` binding it — to a
-    single task name, a category, or ``all``. A list of names also works. The instruction is never pinned:
-    the task reads its language live from the env, which reports the resolved instruction in every reset's
-    meta.
+    single task name, a category, or ``all``. A list of names also works. The env resolves that selection when
+    the run starts, so a task name RoboLab does not hold stops the run after the server boots. The instruction
+    is never pinned: the task reads its language live from the env, which reports the resolved instruction in
+    every reset's meta.
 
     positronic launches a single task-agnostic env server in RoboLab's own Isaac Lab interpreter; the proxy
     drives it over the socket and the task name + instruction type ride each trial's reset token. There is no
@@ -177,31 +35,31 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     subtask progress ``[status, completed, total, score]`` is the privileged ground truth (recorded, never
     fed to the policy).
     """
-    names = _resolve_tasks(task)
-    if timeout is None:
-        # The env truncates itself at each task's episode_length_s; the harness deadline is a backstop above
-        # the longest selected task.
-        timeout = max(_TASKS[name][1] for name in names) + 10.0
     proxy = RemoteEnvControlSystem(RobolabAdapter(camera_dict), serve_robolab())
     # The DROID rig's model (Franka arm + Robotiq 2F-85) rides the env's ``robot_meta`` — the launcher
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
-    # RoboLab exposes no seed hook, so trial params carry no ``eval.seed``.
-    params = [
-        {keys.EVAL_TASK: name, keys.EVAL_INSTRUCTION_TYPE: instruction_type}
-        for name in names
-        for _ in range(trial_count)
-    ]
+
+    def instruction() -> str:
+        # rules-allow: hardcoded-keys — the env names this reset-meta field, not positronic's ``keys.TASK``
+        return proxy.meta['task']
+
+    def tasks() -> list[Task]:
+        # RoboLab truncates an episode at its own budget, so the harness deadline sits above it and the env's
+        # verdict is what ends a trial. ``--eval.timeout`` replaces it with one deadline for the whole sweep.
+        trials = []
+        for params in proxy.tasks(task):
+            deadline = timeout if timeout is not None else params[keys.EVAL_EPISODE_LENGTH] + 10.0
+            trial = Task(instruction_source=instruction, timeout_sec=deadline)
+            trials += [(trial, {**params, keys.EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
+        return number_trials(trials)
+
     return Eval(
-        embodiment,
-        # rules-allow: hardcoded-keys — the env names this reset-meta field; it is not positronic's ``keys.TASK``
-        partial(number_trials, Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=timeout), params),
-        privileged={'subtask': Observation(proxy.privileged['subtask'], None)},
-        done=proxy.done,
+        embodiment, tasks, privileged={'subtask': Observation(proxy.privileged['subtask'], None)}, done=proxy.done
     )
 
 
-# The full 120-task benchmark in one run.
+# Every task the benchmark holds, in one run.
 benchmark = _robolab_eval.override(task='all')
 
 # One category each — the three axes RoboLab reports scores on.

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -24,10 +24,9 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     ``procedural`` — and one task can sit on several axes, so the three category sweeps overlap.
 
     ``_robolab_eval`` leaves ``task`` unbound; each named config below is a ``.override`` binding it — to a
-    single task name, a category, or ``None`` for every task. A list of names also works. The env resolves it when
-    the run starts, so a task name RoboLab does not hold stops the run after the server boots. The instruction
-    is never pinned: the task reads its language live from the env, which reports the resolved instruction in
-    every reset's meta.
+    single task name, a category, or ``None`` for every task. A list of names also works. The env resolves it
+    when the run starts. The instruction is never pinned: the task reads its language live from the env, which
+    reports the resolved instruction in every reset's meta.
 
     positronic launches a single task-agnostic env server in RoboLab's own Isaac Lab interpreter; the proxy
     drives it over the socket and the task name + instruction type ride each trial's reset token. There is no
@@ -45,10 +44,10 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
         return proxy.meta['task']
 
     def tasks() -> list[Task]:
-        # RoboLab truncates an episode at its own budget, so the harness deadline sits above it and the env's
-        # verdict is what ends a trial. ``--eval.timeout`` replaces it with one deadline for the whole sweep.
         trials = []
         for params in proxy.tasks(spec(task=task)):
+            # RoboLab truncates an episode at its own budget, so the deadline sits above it and the env's verdict
+            # ends a trial.
             deadline = timeout if timeout is not None else params[keys.EVAL_EPISODE_LENGTH] + 10.0
             trial = Task(instruction_source=instruction, timeout_sec=deadline)
             trials += [(trial, {**params, keys.EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
@@ -59,7 +58,7 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     )
 
 
-# Every task the benchmark holds, in one run: a spec that names no task narrows nothing.
+# Every task the benchmark holds, in one run.
 benchmark = _robolab_eval.override(task=None)
 
 # One category each — the three axes RoboLab reports scores on.

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -39,17 +39,14 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')
 
-    def instruction() -> str:
-        # rules-allow: hardcoded-keys — the env names this reset-meta field, not positronic's ``keys.TASK``
-        return proxy.meta['task']
-
     def tasks() -> list[Task]:
         trials = []
         for params in proxy.tasks(spec(task=task)):
             # RoboLab truncates an episode at its own budget, so the deadline sits above it and the env's verdict
             # ends a trial.
             deadline = timeout if timeout is not None else params[keys.EVAL_EPISODE_LENGTH] + 10.0
-            trial = Task(instruction_source=instruction, timeout_sec=deadline)
+            # rules-allow: hardcoded-keys — the env names this reset-meta field; it is not positronic's ``keys.TASK``
+            trial = Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=deadline)
             trials += [(trial, {**params, keys.EVAL_INSTRUCTION_TYPE: instruction_type}) for _ in range(trial_count)]
         return number_trials(trials)
 

--- a/positronic/cfg/server.py
+++ b/positronic/cfg/server.py
@@ -10,7 +10,7 @@ from positronic import keys
 from positronic.dataset import Episode
 from positronic.dataset.episode import META_CREATED_TS_NS
 from positronic.dataset.transforms.episode import Derive, FromValue, Group, Identity, Rename
-from positronic.eval import EVAL_SUCCESS, EVAL_TERMINATED
+from positronic.eval import keys as eval_keys
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import GroupTableConfig, RendererConfig
 from positronic.server.positronic_server import main as server_main
@@ -32,7 +32,7 @@ def eval_table():
         '__index__': C(label='#', format='%d'),
         '__duration__': C(label='Duration', format='%.2f sec'),
         keys.TASK: C(label='Task', filter=True),
-        EVAL_SUCCESS: C(
+        eval_keys.SUCCESS: C(
             label='Pass',
             default=False,
             renderer=RendererConfig(
@@ -40,7 +40,7 @@ def eval_table():
                 options={True: {'label': 'Pass', 'variant': 'success'}, False: {'label': 'Fail', 'variant': 'danger'}},
             ),
         ),
-        EVAL_TERMINATED: C(label='Ended', default=False),
+        eval_keys.TERMINATED: C(label='Ended', default=False),
     }
 
 

--- a/positronic/cfg/server.py
+++ b/positronic/cfg/server.py
@@ -10,6 +10,7 @@ from positronic import keys
 from positronic.dataset import Episode
 from positronic.dataset.episode import META_CREATED_TS_NS
 from positronic.dataset.transforms.episode import Derive, FromValue, Group, Identity, Rename
+from positronic.eval import EVAL_SUCCESS, EVAL_TERMINATED
 from positronic.server.positronic_server import ColumnConfig as C
 from positronic.server.positronic_server import GroupTableConfig, RendererConfig
 from positronic.server.positronic_server import main as server_main
@@ -31,7 +32,7 @@ def eval_table():
         '__index__': C(label='#', format='%d'),
         '__duration__': C(label='Duration', format='%.2f sec'),
         keys.TASK: C(label='Task', filter=True),
-        keys.EVAL_SUCCESS: C(
+        EVAL_SUCCESS: C(
             label='Pass',
             default=False,
             renderer=RendererConfig(
@@ -39,7 +40,7 @@ def eval_table():
                 options={True: {'label': 'Pass', 'variant': 'success'}, False: {'label': 'Fail', 'variant': 'danger'}},
             ),
         ),
-        keys.EVAL_TERMINATED: C(label='Ended', default=False),
+        EVAL_TERMINATED: C(label='Ended', default=False),
     }
 
 

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -96,8 +96,7 @@ def test_a_spec_carries_only_what_the_eval_binds():
 
 
 def test_a_sweep_numbers_its_trials_across_every_task():
-    """A sweep runs tasks that differ — each with its own time budget and its own scene params — and numbers
-    the trials once over the whole plan, so a trial's place does not restart with every task."""
+    """Trials of tasks that differ are numbered once over the whole plan."""
     quick = Task(instruction_source='quick', timeout_sec=1.0)
     slow = Task(instruction_source='slow', timeout_sec=90.0)
     pairs = [(quick, {keys.EVAL_TASK: 'quick'}), (slow, {keys.EVAL_TASK: 'slow'}), (slow, {keys.EVAL_TASK: 'slow'})]

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -10,7 +10,8 @@ import pimm
 from positronic import telemetry, telemetry_keys
 from positronic.cfg.eval import number_trials, spec
 from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
-from positronic.eval import EVAL_TASK, EVAL_TRIAL_COUNT, EVAL_TRIAL_INDEX, SCENE, Embodiment, Eval, Task
+from positronic.eval import Embodiment, Eval, Task
+from positronic.eval import keys as eval_keys
 from positronic.policy import Policy, Session
 from positronic.policy.harness import Rollout
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler
@@ -78,7 +79,7 @@ class _EpisodeStub(pimm.ControlSystem):
 def test_the_driver_asks_for_its_tasks_one_at_a_time():
     """The plan belongs to the driver: it asks for each task in turn, and only once the running episode has
     answered."""
-    tasks = [Task(instruction_source='stack', timeout_sec=0.05, meta={EVAL_TRIAL_INDEX: i}) for i in range(2)]
+    tasks = [Task(instruction_source='stack', timeout_sec=0.05, meta={eval_keys.TRIAL_INDEX: i}) for i in range(2)]
     stub = _EpisodeStub()
     driver = TaskDriver(partial(iter, tasks), _IdlePolicy(), None)
     with pimm.World(virtual_time=True) as world:
@@ -99,14 +100,14 @@ def test_a_sweep_numbers_its_trials_across_every_task():
     """Trials of tasks that differ are numbered once over the whole plan."""
     quick = Task(instruction_source='quick', timeout_sec=1.0)
     slow = Task(instruction_source='slow', timeout_sec=90.0)
-    pairs = [(quick, {EVAL_TASK: 'quick'}), (slow, {EVAL_TASK: 'slow'}), (slow, {EVAL_TASK: 'slow'})]
+    pairs = [(quick, {eval_keys.TASK: 'quick'}), (slow, {eval_keys.TASK: 'slow'}), (slow, {eval_keys.TASK: 'slow'})]
     trials = number_trials(pairs)
 
     assert [t.timeout_sec for t in trials] == [1.0, 90.0, 90.0]
-    assert [t.meta[EVAL_TRIAL_INDEX] for t in trials] == [0, 1, 2]
-    assert [t.meta[EVAL_TRIAL_COUNT] for t in trials] == [3, 3, 3]
-    assert [t.meta[EVAL_TASK] for t in trials] == ['quick', 'slow', 'slow']
-    assert [t.prepare_args[SCENE] for t in trials] == [params for _, params in pairs]
+    assert [t.meta[eval_keys.TRIAL_INDEX] for t in trials] == [0, 1, 2]
+    assert [t.meta[eval_keys.TRIAL_COUNT] for t in trials] == [3, 3, 3]
+    assert [t.meta[eval_keys.TASK] for t in trials] == ['quick', 'slow', 'slow']
+    assert [t.prepare_args[eval_keys.SCENE] for t in trials] == [params for _, params in pairs]
 
 
 def test_timed_sweep_needs_an_output_dir():

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -8,7 +8,7 @@ import pytest
 
 import pimm
 from positronic import keys, telemetry, telemetry_keys
-from positronic.cfg.eval import number_trials
+from positronic.cfg.eval import number_trials, spec
 from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
 from positronic.eval import Embodiment, Eval, Task
 from positronic.policy import Policy, Session
@@ -86,6 +86,13 @@ def test_the_driver_asks_for_its_tasks_one_at_a_time():
         drive_scheduler(world.start([driver, stub]), steps=200)
 
     assert stub.asked == tasks
+
+
+def test_a_spec_carries_only_what_the_eval_binds():
+    """An eval leaves an axis unbound to run every value of it, and the env reads an absent key as that."""
+    assert spec(suite='libero_spatial', task_id=None) == {'suite': 'libero_spatial'}
+    assert spec(task_id=0) == {'task_id': 0}, 'zero is a bound task, not an unbound axis'
+    assert spec(task=None) == {}
 
 
 def test_a_sweep_numbers_its_trials_across_every_task():

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -7,10 +7,10 @@ from typing import cast
 import pytest
 
 import pimm
-from positronic import keys, telemetry, telemetry_keys
+from positronic import telemetry, telemetry_keys
 from positronic.cfg.eval import number_trials, spec
 from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
-from positronic.eval import Embodiment, Eval, Task
+from positronic.eval import EVAL_TASK, EVAL_TRIAL_COUNT, EVAL_TRIAL_INDEX, SCENE, Embodiment, Eval, Task
 from positronic.policy import Policy, Session
 from positronic.policy.harness import Rollout
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler
@@ -78,7 +78,7 @@ class _EpisodeStub(pimm.ControlSystem):
 def test_the_driver_asks_for_its_tasks_one_at_a_time():
     """The plan belongs to the driver: it asks for each task in turn, and only once the running episode has
     answered."""
-    tasks = [Task(instruction_source='stack', timeout_sec=0.05, meta={keys.EVAL_TRIAL_INDEX: i}) for i in range(2)]
+    tasks = [Task(instruction_source='stack', timeout_sec=0.05, meta={EVAL_TRIAL_INDEX: i}) for i in range(2)]
     stub = _EpisodeStub()
     driver = TaskDriver(partial(iter, tasks), _IdlePolicy(), None)
     with pimm.World(virtual_time=True) as world:
@@ -99,14 +99,14 @@ def test_a_sweep_numbers_its_trials_across_every_task():
     """Trials of tasks that differ are numbered once over the whole plan."""
     quick = Task(instruction_source='quick', timeout_sec=1.0)
     slow = Task(instruction_source='slow', timeout_sec=90.0)
-    pairs = [(quick, {keys.EVAL_TASK: 'quick'}), (slow, {keys.EVAL_TASK: 'slow'}), (slow, {keys.EVAL_TASK: 'slow'})]
+    pairs = [(quick, {EVAL_TASK: 'quick'}), (slow, {EVAL_TASK: 'slow'}), (slow, {EVAL_TASK: 'slow'})]
     trials = number_trials(pairs)
 
     assert [t.timeout_sec for t in trials] == [1.0, 90.0, 90.0]
-    assert [t.meta[keys.EVAL_TRIAL_INDEX] for t in trials] == [0, 1, 2]
-    assert [t.meta[keys.EVAL_TRIAL_COUNT] for t in trials] == [3, 3, 3]
-    assert [t.meta[keys.EVAL_TASK] for t in trials] == ['quick', 'slow', 'slow']
-    assert [t.prepare_args[keys.SCENE] for t in trials] == [params for _, params in pairs]
+    assert [t.meta[EVAL_TRIAL_INDEX] for t in trials] == [0, 1, 2]
+    assert [t.meta[EVAL_TRIAL_COUNT] for t in trials] == [3, 3, 3]
+    assert [t.meta[EVAL_TASK] for t in trials] == ['quick', 'slow', 'slow']
+    assert [t.prepare_args[SCENE] for t in trials] == [params for _, params in pairs]
 
 
 def test_timed_sweep_needs_an_output_dir():

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -8,6 +8,7 @@ import pytest
 
 import pimm
 from positronic import keys, telemetry, telemetry_keys
+from positronic.cfg.eval import number_trials
 from positronic.cli.eval.run import TaskDriver, _pass_span, main, timed_pass
 from positronic.eval import Embodiment, Eval, Task
 from positronic.policy import Policy, Session
@@ -85,6 +86,21 @@ def test_the_driver_asks_for_its_tasks_one_at_a_time():
         drive_scheduler(world.start([driver, stub]), steps=200)
 
     assert stub.asked == tasks
+
+
+def test_a_sweep_numbers_its_trials_across_every_task():
+    """A sweep runs tasks that differ — each with its own time budget and its own scene params — and numbers
+    the trials once over the whole plan, so a trial's place does not restart with every task."""
+    quick = Task(instruction_source='quick', timeout_sec=1.0)
+    slow = Task(instruction_source='slow', timeout_sec=90.0)
+    pairs = [(quick, {keys.EVAL_TASK: 'quick'}), (slow, {keys.EVAL_TASK: 'slow'}), (slow, {keys.EVAL_TASK: 'slow'})]
+    trials = number_trials(pairs)
+
+    assert [t.timeout_sec for t in trials] == [1.0, 90.0, 90.0]
+    assert [t.meta[keys.EVAL_TRIAL_INDEX] for t in trials] == [0, 1, 2]
+    assert [t.meta[keys.EVAL_TRIAL_COUNT] for t in trials] == [3, 3, 3]
+    assert [t.meta[keys.EVAL_TASK] for t in trials] == ['quick', 'slow', 'slow']
+    assert [t.prepare_args[keys.SCENE] for t in trials] == [params for _, params in pairs]
 
 
 def test_timed_sweep_needs_an_output_dir():

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -11,8 +11,9 @@ from typing import Any
 import numpy as np
 
 import pimm
-from positronic import geom, keys
+from positronic import geom
 from positronic.drivers import vendor_import
+from positronic.drivers.roboarm.models import CONTROL_FRAME, JOINT_NAMES, URDF
 from positronic.drivers.utils import DriverRun, MoveAbandoned, MoveStatus, log_failure
 
 from . import RobotStatus, State, command
@@ -345,10 +346,10 @@ class Robot(pimm.ControlSystem):
         gripper = attach_robotiq_2f85(root, meshes)
         add_default_frame(root, EE_LINK)
         return {
-            keys.URDF: ET.tostring(root, encoding='unicode'),
-            keys.JOINT_NAMES: _revolute_joint_names(urdf_xml),
+            URDF: ET.tostring(root, encoding='unicode'),
+            JOINT_NAMES: _revolute_joint_names(urdf_xml),
             'meshes': meshes,
-            keys.CONTROL_FRAME: DEFAULT_FRAME,
+            CONTROL_FRAME: DEFAULT_FRAME,
             'gripper': gripper,
         }
 

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -13,7 +13,7 @@ import numpy as np
 import pimm
 from positronic import geom
 from positronic.drivers import vendor_import
-from positronic.drivers.roboarm.models import CONTROL_FRAME, JOINT_NAMES, URDF
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.utils import DriverRun, MoveAbandoned, MoveStatus, log_failure
 
 from . import RobotStatus, State, command
@@ -346,10 +346,10 @@ class Robot(pimm.ControlSystem):
         gripper = attach_robotiq_2f85(root, meshes)
         add_default_frame(root, EE_LINK)
         return {
-            URDF: ET.tostring(root, encoding='unicode'),
-            JOINT_NAMES: _revolute_joint_names(urdf_xml),
+            roboarm_keys.URDF: ET.tostring(root, encoding='unicode'),
+            roboarm_keys.JOINT_NAMES: _revolute_joint_names(urdf_xml),
             'meshes': meshes,
-            CONTROL_FRAME: DEFAULT_FRAME,
+            roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
             'gripper': gripper,
         }
 

--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -350,7 +350,7 @@ class Robot(pimm.ControlSystem):
             roboarm_keys.JOINT_NAMES: _revolute_joint_names(urdf_xml),
             'meshes': meshes,
             roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
-            'gripper': gripper,
+            roboarm_keys.GRIPPER: gripper,
         }
 
     def _init_robot(self, robot):

--- a/positronic/drivers/roboarm/ik.py
+++ b/positronic/drivers/roboarm/ik.py
@@ -15,9 +15,9 @@ import numpy as np
 from scipy.optimize import lsq_linear
 from scipy.spatial.transform import Rotation as ScipyRotation
 
-from positronic import geom, keys
+from positronic import geom
 from positronic.dataset import transforms
-from positronic.drivers.roboarm.models import DEFAULT_FRAME
+from positronic.drivers.roboarm.models import CONTROL_FRAME, DEFAULT_FRAME, EE_FRAME, JOINT_NAMES, URDF
 
 _QUAT = geom.Rotation.Representation.QUAT
 
@@ -117,23 +117,23 @@ def assert_default_frame(statics) -> None:
     TODO(#550): delete this. ``CONTROL_FRAME`` goes with that issue, leaving nothing to check: poses are at
     ``DEFAULT_FRAME`` by contract and ``EE_FRAME`` states any offset from it.
     """
-    if keys.CONTROL_FRAME not in statics:
+    if CONTROL_FRAME not in statics:
         return
-    frame = statics[keys.CONTROL_FRAME]
+    frame = statics[CONTROL_FRAME]
     if frame != DEFAULT_FRAME:
         raise ValueError(
             f'Poses are reported in {frame!r}, but every frame transform is measured from {DEFAULT_FRAME!r} '
             '— see positronic/drivers/roboarm/README.md'
         )
-    if keys.URDF in statics:
-        frame_transform(statics[keys.URDF], frame, frame)
+    if URDF in statics:
+        frame_transform(statics[URDF], frame, frame)
 
 
 def ee_frame(episode) -> geom.Transform3D:
     """Where an episode's poses sit relative to ``DEFAULT_FRAME`` — identity unless a codec moved them."""
-    if keys.EE_FRAME not in episode:
+    if EE_FRAME not in episode:
         return geom.Transform3D.identity
-    return geom.Transform3D.from_vector(np.asarray(episode[keys.EE_FRAME], dtype=np.float64), _QUAT)
+    return geom.Transform3D.from_vector(np.asarray(episode[EE_FRAME], dtype=np.float64), _QUAT)
 
 
 def pose_anchor(episode) -> tuple[str, geom.Transform3D]:
@@ -143,9 +143,9 @@ def pose_anchor(episode) -> tuple[str, geom.Transform3D]:
     that name is exact — ``DEFAULT_FRAME`` was added alongside those frames, not in place of them — so the branch
     lives until those datasets are re-expressed, not longer.
     """
-    if keys.EE_FRAME in episode:
+    if EE_FRAME in episode:
         return DEFAULT_FRAME, ee_frame(episode)
-    return episode[keys.CONTROL_FRAME], geom.Transform3D.identity
+    return episode[CONTROL_FRAME], geom.Transform3D.identity
 
 
 def _parse_target(target_ee_pose_vec):
@@ -463,7 +463,7 @@ def ik_joints_from_episode(episode, solver_cls, tgt_ee_pose_key, current_q_key):
     codec has moved elsewhere come back to that frame first.
     """
     frame, offset = pose_anchor(episode)
-    solver = solver_cls(episode[keys.URDF], episode[keys.JOINT_NAMES], frame)
+    solver = solver_cls(episode[URDF], episode[JOINT_NAMES], frame)
     move = partial(change_frame, transform=offset.inv)
     targets = transforms.Elementwise(episode[tgt_ee_pose_key], transforms.lazy_sequence(move))
     return transforms.pairwise(episode[current_q_key], targets, solver.solve)

--- a/positronic/drivers/roboarm/ik.py
+++ b/positronic/drivers/roboarm/ik.py
@@ -17,7 +17,8 @@ from scipy.spatial.transform import Rotation as ScipyRotation
 
 from positronic import geom
 from positronic.dataset import transforms
-from positronic.drivers.roboarm.models import CONTROL_FRAME, DEFAULT_FRAME, EE_FRAME, JOINT_NAMES, URDF
+from positronic.drivers.roboarm import keys as roboarm_keys
+from positronic.drivers.roboarm.models import DEFAULT_FRAME
 
 _QUAT = geom.Rotation.Representation.QUAT
 
@@ -117,23 +118,23 @@ def assert_default_frame(statics) -> None:
     TODO(#550): delete this. ``CONTROL_FRAME`` goes with that issue, leaving nothing to check: poses are at
     ``DEFAULT_FRAME`` by contract and ``EE_FRAME`` states any offset from it.
     """
-    if CONTROL_FRAME not in statics:
+    if roboarm_keys.CONTROL_FRAME not in statics:
         return
-    frame = statics[CONTROL_FRAME]
+    frame = statics[roboarm_keys.CONTROL_FRAME]
     if frame != DEFAULT_FRAME:
         raise ValueError(
             f'Poses are reported in {frame!r}, but every frame transform is measured from {DEFAULT_FRAME!r} '
             '— see positronic/drivers/roboarm/README.md'
         )
-    if URDF in statics:
-        frame_transform(statics[URDF], frame, frame)
+    if roboarm_keys.URDF in statics:
+        frame_transform(statics[roboarm_keys.URDF], frame, frame)
 
 
 def ee_frame(episode) -> geom.Transform3D:
     """Where an episode's poses sit relative to ``DEFAULT_FRAME`` — identity unless a codec moved them."""
-    if EE_FRAME not in episode:
+    if roboarm_keys.EE_FRAME not in episode:
         return geom.Transform3D.identity
-    return geom.Transform3D.from_vector(np.asarray(episode[EE_FRAME], dtype=np.float64), _QUAT)
+    return geom.Transform3D.from_vector(np.asarray(episode[roboarm_keys.EE_FRAME], dtype=np.float64), _QUAT)
 
 
 def pose_anchor(episode) -> tuple[str, geom.Transform3D]:
@@ -143,9 +144,9 @@ def pose_anchor(episode) -> tuple[str, geom.Transform3D]:
     that name is exact — ``DEFAULT_FRAME`` was added alongside those frames, not in place of them — so the branch
     lives until those datasets are re-expressed, not longer.
     """
-    if EE_FRAME in episode:
+    if roboarm_keys.EE_FRAME in episode:
         return DEFAULT_FRAME, ee_frame(episode)
-    return episode[CONTROL_FRAME], geom.Transform3D.identity
+    return episode[roboarm_keys.CONTROL_FRAME], geom.Transform3D.identity
 
 
 def _parse_target(target_ee_pose_vec):
@@ -463,7 +464,7 @@ def ik_joints_from_episode(episode, solver_cls, tgt_ee_pose_key, current_q_key):
     codec has moved elsewhere come back to that frame first.
     """
     frame, offset = pose_anchor(episode)
-    solver = solver_cls(episode[URDF], episode[JOINT_NAMES], frame)
+    solver = solver_cls(episode[roboarm_keys.URDF], episode[roboarm_keys.JOINT_NAMES], frame)
     move = partial(change_frame, transform=offset.inv)
     targets = transforms.Elementwise(episode[tgt_ee_pose_key], transforms.lazy_sequence(move))
     return transforms.pairwise(episode[current_q_key], targets, solver.solve)

--- a/positronic/drivers/roboarm/keys.py
+++ b/positronic/drivers/roboarm/keys.py
@@ -6,6 +6,8 @@
 URDF = 'urdf'
 CONTROL_FRAME = 'control_frame'
 JOINT_NAMES = 'joint_names'
+# The gripper spec the viewer drives: the signal it reads, the joints it moves, their travel at full closure.
+GRIPPER = 'gripper'
 
 # Where the episode's poses sit relative to ``DEFAULT_FRAME``, as a ``[tx,ty,tz,qw,qx,qy,qz]`` transform.
 # Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.

--- a/positronic/drivers/roboarm/keys.py
+++ b/positronic/drivers/roboarm/keys.py
@@ -1,0 +1,12 @@
+"""The keys of the robot model an episode carries, and of the frame its poses are stated in."""
+
+# The robot model, carried in episode statics for the transforms that solve against it (``IKJointsAction``).
+# ``CONTROL_FRAME`` names the frame in ``URDF`` that the embodiment reports ``EE_POSE`` in; every embodiment
+# declares it as ``DEFAULT_FRAME``, and datasets recorded before that convention name their own frame.
+URDF = 'urdf'
+CONTROL_FRAME = 'control_frame'
+JOINT_NAMES = 'joint_names'
+
+# Where the episode's poses sit relative to ``DEFAULT_FRAME``, as a ``[tx,ty,tz,qw,qx,qy,qz]`` transform.
+# Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.
+EE_FRAME = 'ee_frame'

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -9,18 +9,7 @@ from pathlib import Path
 import numpy as np
 
 from positronic import geom, keys
-
-# The robot model, carried in episode statics for the transforms that solve against it (``IKJointsAction``).
-# ``CONTROL_FRAME`` names the frame in ``URDF`` that the embodiment reports ``EE_POSE`` in; every embodiment
-# declares it as ``DEFAULT_FRAME``, and datasets recorded before that convention name their own frame.
-URDF = 'urdf'
-CONTROL_FRAME = 'control_frame'
-JOINT_NAMES = 'joint_names'
-
-# Where the episode's poses sit relative to ``DEFAULT_FRAME``, as a ``[tx,ty,tz,qw,qx,qy,qz]`` transform.
-# Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.
-EE_FRAME = 'ee_frame'
-
+from positronic.drivers.roboarm import keys as roboarm_keys
 
 FLANGE_LINK = 'link8'
 DROID_EEF_LINK = 'droid_eef'
@@ -181,10 +170,10 @@ def bundled_franka_model() -> dict:
     gripper = attach_robotiq_2f85(arm_root, meshes)
     add_default_frame(arm_root, EE_LINK)
     return {
-        URDF: ET.tostring(arm_root, encoding='unicode'),
+        roboarm_keys.URDF: ET.tostring(arm_root, encoding='unicode'),
         'meshes': meshes,
-        JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
-        CONTROL_FRAME: DEFAULT_FRAME,
+        roboarm_keys.JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
+        roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
         'gripper': gripper,
     }
 
@@ -203,10 +192,10 @@ def bundled_panda_model() -> dict:
     mesh_files = {mesh.get('filename') for mesh in root.iter('mesh')}
     add_default_frame(root, EE_LINK)
     return {
-        URDF: ET.tostring(root, encoding='unicode'),
+        roboarm_keys.URDF: ET.tostring(root, encoding='unicode'),
         'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
-        JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
-        CONTROL_FRAME: DEFAULT_FRAME,
+        roboarm_keys.JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
+        roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
         # ``grip`` is recorded in [0, 1] (open→closed); each finger slides 0..0.04 m along its axis.
         'gripper': {'signal': keys.GRIP, 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
     }

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -10,6 +10,18 @@ import numpy as np
 
 from positronic import geom, keys
 
+# The robot model, carried in episode statics for the transforms that solve against it (``IKJointsAction``).
+# ``CONTROL_FRAME`` names the frame in ``URDF`` that the embodiment reports ``EE_POSE`` in; every embodiment
+# declares it as ``DEFAULT_FRAME``, and datasets recorded before that convention name their own frame.
+URDF = 'urdf'
+CONTROL_FRAME = 'control_frame'
+JOINT_NAMES = 'joint_names'
+
+# Where the episode's poses sit relative to ``DEFAULT_FRAME``, as a ``[tx,ty,tz,qw,qx,qy,qz]`` transform.
+# Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.
+EE_FRAME = 'ee_frame'
+
+
 FLANGE_LINK = 'link8'
 DROID_EEF_LINK = 'droid_eef'
 # The franka's own tool frame, ``F_T_EE`` off the flange. TODO(#550): move ``DEFAULT_FRAME`` to the flange.
@@ -169,10 +181,10 @@ def bundled_franka_model() -> dict:
     gripper = attach_robotiq_2f85(arm_root, meshes)
     add_default_frame(arm_root, EE_LINK)
     return {
-        keys.URDF: ET.tostring(arm_root, encoding='unicode'),
+        URDF: ET.tostring(arm_root, encoding='unicode'),
         'meshes': meshes,
-        keys.JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
-        keys.CONTROL_FRAME: DEFAULT_FRAME,
+        JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
+        CONTROL_FRAME: DEFAULT_FRAME,
         'gripper': gripper,
     }
 
@@ -191,10 +203,10 @@ def bundled_panda_model() -> dict:
     mesh_files = {mesh.get('filename') for mesh in root.iter('mesh')}
     add_default_frame(root, EE_LINK)
     return {
-        keys.URDF: ET.tostring(root, encoding='unicode'),
+        URDF: ET.tostring(root, encoding='unicode'),
         'meshes': {name: (mesh_dir / name).read_bytes() for name in sorted(mesh_files)},
-        keys.JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
-        keys.CONTROL_FRAME: DEFAULT_FRAME,
+        JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
+        CONTROL_FRAME: DEFAULT_FRAME,
         # ``grip`` is recorded in [0, 1] (open→closed); each finger slides 0..0.04 m along its axis.
         'gripper': {'signal': keys.GRIP, 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
     }

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -134,7 +134,7 @@ def _bundled_robotiq_2f85() -> dict:
     return {
         'subtree': subtree,
         'meshes': {f.name: f.read_bytes() for f in sorted(mesh_dir.glob('*.stl'))},
-        'gripper': {'signal': keys.GRIP, 'joints': _ROBOTIQ_2F85_JOINTS, 'travel': 0.8},
+        roboarm_keys.GRIPPER: {'signal': keys.GRIP, 'joints': _ROBOTIQ_2F85_JOINTS, 'travel': 0.8},
     }
 
 
@@ -153,7 +153,7 @@ def attach_robotiq_2f85(arm_root: ET.Element, meshes: dict[str, bytes]) -> dict:
     gripper = _bundled_robotiq_2f85()
     arm_root.extend(ET.fromstring(f'<robot>{gripper["subtree"]}</robot>'))
     meshes.update(gripper['meshes'])
-    return gripper['gripper']
+    return gripper[roboarm_keys.GRIPPER]
 
 
 @lru_cache(maxsize=1)
@@ -174,7 +174,7 @@ def bundled_franka_model() -> dict:
         'meshes': meshes,
         roboarm_keys.JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
         roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
-        'gripper': gripper,
+        roboarm_keys.GRIPPER: gripper,
     }
 
 
@@ -197,5 +197,5 @@ def bundled_panda_model() -> dict:
         roboarm_keys.JOINT_NAMES: [f'joint{i}' for i in range(1, 8)],
         roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
         # ``grip`` is recorded in [0, 1] (open→closed); each finger slides 0..0.04 m along its axis.
-        'gripper': {'signal': keys.GRIP, 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
+        roboarm_keys.GRIPPER: {'signal': keys.GRIP, 'joints': ['finger_joint1', 'finger_joint2'], 'travel': 0.04},
     }

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -5,12 +5,12 @@ from pathlib import Path
 import numpy as np
 
 import pimm
-from positronic import geom, keys
+from positronic import geom
 from positronic.drivers.motors.feetech import MotorBus
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.kinematics import Kinematics
-from positronic.drivers.roboarm.models import DEFAULT_FRAME, add_default_frame
+from positronic.drivers.roboarm.models import CONTROL_FRAME, DEFAULT_FRAME, JOINT_NAMES, URDF, add_default_frame
 from positronic.drivers.utils import DriverRun, MoveStatus, log_failure
 
 
@@ -218,9 +218,9 @@ class Robot(pimm.ControlSystem):
         urdf = ET.fromstring(Path(_SO101_URDF_PATH).read_text())
         add_default_frame(urdf, _SO101_EE_LINK)
         return {
-            keys.URDF: ET.tostring(urdf, encoding='unicode'),
-            keys.JOINT_NAMES: _SO101_JOINT_NAMES,
-            keys.CONTROL_FRAME: DEFAULT_FRAME,
+            URDF: ET.tostring(urdf, encoding='unicode'),
+            JOINT_NAMES: _SO101_JOINT_NAMES,
+            CONTROL_FRAME: DEFAULT_FRAME,
         }
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:

--- a/positronic/drivers/roboarm/so101/driver.py
+++ b/positronic/drivers/roboarm/so101/driver.py
@@ -9,8 +9,9 @@ from positronic import geom
 from positronic.drivers.motors.feetech import MotorBus
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.roboarm.kinematics import Kinematics
-from positronic.drivers.roboarm.models import CONTROL_FRAME, DEFAULT_FRAME, JOINT_NAMES, URDF, add_default_frame
+from positronic.drivers.roboarm.models import DEFAULT_FRAME, add_default_frame
 from positronic.drivers.utils import DriverRun, MoveStatus, log_failure
 
 
@@ -218,9 +219,9 @@ class Robot(pimm.ControlSystem):
         urdf = ET.fromstring(Path(_SO101_URDF_PATH).read_text())
         add_default_frame(urdf, _SO101_EE_LINK)
         return {
-            URDF: ET.tostring(urdf, encoding='unicode'),
-            JOINT_NAMES: _SO101_JOINT_NAMES,
-            CONTROL_FRAME: DEFAULT_FRAME,
+            roboarm_keys.URDF: ET.tostring(urdf, encoding='unicode'),
+            roboarm_keys.JOINT_NAMES: _SO101_JOINT_NAMES,
+            roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
         }
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:

--- a/positronic/drivers/roboarm/tests/test_ik.py
+++ b/positronic/drivers/roboarm/tests/test_ik.py
@@ -8,6 +8,7 @@ import pytest
 from positronic import geom, keys
 from positronic.dataset.episode import EpisodeContainer
 from positronic.dataset.tests.utils import DummySignal
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.roboarm.ik import (
     DLSIKSolver,
     DLSIKSolverWithLimits,
@@ -18,14 +19,10 @@ from positronic.drivers.roboarm.ik import (
     pose_anchor,
 )
 from positronic.drivers.roboarm.models import (
-    CONTROL_FRAME,
     DEFAULT_FRAME,
     DROID_EE_FRAME,
     DROID_EEF_LINK,
-    EE_FRAME,
     EE_LINK,
-    JOINT_NAMES,
-    URDF,
     bundled_franka_model,
     bundled_panda_model,
 )
@@ -115,9 +112,9 @@ def test_ik_joints_from_episode():
         data={
             keys.JOINTS: DummySignal(ts, q_traj),
             keys.TARGET_EE_POSE: DummySignal(ts, ee_poses),
-            URDF: PANDA_URDF,
-            JOINT_NAMES: PANDA_JOINTS,
-            CONTROL_FRAME: PANDA_FRAME,
+            roboarm_keys.URDF: PANDA_URDF,
+            roboarm_keys.JOINT_NAMES: PANDA_JOINTS,
+            roboarm_keys.CONTROL_FRAME: PANDA_FRAME,
         }
     )
     result = ik_joints_from_episode(episode, DLSIKSolverWithLimits, keys.TARGET_EE_POSE, keys.JOINTS)
@@ -146,7 +143,7 @@ def test_ik_joints_from_episode_solves_targets_a_codec_moved():
     ts = np.arange(n_steps, dtype=np.int64) * 100_000_000
     q_traj = np.linspace(TEST_CONFIGS[0], TEST_CONFIGS[1], n_steps)
     quat = geom.Rotation.Representation.QUAT
-    urdf = bundled_panda_model()[URDF]
+    urdf = bundled_panda_model()[roboarm_keys.URDF]
     offset = geom.Transform3D(np.array([0.0, 0.0, 0.05]), geom.Rotation.from_euler([0.0, 0.0, np.pi / 4]))
     anchored = [geom.Transform3D.from_vector(_fk_site(urdf, q, DEFAULT_FRAME), quat) for q in q_traj]
     moved = np.array([(pose * offset).as_vector(quat) for pose in anchored])
@@ -155,10 +152,10 @@ def test_ik_joints_from_episode_solves_targets_a_codec_moved():
         data={
             keys.JOINTS: DummySignal(ts, q_traj),
             keys.TARGET_EE_POSE: DummySignal(ts, moved),
-            URDF: urdf,
-            JOINT_NAMES: PANDA_JOINTS,
-            CONTROL_FRAME: DEFAULT_FRAME,
-            EE_FRAME: offset.as_vector(quat),
+            roboarm_keys.URDF: urdf,
+            roboarm_keys.JOINT_NAMES: PANDA_JOINTS,
+            roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
+            roboarm_keys.EE_FRAME: offset.as_vector(quat),
         }
     )
     result = ik_joints_from_episode(episode, DLSIKSolverWithLimits, keys.TARGET_EE_POSE, keys.JOINTS)
@@ -169,7 +166,7 @@ def test_ik_joints_from_episode_solves_targets_a_codec_moved():
 
 
 def test_frame_transform_reproduces_droid_eef_across_configs():
-    urdf = bundled_franka_model()[URDF]
+    urdf = bundled_franka_model()[roboarm_keys.URDF]
     transform = frame_transform(urdf, EE_LINK, DROID_EEF_LINK)
     quat = geom.Rotation.Representation.QUAT
     for q in TEST_CONFIGS:
@@ -181,13 +178,13 @@ def test_frame_transform_reproduces_droid_eef_across_configs():
 
 @pytest.mark.parametrize('model', [bundled_franka_model(), bundled_panda_model()], ids=['franka', 'panda'])
 def test_bundled_model_declares_the_frame_it_reports_in(model):
-    assert model[CONTROL_FRAME] == DEFAULT_FRAME
-    frame_transform(model[URDF], DEFAULT_FRAME, DEFAULT_FRAME)
+    assert model[roboarm_keys.CONTROL_FRAME] == DEFAULT_FRAME
+    frame_transform(model[roboarm_keys.URDF], DEFAULT_FRAME, DEFAULT_FRAME)
 
 
 def test_declared_droid_frame_matches_the_model_geometry():
     """The checkpoint states its frame as a constant; this pins it to where the model puts that frame."""
-    urdf = bundled_franka_model()[URDF]
+    urdf = bundled_franka_model()[roboarm_keys.URDF]
     measured = frame_transform(urdf, DEFAULT_FRAME, DROID_EEF_LINK)
     np.testing.assert_allclose(DROID_EE_FRAME.as_matrix, measured.as_matrix, atol=1e-9)
 
@@ -198,15 +195,17 @@ def test_default_frame_still_coincides_with_the_franka_tool_frame():
     ``DEFAULT_FRAME`` sits. TODO(#550): moving it to the flange invalidates both, so re-express those
     recordings and re-measure the constant in the same change.
     """
-    transform = frame_transform(bundled_franka_model()[URDF], DEFAULT_FRAME, EE_LINK)
+    transform = frame_transform(bundled_franka_model()[roboarm_keys.URDF], DEFAULT_FRAME, EE_LINK)
     np.testing.assert_allclose(transform.as_matrix, np.eye(4), atol=1e-12)
 
 
 def test_pose_anchor_reads_a_stated_frame_and_falls_back_to_the_name():
     offset = geom.Transform3D(np.array([0.0, 0.0, 0.05]), geom.Rotation.identity)
     quat = geom.Rotation.Representation.QUAT
-    stated = EpisodeContainer(data={CONTROL_FRAME: PANDA_FRAME, EE_FRAME: offset.as_vector(quat)})
-    legacy = EpisodeContainer(data={CONTROL_FRAME: PANDA_FRAME})
+    stated = EpisodeContainer(
+        data={roboarm_keys.CONTROL_FRAME: PANDA_FRAME, roboarm_keys.EE_FRAME: offset.as_vector(quat)}
+    )
+    legacy = EpisodeContainer(data={roboarm_keys.CONTROL_FRAME: PANDA_FRAME})
 
     assert pose_anchor(stated)[0] == DEFAULT_FRAME
     np.testing.assert_allclose(pose_anchor(stated)[1].as_vector(quat), offset.as_vector(quat), atol=1e-12)
@@ -217,11 +216,11 @@ def test_pose_anchor_reads_a_stated_frame_and_falls_back_to_the_name():
 def test_frame_transform_rejects_frames_across_movable_joints():
     # rules-allow: hardcoded-keys — the base link is this test's input, not a name it shares with the code
     with pytest.raises(ValueError, match='movable joints'):
-        frame_transform(bundled_franka_model()[URDF], 'link0', EE_LINK)
+        frame_transform(bundled_franka_model()[roboarm_keys.URDF], 'link0', EE_LINK)
 
 
 def test_frame_transform_identity_when_frames_match():
-    transform = frame_transform(bundled_franka_model()[URDF], EE_LINK, EE_LINK)
+    transform = frame_transform(bundled_franka_model()[roboarm_keys.URDF], EE_LINK, EE_LINK)
     np.testing.assert_allclose(transform.translation, 0.0, atol=1e-12)
     assert transform.rotation == geom.Rotation.identity
 

--- a/positronic/drivers/roboarm/tests/test_ik.py
+++ b/positronic/drivers/roboarm/tests/test_ik.py
@@ -18,18 +18,22 @@ from positronic.drivers.roboarm.ik import (
     pose_anchor,
 )
 from positronic.drivers.roboarm.models import (
+    CONTROL_FRAME,
     DEFAULT_FRAME,
     DROID_EE_FRAME,
     DROID_EEF_LINK,
+    EE_FRAME,
     EE_LINK,
+    JOINT_NAMES,
+    URDF,
     bundled_franka_model,
     bundled_panda_model,
 )
 from positronic.utils import package_assets_path
 
-URDF = Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text()
-JOINT_NAMES = [f'joint{i}' for i in range(1, 8)]
-CONTROL_FRAME = 'end_effector'
+PANDA_URDF = Path(package_assets_path('assets/mujoco/panda_ik.xml')).read_text()
+PANDA_JOINTS = [f'joint{i}' for i in range(1, 8)]
+PANDA_FRAME = 'end_effector'
 
 # Reachable joint configs: home, stretched, and two arbitrary
 TEST_CONFIGS = [
@@ -43,10 +47,10 @@ def _fk(urdf_xml, q):
     """Compute EE pose [tx,ty,tz,w,x,y,z] via MuJoCo FK."""
     model = mj.MjModel.from_xml_string(urdf_xml)
     data = mj.MjData(model)
-    qpos_ids = [model.joint(n).qposadr.item() for n in JOINT_NAMES]
+    qpos_ids = [model.joint(n).qposadr.item() for n in PANDA_JOINTS]
     data.qpos[qpos_ids] = q
     mj.mj_forward(model, data)
-    site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, CONTROL_FRAME)
+    site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, PANDA_FRAME)
     pos = data.site_xpos[site_id].copy()
     quat = np.empty(4)
     mj.mju_mat2Quat(quat, data.site_xmat[site_id])
@@ -66,9 +70,9 @@ def _assert_fk_matches(solver, q_start, target_pose, pos_tol=1e-3, rot_tol=1e-2)
 
 @pytest.mark.parametrize('q_target', TEST_CONFIGS)
 def test_dls_solver(q_target):
-    target_pose = _fk(URDF, q_target)
+    target_pose = _fk(PANDA_URDF, q_target)
     q_start = np.zeros(7)
-    solver = DLSIKSolver(URDF, JOINT_NAMES, CONTROL_FRAME)
+    solver = DLSIKSolver(PANDA_URDF, PANDA_JOINTS, PANDA_FRAME)
     _assert_fk_matches(solver, q_start, target_pose)
 
 
@@ -79,9 +83,9 @@ def test_dls_solver_with_limits():
     well from nearby starting points but can get stuck from far away (q=zeros).
     In practice, ik_joints_from_episode always passes the current joint state.
     """
-    solver = DLSIKSolverWithLimits(URDF, JOINT_NAMES, CONTROL_FRAME)
+    solver = DLSIKSolverWithLimits(PANDA_URDF, PANDA_JOINTS, PANDA_FRAME)
     for q_target in TEST_CONFIGS:
-        target_pose = _fk(URDF, q_target)
+        target_pose = _fk(PANDA_URDF, q_target)
         # Start from a perturbed target (±0.3 rad), clamped to limits
         rng = np.random.RandomState(42)
         q_start = np.clip(q_target + rng.uniform(-0.3, 0.3, 7), solver._joint_lower, solver._joint_upper)
@@ -93,9 +97,9 @@ def test_dls_solver_with_limits():
 
 @pytest.mark.parametrize('q_target', TEST_CONFIGS)
 def test_lm_solver(q_target):
-    target_pose = _fk(URDF, q_target)
+    target_pose = _fk(PANDA_URDF, q_target)
     q_start = np.zeros(7)
-    solver = LMIKSolver(URDF, JOINT_NAMES, CONTROL_FRAME)
+    solver = LMIKSolver(PANDA_URDF, PANDA_JOINTS, PANDA_FRAME)
     _assert_fk_matches(solver, q_start, target_pose)
 
 
@@ -105,29 +109,29 @@ def test_ik_joints_from_episode():
 
     # Generate a trajectory of EE poses from known joint configs
     q_traj = np.linspace(TEST_CONFIGS[0], TEST_CONFIGS[1], n_steps)
-    ee_poses = np.array([_fk(URDF, q) for q in q_traj])
+    ee_poses = np.array([_fk(PANDA_URDF, q) for q in q_traj])
 
     episode = EpisodeContainer(
         data={
             keys.JOINTS: DummySignal(ts, q_traj),
             keys.TARGET_EE_POSE: DummySignal(ts, ee_poses),
-            keys.URDF: URDF,
-            keys.JOINT_NAMES: JOINT_NAMES,
-            keys.CONTROL_FRAME: CONTROL_FRAME,
+            URDF: PANDA_URDF,
+            JOINT_NAMES: PANDA_JOINTS,
+            CONTROL_FRAME: PANDA_FRAME,
         }
     )
     result = ik_joints_from_episode(episode, DLSIKSolverWithLimits, keys.TARGET_EE_POSE, keys.JOINTS)
 
     assert len(result) == n_steps
     for i in range(n_steps):
-        reconstructed_pose = _fk(URDF, result[i][0])
+        reconstructed_pose = _fk(PANDA_URDF, result[i][0])
         np.testing.assert_allclose(reconstructed_pose[:3], ee_poses[i, :3], atol=1e-3)
 
 
 def _fk_site(urdf_xml, q, frame):
     model = _prepare_spec(urdf_xml, frame).compile()
     data = mj.MjData(model)  # pyright: ignore[reportAttributeAccessIssue]
-    qpos_ids = [model.joint(n).qposadr.item() for n in JOINT_NAMES]
+    qpos_ids = [model.joint(n).qposadr.item() for n in PANDA_JOINTS]
     data.qpos[qpos_ids] = q
     mj.mj_forward(model, data)  # pyright: ignore[reportAttributeAccessIssue]
     sid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, frame)  # pyright: ignore[reportAttributeAccessIssue]
@@ -142,7 +146,7 @@ def test_ik_joints_from_episode_solves_targets_a_codec_moved():
     ts = np.arange(n_steps, dtype=np.int64) * 100_000_000
     q_traj = np.linspace(TEST_CONFIGS[0], TEST_CONFIGS[1], n_steps)
     quat = geom.Rotation.Representation.QUAT
-    urdf = bundled_panda_model()[keys.URDF]
+    urdf = bundled_panda_model()[URDF]
     offset = geom.Transform3D(np.array([0.0, 0.0, 0.05]), geom.Rotation.from_euler([0.0, 0.0, np.pi / 4]))
     anchored = [geom.Transform3D.from_vector(_fk_site(urdf, q, DEFAULT_FRAME), quat) for q in q_traj]
     moved = np.array([(pose * offset).as_vector(quat) for pose in anchored])
@@ -151,10 +155,10 @@ def test_ik_joints_from_episode_solves_targets_a_codec_moved():
         data={
             keys.JOINTS: DummySignal(ts, q_traj),
             keys.TARGET_EE_POSE: DummySignal(ts, moved),
-            keys.URDF: urdf,
-            keys.JOINT_NAMES: JOINT_NAMES,
-            keys.CONTROL_FRAME: DEFAULT_FRAME,
-            keys.EE_FRAME: offset.as_vector(quat),
+            URDF: urdf,
+            JOINT_NAMES: PANDA_JOINTS,
+            CONTROL_FRAME: DEFAULT_FRAME,
+            EE_FRAME: offset.as_vector(quat),
         }
     )
     result = ik_joints_from_episode(episode, DLSIKSolverWithLimits, keys.TARGET_EE_POSE, keys.JOINTS)
@@ -165,7 +169,7 @@ def test_ik_joints_from_episode_solves_targets_a_codec_moved():
 
 
 def test_frame_transform_reproduces_droid_eef_across_configs():
-    urdf = bundled_franka_model()[keys.URDF]
+    urdf = bundled_franka_model()[URDF]
     transform = frame_transform(urdf, EE_LINK, DROID_EEF_LINK)
     quat = geom.Rotation.Representation.QUAT
     for q in TEST_CONFIGS:
@@ -177,13 +181,13 @@ def test_frame_transform_reproduces_droid_eef_across_configs():
 
 @pytest.mark.parametrize('model', [bundled_franka_model(), bundled_panda_model()], ids=['franka', 'panda'])
 def test_bundled_model_declares_the_frame_it_reports_in(model):
-    assert model[keys.CONTROL_FRAME] == DEFAULT_FRAME
-    frame_transform(model[keys.URDF], DEFAULT_FRAME, DEFAULT_FRAME)
+    assert model[CONTROL_FRAME] == DEFAULT_FRAME
+    frame_transform(model[URDF], DEFAULT_FRAME, DEFAULT_FRAME)
 
 
 def test_declared_droid_frame_matches_the_model_geometry():
     """The checkpoint states its frame as a constant; this pins it to where the model puts that frame."""
-    urdf = bundled_franka_model()[keys.URDF]
+    urdf = bundled_franka_model()[URDF]
     measured = frame_transform(urdf, DEFAULT_FRAME, DROID_EEF_LINK)
     np.testing.assert_allclose(DROID_EE_FRAME.as_matrix, measured.as_matrix, atol=1e-9)
 
@@ -194,39 +198,39 @@ def test_default_frame_still_coincides_with_the_franka_tool_frame():
     ``DEFAULT_FRAME`` sits. TODO(#550): moving it to the flange invalidates both, so re-express those
     recordings and re-measure the constant in the same change.
     """
-    transform = frame_transform(bundled_franka_model()[keys.URDF], DEFAULT_FRAME, EE_LINK)
+    transform = frame_transform(bundled_franka_model()[URDF], DEFAULT_FRAME, EE_LINK)
     np.testing.assert_allclose(transform.as_matrix, np.eye(4), atol=1e-12)
 
 
 def test_pose_anchor_reads_a_stated_frame_and_falls_back_to_the_name():
     offset = geom.Transform3D(np.array([0.0, 0.0, 0.05]), geom.Rotation.identity)
     quat = geom.Rotation.Representation.QUAT
-    stated = EpisodeContainer(data={keys.CONTROL_FRAME: CONTROL_FRAME, keys.EE_FRAME: offset.as_vector(quat)})
-    legacy = EpisodeContainer(data={keys.CONTROL_FRAME: CONTROL_FRAME})
+    stated = EpisodeContainer(data={CONTROL_FRAME: PANDA_FRAME, EE_FRAME: offset.as_vector(quat)})
+    legacy = EpisodeContainer(data={CONTROL_FRAME: PANDA_FRAME})
 
     assert pose_anchor(stated)[0] == DEFAULT_FRAME
     np.testing.assert_allclose(pose_anchor(stated)[1].as_vector(quat), offset.as_vector(quat), atol=1e-12)
-    assert pose_anchor(legacy)[0] == CONTROL_FRAME
+    assert pose_anchor(legacy)[0] == PANDA_FRAME
     np.testing.assert_allclose(pose_anchor(legacy)[1].as_matrix, np.eye(4), atol=1e-12)
 
 
 def test_frame_transform_rejects_frames_across_movable_joints():
     # rules-allow: hardcoded-keys — the base link is this test's input, not a name it shares with the code
     with pytest.raises(ValueError, match='movable joints'):
-        frame_transform(bundled_franka_model()[keys.URDF], 'link0', EE_LINK)
+        frame_transform(bundled_franka_model()[URDF], 'link0', EE_LINK)
 
 
 def test_frame_transform_identity_when_frames_match():
-    transform = frame_transform(bundled_franka_model()[keys.URDF], EE_LINK, EE_LINK)
+    transform = frame_transform(bundled_franka_model()[URDF], EE_LINK, EE_LINK)
     np.testing.assert_allclose(transform.translation, 0.0, atol=1e-12)
     assert transform.rotation == geom.Rotation.identity
 
 
 @pytest.mark.parametrize('solver_cls', [DLSIKSolver, DLSIKSolverWithLimits])
 def test_pickle_roundtrip(solver_cls):
-    solver = solver_cls(URDF, JOINT_NAMES, CONTROL_FRAME)
+    solver = solver_cls(PANDA_URDF, PANDA_JOINTS, PANDA_FRAME)
     # Force model build before pickling
-    target_pose = _fk(URDF, TEST_CONFIGS[0])
+    target_pose = _fk(PANDA_URDF, TEST_CONFIGS[0])
     solver.solve(np.zeros(7), target_pose)
     assert solver._mj is not None
 
@@ -240,5 +244,5 @@ def test_pickle_roundtrip(solver_cls):
     # Still works after unpickling (start near target for limit-aware solver)
     q_start = TEST_CONFIGS[0] + 0.05
     q_result = restored.solve(q_start, target_pose)
-    result_pose = _fk(URDF, q_result)
+    result_pose = _fk(PANDA_URDF, q_result)
     np.testing.assert_allclose(result_pose[:3], target_pose[:3], atol=1e-3)

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -22,8 +22,9 @@ import mujoco as mj
 import numpy as np
 
 import pimm
-from positronic import geom, keys
+from positronic import geom
 from positronic.drivers import vendor_import
+from positronic.drivers.roboarm.models import CONTROL_FRAME, JOINT_NAMES
 from positronic.drivers.utils import DriverRun, MoveAbandoned, MoveStatus, log_failure
 from positronic.utils import package_assets_path
 
@@ -360,7 +361,7 @@ class Robot(pimm.ControlSystem):
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         with _opened(self._connect, self._channel, self._sim) as vendor:
             chain = self._chain(vendor, should_stop, clock)
-            meta = {'robot': 'i2rt_yam', keys.JOINT_NAMES: list(_JOINT_NAMES), keys.CONTROL_FRAME: DEFAULT_FRAME}
+            meta = {'robot': 'i2rt_yam', JOINT_NAMES: list(_JOINT_NAMES), CONTROL_FRAME: DEFAULT_FRAME}
             self.robot_meta.emit(meta)
 
             q_target, grip_target = yield from chain.park(0.0)  # nothing has asked for a grip yet

--- a/positronic/drivers/roboarm/yam.py
+++ b/positronic/drivers/roboarm/yam.py
@@ -24,7 +24,7 @@ import numpy as np
 import pimm
 from positronic import geom
 from positronic.drivers import vendor_import
-from positronic.drivers.roboarm.models import CONTROL_FRAME, JOINT_NAMES
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.utils import DriverRun, MoveAbandoned, MoveStatus, log_failure
 from positronic.utils import package_assets_path
 
@@ -361,7 +361,11 @@ class Robot(pimm.ControlSystem):
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         with _opened(self._connect, self._channel, self._sim) as vendor:
             chain = self._chain(vendor, should_stop, clock)
-            meta = {'robot': 'i2rt_yam', JOINT_NAMES: list(_JOINT_NAMES), CONTROL_FRAME: DEFAULT_FRAME}
+            meta = {
+                'robot': 'i2rt_yam',
+                roboarm_keys.JOINT_NAMES: list(_JOINT_NAMES),
+                roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
+            }
             self.robot_meta.emit(meta)
 
             q_target, grip_target = yield from chain.park(0.0)  # nothing has asked for a grip yet

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -101,7 +101,7 @@ class Task:
 # [✓] A session reports the model's meta, so a policy holds none.
 # [✓] The episode call carries the session that runs it, so the Harness holds no policy.
 # [✓] The episode call names where it records, so the Harness holds no dataset.
-# [ ] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.
+# [✓] A benchmark answers ``tasks(spec)``, so positronic holds no task table of its own.
 # [ ] A task carries its instruction as data, so no trial reads it after the reset.
 # [ ] A sim eval config names a selection, and a spec flag narrows it to one task.
 # [ ] A task names its model, and a routed policy serves the mix.

--- a/positronic/eval.py
+++ b/positronic/eval.py
@@ -6,8 +6,50 @@ import pimm
 from positronic import keys
 from positronic.dataset.serializers import Serializer
 
+# The names of what a trial readies before it opens. ``Embodiment.prepare_handlers`` is keyed by them, and so
+# is what a ``Task`` asks for. A rig with two arms names its arms ``arm.{side}``. ``SCENE`` means the world
+# this trial runs in is ready, drawn by whichever handler the embodiment binds.
+ARM = 'arm'
+GRIPPER = 'gripper'
+SCENE = 'scene'
+
+# The 3D viewer's pointers into an episode: which signals carry joint angles, which carry poses. One arm per
+# ``JOINT_SIGNALS`` entry, each running ``URDF`` and standing where ``MOUNTS`` places it, keyed by that signal.
+JOINT_SIGNALS = 'joint_signals'
+POSE_SIGNALS = 'pose_signals'
+MOUNTS = 'mounts'
+
 # Embodiment-level static meta: how recorded signals map to the canonical robot fields.
-ROBOT_STATIC_META = {keys.JOINT_SIGNALS: [keys.JOINTS], keys.POSE_SIGNALS: [keys.EE_POSE, keys.TARGET_EE_POSE]}
+ROBOT_STATIC_META = {JOINT_SIGNALS: [keys.JOINTS], POSE_SIGNALS: [keys.EE_POSE, keys.TARGET_EE_POSE]}
+
+# What a trial reports when it ends, in its episode's statics. The harness writes ``EVAL_TERMINATED``:
+# True when a terminal was delivered inside the budget, False when the budget ran out. ``EVAL_SUCCESS``
+# rides in the terminal payload an env's adapter returns, so an env that reports it only on success
+# leaves it absent on failure — a reader defaults it rather than assuming a False.
+EVAL_SUCCESS = 'eval.success'
+EVAL_TERMINATED = 'eval.terminated'
+# Whether the trial charged each model call the wall time it really took. True on a real rig whatever the
+# task asked, since it cannot hold the world still while the model thinks.
+EVAL_CHARGE_INFERENCE_TIME = 'eval.charge_inference_time'
+# Who ended the trial, when it was not the task's own ground truth. An env's terminal leaves it absent.
+EVAL_ENDED_BY = 'eval.ended_by'
+ENDED_BY_OPERATOR = 'operator'
+
+# The conditions the trial ran under, stamped into its episode's statics. ``EVAL_UNIVERSE`` is ``'sim'`` or
+# ``'real'``; ``EVAL_TIMEOUT`` is absent from an episode whose task set no budget.
+EVAL_UNIVERSE = 'eval.universe'
+EVAL_EMBODIMENT = 'eval.embodiment'
+EVAL_TIMEOUT = 'eval.timeout'
+
+# A trial's place in its eval's sweep, stamped into every trial's params and recorded in its episode's
+# statics. ``EVAL_SEED`` also rides an env's reset token, where absent means the env draws its own.
+EVAL_SEED = 'eval.seed'
+EVAL_TRIAL_INDEX = 'eval.trial_index'
+EVAL_TRIAL_COUNT = 'eval.trial_count'
+
+# The id of the task a trial runs, as the benchmark names it. The episode records it; positronic never reads
+# inside it.
+EVAL_TASK = 'eval.task'
 
 
 @dataclass
@@ -52,7 +94,7 @@ class Embodiment:
     descriptor: str
     observations: dict[str, Observation]
     commands: dict[str, Command]
-    # Everything a trial readies before it opens, keyed by ``keys.ARM``, ``keys.SCENE`` and the like. One
+    # Everything a trial readies before it opens, keyed by ``ARM``, ``SCENE`` and the like. One
     # handler serves one caller, so a device backing several command channels appears here once.
     prepare_handlers: dict[str, pimm.calls.ControlSystemHandler[Any, None]]
     static_meta: dict[str, Any]

--- a/positronic/eval/__init__.py
+++ b/positronic/eval/__init__.py
@@ -3,53 +3,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import pimm
-from positronic import keys
 from positronic.dataset.serializers import Serializer
-
-# The names of what a trial readies before it opens. ``Embodiment.prepare_handlers`` is keyed by them, and so
-# is what a ``Task`` asks for. A rig with two arms names its arms ``arm.{side}``. ``SCENE`` means the world
-# this trial runs in is ready, drawn by whichever handler the embodiment binds.
-ARM = 'arm'
-GRIPPER = 'gripper'
-SCENE = 'scene'
-
-# The 3D viewer's pointers into an episode: which signals carry joint angles, which carry poses. One arm per
-# ``JOINT_SIGNALS`` entry, each running ``URDF`` and standing where ``MOUNTS`` places it, keyed by that signal.
-JOINT_SIGNALS = 'joint_signals'
-POSE_SIGNALS = 'pose_signals'
-MOUNTS = 'mounts'
+from positronic.eval import keys as eval_keys
+from positronic.keys import EE_POSE, JOINTS, TARGET_EE_POSE
 
 # Embodiment-level static meta: how recorded signals map to the canonical robot fields.
-ROBOT_STATIC_META = {JOINT_SIGNALS: [keys.JOINTS], POSE_SIGNALS: [keys.EE_POSE, keys.TARGET_EE_POSE]}
-
-# What a trial reports when it ends, in its episode's statics. The harness writes ``EVAL_TERMINATED``:
-# True when a terminal was delivered inside the budget, False when the budget ran out. ``EVAL_SUCCESS``
-# rides in the terminal payload an env's adapter returns, so an env that reports it only on success
-# leaves it absent on failure — a reader defaults it rather than assuming a False.
-EVAL_SUCCESS = 'eval.success'
-EVAL_TERMINATED = 'eval.terminated'
-# Whether the trial charged each model call the wall time it really took. True on a real rig whatever the
-# task asked, since it cannot hold the world still while the model thinks.
-EVAL_CHARGE_INFERENCE_TIME = 'eval.charge_inference_time'
-# Who ended the trial, when it was not the task's own ground truth. An env's terminal leaves it absent.
-EVAL_ENDED_BY = 'eval.ended_by'
-ENDED_BY_OPERATOR = 'operator'
-
-# The conditions the trial ran under, stamped into its episode's statics. ``EVAL_UNIVERSE`` is ``'sim'`` or
-# ``'real'``; ``EVAL_TIMEOUT`` is absent from an episode whose task set no budget.
-EVAL_UNIVERSE = 'eval.universe'
-EVAL_EMBODIMENT = 'eval.embodiment'
-EVAL_TIMEOUT = 'eval.timeout'
-
-# A trial's place in its eval's sweep, stamped into every trial's params and recorded in its episode's
-# statics. ``EVAL_SEED`` also rides an env's reset token, where absent means the env draws its own.
-EVAL_SEED = 'eval.seed'
-EVAL_TRIAL_INDEX = 'eval.trial_index'
-EVAL_TRIAL_COUNT = 'eval.trial_count'
-
-# The id of the task a trial runs, as the benchmark names it. The episode records it; positronic never reads
-# inside it.
-EVAL_TASK = 'eval.task'
+ROBOT_STATIC_META = {eval_keys.JOINT_SIGNALS: [JOINTS], eval_keys.POSE_SIGNALS: [EE_POSE, TARGET_EE_POSE]}
 
 
 @dataclass

--- a/positronic/eval/keys.py
+++ b/positronic/eval/keys.py
@@ -1,0 +1,43 @@
+"""The keys a trial writes: what it readies, the conditions it runs under and the verdict it ends on."""
+
+# The names of what a trial readies before it opens. ``Embodiment.prepare_handlers`` is keyed by them, and so
+# is what a ``Task`` asks for. A rig with two arms names its arms ``arm.{side}``. ``SCENE`` means the world
+# this trial runs in is ready, drawn by whichever handler the embodiment binds.
+ARM = 'arm'
+GRIPPER = 'gripper'
+SCENE = 'scene'
+
+# The 3D viewer's pointers into an episode: which signals carry joint angles, which carry poses. One arm per
+# ``JOINT_SIGNALS`` entry, each running ``URDF`` and standing where ``MOUNTS`` places it, keyed by that signal.
+JOINT_SIGNALS = 'joint_signals'
+POSE_SIGNALS = 'pose_signals'
+MOUNTS = 'mounts'
+
+# What a trial reports when it ends, in its episode's statics. The harness writes ``TERMINATED``:
+# True when a terminal was delivered inside the budget, False when the budget ran out. ``SUCCESS``
+# rides in the terminal payload an env's adapter returns, so an env that reports it only on success
+# leaves it absent on failure — a reader defaults it rather than assuming a False.
+SUCCESS = 'eval.success'
+TERMINATED = 'eval.terminated'
+# Whether the trial charged each model call the wall time it really took. True on a real rig whatever the
+# task asked, since it cannot hold the world still while the model thinks.
+CHARGE_INFERENCE_TIME = 'eval.charge_inference_time'
+# Who ended the trial, when it was not the task's own ground truth. An env's terminal leaves it absent.
+ENDED_BY = 'eval.ended_by'
+ENDED_BY_OPERATOR = 'operator'
+
+# The conditions the trial ran under, stamped into its episode's statics. ``UNIVERSE`` is ``'sim'`` or
+# ``'real'``; ``TIMEOUT`` is absent from an episode whose task set no budget.
+UNIVERSE = 'eval.universe'
+EMBODIMENT = 'eval.embodiment'
+TIMEOUT = 'eval.timeout'
+
+# A trial's place in its eval's sweep, stamped into every trial's params and recorded in its episode's
+# statics. ``SEED`` also rides an env's reset token, where absent means the env draws its own.
+SEED = 'eval.seed'
+TRIAL_INDEX = 'eval.trial_index'
+TRIAL_COUNT = 'eval.trial_count'
+
+# The id of the task a trial runs, as the benchmark names it. The episode records it; positronic never reads
+# inside it.
+TASK = 'eval.task'

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -19,7 +19,8 @@ from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.cli.eval.run import prepare_output_dir, run, run_world
 from positronic.dataset.local_dataset import load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
-from positronic.eval import ENDED_BY_OPERATOR, EVAL_ENDED_BY, Embodiment, Task
+from positronic.eval import Embodiment, Task
+from positronic.eval import keys as eval_keys
 from positronic.policy import Policy
 from positronic.policy.harness import Rollout
 
@@ -64,7 +65,7 @@ class KeyboardOperator(KeyboardControl):
                 except Exception as e:
                     logger.error(f'Episode failed to open: {e}')
             case 'p':
-                self.done.emit({EVAL_ENDED_BY: ENDED_BY_OPERATOR})
+                self.done.emit({eval_keys.ENDED_BY: eval_keys.ENDED_BY_OPERATOR})
 
 
 def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir=None):

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -15,12 +15,11 @@ import positronic.cfg.embodiment
 import positronic.cfg.eval.real.droid
 import positronic.cfg.policy as policy_cfg
 from pimm.logging import init_logging
-from positronic import keys
 from positronic.cfg.eval.sim.positronic import stack_cubes
 from positronic.cli.eval.run import prepare_output_dir, run, run_world
 from positronic.dataset.local_dataset import load_all_datasets
 from positronic.drivers.keyboard import KeyboardControl
-from positronic.eval import Embodiment, Task
+from positronic.eval import ENDED_BY_OPERATOR, EVAL_ENDED_BY, Embodiment, Task
 from positronic.policy import Policy
 from positronic.policy.harness import Rollout
 
@@ -65,7 +64,7 @@ class KeyboardOperator(KeyboardControl):
                 except Exception as e:
                     logger.error(f'Episode failed to open: {e}')
             case 'p':
-                self.done.emit({keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR})
+                self.done.emit({EVAL_ENDED_BY: ENDED_BY_OPERATOR})
 
 
 def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir=None):

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -116,6 +116,9 @@ ENDED_BY_OPERATOR = 'operator'
 EVAL_UNIVERSE = 'eval.universe'
 EVAL_EMBODIMENT = 'eval.embodiment'
 EVAL_TIMEOUT = 'eval.timeout'
+# The seconds the benchmark gives an episode of this task, carried in the trial's params. A config reads it
+# to set the trial's deadline, which the harness records as ``EVAL_TIMEOUT``.
+EVAL_EPISODE_LENGTH = 'eval.episode_length'
 
 # A trial's place in its eval's sweep, stamped into every trial's params and recorded in its episode's
 # statics. ``EVAL_SEED`` also rides an env's reset token, where absent means the env draws its own.
@@ -123,9 +126,10 @@ EVAL_SEED = 'eval.seed'
 EVAL_TRIAL_INDEX = 'eval.trial_index'
 EVAL_TRIAL_COUNT = 'eval.trial_count'
 
-# The scene a trial runs, named by its eval config in the trial's params and read back by the benchmark's
-# adapter to build the env's reset token. LIBERO names a task inside a suite plus the render and control
-# settings its server caches an env by; RoboLab names a task and the phrasing of its instruction.
+# The scene a trial runs. The benchmark's adapter names the task in the trial's params, from the task records
+# the env answers with, and reads them back to build the env's reset token; the eval config adds the settings
+# it owns. LIBERO names a task inside a suite plus the render and control settings its server caches an env
+# by; RoboLab names a task and the phrasing of its instruction.
 EVAL_SUITE = 'eval.suite'
 EVAL_TASK_ID = 'eval.task_id'
 EVAL_CAMERA_RESOLUTION = 'eval.camera_resolution'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -1,10 +1,11 @@
 """Canonical names on the positronic embodiment/inference wire.
 
-Every sim adapter and embodiment produces the signal keys and every vendor codec consumes them;
-every policy reports the handshake fields and the analysis configs read them back off an episode. They
-are defined here once, in a leaf module with no positronic imports, so a rename is a single-site
-change the type checker propagates instead of a string literal duplicated across codecs, evals,
-configs, adapters and datasets.
+Every sim adapter and embodiment produces them and every vendor codec consumes them. They are defined
+here once, in a leaf module with no positronic imports, so a rename is a single-site change the type
+checker propagates instead of a string literal duplicated across codecs, configs, adapters and datasets.
+A key one package owns lives in that package instead: a trial's in ``positronic.eval``, the robot
+model's in ``drivers.roboarm.models``, the inference handshake's in ``policy.base``, a benchmark's in
+its adapter.
 """
 
 # The arm's command channel, and the signals a recorded command unfolds into. The suffixes are the
@@ -16,13 +17,6 @@ TARGET_JOINTS = f'{ROBOT_COMMAND}.joints'
 
 # The gripper's command channel: a scalar target beside the arm's ``ROBOT_COMMAND``.
 TARGET_GRIP = 'target_grip'
-
-# The names of what a trial readies before it opens. ``Embodiment.prepare_handlers`` is keyed by them, and so
-# is what a ``Task`` asks for. A rig with two arms names its arms ``arm.{side}``. ``SCENE`` means the world
-# this trial runs in is ready, drawn by whichever handler the embodiment binds.
-ARM = 'arm'
-GRIPPER = 'gripper'
-SCENE = 'scene'
 
 
 def is_robot_command(name: str) -> bool:
@@ -60,82 +54,3 @@ EXTERIOR_IMAGE = f'{IMAGE_PREFIX}exterior'
 OBS_TIME_NS = 'obs_time_ns'
 WALL_TIME_NS = 'wall_time_ns'
 ACTION_TIMESTAMP = 'timestamp'
-
-# The robot model, carried in episode statics for the transforms that solve against it (``IKJointsAction``).
-# ``CONTROL_FRAME`` names the frame in ``URDF`` that the embodiment reports ``EE_POSE`` in; every embodiment
-# declares it as ``models.DEFAULT_FRAME``, and datasets recorded before that convention name their own frame.
-URDF = 'urdf'
-CONTROL_FRAME = 'control_frame'
-JOINT_NAMES = 'joint_names'
-
-# Where the episode's poses sit relative to ``models.DEFAULT_FRAME``, as a ``[tx,ty,tz,qw,qx,qy,qz]``
-# transform. Absent means they are in that frame itself; ``ChangeEEFrame`` writes it when it moves them.
-EE_FRAME = 'ee_frame'
-
-# The 3D viewer's pointers into an episode: which signals carry joint angles, which carry poses. One arm per
-# ``JOINT_SIGNALS`` entry, each running ``URDF`` and standing where ``MOUNTS`` places it, keyed by that signal.
-JOINT_SIGNALS = 'joint_signals'
-POSE_SIGNALS = 'pose_signals'
-MOUNTS = 'mounts'
-
-# The inference handshake: a policy reports these through its ``meta``, a remote policy nests the serving
-# half under ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy
-# at the top level and the vendor under ``SERVER``, so a reader composes a prefix with a field:
-# f'{SERVER_META}.{TYPE}'.
-TYPE = 'type'
-CHECKPOINT_ID = 'checkpoint_id'
-CHECKPOINT_PATH = 'checkpoint_path'
-EXPERIMENT_NAME = 'experiment_name'
-CONFIG_NAME = 'config_name'
-HOST = 'host'
-PORT = 'port'
-SERVER = 'server'
-# The wire half of the handshake: what the server declares for the rig to build and obey.
-LOCAL_STACK = 'local_stack'
-COMPRESS_IMAGES = 'compress_images'
-POSITRONIC_VERSION = 'positronic_version'
-
-POLICY_META = 'inference.policy'
-SERVER_META = f'{POLICY_META}.{SERVER}'
-
-# What a trial reports when it ends, in its episode's statics. The harness writes ``EVAL_TERMINATED``:
-# True when a terminal was delivered inside the budget, False when the budget ran out. ``EVAL_SUCCESS``
-# rides in the terminal payload an env's adapter returns, so an env that reports it only on success
-# leaves it absent on failure — a reader defaults it rather than assuming a False.
-EVAL_SUCCESS = 'eval.success'
-EVAL_TERMINATED = 'eval.terminated'
-# Whether the trial charged each model call the wall time it really took. True on a real rig whatever the
-# task asked, since it cannot hold the world still while the model thinks.
-EVAL_CHARGE_INFERENCE_TIME = 'eval.charge_inference_time'
-# Who ended the trial, when it was not the task's own ground truth. An env's terminal leaves it absent.
-EVAL_ENDED_BY = 'eval.ended_by'
-ENDED_BY_OPERATOR = 'operator'
-
-# The conditions the trial ran under, stamped into its episode's statics. ``EVAL_UNIVERSE`` is ``'sim'`` or
-# ``'real'``; ``EVAL_TIMEOUT`` is absent from an episode whose task set no budget.
-EVAL_UNIVERSE = 'eval.universe'
-EVAL_EMBODIMENT = 'eval.embodiment'
-EVAL_TIMEOUT = 'eval.timeout'
-# The seconds the benchmark gives an episode of this task; a config sets the trial's deadline from it.
-EVAL_EPISODE_LENGTH = 'eval.episode_length'
-
-# A trial's place in its eval's sweep, stamped into every trial's params and recorded in its episode's
-# statics. ``EVAL_SEED`` also rides an env's reset token, where absent means the env draws its own.
-EVAL_SEED = 'eval.seed'
-EVAL_TRIAL_INDEX = 'eval.trial_index'
-EVAL_TRIAL_COUNT = 'eval.trial_count'
-
-# The id of the task a trial runs, as the benchmark names it. The episode records it; positronic never reads
-# inside it.
-EVAL_TASK = 'eval.task'
-
-# The scene a trial runs: the task, as the benchmark's adapter names it from the env's task records, plus the
-# settings the eval config owns; the adapter reads them back into the reset token. LIBERO names a task by
-# suite and index plus the render and control settings its server caches an env by; RoboLab adds the phrasing
-# of its instruction.
-EVAL_SUITE = 'eval.suite'
-EVAL_TASK_ID = 'eval.task_id'
-EVAL_CAMERA_RESOLUTION = 'eval.camera_resolution'
-EVAL_CONTROL_MODE = 'eval.control_mode'
-EVAL_SETTLE_STEPS = 'eval.settle_steps'
-EVAL_INSTRUCTION_TYPE = 'eval.instruction_type'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -116,8 +116,7 @@ ENDED_BY_OPERATOR = 'operator'
 EVAL_UNIVERSE = 'eval.universe'
 EVAL_EMBODIMENT = 'eval.embodiment'
 EVAL_TIMEOUT = 'eval.timeout'
-# The seconds the benchmark gives an episode of this task, carried in the trial's params. A config reads it
-# to set the trial's deadline, which the harness records as ``EVAL_TIMEOUT``.
+# The seconds the benchmark gives an episode of this task; a config sets the trial's deadline from it.
 EVAL_EPISODE_LENGTH = 'eval.episode_length'
 
 # A trial's place in its eval's sweep, stamped into every trial's params and recorded in its episode's
@@ -126,14 +125,14 @@ EVAL_SEED = 'eval.seed'
 EVAL_TRIAL_INDEX = 'eval.trial_index'
 EVAL_TRIAL_COUNT = 'eval.trial_count'
 
-# The id of the task a trial runs, as the benchmark names it. Every task record carries it, and the episode
-# records it, so a report groups trials by task across benchmarks. positronic never reads inside it.
+# The id of the task a trial runs, as the benchmark names it. The episode records it; positronic never reads
+# inside it.
 EVAL_TASK = 'eval.task'
 
-# The scene a trial runs. The benchmark's adapter names the task in the trial's params, from the task records
-# the env answers with, and reads them back to build the env's reset token; the eval config adds the settings
-# it owns. LIBERO names a task by its suite and its index, plus the render and control settings its server
-# caches an env by; RoboLab names the task with its id, plus the phrasing of its instruction.
+# The scene a trial runs: the task, as the benchmark's adapter names it from the env's task records, plus the
+# settings the eval config owns; the adapter reads them back into the reset token. LIBERO names a task by
+# suite and index plus the render and control settings its server caches an env by; RoboLab adds the phrasing
+# of its instruction.
 EVAL_SUITE = 'eval.suite'
 EVAL_TASK_ID = 'eval.task_id'
 EVAL_CAMERA_RESOLUTION = 'eval.camera_resolution'

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -3,9 +3,8 @@
 Every sim adapter and embodiment produces them and every vendor codec consumes them. They are defined
 here once, in a leaf module with no positronic imports, so a rename is a single-site change the type
 checker propagates instead of a string literal duplicated across codecs, configs, adapters and datasets.
-A key one package owns lives in that package instead: a trial's in ``positronic.eval``, the robot
-model's in ``drivers.roboarm.models``, the inference handshake's in ``policy.base``, a benchmark's in
-its adapter.
+A key one package owns lives in that package's own ``keys`` module instead: a trial's in ``eval.keys``,
+the robot model's in ``drivers.roboarm.keys``, and so on.
 """
 
 # The arm's command channel, and the signals a recorded command unfolds into. The suffixes are the

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -126,14 +126,17 @@ EVAL_SEED = 'eval.seed'
 EVAL_TRIAL_INDEX = 'eval.trial_index'
 EVAL_TRIAL_COUNT = 'eval.trial_count'
 
+# The id of the task a trial runs, as the benchmark names it. Every task record carries it, and the episode
+# records it, so a report groups trials by task across benchmarks. positronic never reads inside it.
+EVAL_TASK = 'eval.task'
+
 # The scene a trial runs. The benchmark's adapter names the task in the trial's params, from the task records
 # the env answers with, and reads them back to build the env's reset token; the eval config adds the settings
-# it owns. LIBERO names a task inside a suite plus the render and control settings its server caches an env
-# by; RoboLab names a task and the phrasing of its instruction.
+# it owns. LIBERO names a task by its suite and its index, plus the render and control settings its server
+# caches an env by; RoboLab names the task with its id, plus the phrasing of its instruction.
 EVAL_SUITE = 'eval.suite'
 EVAL_TASK_ID = 'eval.task_id'
 EVAL_CAMERA_RESOLUTION = 'eval.camera_resolution'
 EVAL_CONTROL_MODE = 'eval.control_mode'
 EVAL_SETTLE_STEPS = 'eval.settle_steps'
-EVAL_TASK = 'eval.task'
 EVAL_INSTRUCTION_TYPE = 'eval.instruction_type'

--- a/positronic/offboard/keys.py
+++ b/positronic/offboard/keys.py
@@ -1,0 +1,10 @@
+"""The keys of the server's own entries in the meta it hands a client."""
+
+# The server's own entries in the ``META`` it hands over: where it serves, which checkpoint it resolved, and
+# what the rig builds and obeys — the local stack spec, image compression, the positronic version it runs.
+HOST = 'host'
+PORT = 'port'
+CHECKPOINT_ID = 'checkpoint_id'
+LOCAL_STACK = 'local_stack'
+COMPRESS_IMAGES = 'compress_images'
+POSITRONIC_VERSION = 'positronic_version'

--- a/positronic/offboard/protocol.py
+++ b/positronic/offboard/protocol.py
@@ -25,15 +25,6 @@ META = 'meta'
 RESULT = 'result'
 ERROR = 'error'
 
-# The server's own entries in the ``META`` it hands over: where it serves, which checkpoint it resolved, and
-# what the rig builds and obeys — the local stack spec, image compression, the positronic version it runs.
-HOST = 'host'
-PORT = 'port'
-CHECKPOINT_ID = 'checkpoint_id'
-LOCAL_STACK = 'local_stack'
-COMPRESS_IMAGES = 'compress_images'
-POSITRONIC_VERSION = 'positronic_version'
-
 
 class ServerStatus(StrEnum):
     READY = 'ready'

--- a/positronic/offboard/protocol.py
+++ b/positronic/offboard/protocol.py
@@ -25,6 +25,15 @@ META = 'meta'
 RESULT = 'result'
 ERROR = 'error'
 
+# The server's own entries in the ``META`` it hands over: where it serves, which checkpoint it resolved, and
+# what the rig builds and obeys — the local stack spec, image compression, the positronic version it runs.
+HOST = 'host'
+PORT = 'port'
+CHECKPOINT_ID = 'checkpoint_id'
+LOCAL_STACK = 'local_stack'
+COMPRESS_IMAGES = 'compress_images'
+POSITRONIC_VERSION = 'positronic_version'
+
 
 class ServerStatus(StrEnum):
     READY = 'ready'

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -18,12 +18,21 @@ from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocke
 from starlette.datastructures import QueryParams
 
 from positronic.policy import Policy, Recorder
-from positronic.policy.base import CHECKPOINT_ID, COMPRESS_IMAGES, HOST, LOCAL_STACK, PORT, POSITRONIC_VERSION, Layer
+from positronic.policy.base import Layer
 from positronic.policy.executor import blocking
 from positronic.policy.spec import ModelSource, Pipeline, split
 
 from . import protocol
-from .protocol import deserialise, serialise
+from .protocol import (
+    CHECKPOINT_ID,
+    COMPRESS_IMAGES,
+    HOST,
+    LOCAL_STACK,
+    PORT,
+    POSITRONIC_VERSION,
+    deserialise,
+    serialise,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -17,22 +17,14 @@ import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect, WebSocketException, status
 from starlette.datastructures import QueryParams
 
+from positronic.offboard import keys as offboard_keys
 from positronic.policy import Policy, Recorder
 from positronic.policy.base import Layer
 from positronic.policy.executor import blocking
 from positronic.policy.spec import ModelSource, Pipeline, split
 
 from . import protocol
-from .protocol import (
-    CHECKPOINT_ID,
-    COMPRESS_IMAGES,
-    HOST,
-    LOCAL_STACK,
-    PORT,
-    POSITRONIC_VERSION,
-    deserialise,
-    serialise,
-)
+from .protocol import deserialise, serialise
 
 logger = logging.getLogger(__name__)
 
@@ -234,7 +226,7 @@ class PolicyServer:
         self._manager = PolicyManager(self._source)
         self.host = host
         self.port = port
-        self.metadata: dict[str, Any] = {HOST: host, PORT: port}
+        self.metadata: dict[str, Any] = {offboard_keys.HOST: host, offboard_keys.PORT: port}
         # Synced once; each session builds its own ``Recorder`` so concurrent streams never mix.
         self._recording_dir = pos3.sync(recording_dir) if recording_dir else None
 
@@ -347,11 +339,11 @@ class PolicyServer:
             meta = {
                 **self.metadata,
                 **self._source.meta(rid),
-                CHECKPOINT_ID: rid,
+                offboard_keys.CHECKPOINT_ID: rid,
                 **session.meta,
-                LOCAL_STACK: local_spec,
-                COMPRESS_IMAGES: border.compress_images,
-                POSITRONIC_VERSION: _pkg_version('positronic'),
+                offboard_keys.LOCAL_STACK: local_spec,
+                offboard_keys.COMPRESS_IMAGES: border.compress_images,
+                offboard_keys.POSITRONIC_VERSION: _pkg_version('positronic'),
             }
             await websocket.send_bytes(serialise({protocol.STATUS: protocol.ServerStatus.READY, protocol.META: meta}))
 

--- a/positronic/offboard/server.py
+++ b/positronic/offboard/server.py
@@ -17,9 +17,8 @@ import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect, WebSocketException, status
 from starlette.datastructures import QueryParams
 
-from positronic import keys
 from positronic.policy import Policy, Recorder
-from positronic.policy.base import Layer
+from positronic.policy.base import CHECKPOINT_ID, COMPRESS_IMAGES, HOST, LOCAL_STACK, PORT, POSITRONIC_VERSION, Layer
 from positronic.policy.executor import blocking
 from positronic.policy.spec import ModelSource, Pipeline, split
 
@@ -226,7 +225,7 @@ class PolicyServer:
         self._manager = PolicyManager(self._source)
         self.host = host
         self.port = port
-        self.metadata: dict[str, Any] = {keys.HOST: host, keys.PORT: port}
+        self.metadata: dict[str, Any] = {HOST: host, PORT: port}
         # Synced once; each session builds its own ``Recorder`` so concurrent streams never mix.
         self._recording_dir = pos3.sync(recording_dir) if recording_dir else None
 
@@ -339,11 +338,11 @@ class PolicyServer:
             meta = {
                 **self.metadata,
                 **self._source.meta(rid),
-                keys.CHECKPOINT_ID: rid,
+                CHECKPOINT_ID: rid,
                 **session.meta,
-                keys.LOCAL_STACK: local_spec,
-                keys.COMPRESS_IMAGES: border.compress_images,
-                keys.POSITRONIC_VERSION: _pkg_version('positronic'),
+                LOCAL_STACK: local_spec,
+                COMPRESS_IMAGES: border.compress_images,
+                POSITRONIC_VERSION: _pkg_version('positronic'),
             }
             await websocket.send_bytes(serialise({protocol.STATUS: protocol.ServerStatus.READY, protocol.META: meta}))
 

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -14,6 +14,7 @@ from positronic.drivers.roboarm import command
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _ConnectRetries
 from positronic.offboard.tests.conftest import ANSWER_SEC, round_trip
 from positronic.policy import RemotePolicy
+from positronic.policy.base import POSITRONIC_VERSION
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.remote import _prepare_obs
@@ -490,7 +491,7 @@ def test_declared_stack_built_at_session_open(open_session):
 
 
 def test_unknown_declared_entry_fails_before_motion():
-    policy, _ = _mock_remote_policy({'local_stack': {'name': 'run_arbitrary_code'}, keys.POSITRONIC_VERSION: '9.9.9'})
+    policy, _ = _mock_remote_policy({'local_stack': {'name': 'run_arbitrary_code'}, POSITRONIC_VERSION: '9.9.9'})
     with pytest.raises(ValueError, match='9.9.9'):
         policy.new_session()
 

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -12,9 +12,9 @@ from websockets.http11 import Response
 from positronic import keys, telemetry, telemetry_keys
 from positronic.drivers.roboarm import command
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _ConnectRetries
+from positronic.offboard.protocol import POSITRONIC_VERSION
 from positronic.offboard.tests.conftest import ANSWER_SEC, round_trip
 from positronic.policy import RemotePolicy
-from positronic.policy.base import POSITRONIC_VERSION
 from positronic.policy.codec import ActionHorizon
 from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.remote import _prepare_obs

--- a/positronic/offboard/tests/test_remote_policy.py
+++ b/positronic/offboard/tests/test_remote_policy.py
@@ -11,8 +11,8 @@ from websockets.http11 import Response
 
 from positronic import keys, telemetry, telemetry_keys
 from positronic.drivers.roboarm import command
+from positronic.offboard import keys as offboard_keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, _ConnectRetries
-from positronic.offboard.protocol import POSITRONIC_VERSION
 from positronic.offboard.tests.conftest import ANSWER_SEC, round_trip
 from positronic.policy import RemotePolicy
 from positronic.policy.codec import ActionHorizon
@@ -491,7 +491,10 @@ def test_declared_stack_built_at_session_open(open_session):
 
 
 def test_unknown_declared_entry_fails_before_motion():
-    policy, _ = _mock_remote_policy({'local_stack': {'name': 'run_arbitrary_code'}, POSITRONIC_VERSION: '9.9.9'})
+    policy, _ = _mock_remote_policy({
+        'local_stack': {'name': 'run_arbitrary_code'},
+        offboard_keys.POSITRONIC_VERSION: '9.9.9',
+    })
     with pytest.raises(ValueError, match='9.9.9'):
         policy.new_session()
 

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -13,8 +13,9 @@ from websockets.exceptions import InvalidStatus
 from websockets.sync.client import connect
 
 from positronic import keys
+from positronic.offboard import keys as offboard_keys
 from positronic.offboard.client import InferenceClient, InferenceSession, _ConnectRetries
-from positronic.offboard.protocol import POSITRONIC_VERSION, deserialise
+from positronic.offboard.protocol import deserialise
 from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer, bearer
 from positronic.offboard.server_utils import warmup
 from positronic.offboard.tests.conftest import round_trip
@@ -60,7 +61,7 @@ def test_full_inference_cycle(stub_server):
         assert session.metadata['model_name'] == 'stub'
         assert session.metadata['type'] == 'stub'
         assert session.metadata['local_stack'] == {'name': 'chunked_schedule'}
-        assert POSITRONIC_VERSION in session.metadata
+        assert offboard_keys.POSITRONIC_VERSION in session.metadata
 
         obs = {'image': 'test'}
         result = session.infer(obs)
@@ -465,7 +466,7 @@ def test_auth_accepts_the_token(authed_endpoint):
     try:
         # Reaching the handshake metadata means the upgrade completed and the server's first frame arrived.
         # An ingress that drops ``Upgrade`` never gets that far: it answers the handshake with a plain 200.
-        assert POSITRONIC_VERSION in session.metadata
+        assert offboard_keys.POSITRONIC_VERSION in session.metadata
     finally:
         session.close()
 

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -19,7 +19,7 @@ from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer
 from positronic.offboard.server_utils import warmup
 from positronic.offboard.tests.conftest import round_trip
 from positronic.policy import Codec, Policy, RemotePolicy, Session
-from positronic.policy.base import Runtime
+from positronic.policy.base import POSITRONIC_VERSION, Runtime
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.layers import ChunkedSchedule, TemporalStack
 from positronic.policy.spec import ModelSource, PolicySource, inline, remote
@@ -60,7 +60,7 @@ def test_full_inference_cycle(stub_server):
         assert session.metadata['model_name'] == 'stub'
         assert session.metadata['type'] == 'stub'
         assert session.metadata['local_stack'] == {'name': 'chunked_schedule'}
-        assert keys.POSITRONIC_VERSION in session.metadata
+        assert POSITRONIC_VERSION in session.metadata
 
         obs = {'image': 'test'}
         result = session.infer(obs)
@@ -465,7 +465,7 @@ def test_auth_accepts_the_token(authed_endpoint):
     try:
         # Reaching the handshake metadata means the upgrade completed and the server's first frame arrived.
         # An ingress that drops ``Upgrade`` never gets that far: it answers the handshake with a plain 200.
-        assert keys.POSITRONIC_VERSION in session.metadata
+        assert POSITRONIC_VERSION in session.metadata
     finally:
         session.close()
 

--- a/positronic/offboard/tests/test_server.py
+++ b/positronic/offboard/tests/test_server.py
@@ -14,12 +14,12 @@ from websockets.sync.client import connect
 
 from positronic import keys
 from positronic.offboard.client import InferenceClient, InferenceSession, _ConnectRetries
-from positronic.offboard.protocol import deserialise
+from positronic.offboard.protocol import POSITRONIC_VERSION, deserialise
 from positronic.offboard.server import AUTH_HEADER, AUTH_TOKEN_ENV, PolicyServer, bearer
 from positronic.offboard.server_utils import warmup
 from positronic.offboard.tests.conftest import round_trip
 from positronic.policy import Codec, Policy, RemotePolicy, Session
-from positronic.policy.base import POSITRONIC_VERSION, Runtime
+from positronic.policy.base import Runtime
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.layers import ChunkedSchedule, TemporalStack
 from positronic.policy.spec import ModelSource, PolicySource, inline, remote

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -4,19 +4,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from typing import Any, ClassVar
 
-# What a policy reports about itself through its ``meta``; a remote policy nests the server's meta under
-# ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy at the top
-# level and the vendor under ``SERVER``, so a reader composes a prefix with a field: f'{SERVER_META}.{TYPE}'.
-TYPE = 'type'
-CHECKPOINT_PATH = 'checkpoint_path'
-EXPERIMENT_NAME = 'experiment_name'
-CONFIG_NAME = 'config_name'
-SERVER = 'server'
-
-POLICY_META = 'inference.policy'
-SERVER_META = f'{POLICY_META}.{SERVER}'
-
-
 # Structural keys of the wire spec: ``|`` serializes as ``{SEQ: [...]}``, ``&`` as ``{PAR: [...]}``.
 SEQ = 'seq'
 PAR = 'par'

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -4,22 +4,14 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from typing import Any, ClassVar
 
-# The inference handshake: a policy reports these through its ``meta``, a remote policy nests the serving
-# half under ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy
-# at the top level and the vendor under ``SERVER``, so a reader composes a prefix with a field:
-# f'{SERVER_META}.{TYPE}'.
+# What a policy reports about itself through its ``meta``; a remote policy nests the server's meta under
+# ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy at the top
+# level and the vendor under ``SERVER``, so a reader composes a prefix with a field: f'{SERVER_META}.{TYPE}'.
 TYPE = 'type'
-CHECKPOINT_ID = 'checkpoint_id'
 CHECKPOINT_PATH = 'checkpoint_path'
 EXPERIMENT_NAME = 'experiment_name'
 CONFIG_NAME = 'config_name'
-HOST = 'host'
-PORT = 'port'
 SERVER = 'server'
-# The wire half of the handshake: what the server declares for the rig to build and obey.
-LOCAL_STACK = 'local_stack'
-COMPRESS_IMAGES = 'compress_images'
-POSITRONIC_VERSION = 'positronic_version'
 
 POLICY_META = 'inference.policy'
 SERVER_META = f'{POLICY_META}.{SERVER}'

--- a/positronic/policy/base.py
+++ b/positronic/policy/base.py
@@ -4,6 +4,27 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from typing import Any, ClassVar
 
+# The inference handshake: a policy reports these through its ``meta``, a remote policy nests the serving
+# half under ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy
+# at the top level and the vendor under ``SERVER``, so a reader composes a prefix with a field:
+# f'{SERVER_META}.{TYPE}'.
+TYPE = 'type'
+CHECKPOINT_ID = 'checkpoint_id'
+CHECKPOINT_PATH = 'checkpoint_path'
+EXPERIMENT_NAME = 'experiment_name'
+CONFIG_NAME = 'config_name'
+HOST = 'host'
+PORT = 'port'
+SERVER = 'server'
+# The wire half of the handshake: what the server declares for the rig to build and obey.
+LOCAL_STACK = 'local_stack'
+COMPRESS_IMAGES = 'compress_images'
+POSITRONIC_VERSION = 'positronic_version'
+
+POLICY_META = 'inference.policy'
+SERVER_META = f'{POLICY_META}.{SERVER}'
+
+
 # Structural keys of the wire spec: ``|`` serializes as ``{SEQ: [...]}``, ``&`` as ``{PAR: [...]}``.
 SEQ = 'seq'
 PAR = 'par'

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -23,7 +23,7 @@ from positronic.dataset.transforms import Elementwise, lazy_sequence
 from positronic.dataset.transforms.episode import Derive, EpisodeTransform, FromValue, Group, Identity
 from positronic.drivers.roboarm import command
 from positronic.drivers.roboarm.ik import assert_default_frame, change_frame, ee_frame
-from positronic.drivers.roboarm.models import DEFAULT_FRAME
+from positronic.drivers.roboarm.models import DEFAULT_FRAME, EE_FRAME
 from positronic.policy.base import PAR, SEQ, DelegatingSession, Layer, Session, _ComposedLayer
 from positronic.utils import merge_dicts
 
@@ -176,10 +176,10 @@ class _ComposedCodec(Codec):
         # ``ee_frame`` states where poses sit, not how a codec is configured, so declaring it means having moved
         # them. Agreeing on a value buys nothing here: the second move starts where the first left off. Under
         # ``&`` both halves see the same input, which is why the check belongs to sequential composition.
-        if obs_keys.EE_FRAME in left and obs_keys.EE_FRAME in right:
+        if EE_FRAME in left and EE_FRAME in right:
             raise ValueError(
-                f'sequential codecs both declare {obs_keys.EE_FRAME}: poses come out at the product of both '
-                f'moves, which neither {left[obs_keys.EE_FRAME]} nor {right[obs_keys.EE_FRAME]} names'
+                f'sequential codecs both declare {EE_FRAME}: poses come out at the product of both '
+                f'moves, which neither {left[EE_FRAME]} nor {right[EE_FRAME]} names'
             )
         return _merged_meta(left, right)
 
@@ -542,7 +542,7 @@ class ChangeEEFrame(Codec):
                     f'{DEFAULT_FRAME!r}; ``transform`` names the policy frame from there, so re-expressing an '
                     'episode a codec already moved would train on a frame the checkpoint does not declare'
                 )
-            derived: dict[str, Any] = {obs_keys.EE_FRAME: FromValue(codec._transform.as_vector(_QUAT))}
+            derived: dict[str, Any] = {EE_FRAME: FromValue(codec._transform.as_vector(_QUAT))}
             derived.update({key: partial(self._derive_pose, key) for key in codec._keys if key in episode})
             return Group(Derive(**derived), Identity())(episode)
 
@@ -576,7 +576,7 @@ class ChangeEEFrame(Codec):
 
     @property
     def meta(self):
-        return {obs_keys.EE_FRAME: self._transform.as_vector(_QUAT).tolist()}
+        return {EE_FRAME: self._transform.as_vector(_QUAT).tolist()}
 
     def to_spec(self):
         # Lists, not tuples, so the spec is identical before and after a wire round-trip.

--- a/positronic/policy/codec.py
+++ b/positronic/policy/codec.py
@@ -22,8 +22,9 @@ from positronic import keys as obs_keys
 from positronic.dataset.transforms import Elementwise, lazy_sequence
 from positronic.dataset.transforms.episode import Derive, EpisodeTransform, FromValue, Group, Identity
 from positronic.drivers.roboarm import command
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.roboarm.ik import assert_default_frame, change_frame, ee_frame
-from positronic.drivers.roboarm.models import DEFAULT_FRAME, EE_FRAME
+from positronic.drivers.roboarm.models import DEFAULT_FRAME
 from positronic.policy.base import PAR, SEQ, DelegatingSession, Layer, Session, _ComposedLayer
 from positronic.utils import merge_dicts
 
@@ -176,10 +177,10 @@ class _ComposedCodec(Codec):
         # ``ee_frame`` states where poses sit, not how a codec is configured, so declaring it means having moved
         # them. Agreeing on a value buys nothing here: the second move starts where the first left off. Under
         # ``&`` both halves see the same input, which is why the check belongs to sequential composition.
-        if EE_FRAME in left and EE_FRAME in right:
+        if roboarm_keys.EE_FRAME in left and roboarm_keys.EE_FRAME in right:
             raise ValueError(
-                f'sequential codecs both declare {EE_FRAME}: poses come out at the product of both '
-                f'moves, which neither {left[EE_FRAME]} nor {right[EE_FRAME]} names'
+                f'sequential codecs both declare {roboarm_keys.EE_FRAME}: poses come out at the product of both '
+                f'moves, which neither {left[roboarm_keys.EE_FRAME]} nor {right[roboarm_keys.EE_FRAME]} names'
             )
         return _merged_meta(left, right)
 
@@ -542,7 +543,7 @@ class ChangeEEFrame(Codec):
                     f'{DEFAULT_FRAME!r}; ``transform`` names the policy frame from there, so re-expressing an '
                     'episode a codec already moved would train on a frame the checkpoint does not declare'
                 )
-            derived: dict[str, Any] = {EE_FRAME: FromValue(codec._transform.as_vector(_QUAT))}
+            derived: dict[str, Any] = {roboarm_keys.EE_FRAME: FromValue(codec._transform.as_vector(_QUAT))}
             derived.update({key: partial(self._derive_pose, key) for key in codec._keys if key in episode})
             return Group(Derive(**derived), Identity())(episode)
 
@@ -576,7 +577,7 @@ class ChangeEEFrame(Codec):
 
     @property
     def meta(self):
-        return {EE_FRAME: self._transform.as_vector(_QUAT).tolist()}
+        return {roboarm_keys.EE_FRAME: self._transform.as_vector(_QUAT).tolist()}
 
     def to_spec(self):
         # Lists, not tuples, so the spec is identical before and after a wire round-trip.

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -12,8 +12,17 @@ from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.drivers.roboarm.ik import assert_default_frame
-from positronic.eval import Embodiment, Task
-from positronic.policy.base import Policy
+from positronic.eval import (
+    EVAL_CHARGE_INFERENCE_TIME,
+    EVAL_EMBODIMENT,
+    EVAL_TERMINATED,
+    EVAL_TIMEOUT,
+    EVAL_UNIVERSE,
+    SCENE,
+    Embodiment,
+    Task,
+)
+from positronic.policy.base import POLICY_META, Policy
 from positronic.policy.executor import Executor
 from positronic.utils import flatten_dict, frozen_view
 
@@ -226,14 +235,14 @@ class Harness(pimm.ControlSystem):
 
     def _build_episode_meta(self) -> dict[str, Any]:
         meta = self._statics()
-        meta[keys.EVAL_UNIVERSE] = 'sim' if self._embodiment.simulated else 'real'
-        meta[keys.EVAL_EMBODIMENT] = self._embodiment.descriptor
-        meta[keys.EVAL_CHARGE_INFERENCE_TIME] = self._charges_wall_time
+        meta[EVAL_UNIVERSE] = 'sim' if self._embodiment.simulated else 'real'
+        meta[EVAL_EMBODIMENT] = self._embodiment.descriptor
+        meta[EVAL_CHARGE_INFERENCE_TIME] = self._charges_wall_time
         if self._task.timeout_sec is not None:  # the recorder takes no nulls, and an unbounded episode has none
-            meta[keys.EVAL_TIMEOUT] = self._task.timeout_sec
+            meta[EVAL_TIMEOUT] = self._task.timeout_sec
         assert self._inference is not None, 'only a live episode has meta'
         for k, v in flatten_dict(self._inference.meta).items():
-            meta[f'{keys.POLICY_META}.{k}'] = v
+            meta[f'{POLICY_META}.{k}'] = v
         meta.update(self._task.meta)
         meta[keys.TASK] = self._task.instruction
         return meta
@@ -337,7 +346,7 @@ class Harness(pimm.ControlSystem):
         # goes back where it put it — the trial's own args, not a fresh draw. The scene is a person's to set
         # up, and is not asked again. The terminal waits on the move: a scene the next trial draws rebuilds
         # the model an unfinished one is still travelling under, which nothing but its timeout would end.
-        yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != keys.SCENE})
+        yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != SCENE})
         # The answer waits until the model is out of this episode's function. An in-process policy is one
         # model across every episode, so the session that the next ask opens must not overtake it. The move
         # back above gives the function that time.
@@ -445,9 +454,9 @@ class Harness(pimm.ControlSystem):
         """
         deadline_ns = self._deadline_ns
         if done is not None and done.data and (deadline_ns is None or done.ts <= deadline_ns):
-            return {**done.data, keys.EVAL_TERMINATED: True}
+            return {**done.data, EVAL_TERMINATED: True}
         if deadline_ns is not None and clock.now_ns() >= deadline_ns:
-            return {keys.EVAL_TERMINATED: False}
+            return {EVAL_TERMINATED: False}
         return None
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -12,17 +12,10 @@ from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.ds_writer_agent import DsWriterCommand
 from positronic.dataset.serializers import expand_suffixed
 from positronic.drivers.roboarm.ik import assert_default_frame
-from positronic.eval import (
-    EVAL_CHARGE_INFERENCE_TIME,
-    EVAL_EMBODIMENT,
-    EVAL_TERMINATED,
-    EVAL_TIMEOUT,
-    EVAL_UNIVERSE,
-    SCENE,
-    Embodiment,
-    Task,
-)
-from positronic.policy.base import POLICY_META, Policy
+from positronic.eval import Embodiment, Task
+from positronic.eval import keys as eval_keys
+from positronic.policy import keys as policy_keys
+from positronic.policy.base import Policy
 from positronic.policy.executor import Executor
 from positronic.utils import flatten_dict, frozen_view
 
@@ -235,14 +228,14 @@ class Harness(pimm.ControlSystem):
 
     def _build_episode_meta(self) -> dict[str, Any]:
         meta = self._statics()
-        meta[EVAL_UNIVERSE] = 'sim' if self._embodiment.simulated else 'real'
-        meta[EVAL_EMBODIMENT] = self._embodiment.descriptor
-        meta[EVAL_CHARGE_INFERENCE_TIME] = self._charges_wall_time
+        meta[eval_keys.UNIVERSE] = 'sim' if self._embodiment.simulated else 'real'
+        meta[eval_keys.EMBODIMENT] = self._embodiment.descriptor
+        meta[eval_keys.CHARGE_INFERENCE_TIME] = self._charges_wall_time
         if self._task.timeout_sec is not None:  # the recorder takes no nulls, and an unbounded episode has none
-            meta[EVAL_TIMEOUT] = self._task.timeout_sec
+            meta[eval_keys.TIMEOUT] = self._task.timeout_sec
         assert self._inference is not None, 'only a live episode has meta'
         for k, v in flatten_dict(self._inference.meta).items():
-            meta[f'{POLICY_META}.{k}'] = v
+            meta[f'{policy_keys.POLICY_META}.{k}'] = v
         meta.update(self._task.meta)
         meta[keys.TASK] = self._task.instruction
         return meta
@@ -346,7 +339,7 @@ class Harness(pimm.ControlSystem):
         # goes back where it put it — the trial's own args, not a fresh draw. The scene is a person's to set
         # up, and is not asked again. The terminal waits on the move: a scene the next trial draws rebuilds
         # the model an unfinished one is still travelling under, which nothing but its timeout would end.
-        yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != SCENE})
+        yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != eval_keys.SCENE})
         # The answer waits until the model is out of this episode's function. An in-process policy is one
         # model across every episode, so the session that the next ask opens must not overtake it. The move
         # back above gives the function that time.
@@ -454,9 +447,9 @@ class Harness(pimm.ControlSystem):
         """
         deadline_ns = self._deadline_ns
         if done is not None and done.data and (deadline_ns is None or done.ts <= deadline_ns):
-            return {**done.data, EVAL_TERMINATED: True}
+            return {**done.data, eval_keys.TERMINATED: True}
         if deadline_ns is not None and clock.now_ns() >= deadline_ns:
-            return {EVAL_TERMINATED: False}
+            return {eval_keys.TERMINATED: False}
         return None
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:

--- a/positronic/policy/keys.py
+++ b/positronic/policy/keys.py
@@ -1,0 +1,13 @@
+"""The keys of what a policy reports about itself, and where the harness records them."""
+
+# What a policy reports about itself through its ``meta``; a remote policy nests the server's meta under
+# ``SERVER``, and the harness records the result under ``POLICY_META``. ``TYPE`` names the policy at the top
+# level and the vendor under ``SERVER``, so a reader composes a prefix with a field: f'{SERVER_META}.{TYPE}'.
+TYPE = 'type'
+CHECKPOINT_PATH = 'checkpoint_path'
+EXPERIMENT_NAME = 'experiment_name'
+CONFIG_NAME = 'config_name'
+SERVER = 'server'
+
+POLICY_META = 'inference.policy'
+SERVER_META = f'{POLICY_META}.{SERVER}'

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -7,7 +7,8 @@ import pos3
 
 from positronic import telemetry, telemetry_keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
-from positronic.policy.base import COMPRESS_IMAGES, LOCAL_STACK, POSITRONIC_VERSION, SERVER, TYPE
+from positronic.offboard.protocol import COMPRESS_IMAGES, LOCAL_STACK, POSITRONIC_VERSION
+from positronic.policy.base import SERVER, TYPE
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -5,8 +5,9 @@ from typing import Any
 import numpy as np
 import pos3
 
-from positronic import keys, telemetry, telemetry_keys
+from positronic import telemetry, telemetry_keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
+from positronic.policy.base import COMPRESS_IMAGES, LOCAL_STACK, POSITRONIC_VERSION, SERVER, TYPE
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 
@@ -98,7 +99,7 @@ class RemoteSession(Session):
 
     @property
     def meta(self) -> dict[str, Any]:
-        return flatten_dict({keys.TYPE: 'remote', keys.SERVER: self._session.metadata})
+        return flatten_dict({TYPE: 'remote', SERVER: self._session.metadata})
 
     def close(self):
         assert self._answer is None or self._answer.done(), (
@@ -130,7 +131,7 @@ class _Endpoint(Policy):
     def new_session(self, context=None, rt=None) -> RemoteSession:
         if rt is None:
             raise ValueError('A remote session runs its inference on a runtime: pass rt to new_session.')
-        compress = bool(self.server_meta().get(keys.COMPRESS_IMAGES))
+        compress = bool(self.server_meta().get(COMPRESS_IMAGES))
         ws_session = self._client.new_session()
         return RemoteSession(ws_session, rt, compress_images=compress)
 
@@ -171,8 +172,8 @@ class RemotePolicy(Policy):
 
     def _resolve_stack(self) -> Layer:
         meta = self._endpoint.server_meta()
-        version = meta.get(keys.POSITRONIC_VERSION, 'unknown')
-        declared = meta.get(keys.LOCAL_STACK)
+        version = meta.get(POSITRONIC_VERSION, 'unknown')
+        declared = meta.get(LOCAL_STACK)
         try:
             stack = from_spec(declared) if declared is not None else None
         except Exception as e:

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -6,9 +6,9 @@ import numpy as np
 import pos3
 
 from positronic import telemetry, telemetry_keys
+from positronic.offboard import keys as offboard_keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT, InferenceClient, InferenceSession
-from positronic.offboard.protocol import COMPRESS_IMAGES, LOCAL_STACK, POSITRONIC_VERSION
-from positronic.policy.base import SERVER, TYPE
+from positronic.policy import keys as policy_keys
 from positronic.utils import flatten_dict
 from positronic.utils.serialization import encode_jpeg
 
@@ -100,7 +100,7 @@ class RemoteSession(Session):
 
     @property
     def meta(self) -> dict[str, Any]:
-        return flatten_dict({TYPE: 'remote', SERVER: self._session.metadata})
+        return flatten_dict({policy_keys.TYPE: 'remote', policy_keys.SERVER: self._session.metadata})
 
     def close(self):
         assert self._answer is None or self._answer.done(), (
@@ -132,7 +132,7 @@ class _Endpoint(Policy):
     def new_session(self, context=None, rt=None) -> RemoteSession:
         if rt is None:
             raise ValueError('A remote session runs its inference on a runtime: pass rt to new_session.')
-        compress = bool(self.server_meta().get(COMPRESS_IMAGES))
+        compress = bool(self.server_meta().get(offboard_keys.COMPRESS_IMAGES))
         ws_session = self._client.new_session()
         return RemoteSession(ws_session, rt, compress_images=compress)
 
@@ -173,8 +173,8 @@ class RemotePolicy(Policy):
 
     def _resolve_stack(self) -> Layer:
         meta = self._endpoint.server_meta()
-        version = meta.get(POSITRONIC_VERSION, 'unknown')
-        declared = meta.get(LOCAL_STACK)
+        version = meta.get(offboard_keys.POSITRONIC_VERSION, 'unknown')
+        declared = meta.get(offboard_keys.LOCAL_STACK)
         try:
             stack = from_spec(declared) if declared is not None else None
         except Exception as e:

--- a/positronic/policy/spec.py
+++ b/positronic/policy/spec.py
@@ -28,7 +28,7 @@ import operator
 from collections.abc import Callable
 from typing import Any
 
-from positronic import keys
+from positronic.drivers.roboarm.models import EE_FRAME
 from positronic.policy.action import AbsoluteJointsAction, AbsolutePositionAction, JointDeltaAction
 from positronic.policy.base import PAR, SEQ, Layer, Policy
 from positronic.policy.codec import (
@@ -116,10 +116,10 @@ class Pipeline:
         self.source = source
         # Which side of ``remote`` the conversion sits on is a choice; doing it on both sides is not. Two
         # declarations convert twice, leaving poses at the product while the handshake still names one of them.
-        declared = [c for c in self.components if isinstance(c, Codec) and keys.EE_FRAME in c.meta]
+        declared = [c for c in self.components if isinstance(c, Codec) and EE_FRAME in c.meta]
         if len(declared) > 1:
             raise ValueError(
-                f'{len(declared)} components of this pipeline declare {keys.EE_FRAME}; each converts, so poses '
+                f'{len(declared)} components of this pipeline declare {EE_FRAME}; each converts, so poses '
                 'end up at the product of their transforms. Declare the frame once.'
             )
 

--- a/positronic/policy/spec.py
+++ b/positronic/policy/spec.py
@@ -28,7 +28,7 @@ import operator
 from collections.abc import Callable
 from typing import Any
 
-from positronic.drivers.roboarm.models import EE_FRAME
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.policy.action import AbsoluteJointsAction, AbsolutePositionAction, JointDeltaAction
 from positronic.policy.base import PAR, SEQ, Layer, Policy
 from positronic.policy.codec import (
@@ -116,10 +116,10 @@ class Pipeline:
         self.source = source
         # Which side of ``remote`` the conversion sits on is a choice; doing it on both sides is not. Two
         # declarations convert twice, leaving poses at the product while the handshake still names one of them.
-        declared = [c for c in self.components if isinstance(c, Codec) and EE_FRAME in c.meta]
+        declared = [c for c in self.components if isinstance(c, Codec) and roboarm_keys.EE_FRAME in c.meta]
         if len(declared) > 1:
             raise ValueError(
-                f'{len(declared)} components of this pipeline declare {EE_FRAME}; each converts, so poses '
+                f'{len(declared)} components of this pipeline declare {roboarm_keys.EE_FRAME}; each converts, so poses '
                 'end up at the product of their transforms. Declare the frame once.'
             )
 

--- a/positronic/policy/tests/test_change_ee_frame.py
+++ b/positronic/policy/tests/test_change_ee_frame.py
@@ -6,13 +6,22 @@ from positronic import keys
 from positronic.dataset.episode import EpisodeContainer
 from positronic.dataset.tests.utils import DummySignal
 from positronic.drivers.roboarm.ik import frame_transform
-from positronic.drivers.roboarm.models import DEFAULT_FRAME, DROID_EEF_LINK, EE_LINK, FLANGE_LINK, bundled_franka_model
+from positronic.drivers.roboarm.models import (
+    CONTROL_FRAME,
+    DEFAULT_FRAME,
+    DROID_EEF_LINK,
+    EE_FRAME,
+    EE_LINK,
+    FLANGE_LINK,
+    URDF,
+    bundled_franka_model,
+)
 from positronic.geom import Rotation, Transform3D, quat_closest
 from positronic.policy.codec import ChangeEEFrame
 from positronic.policy.spec import from_spec
 
 QUAT = Rotation.Representation.QUAT
-URDF = bundled_franka_model()[keys.URDF]
+URDF = bundled_franka_model()[URDF]
 TO_DROID = frame_transform(URDF, DEFAULT_FRAME, DROID_EEF_LINK)
 
 
@@ -131,7 +140,7 @@ def test_encode_passes_through_when_no_pose_key_is_present():
 
 def test_advertises_the_frame_it_speaks():
     codec = ChangeEEFrame(TO_DROID)
-    np.testing.assert_allclose(codec.meta[keys.EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-12)
+    np.testing.assert_allclose(codec.meta[EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-12)
     assert codec.training_encoder.meta == codec.meta
 
 
@@ -152,8 +161,8 @@ def test_training_encoder_maps_both_poses_forward():
     ts = [1000, 2000]
     episode = EpisodeContainer(
         data={
-            keys.URDF: URDF,
-            keys.CONTROL_FRAME: DEFAULT_FRAME,
+            URDF: URDF,
+            CONTROL_FRAME: DEFAULT_FRAME,
             keys.EE_POSE: DummySignal(ts, np.stack([obs_pose.as_vector(QUAT)] * 2)),
             keys.TARGET_EE_POSE: DummySignal(ts, np.stack([cmd_pose.as_vector(QUAT)] * 2)),
             keys.GRIP: DummySignal(ts, np.array([0.0, 1.0])),
@@ -164,7 +173,7 @@ def test_training_encoder_maps_both_poses_forward():
 
     np.testing.assert_allclose(out[keys.EE_POSE][0][0], (obs_pose * TO_DROID).as_vector(QUAT), atol=1e-9)
     np.testing.assert_allclose(out[keys.TARGET_EE_POSE][0][0], (cmd_pose * TO_DROID).as_vector(QUAT), atol=1e-9)
-    np.testing.assert_allclose(out[keys.EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
+    np.testing.assert_allclose(out[EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
     assert keys.GRIP in out, 'unrelated signals pass through'
 
 
@@ -175,19 +184,19 @@ def _episode(**statics):
 def test_training_encoder_rejects_poses_anchored_elsewhere():
     """A recording predating the contract names its own frame, and moving those poses is a silent 10cm."""
     with pytest.raises(ValueError, match=EE_LINK):
-        ChangeEEFrame(TO_DROID).training_encoder(_episode(**{keys.URDF: URDF, keys.CONTROL_FRAME: EE_LINK}))
+        ChangeEEFrame(TO_DROID).training_encoder(_episode(**{URDF: URDF, CONTROL_FRAME: EE_LINK}))
 
 
 def test_training_encoder_accepts_a_rig_that_ships_no_model():
     """What frame the poses sit in is what the recording states; a model confirms that but is not the claim."""
-    out = ChangeEEFrame(TO_DROID).training_encoder(_episode(**{keys.CONTROL_FRAME: DEFAULT_FRAME}))
-    np.testing.assert_allclose(out[keys.EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
+    out = ChangeEEFrame(TO_DROID).training_encoder(_episode(**{CONTROL_FRAME: DEFAULT_FRAME}))
+    np.testing.assert_allclose(out[EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
 
 
 def test_training_encoder_rejects_an_episode_another_codec_already_moved():
     """The transform names the policy frame from ``default``, so it has no meaning applied twice — the poses
     would land at the product while ``meta`` still declares one of the pair."""
-    moved = _episode(**{keys.CONTROL_FRAME: DEFAULT_FRAME, keys.EE_FRAME: TO_DROID.as_vector(QUAT)})
+    moved = _episode(**{CONTROL_FRAME: DEFAULT_FRAME, EE_FRAME: TO_DROID.as_vector(QUAT)})
     with pytest.raises(ValueError, match='already sit at'):
         ChangeEEFrame(TO_DROID).training_encoder(moved)
 
@@ -197,8 +206,8 @@ def test_training_encoder_skips_absent_command_pose():
     ts = [1000, 2000]
     episode = EpisodeContainer(
         data={
-            keys.URDF: URDF,
-            keys.CONTROL_FRAME: DEFAULT_FRAME,
+            URDF: URDF,
+            CONTROL_FRAME: DEFAULT_FRAME,
             keys.EE_POSE: DummySignal(ts, np.stack([obs_pose.as_vector(QUAT)] * 2)),
             keys.TARGET_JOINTS: DummySignal(ts, np.zeros((2, 7), dtype=np.float32)),
         }

--- a/positronic/policy/tests/test_change_ee_frame.py
+++ b/positronic/policy/tests/test_change_ee_frame.py
@@ -5,24 +5,16 @@ import positronic.drivers.roboarm.command as cmd_module
 from positronic import keys
 from positronic.dataset.episode import EpisodeContainer
 from positronic.dataset.tests.utils import DummySignal
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.roboarm.ik import frame_transform
-from positronic.drivers.roboarm.models import (
-    CONTROL_FRAME,
-    DEFAULT_FRAME,
-    DROID_EEF_LINK,
-    EE_FRAME,
-    EE_LINK,
-    FLANGE_LINK,
-    URDF,
-    bundled_franka_model,
-)
+from positronic.drivers.roboarm.models import DEFAULT_FRAME, DROID_EEF_LINK, EE_LINK, FLANGE_LINK, bundled_franka_model
 from positronic.geom import Rotation, Transform3D, quat_closest
 from positronic.policy.codec import ChangeEEFrame
 from positronic.policy.spec import from_spec
 
 QUAT = Rotation.Representation.QUAT
-URDF = bundled_franka_model()[URDF]
-TO_DROID = frame_transform(URDF, DEFAULT_FRAME, DROID_EEF_LINK)
+FRANKA_URDF = bundled_franka_model()[roboarm_keys.URDF]
+TO_DROID = frame_transform(FRANKA_URDF, DEFAULT_FRAME, DROID_EEF_LINK)
 
 
 def _pose(t, euler):
@@ -30,7 +22,7 @@ def _pose(t, euler):
 
 
 def test_droid_eef_matches_robolab_eef_frame():
-    transform = frame_transform(URDF, FLANGE_LINK, DROID_EEF_LINK)
+    transform = frame_transform(FRANKA_URDF, FLANGE_LINK, DROID_EEF_LINK)
     expected = Rotation.from_euler([0.0, 0.0, np.pi / 2])
     np.testing.assert_allclose(transform.translation, [0.0, 0.0, 0.01817402261], atol=1e-9)
     assert quat_closest(transform.rotation, expected) == expected
@@ -140,7 +132,7 @@ def test_encode_passes_through_when_no_pose_key_is_present():
 
 def test_advertises_the_frame_it_speaks():
     codec = ChangeEEFrame(TO_DROID)
-    np.testing.assert_allclose(codec.meta[EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-12)
+    np.testing.assert_allclose(codec.meta[roboarm_keys.EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-12)
     assert codec.training_encoder.meta == codec.meta
 
 
@@ -161,8 +153,8 @@ def test_training_encoder_maps_both_poses_forward():
     ts = [1000, 2000]
     episode = EpisodeContainer(
         data={
-            URDF: URDF,
-            CONTROL_FRAME: DEFAULT_FRAME,
+            roboarm_keys.URDF: FRANKA_URDF,
+            roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
             keys.EE_POSE: DummySignal(ts, np.stack([obs_pose.as_vector(QUAT)] * 2)),
             keys.TARGET_EE_POSE: DummySignal(ts, np.stack([cmd_pose.as_vector(QUAT)] * 2)),
             keys.GRIP: DummySignal(ts, np.array([0.0, 1.0])),
@@ -173,7 +165,7 @@ def test_training_encoder_maps_both_poses_forward():
 
     np.testing.assert_allclose(out[keys.EE_POSE][0][0], (obs_pose * TO_DROID).as_vector(QUAT), atol=1e-9)
     np.testing.assert_allclose(out[keys.TARGET_EE_POSE][0][0], (cmd_pose * TO_DROID).as_vector(QUAT), atol=1e-9)
-    np.testing.assert_allclose(out[EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
+    np.testing.assert_allclose(out[roboarm_keys.EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
     assert keys.GRIP in out, 'unrelated signals pass through'
 
 
@@ -184,19 +176,21 @@ def _episode(**statics):
 def test_training_encoder_rejects_poses_anchored_elsewhere():
     """A recording predating the contract names its own frame, and moving those poses is a silent 10cm."""
     with pytest.raises(ValueError, match=EE_LINK):
-        ChangeEEFrame(TO_DROID).training_encoder(_episode(**{URDF: URDF, CONTROL_FRAME: EE_LINK}))
+        ChangeEEFrame(TO_DROID).training_encoder(
+            _episode(**{roboarm_keys.URDF: FRANKA_URDF, roboarm_keys.CONTROL_FRAME: EE_LINK})
+        )
 
 
 def test_training_encoder_accepts_a_rig_that_ships_no_model():
     """What frame the poses sit in is what the recording states; a model confirms that but is not the claim."""
-    out = ChangeEEFrame(TO_DROID).training_encoder(_episode(**{CONTROL_FRAME: DEFAULT_FRAME}))
-    np.testing.assert_allclose(out[EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
+    out = ChangeEEFrame(TO_DROID).training_encoder(_episode(**{roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME}))
+    np.testing.assert_allclose(out[roboarm_keys.EE_FRAME], TO_DROID.as_vector(QUAT), atol=1e-9)
 
 
 def test_training_encoder_rejects_an_episode_another_codec_already_moved():
     """The transform names the policy frame from ``default``, so it has no meaning applied twice — the poses
     would land at the product while ``meta`` still declares one of the pair."""
-    moved = _episode(**{CONTROL_FRAME: DEFAULT_FRAME, EE_FRAME: TO_DROID.as_vector(QUAT)})
+    moved = _episode(**{roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME, roboarm_keys.EE_FRAME: TO_DROID.as_vector(QUAT)})
     with pytest.raises(ValueError, match='already sit at'):
         ChangeEEFrame(TO_DROID).training_encoder(moved)
 
@@ -206,8 +200,8 @@ def test_training_encoder_skips_absent_command_pose():
     ts = [1000, 2000]
     episode = EpisodeContainer(
         data={
-            URDF: URDF,
-            CONTROL_FRAME: DEFAULT_FRAME,
+            roboarm_keys.URDF: FRANKA_URDF,
+            roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
             keys.EE_POSE: DummySignal(ts, np.stack([obs_pose.as_vector(QUAT)] * 2)),
             keys.TARGET_JOINTS: DummySignal(ts, np.zeros((2, 7), dtype=np.float32)),
         }

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -39,7 +39,7 @@ from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import CartesianPosition, CommandType
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
-from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation, Task
+from positronic.eval import ENDED_BY_OPERATOR, EVAL_ENDED_BY, ROBOT_STATIC_META, Command, Embodiment, Observation, Task
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import DelegatingPolicy, DelegatingSession, Policy, Session
 from positronic.policy.codec import ActionTiming
@@ -222,7 +222,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
             (robot.inject_error, 0.0),  # one-shot error: StopOnFault stops the arm for that frame
             (None, 0.5),
             (None, 1.5),  # more cycles after recovery
-            (partial(done_em.emit, {keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR}), 0.0),
+            (partial(done_em.emit, {EVAL_ENDED_BY: ENDED_BY_OPERATOR}), 0.0),
             (None, 0.5),  # let DsWriterAgent commit before world exit
         ]
         scheduler = world.start([harness, ManualDriver(script), robot, gripper, ds_agent])

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -39,7 +39,8 @@ from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import CartesianPosition, CommandType
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
-from positronic.eval import ENDED_BY_OPERATOR, EVAL_ENDED_BY, ROBOT_STATIC_META, Command, Embodiment, Observation, Task
+from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation, Task
+from positronic.eval import keys as eval_keys
 from positronic.geom import Rotation, Transform3D
 from positronic.policy.base import DelegatingPolicy, DelegatingSession, Policy, Session
 from positronic.policy.codec import ActionTiming
@@ -222,7 +223,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
             (robot.inject_error, 0.0),  # one-shot error: StopOnFault stops the arm for that frame
             (None, 0.5),
             (None, 1.5),  # more cycles after recovery
-            (partial(done_em.emit, {EVAL_ENDED_BY: ENDED_BY_OPERATOR}), 0.0),
+            (partial(done_em.emit, {eval_keys.ENDED_BY: eval_keys.ENDED_BY_OPERATOR}), 0.0),
             (None, 0.5),  # let DsWriterAgent commit before world exit
         ]
         scheduler = world.start([harness, ManualDriver(script), robot, gripper, ds_agent])

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -16,35 +16,12 @@ from positronic.dataset.ds_writer_agent import DsWriterCommand, DsWriterCommandT
 from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import RobotStatus
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.roboarm.command import CartesianDelta, CartesianPosition, JointPosition, from_wire, to_wire
-from positronic.drivers.roboarm.models import (
-    CONTROL_FRAME,
-    DEFAULT_FRAME,
-    EE_LINK,
-    JOINT_NAMES,
-    URDF,
-    bundled_franka_model,
-)
+from positronic.drivers.roboarm.models import DEFAULT_FRAME, EE_LINK, bundled_franka_model
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
-from positronic.eval import (
-    ARM,
-    ENDED_BY_OPERATOR,
-    EVAL_CHARGE_INFERENCE_TIME,
-    EVAL_EMBODIMENT,
-    EVAL_ENDED_BY,
-    EVAL_SEED,
-    EVAL_SUCCESS,
-    EVAL_TERMINATED,
-    EVAL_TIMEOUT,
-    EVAL_TRIAL_INDEX,
-    EVAL_UNIVERSE,
-    JOINT_SIGNALS,
-    SCENE,
-    Command,
-    Embodiment,
-    Observation,
-    Task,
-)
+from positronic.eval import Command, Embodiment, Observation, Task
+from positronic.eval import keys as eval_keys
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import DelegatingSession, Layer, Policy, Session
@@ -78,7 +55,7 @@ def _eval_pass(run_id: str):
 
 CAM = 'image.cam'
 # What an operator's finish puts on ``done``; the harness stamps ``eval.terminated`` over it.
-OPERATOR_DONE = {EVAL_ENDED_BY: ENDED_BY_OPERATOR}
+OPERATOR_DONE = {eval_keys.ENDED_BY: eval_keys.ENDED_BY_OPERATOR}
 
 
 def make_embodiment(
@@ -472,7 +449,10 @@ def test_robot_model_stays_out_of_the_observation(world):
     """A codec carries its frame as a transform, so the model never has to leave the rig."""
     policy = SpyPolicy()
     model = bundled_franka_model()
-    statics = {URDF: model[URDF], CONTROL_FRAME: model[CONTROL_FRAME]}
+    statics = {
+        roboarm_keys.URDF: model[roboarm_keys.URDF],
+        roboarm_keys.CONTROL_FRAME: model[roboarm_keys.CONTROL_FRAME],
+    }
     harness = Harness(make_embodiment(static_meta=statics))
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands['target_grip']._bind(RecordingEmitter())
@@ -494,7 +474,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     drive_scheduler(scheduler, steps=20)
 
     assert policy.last_obs is not None
-    assert URDF not in policy.last_obs and CONTROL_FRAME not in policy.last_obs
+    assert roboarm_keys.URDF not in policy.last_obs and roboarm_keys.CONTROL_FRAME not in policy.last_obs
 
 
 @pytest.mark.timeout(3.0)
@@ -517,7 +497,7 @@ def _run_with_model(world, model, static_meta=None):
 @pytest.mark.timeout(3.0)
 def test_rejects_a_control_frame_that_is_not_the_default(world):
     """A rig reporting at another of its own frames shifts every codec transform by the offset between them."""
-    statics = {URDF: bundled_franka_model()[URDF], CONTROL_FRAME: EE_LINK}
+    statics = {roboarm_keys.URDF: bundled_franka_model()[roboarm_keys.URDF], roboarm_keys.CONTROL_FRAME: EE_LINK}
     with pytest.raises(ValueError, match=EE_LINK):
         _run_with_model(world, None, static_meta=statics)
 
@@ -525,7 +505,10 @@ def test_rejects_a_control_frame_that_is_not_the_default(world):
 @pytest.mark.timeout(3.0)
 def test_rejects_a_default_frame_the_model_does_not_declare(world):
     """Every frame transform is measured from this one, so a name the model lacks must not run."""
-    statics = {URDF: '<robot name="r"><link name="base"/></robot>', CONTROL_FRAME: DEFAULT_FRAME}
+    statics = {
+        roboarm_keys.URDF: '<robot name="r"><link name="base"/></robot>',
+        roboarm_keys.CONTROL_FRAME: DEFAULT_FRAME,
+    }
     with pytest.raises(ValueError, match=DEFAULT_FRAME):
         _run_with_model(world, None, static_meta=statics)
 
@@ -534,7 +517,7 @@ def test_rejects_a_default_frame_the_model_does_not_declare(world):
 def test_rejects_a_control_frame_a_late_model_declares(world):
     """A remote env publishes its model a turn after the reset that produced it, so the check runs on the
     live metadata rather than on whatever was known when the episode opened."""
-    model = {URDF: bundled_franka_model()[URDF], CONTROL_FRAME: EE_LINK}
+    model = {roboarm_keys.URDF: bundled_franka_model()[roboarm_keys.URDF], roboarm_keys.CONTROL_FRAME: EE_LINK}
     with pytest.raises(ValueError, match=EE_LINK):
         _run_with_model(world, model)
 
@@ -590,11 +573,11 @@ def test_harness_waits_for_complete_inputs(world):
 @pytest.mark.timeout(3.0)
 def test_episode_meta_stamped_at_finalize(world):
     policy = StubPolicy(meta={'type': 'stub', 'checkpoint': 'v1'})
-    harness = Harness(make_embodiment(), static_meta={JOINT_SIGNALS: [keys.JOINTS]})
+    harness = Harness(make_embodiment(), static_meta={eval_keys.JOINT_SIGNALS: [keys.JOINTS]})
     p = _pair_all(world, harness, policy)
 
     driver = ManualDriver([
-        (partial(p['meta_em'].emit, {URDF: '<robot/>', JOINT_NAMES: ['j1']}), 0.0),
+        (partial(p['meta_em'].emit, {roboarm_keys.URDF: '<robot/>', roboarm_keys.JOINT_NAMES: ['j1']}), 0.0),
         (partial(p['perform_task'], Task(instruction_source='test', timeout_sec=None)), 0.01),
         (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),
         (None, 0.02),
@@ -606,9 +589,9 @@ def test_episode_meta_stamped_at_finalize(world):
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
     meta = stops[0].static_data
-    assert meta[JOINT_SIGNALS] == [keys.JOINTS]
-    assert meta[URDF] == '<robot/>'
-    assert meta[JOINT_NAMES] == ['j1']
+    assert meta[eval_keys.JOINT_SIGNALS] == [keys.JOINTS]
+    assert meta[roboarm_keys.URDF] == '<robot/>'
+    assert meta[roboarm_keys.JOINT_NAMES] == ['j1']
     assert meta['inference.policy.type'] == 'stub'
     assert meta['inference.policy.checkpoint'] == 'v1'
     assert meta[keys.TASK] == 'test'
@@ -666,10 +649,10 @@ def test_a_call_that_names_no_dataset_runs_the_trial_and_records_nothing(world):
     answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
     emit_ready_payload(p['frame_em'], p['robot_em'], p['grip_em'], make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]))
     drive_scheduler(scheduler, steps=5)
-    p['done_em'].emit({EVAL_SUCCESS: True})
+    p['done_em'].emit({eval_keys.SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
-    assert answer.result() == {EVAL_SUCCESS: True, EVAL_TERMINATED: True}
+    assert answer.result() == {eval_keys.SUCCESS: True, eval_keys.TERMINATED: True}
     assert policy.observations, 'the trial never reached the policy'
     starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
     assert [c.output_path for c in starts] == [None]
@@ -687,10 +670,10 @@ def test_the_call_is_answered_with_the_terminal_the_episode_ended_on(world):
     drive_scheduler(scheduler, steps=5)
     assert not answer.done()
 
-    p['done_em'].emit({EVAL_SUCCESS: True})
+    p['done_em'].emit({eval_keys.SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
-    assert answer.result() == {EVAL_SUCCESS: True, EVAL_TERMINATED: True}
+    assert answer.result() == {eval_keys.SUCCESS: True, eval_keys.TERMINATED: True}
 
 
 @pytest.mark.timeout(3.0)
@@ -785,8 +768,8 @@ def test_trial_ends_at_its_timeout(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[EVAL_TERMINATED] is False
-    assert EVAL_SUCCESS not in stops[0].static_data
+    assert stops[0].static_data[eval_keys.TERMINATED] is False
+    assert eval_keys.SUCCESS not in stops[0].static_data
 
 
 @pytest.mark.timeout(3.0)
@@ -795,13 +778,13 @@ def test_trial_budget_starts_when_the_rig_is_ready(world):
     draw is not the trial's to spend."""
     scene = _Scene(lambda _: None, draw_s=0.2)
     policy = StubPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene, _Pacer()])
     opened = world.clock.now()
-    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=0.05, prepare_args={SCENE: {}}))
+    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=0.05, prepare_args={eval_keys.SCENE: {}}))
     drive_scheduler(scheduler, steps=2000)
 
     assert answer.done(), 'the trial never ended'
@@ -822,13 +805,13 @@ def test_trial_stop_signal_terminates(world):
     # Trial is live and unbounded by the clock: nothing committed yet.
     assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
 
-    p['done_em'].emit({EVAL_SUCCESS: True})
+    p['done_em'].emit({eval_keys.SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[EVAL_TERMINATED] is True
-    assert stops[0].static_data[EVAL_SUCCESS] is True  # the delivered payload lands in static data
+    assert stops[0].static_data[eval_keys.TERMINATED] is True
+    assert stops[0].static_data[eval_keys.SUCCESS] is True  # the delivered payload lands in static data
 
 
 @pytest.mark.timeout(3.0)
@@ -852,7 +835,7 @@ def test_stale_done_does_not_terminate_next_trial(world):
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 0
 
-    p['done_em'].emit({EVAL_SUCCESS: True})  # fresh truthy: ends trial 0
+    p['done_em'].emit({eval_keys.SUCCESS: True})  # fresh truthy: ends trial 0
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
@@ -861,11 +844,11 @@ def test_stale_done_does_not_terminate_next_trial(world):
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
-    p['done_em'].emit({EVAL_SUCCESS: True})  # a fresh delivery ends trial 1
+    p['done_em'].emit({eval_keys.SUCCESS: True})  # a fresh delivery ends trial 1
     drive_scheduler(scheduler, steps=10)
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2
-    assert all(s.static_data[EVAL_TERMINATED] is True for s in stops)
+    assert all(s.static_data[eval_keys.TERMINATED] is True for s in stops)
 
 
 class _FrameIndexDevice(pimm.ControlSystem):
@@ -902,7 +885,7 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
         descriptor='',
         observations={'frame': Observation(device.state, None)},
         commands={keys.ROBOT_COMMAND: Command(device.cmd, None)},
-        prepare_handlers={SCENE: device.env_reset},
+        prepare_handlers={eval_keys.SCENE: device.env_reset},
         static_meta={},
         meta_source=device.meta,
         control_systems=(device,),
@@ -914,7 +897,7 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
     wire.wire_embodiment(world, harness, embodiment, record=False)
 
     scheduler = world.start([harness, device])
-    perform_task(Task(instruction_source='t', timeout_sec=100.0, prepare_args={SCENE: {}}))
+    perform_task(Task(instruction_source='t', timeout_sec=100.0, prepare_args={eval_keys.SCENE: {}}))
     drive_scheduler(scheduler, steps=20)
 
     assert policy.observations, 'policy was never called'
@@ -939,7 +922,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
                 self.state.emit(0.0)
                 n += 1
                 if n == 5:
-                    self.done.emit({EVAL_SUCCESS: True})
+                    self.done.emit({eval_keys.SUCCESS: True})
                 yield pimm.Sleep(0.01)
 
     device = _Device()
@@ -966,8 +949,8 @@ def test_task_done_terminates_through_wire_embodiment(world):
 
     stops = [d for _, d in ds_recorder.emitted if d.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[EVAL_TERMINATED] is True
-    assert stops[0].static_data[EVAL_SUCCESS] is True
+    assert stops[0].static_data[eval_keys.TERMINATED] is True
+    assert stops[0].static_data[eval_keys.SUCCESS] is True
 
 
 @pytest.mark.timeout(3.0)
@@ -982,7 +965,7 @@ def test_done_after_deadline_is_a_timeout(world):
     # The 0.05s deadline lapses first; done lands at ~0.1s, after the trial has already timed out.
     driver = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.1),
-        (partial(p['done_em'].emit, {EVAL_SUCCESS: True}), 0.3),
+        (partial(p['done_em'].emit, {eval_keys.SUCCESS: True}), 0.3),
         (None, 0.0),
     ])
     scheduler = world.start([harness, driver])
@@ -991,8 +974,8 @@ def test_done_after_deadline_is_a_timeout(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[EVAL_TERMINATED] is False
-    assert EVAL_SUCCESS not in stops[0].static_data
+    assert stops[0].static_data[eval_keys.TERMINATED] is False
+    assert eval_keys.SUCCESS not in stops[0].static_data
 
 
 @pytest.mark.timeout(3.0)
@@ -1000,15 +983,15 @@ def test_a_handler_the_trial_does_not_name_is_left_alone(world):
     """A rig readies more than any one trial wants, so what a trial leaves unnamed it leaves as it stands."""
     drawn, moved = [], []
     scene, arm = _Scene(drawn.append), _Scene(moved.append)
-    handlers = {SCENE: scene.env_reset, ARM: arm.env_reset}
+    handlers = {eval_keys.SCENE: scene.env_reset, eval_keys.ARM: arm.env_reset}
     policy = StubPolicy()
     harness = Harness(make_embodiment(prepare_handlers=handlers))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], scene.env_reset)
-    wire_call(world, harness.prepare[ARM], arm.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[eval_keys.ARM], arm.env_reset)
 
     scheduler = world.start([harness, scene, arm])
-    p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={SCENE: {}}))
+    p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.SCENE: {}}))
     drive_scheduler(scheduler, steps=50)
 
     assert drawn == [{}]
@@ -1023,15 +1006,15 @@ def test_every_rig_is_put_back_where_the_trial_placed_it(world, simulated):
     sim rig is asked no differently."""
     placed = []
     arm = _Scene(placed.append)
-    handlers = {ARM: arm.env_reset}
+    handlers = {eval_keys.ARM: arm.env_reset}
     policy = StubPolicy()
     harness = Harness(make_embodiment(simulated=simulated, prepare_handlers=handlers))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[ARM], arm.env_reset)
+    wire_call(world, harness.prepare[eval_keys.ARM], arm.env_reset)
 
     start = JointPosition(np.arange(7, dtype=np.float64))
     scheduler = world.start([harness, arm, _Pacer()])
-    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={ARM: start}))
+    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.ARM: start}))
     drive_scheduler(scheduler, steps=2000)
 
     assert answer.done(), 'the episode never ended, so there was no close to be put back by'
@@ -1062,12 +1045,12 @@ def test_a_trial_does_not_end_until_the_rig_is_back_where_it_started(world):
     move still travelling and rebuilds the model under it, leaving nothing but its timeout to end it."""
     arm = _PlacesOnce()
     policy = StubPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={ARM: arm.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.ARM: arm.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[ARM], arm.env_reset)
+    wire_call(world, harness.prepare[eval_keys.ARM], arm.env_reset)
 
     scheduler = world.start([harness, arm, _Pacer()])
-    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={ARM: JointPosition(np.zeros(7))})
+    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.ARM: JointPosition(np.zeros(7))})
     answer = p['perform_task'](task)
     drive_scheduler(scheduler, steps=2000)
 
@@ -1121,12 +1104,12 @@ def test_no_deadline_is_published_while_the_rig_is_still_readying(world):
 
     scene = _SlowScene()
     policy = StubPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
-    p['perform_task'](Task(instruction_source='t', timeout_sec=5.0, prepare_args={SCENE: {}}))
+    p['perform_task'](Task(instruction_source='t', timeout_sec=5.0, prepare_args={eval_keys.SCENE: {}}))
     drive_scheduler(scheduler, steps=100)
     assert _deadlines(p) == [], 'a deadline went out while the rig was still readying'
 
@@ -1146,7 +1129,7 @@ def test_the_deadline_clears_when_the_episode_ends(world):
 
     driver = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.2),
-        (partial(p['done_em'].emit, {EVAL_SUCCESS: True}), 100.0),
+        (partial(p['done_em'].emit, {eval_keys.SUCCESS: True}), 100.0),
     ])
     scheduler = world.start([harness, driver])
     p['perform_task'](Task(instruction_source='t', timeout_sec=5.0))
@@ -1230,15 +1213,15 @@ def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     """Only the handlers a task names are asked, so a name matching none of them would go unasked and the
     trial would open on a rig nothing readied."""
     scene = _Scene(lambda _params: None)
-    embodiment = make_embodiment(descriptor='yam', prepare_handlers={SCENE: scene.env_reset})
+    embodiment = make_embodiment(descriptor='yam', prepare_handlers={eval_keys.SCENE: scene.env_reset})
     policy = StubPolicy()
     harness = Harness(embodiment)
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
     answer = p['perform_task'](
-        Task(instruction_source='stack', timeout_sec=0.05, prepare_args={ARM: JointPosition(np.zeros(7))})
+        Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.ARM: JointPosition(np.zeros(7))})
     )
 
     named = r"\['arm'\] is not something yam readies; it readies \['scene'\]"
@@ -1257,29 +1240,31 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
     seeds = []
 
     def reset(params):
-        seeds.append(params.get(EVAL_SEED))
+        seeds.append(params.get(eval_keys.SEED))
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
     scene = _Scene(reset)
-    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
     for i in range(2):
-        seed = {EVAL_SEED: 7 + i}
-        p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={SCENE: seed}, meta=seed))
+        seed = {eval_keys.SEED: 7 + i}
+        p['perform_task'](
+            Task(instruction_source='stack', timeout_sec=0.05, prepare_args={eval_keys.SCENE: seed}, meta=seed)
+        )
         drive_scheduler(scheduler, steps=200)
 
     assert seeds == [7, 8]
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2
-    assert [s.static_data[EVAL_SEED] for s in stops] == [7, 8]
+    assert [s.static_data[eval_keys.SEED] for s in stops] == [7, 8]
     assert all(s.static_data[keys.TASK] == 'stack' for s in stops)
-    assert all(s.static_data[EVAL_UNIVERSE] == 'real' for s in stops)
-    assert all(s.static_data[EVAL_EMBODIMENT] == '' for s in stops)
-    assert all(s.static_data[EVAL_TIMEOUT] == 0.05 for s in stops)
-    assert all(s.static_data[EVAL_CHARGE_INFERENCE_TIME] is True for s in stops)
+    assert all(s.static_data[eval_keys.UNIVERSE] == 'real' for s in stops)
+    assert all(s.static_data[eval_keys.EMBODIMENT] == '' for s in stops)
+    assert all(s.static_data[eval_keys.TIMEOUT] == 0.05 for s in stops)
+    assert all(s.static_data[eval_keys.CHARGE_INFERENCE_TIME] is True for s in stops)
 
 
 @pytest.mark.timeout(3.0)
@@ -1312,7 +1297,7 @@ def test_timeout_during_inference_drops_the_chunk(world):
 
     stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[EVAL_TERMINATED] is False
+    assert stops[0].static_data[eval_keys.TERMINATED] is False
     # A trial that times out mid-call plays nothing: the chunk it was waiting on is dropped.
     assert not _emitted_commands(cmd_recorder)
     assert not _emitted_grips(grip_recorder)
@@ -1337,7 +1322,7 @@ def test_a_terminal_landing_while_idle_does_not_end_the_next_episode(world):
 
     assert _ds_types(p).count(DsWriterCommandType.START_EPISODE) == 1
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert EVAL_ENDED_BY not in stops[0].static_data, 'the idle terminal ended the episode that followed it'
+    assert eval_keys.ENDED_BY not in stops[0].static_data, 'the idle terminal ended the episode that followed it'
 
 
 @pytest.mark.timeout(3.0)
@@ -1486,13 +1471,15 @@ def test_a_task_the_reset_resolves_reaches_the_policy(world):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
     drawing = _Scene(reset)
-    harness = Harness(make_embodiment(prepare_handlers={SCENE: drawing.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.SCENE: drawing.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], drawing.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], drawing.env_reset)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     scheduler = world.start([harness, drawing])
-    p['perform_task'](Task(instruction_source=lambda: scene['task'], timeout_sec=0.05, prepare_args={SCENE: {}}))
+    p['perform_task'](
+        Task(instruction_source=lambda: scene['task'], timeout_sec=0.05, prepare_args={eval_keys.SCENE: {}})
+    )
     emit_ready_payload(p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
     drive_scheduler(scheduler, steps=200)
 
@@ -1776,7 +1763,7 @@ def test_stop_mid_episode_keeps_episode_open_for_recorder_flush(world, tmp_path)
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     # Never ends within the drive: the stop, not the deadline, is what winds this episode down.
-    _ask(world, harness, policy, Task(instruction_source='stack', timeout_sec=10.0, meta={EVAL_TRIAL_INDEX: 0}))
+    _ask(world, harness, policy, Task(instruction_source='stack', timeout_sec=10.0, meta={eval_keys.TRIAL_INDEX: 0}))
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
 
@@ -1829,7 +1816,7 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
 
     with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-taxonomy'), _eval_pass('run-taxonomy'):
         scheduler = world.start([harness, producer])
-        p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, meta={EVAL_TRIAL_INDEX: 0}))
+        p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, meta={eval_keys.TRIAL_INDEX: 0}))
         drive_scheduler(scheduler, steps=400)
 
     spans = list(telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS)))
@@ -1895,10 +1882,15 @@ def test_failed_pass_seals_open_episode_span(world, tmp_path):
 
     policy = StubPolicy()
     scene = pimm.calls.ControlSystemHandler[Any, None](Passive())
-    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene}))
-    wire_call(world, harness.prepare[SCENE], scene)
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.SCENE: scene}))
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene)
     harness.ds_command._bind(RecordingEmitter())
-    task = Task(instruction_source='stack', timeout_sec=10.0, prepare_args={SCENE: {}}, meta={EVAL_TRIAL_INDEX: 0})
+    task = Task(
+        instruction_source='stack',
+        timeout_sec=10.0,
+        prepare_args={eval_keys.SCENE: {}},
+        meta={eval_keys.TRIAL_INDEX: 0},
+    )
     _ask(world, harness, policy, task)
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
@@ -1936,14 +1928,14 @@ def test_episode_virtual_duration_starts_when_the_rig_is_ready(world, tmp_path):
     instead of inflating the real-time factor the report derives from it."""
     scene = _Scene(lambda _: None, draw_s=0.2)
     policy = ChunkPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={eval_keys.SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[eval_keys.SCENE], scene.env_reset)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-anchor'), _eval_pass('run-anchor'):
         scheduler = world.start([harness, scene])
-        p['perform_task'](Task(instruction_source='test', timeout_sec=None, prepare_args={SCENE: {}}))
+        p['perform_task'](Task(instruction_source='test', timeout_sec=None, prepare_args={eval_keys.SCENE: {}}))
         draw_start = world.clock.now()
         for _ in range(1000):
             drive_scheduler(scheduler, steps=1)

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -17,9 +17,34 @@ from positronic.dataset.serializers import Serializers
 from positronic.drivers import roboarm
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import CartesianDelta, CartesianPosition, JointPosition, from_wire, to_wire
-from positronic.drivers.roboarm.models import DEFAULT_FRAME, EE_LINK, bundled_franka_model
+from positronic.drivers.roboarm.models import (
+    CONTROL_FRAME,
+    DEFAULT_FRAME,
+    EE_LINK,
+    JOINT_NAMES,
+    URDF,
+    bundled_franka_model,
+)
 from positronic.drivers.roboarm.tests.fakes import make_robot_state
-from positronic.eval import Command, Embodiment, Observation, Task
+from positronic.eval import (
+    ARM,
+    ENDED_BY_OPERATOR,
+    EVAL_CHARGE_INFERENCE_TIME,
+    EVAL_EMBODIMENT,
+    EVAL_ENDED_BY,
+    EVAL_SEED,
+    EVAL_SUCCESS,
+    EVAL_TERMINATED,
+    EVAL_TIMEOUT,
+    EVAL_TRIAL_INDEX,
+    EVAL_UNIVERSE,
+    JOINT_SIGNALS,
+    SCENE,
+    Command,
+    Embodiment,
+    Observation,
+    Task,
+)
 from positronic.geom import Rotation, Transform3D
 from positronic.offboard.client import InferenceSession
 from positronic.policy.base import DelegatingSession, Layer, Policy, Session
@@ -53,7 +78,7 @@ def _eval_pass(run_id: str):
 
 CAM = 'image.cam'
 # What an operator's finish puts on ``done``; the harness stamps ``eval.terminated`` over it.
-OPERATOR_DONE = {keys.EVAL_ENDED_BY: keys.ENDED_BY_OPERATOR}
+OPERATOR_DONE = {EVAL_ENDED_BY: ENDED_BY_OPERATOR}
 
 
 def make_embodiment(
@@ -447,7 +472,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     """A codec carries its frame as a transform, so the model never has to leave the rig."""
     policy = SpyPolicy()
     model = bundled_franka_model()
-    statics = {keys.URDF: model[keys.URDF], keys.CONTROL_FRAME: model[keys.CONTROL_FRAME]}
+    statics = {URDF: model[URDF], CONTROL_FRAME: model[CONTROL_FRAME]}
     harness = Harness(make_embodiment(static_meta=statics))
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands['target_grip']._bind(RecordingEmitter())
@@ -469,7 +494,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     drive_scheduler(scheduler, steps=20)
 
     assert policy.last_obs is not None
-    assert keys.URDF not in policy.last_obs and keys.CONTROL_FRAME not in policy.last_obs
+    assert URDF not in policy.last_obs and CONTROL_FRAME not in policy.last_obs
 
 
 @pytest.mark.timeout(3.0)
@@ -492,7 +517,7 @@ def _run_with_model(world, model, static_meta=None):
 @pytest.mark.timeout(3.0)
 def test_rejects_a_control_frame_that_is_not_the_default(world):
     """A rig reporting at another of its own frames shifts every codec transform by the offset between them."""
-    statics = {keys.URDF: bundled_franka_model()[keys.URDF], keys.CONTROL_FRAME: EE_LINK}
+    statics = {URDF: bundled_franka_model()[URDF], CONTROL_FRAME: EE_LINK}
     with pytest.raises(ValueError, match=EE_LINK):
         _run_with_model(world, None, static_meta=statics)
 
@@ -500,7 +525,7 @@ def test_rejects_a_control_frame_that_is_not_the_default(world):
 @pytest.mark.timeout(3.0)
 def test_rejects_a_default_frame_the_model_does_not_declare(world):
     """Every frame transform is measured from this one, so a name the model lacks must not run."""
-    statics = {keys.URDF: '<robot name="r"><link name="base"/></robot>', keys.CONTROL_FRAME: DEFAULT_FRAME}
+    statics = {URDF: '<robot name="r"><link name="base"/></robot>', CONTROL_FRAME: DEFAULT_FRAME}
     with pytest.raises(ValueError, match=DEFAULT_FRAME):
         _run_with_model(world, None, static_meta=statics)
 
@@ -509,7 +534,7 @@ def test_rejects_a_default_frame_the_model_does_not_declare(world):
 def test_rejects_a_control_frame_a_late_model_declares(world):
     """A remote env publishes its model a turn after the reset that produced it, so the check runs on the
     live metadata rather than on whatever was known when the episode opened."""
-    model = {keys.URDF: bundled_franka_model()[keys.URDF], keys.CONTROL_FRAME: EE_LINK}
+    model = {URDF: bundled_franka_model()[URDF], CONTROL_FRAME: EE_LINK}
     with pytest.raises(ValueError, match=EE_LINK):
         _run_with_model(world, model)
 
@@ -565,11 +590,11 @@ def test_harness_waits_for_complete_inputs(world):
 @pytest.mark.timeout(3.0)
 def test_episode_meta_stamped_at_finalize(world):
     policy = StubPolicy(meta={'type': 'stub', 'checkpoint': 'v1'})
-    harness = Harness(make_embodiment(), static_meta={keys.JOINT_SIGNALS: [keys.JOINTS]})
+    harness = Harness(make_embodiment(), static_meta={JOINT_SIGNALS: [keys.JOINTS]})
     p = _pair_all(world, harness, policy)
 
     driver = ManualDriver([
-        (partial(p['meta_em'].emit, {keys.URDF: '<robot/>', keys.JOINT_NAMES: ['j1']}), 0.0),
+        (partial(p['meta_em'].emit, {URDF: '<robot/>', JOINT_NAMES: ['j1']}), 0.0),
         (partial(p['perform_task'], Task(instruction_source='test', timeout_sec=None)), 0.01),
         (partial(p['done_em'].emit, OPERATOR_DONE), 0.02),
         (None, 0.02),
@@ -581,9 +606,9 @@ def test_episode_meta_stamped_at_finalize(world):
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
     meta = stops[0].static_data
-    assert meta[keys.JOINT_SIGNALS] == [keys.JOINTS]
-    assert meta[keys.URDF] == '<robot/>'
-    assert meta[keys.JOINT_NAMES] == ['j1']
+    assert meta[JOINT_SIGNALS] == [keys.JOINTS]
+    assert meta[URDF] == '<robot/>'
+    assert meta[JOINT_NAMES] == ['j1']
     assert meta['inference.policy.type'] == 'stub'
     assert meta['inference.policy.checkpoint'] == 'v1'
     assert meta[keys.TASK] == 'test'
@@ -641,10 +666,10 @@ def test_a_call_that_names_no_dataset_runs_the_trial_and_records_nothing(world):
     answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
     emit_ready_payload(p['frame_em'], p['robot_em'], p['grip_em'], make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]))
     drive_scheduler(scheduler, steps=5)
-    p['done_em'].emit({keys.EVAL_SUCCESS: True})
+    p['done_em'].emit({EVAL_SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
-    assert answer.result() == {keys.EVAL_SUCCESS: True, keys.EVAL_TERMINATED: True}
+    assert answer.result() == {EVAL_SUCCESS: True, EVAL_TERMINATED: True}
     assert policy.observations, 'the trial never reached the policy'
     starts = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.START_EPISODE]
     assert [c.output_path for c in starts] == [None]
@@ -662,10 +687,10 @@ def test_the_call_is_answered_with_the_terminal_the_episode_ended_on(world):
     drive_scheduler(scheduler, steps=5)
     assert not answer.done()
 
-    p['done_em'].emit({keys.EVAL_SUCCESS: True})
+    p['done_em'].emit({EVAL_SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
-    assert answer.result() == {keys.EVAL_SUCCESS: True, keys.EVAL_TERMINATED: True}
+    assert answer.result() == {EVAL_SUCCESS: True, EVAL_TERMINATED: True}
 
 
 @pytest.mark.timeout(3.0)
@@ -760,8 +785,8 @@ def test_trial_ends_at_its_timeout(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
-    assert keys.EVAL_SUCCESS not in stops[0].static_data
+    assert stops[0].static_data[EVAL_TERMINATED] is False
+    assert EVAL_SUCCESS not in stops[0].static_data
 
 
 @pytest.mark.timeout(3.0)
@@ -770,13 +795,13 @@ def test_trial_budget_starts_when_the_rig_is_ready(world):
     draw is not the trial's to spend."""
     scene = _Scene(lambda _: None, draw_s=0.2)
     policy = StubPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene, _Pacer()])
     opened = world.clock.now()
-    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=0.05, prepare_args={keys.SCENE: {}}))
+    answer = p['perform_task'](Task(instruction_source='test', timeout_sec=0.05, prepare_args={SCENE: {}}))
     drive_scheduler(scheduler, steps=2000)
 
     assert answer.done(), 'the trial never ended'
@@ -797,13 +822,13 @@ def test_trial_stop_signal_terminates(world):
     # Trial is live and unbounded by the clock: nothing committed yet.
     assert not [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
 
-    p['done_em'].emit({keys.EVAL_SUCCESS: True})
+    p['done_em'].emit({EVAL_SUCCESS: True})
     drive_scheduler(scheduler, steps=10)
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[keys.EVAL_TERMINATED] is True
-    assert stops[0].static_data[keys.EVAL_SUCCESS] is True  # the delivered payload lands in static data
+    assert stops[0].static_data[EVAL_TERMINATED] is True
+    assert stops[0].static_data[EVAL_SUCCESS] is True  # the delivered payload lands in static data
 
 
 @pytest.mark.timeout(3.0)
@@ -827,7 +852,7 @@ def test_stale_done_does_not_terminate_next_trial(world):
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 0
 
-    p['done_em'].emit({keys.EVAL_SUCCESS: True})  # fresh truthy: ends trial 0
+    p['done_em'].emit({EVAL_SUCCESS: True})  # fresh truthy: ends trial 0
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
@@ -836,11 +861,11 @@ def test_stale_done_does_not_terminate_next_trial(world):
     drive_scheduler(scheduler, steps=10)
     assert stop_count() == 1
 
-    p['done_em'].emit({keys.EVAL_SUCCESS: True})  # a fresh delivery ends trial 1
+    p['done_em'].emit({EVAL_SUCCESS: True})  # a fresh delivery ends trial 1
     drive_scheduler(scheduler, steps=10)
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2
-    assert all(s.static_data[keys.EVAL_TERMINATED] is True for s in stops)
+    assert all(s.static_data[EVAL_TERMINATED] is True for s in stops)
 
 
 class _FrameIndexDevice(pimm.ControlSystem):
@@ -877,7 +902,7 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
         descriptor='',
         observations={'frame': Observation(device.state, None)},
         commands={keys.ROBOT_COMMAND: Command(device.cmd, None)},
-        prepare_handlers={keys.SCENE: device.env_reset},
+        prepare_handlers={SCENE: device.env_reset},
         static_meta={},
         meta_source=device.meta,
         control_systems=(device,),
@@ -889,7 +914,7 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
     wire.wire_embodiment(world, harness, embodiment, record=False)
 
     scheduler = world.start([harness, device])
-    perform_task(Task(instruction_source='t', timeout_sec=100.0, prepare_args={keys.SCENE: {}}))
+    perform_task(Task(instruction_source='t', timeout_sec=100.0, prepare_args={SCENE: {}}))
     drive_scheduler(scheduler, steps=20)
 
     assert policy.observations, 'policy was never called'
@@ -914,7 +939,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
                 self.state.emit(0.0)
                 n += 1
                 if n == 5:
-                    self.done.emit({keys.EVAL_SUCCESS: True})
+                    self.done.emit({EVAL_SUCCESS: True})
                 yield pimm.Sleep(0.01)
 
     device = _Device()
@@ -941,8 +966,8 @@ def test_task_done_terminates_through_wire_embodiment(world):
 
     stops = [d for _, d in ds_recorder.emitted if d.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[keys.EVAL_TERMINATED] is True
-    assert stops[0].static_data[keys.EVAL_SUCCESS] is True
+    assert stops[0].static_data[EVAL_TERMINATED] is True
+    assert stops[0].static_data[EVAL_SUCCESS] is True
 
 
 @pytest.mark.timeout(3.0)
@@ -957,7 +982,7 @@ def test_done_after_deadline_is_a_timeout(world):
     # The 0.05s deadline lapses first; done lands at ~0.1s, after the trial has already timed out.
     driver = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.1),
-        (partial(p['done_em'].emit, {keys.EVAL_SUCCESS: True}), 0.3),
+        (partial(p['done_em'].emit, {EVAL_SUCCESS: True}), 0.3),
         (None, 0.0),
     ])
     scheduler = world.start([harness, driver])
@@ -966,8 +991,8 @@ def test_done_after_deadline_is_a_timeout(world):
 
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
-    assert keys.EVAL_SUCCESS not in stops[0].static_data
+    assert stops[0].static_data[EVAL_TERMINATED] is False
+    assert EVAL_SUCCESS not in stops[0].static_data
 
 
 @pytest.mark.timeout(3.0)
@@ -975,15 +1000,15 @@ def test_a_handler_the_trial_does_not_name_is_left_alone(world):
     """A rig readies more than any one trial wants, so what a trial leaves unnamed it leaves as it stands."""
     drawn, moved = [], []
     scene, arm = _Scene(drawn.append), _Scene(moved.append)
-    handlers = {keys.SCENE: scene.env_reset, keys.ARM: arm.env_reset}
+    handlers = {SCENE: scene.env_reset, ARM: arm.env_reset}
     policy = StubPolicy()
     harness = Harness(make_embodiment(prepare_handlers=handlers))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
-    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+    wire_call(world, harness.prepare[SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[ARM], arm.env_reset)
 
     scheduler = world.start([harness, scene, arm])
-    p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.SCENE: {}}))
+    p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={SCENE: {}}))
     drive_scheduler(scheduler, steps=50)
 
     assert drawn == [{}]
@@ -998,15 +1023,15 @@ def test_every_rig_is_put_back_where_the_trial_placed_it(world, simulated):
     sim rig is asked no differently."""
     placed = []
     arm = _Scene(placed.append)
-    handlers = {keys.ARM: arm.env_reset}
+    handlers = {ARM: arm.env_reset}
     policy = StubPolicy()
     harness = Harness(make_embodiment(simulated=simulated, prepare_handlers=handlers))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+    wire_call(world, harness.prepare[ARM], arm.env_reset)
 
     start = JointPosition(np.arange(7, dtype=np.float64))
     scheduler = world.start([harness, arm, _Pacer()])
-    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: start}))
+    answer = p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={ARM: start}))
     drive_scheduler(scheduler, steps=2000)
 
     assert answer.done(), 'the episode never ended, so there was no close to be put back by'
@@ -1037,12 +1062,12 @@ def test_a_trial_does_not_end_until_the_rig_is_back_where_it_started(world):
     move still travelling and rebuilds the model under it, leaving nothing but its timeout to end it."""
     arm = _PlacesOnce()
     policy = StubPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={keys.ARM: arm.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={ARM: arm.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.ARM], arm.env_reset)
+    wire_call(world, harness.prepare[ARM], arm.env_reset)
 
     scheduler = world.start([harness, arm, _Pacer()])
-    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: JointPosition(np.zeros(7))})
+    task = Task(instruction_source='stack', timeout_sec=0.05, prepare_args={ARM: JointPosition(np.zeros(7))})
     answer = p['perform_task'](task)
     drive_scheduler(scheduler, steps=2000)
 
@@ -1096,12 +1121,12 @@ def test_no_deadline_is_published_while_the_rig_is_still_readying(world):
 
     scene = _SlowScene()
     policy = StubPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
-    p['perform_task'](Task(instruction_source='t', timeout_sec=5.0, prepare_args={keys.SCENE: {}}))
+    p['perform_task'](Task(instruction_source='t', timeout_sec=5.0, prepare_args={SCENE: {}}))
     drive_scheduler(scheduler, steps=100)
     assert _deadlines(p) == [], 'a deadline went out while the rig was still readying'
 
@@ -1121,7 +1146,7 @@ def test_the_deadline_clears_when_the_episode_ends(world):
 
     driver = ManualDriver([
         (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 0.2),
-        (partial(p['done_em'].emit, {keys.EVAL_SUCCESS: True}), 100.0),
+        (partial(p['done_em'].emit, {EVAL_SUCCESS: True}), 100.0),
     ])
     scheduler = world.start([harness, driver])
     p['perform_task'](Task(instruction_source='t', timeout_sec=5.0))
@@ -1205,15 +1230,15 @@ def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     """Only the handlers a task names are asked, so a name matching none of them would go unasked and the
     trial would open on a rig nothing readied."""
     scene = _Scene(lambda _params: None)
-    embodiment = make_embodiment(descriptor='yam', prepare_handlers={keys.SCENE: scene.env_reset})
+    embodiment = make_embodiment(descriptor='yam', prepare_handlers={SCENE: scene.env_reset})
     policy = StubPolicy()
     harness = Harness(embodiment)
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
     answer = p['perform_task'](
-        Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.ARM: JointPosition(np.zeros(7))})
+        Task(instruction_source='stack', timeout_sec=0.05, prepare_args={ARM: JointPosition(np.zeros(7))})
     )
 
     named = r"\['arm'\] is not something yam readies; it readies \['scene'\]"
@@ -1232,31 +1257,29 @@ def test_trial_seed_reaches_task_reset_and_meta(world):
     seeds = []
 
     def reset(params):
-        seeds.append(params.get(keys.EVAL_SEED))
+        seeds.append(params.get(EVAL_SEED))
         p['meta_em'].emit({})  # the producer publishes fresh scene meta, recorded into the episode at finalize
 
     scene = _Scene(reset)
-    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[SCENE], scene.env_reset)
 
     scheduler = world.start([harness, scene])
     for i in range(2):
-        seed = {keys.EVAL_SEED: 7 + i}
-        p['perform_task'](
-            Task(instruction_source='stack', timeout_sec=0.05, prepare_args={keys.SCENE: seed}, meta=seed)
-        )
+        seed = {EVAL_SEED: 7 + i}
+        p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, prepare_args={SCENE: seed}, meta=seed))
         drive_scheduler(scheduler, steps=200)
 
     assert seeds == [7, 8]
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 2
-    assert [s.static_data[keys.EVAL_SEED] for s in stops] == [7, 8]
+    assert [s.static_data[EVAL_SEED] for s in stops] == [7, 8]
     assert all(s.static_data[keys.TASK] == 'stack' for s in stops)
-    assert all(s.static_data[keys.EVAL_UNIVERSE] == 'real' for s in stops)
-    assert all(s.static_data[keys.EVAL_EMBODIMENT] == '' for s in stops)
-    assert all(s.static_data[keys.EVAL_TIMEOUT] == 0.05 for s in stops)
-    assert all(s.static_data[keys.EVAL_CHARGE_INFERENCE_TIME] is True for s in stops)
+    assert all(s.static_data[EVAL_UNIVERSE] == 'real' for s in stops)
+    assert all(s.static_data[EVAL_EMBODIMENT] == '' for s in stops)
+    assert all(s.static_data[EVAL_TIMEOUT] == 0.05 for s in stops)
+    assert all(s.static_data[EVAL_CHARGE_INFERENCE_TIME] is True for s in stops)
 
 
 @pytest.mark.timeout(3.0)
@@ -1289,7 +1312,7 @@ def test_timeout_during_inference_drops_the_chunk(world):
 
     stops = [data for _, data in ds_recorder.emitted if data.type == DsWriterCommandType.STOP_EPISODE]
     assert len(stops) == 1
-    assert stops[0].static_data[keys.EVAL_TERMINATED] is False
+    assert stops[0].static_data[EVAL_TERMINATED] is False
     # A trial that times out mid-call plays nothing: the chunk it was waiting on is dropped.
     assert not _emitted_commands(cmd_recorder)
     assert not _emitted_grips(grip_recorder)
@@ -1314,7 +1337,7 @@ def test_a_terminal_landing_while_idle_does_not_end_the_next_episode(world):
 
     assert _ds_types(p).count(DsWriterCommandType.START_EPISODE) == 1
     stops = [c for c in _ds_commands(p) if c.type == DsWriterCommandType.STOP_EPISODE]
-    assert keys.EVAL_ENDED_BY not in stops[0].static_data, 'the idle terminal ended the episode that followed it'
+    assert EVAL_ENDED_BY not in stops[0].static_data, 'the idle terminal ended the episode that followed it'
 
 
 @pytest.mark.timeout(3.0)
@@ -1463,13 +1486,13 @@ def test_a_task_the_reset_resolves_reaches_the_policy(world):
         scene['task'] = 'resolved-on-reset'  # the env reports its task only here
 
     drawing = _Scene(reset)
-    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: drawing.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={SCENE: drawing.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], drawing.env_reset)
+    wire_call(world, harness.prepare[SCENE], drawing.env_reset)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     scheduler = world.start([harness, drawing])
-    p['perform_task'](Task(instruction_source=lambda: scene['task'], timeout_sec=0.05, prepare_args={keys.SCENE: {}}))
+    p['perform_task'](Task(instruction_source=lambda: scene['task'], timeout_sec=0.05, prepare_args={SCENE: {}}))
     emit_ready_payload(p['frame_em'], p['robot_em'], p['grip_em'], robot_state)
     drive_scheduler(scheduler, steps=200)
 
@@ -1753,7 +1776,7 @@ def test_stop_mid_episode_keeps_episode_open_for_recorder_flush(world, tmp_path)
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
     # Never ends within the drive: the stop, not the deadline, is what winds this episode down.
-    _ask(world, harness, policy, Task(instruction_source='stack', timeout_sec=10.0, meta={keys.EVAL_TRIAL_INDEX: 0}))
+    _ask(world, harness, policy, Task(instruction_source='stack', timeout_sec=10.0, meta={EVAL_TRIAL_INDEX: 0}))
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
 
@@ -1806,7 +1829,7 @@ def test_timing_spans_recorded_with_taxonomy(world, tmp_path):
 
     with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-taxonomy'), _eval_pass('run-taxonomy'):
         scheduler = world.start([harness, producer])
-        p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, meta={keys.EVAL_TRIAL_INDEX: 0}))
+        p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, meta={EVAL_TRIAL_INDEX: 0}))
         drive_scheduler(scheduler, steps=400)
 
     spans = list(telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS)))
@@ -1872,12 +1895,10 @@ def test_failed_pass_seals_open_episode_span(world, tmp_path):
 
     policy = StubPolicy()
     scene = pimm.calls.ControlSystemHandler[Any, None](Passive())
-    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene}))
-    wire_call(world, harness.prepare[keys.SCENE], scene)
+    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene}))
+    wire_call(world, harness.prepare[SCENE], scene)
     harness.ds_command._bind(RecordingEmitter())
-    task = Task(
-        instruction_source='stack', timeout_sec=10.0, prepare_args={keys.SCENE: {}}, meta={keys.EVAL_TRIAL_INDEX: 0}
-    )
+    task = Task(instruction_source='stack', timeout_sec=10.0, prepare_args={SCENE: {}}, meta={EVAL_TRIAL_INDEX: 0})
     _ask(world, harness, policy, task)
     stop = SimpleNamespace(value=False)
     clock = _ManualClock()
@@ -1915,14 +1936,14 @@ def test_episode_virtual_duration_starts_when_the_rig_is_ready(world, tmp_path):
     instead of inflating the real-time factor the report derives from it."""
     scene = _Scene(lambda _: None, draw_s=0.2)
     policy = ChunkPolicy()
-    harness = Harness(make_embodiment(prepare_handlers={keys.SCENE: scene.env_reset}))
+    harness = Harness(make_embodiment(prepare_handlers={SCENE: scene.env_reset}))
     p = _pair_all(world, harness, policy)
-    wire_call(world, harness.prepare[keys.SCENE], scene.env_reset)
+    wire_call(world, harness.prepare[SCENE], scene.env_reset)
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
     with telemetry.bind(tmp_path, telemetry_keys.HARNESS_PROCESS, 'run-anchor'), _eval_pass('run-anchor'):
         scheduler = world.start([harness, scene])
-        p['perform_task'](Task(instruction_source='test', timeout_sec=None, prepare_args={keys.SCENE: {}}))
+        p['perform_task'](Task(instruction_source='test', timeout_sec=None, prepare_args={SCENE: {}}))
         draw_start = world.clock.now()
         for _ in range(1000):
             drive_scheduler(scheduler, steps=1)

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -7,8 +7,8 @@ import pytest
 
 from positronic import keys
 from positronic.drivers.roboarm import RobotStatus
+from positronic.drivers.roboarm import keys as roboarm_keys
 from positronic.drivers.roboarm.command import Impedance, JointDelta
-from positronic.drivers.roboarm.models import EE_FRAME
 from positronic.geom import Rotation, Transform3D
 from positronic.policy import spec
 from positronic.policy.action import AbsoluteJointsAction, AbsolutePositionAction, IKJointsAction, JointDeltaAction
@@ -251,20 +251,20 @@ class TestPipelineComposition:
         """Poses come out at the product of both transforms, which neither codec's declaration names."""
         a = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
         b = Transform3D(np.array([0.01, 0.0, 0.02]), Rotation.from_euler([0.0, 0.0, -0.4]))
-        with pytest.raises(ValueError, match=EE_FRAME):
+        with pytest.raises(ValueError, match=roboarm_keys.EE_FRAME):
             _ = (ChangeEEFrame(a) | ChangeEEFrame(b)).meta
 
     def test_the_same_frame_twice_is_still_two_moves(self):
         """The second move starts where the first left off, so the shared value names neither end of the pair."""
         a = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
-        with pytest.raises(ValueError, match=EE_FRAME):
+        with pytest.raises(ValueError, match=roboarm_keys.EE_FRAME):
             _ = (ChangeEEFrame(a) | ChangeEEFrame(a)).meta
 
     def test_parallel_frame_codecs_keep_the_frame_they_share(self):
         """Both halves encode the same input, so one move happens and the shared declaration describes it."""
         a = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
         np.testing.assert_allclose(
-            (ChangeEEFrame(a) & ChangeEEFrame(a)).meta[EE_FRAME], a.as_vector(Rotation.Representation.QUAT)
+            (ChangeEEFrame(a) & ChangeEEFrame(a)).meta[roboarm_keys.EE_FRAME], a.as_vector(Rotation.Representation.QUAT)
         )
 
 
@@ -534,7 +534,7 @@ class TestPipe:
         """Rig-side and server-side conversion are alternatives; running both puts poses at the product."""
         t = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
         chain = ChangeEEFrame(t) | spec.remote | (ActionTimestamp(fps=10.0) | ChangeEEFrame(t))
-        with pytest.raises(ValueError, match=EE_FRAME):
+        with pytest.raises(ValueError, match=roboarm_keys.EE_FRAME):
             _ = chain | spec.PolicySource(_ConstPolicy([]))
 
     def test_pipe_composes_no_further(self):

--- a/positronic/policy/tests/test_layers.py
+++ b/positronic/policy/tests/test_layers.py
@@ -8,6 +8,7 @@ import pytest
 from positronic import keys
 from positronic.drivers.roboarm import RobotStatus
 from positronic.drivers.roboarm.command import Impedance, JointDelta
+from positronic.drivers.roboarm.models import EE_FRAME
 from positronic.geom import Rotation, Transform3D
 from positronic.policy import spec
 from positronic.policy.action import AbsoluteJointsAction, AbsolutePositionAction, IKJointsAction, JointDeltaAction
@@ -250,20 +251,20 @@ class TestPipelineComposition:
         """Poses come out at the product of both transforms, which neither codec's declaration names."""
         a = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
         b = Transform3D(np.array([0.01, 0.0, 0.02]), Rotation.from_euler([0.0, 0.0, -0.4]))
-        with pytest.raises(ValueError, match=keys.EE_FRAME):
+        with pytest.raises(ValueError, match=EE_FRAME):
             _ = (ChangeEEFrame(a) | ChangeEEFrame(b)).meta
 
     def test_the_same_frame_twice_is_still_two_moves(self):
         """The second move starts where the first left off, so the shared value names neither end of the pair."""
         a = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
-        with pytest.raises(ValueError, match=keys.EE_FRAME):
+        with pytest.raises(ValueError, match=EE_FRAME):
             _ = (ChangeEEFrame(a) | ChangeEEFrame(a)).meta
 
     def test_parallel_frame_codecs_keep_the_frame_they_share(self):
         """Both halves encode the same input, so one move happens and the shared declaration describes it."""
         a = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
         np.testing.assert_allclose(
-            (ChangeEEFrame(a) & ChangeEEFrame(a)).meta[keys.EE_FRAME], a.as_vector(Rotation.Representation.QUAT)
+            (ChangeEEFrame(a) & ChangeEEFrame(a)).meta[EE_FRAME], a.as_vector(Rotation.Representation.QUAT)
         )
 
 
@@ -533,7 +534,7 @@ class TestPipe:
         """Rig-side and server-side conversion are alternatives; running both puts poses at the product."""
         t = Transform3D(np.array([0.0, 0.0, 0.05]), Rotation.from_euler([0.0, 0.0, 0.3]))
         chain = ChangeEEFrame(t) | spec.remote | (ActionTimestamp(fps=10.0) | ChangeEEFrame(t))
-        with pytest.raises(ValueError, match=keys.EE_FRAME):
+        with pytest.raises(ValueError, match=EE_FRAME):
             _ = chain | spec.PolicySource(_ConstPolicy([]))
 
     def test_pipe_composes_no_further(self):

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -20,13 +20,14 @@ import rerun.blueprint as rrb
 from av.video.stream import VideoStream
 from rerun.urdf import UrdfTree
 
-from positronic import keys
 from positronic.dataset.dataset import Dataset
 from positronic.dataset.episode import Episode
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.dataset.signal import Kind
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.video import VideoSignal
+from positronic.drivers.roboarm.models import JOINT_NAMES, URDF
+from positronic.eval import JOINT_SIGNALS, MOUNTS, POSE_SIGNALS
 from positronic.utils.rerun_compat import flatten_numeric, log_series_styles, set_timeline_time
 
 # TODO: 3D visualization roles (pose_signals, joint_signals) are currently read from episode
@@ -168,14 +169,14 @@ def _unplotted_notice(unplotted: dict[str, int]) -> str:
     )
 
 
-# The retired singular spelling of `keys.JOINT_SIGNALS`. It lives here rather than in `keys` because nothing
+# The retired singular spelling of `JOINT_SIGNALS`. It lives here rather than in `keys` because nothing
 # writes it any more — only released data carries it, and only until #587 converts that data.
 _SINGULAR_JOINT_SIGNAL = 'joint_signal'
 
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
-    pose_set = set(ep.static.get(keys.POSE_SIGNALS, []))
-    joint_set = set(ep.static.get(keys.JOINT_SIGNALS, []))
+    pose_set = set(ep.static.get(POSE_SIGNALS, []))
+    joint_set = set(ep.static.get(JOINT_SIGNALS, []))
     # TODO(#587): drop once the published PhAIL dataset carries the plural key. Its `static.json` has the
     # singular one baked in, so without this a released episode loses its arm model and joint names.
     if _SINGULAR_JOINT_SIGNAL in ep.static:
@@ -269,7 +270,7 @@ def _build_blueprint(signals: EpisodeSignals, ep: Episode) -> rrb.Blueprint:
 
 def _setup_series_names(signals: EpisodeSignals, ep: Episode) -> None:
     joint_set = set(signals.joints)
-    joint_names = ep.static.get(keys.JOINT_NAMES)
+    joint_names = ep.static.get(JOINT_NAMES)
     pose_set = set(signals.poses)
     for key, dim in signals.plotted.items():
         is_joint_vel = key.endswith('.dq') and f'{key[: -len(".dq")]}.q' in joint_set
@@ -552,8 +553,8 @@ def _log_urdf_robot(
     ep: Episode, joint_sig: str, numeric_data: dict[str, tuple[np.ndarray, np.ndarray]], drainer: _BinaryStreamDrainer
 ) -> Iterator[bytes]:
     """Log the episode's robot model, its joints animated by `joint_sig`."""
-    joint_names = ep.static.get(keys.JOINT_NAMES)
-    urdf_str = ep.static.get(keys.URDF)
+    joint_names = ep.static.get(JOINT_NAMES)
+    urdf_str = ep.static.get(URDF)
     meshes = ep.static.get('meshes')
     if not (joint_names and urdf_str and meshes):
         return
@@ -563,7 +564,7 @@ def _log_urdf_robot(
             f'{joint_sig} carries {q_vals.shape[1]} angles for {len(joint_names)} model joints; skipping its model'
         )
         return
-    mount = ep.static.get(keys.MOUNTS, {}).get(joint_sig)
+    mount = ep.static.get(MOUNTS, {}).get(joint_sig)
     namespace = f'{joint_sig}.'
     prefix = f'/3d/robot/{joint_sig}'
 

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -455,7 +455,7 @@ def _log_numeric_signals(
     A signal too wide to plot is still read, so that a joint or pose vector of any width reaches the
     3D view.
     """
-    gripper = ep.static.get(eval_keys.GRIPPER)
+    gripper = ep.static.get(roboarm_keys.GRIPPER)
     stash_keys = set(signals.poses) | set(signals.joints)
     if gripper:
         stash_keys.add(gripper['signal'])
@@ -595,7 +595,7 @@ def _log_urdf_robot(
         # its direction; recordings can overshoot slightly, so clip before scaling by ``travel``.
         # TODO: the spec names one signal, so every model grips with it. Arms that grip independently
         # need it pluralized the way `joint_signals` is.
-        gripper = ep.static.get(eval_keys.GRIPPER)
+        gripper = ep.static.get(roboarm_keys.GRIPPER)
         if gripper and gripper['signal'] in numeric_data:
             grip_ts, grip_vals = numeric_data[gripper['signal']]
             grip_keep = _decimation_indices(grip_ts, _URDF_ANIM_HZ)

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -455,7 +455,7 @@ def _log_numeric_signals(
     A signal too wide to plot is still read, so that a joint or pose vector of any width reaches the
     3D view.
     """
-    gripper = ep.static.get(keys.GRIPPER)
+    gripper = ep.static.get(eval_keys.GRIPPER)
     stash_keys = set(signals.poses) | set(signals.joints)
     if gripper:
         stash_keys.add(gripper['signal'])
@@ -595,7 +595,7 @@ def _log_urdf_robot(
         # its direction; recordings can overshoot slightly, so clip before scaling by ``travel``.
         # TODO: the spec names one signal, so every model grips with it. Arms that grip independently
         # need it pluralized the way `joint_signals` is.
-        gripper = ep.static.get(keys.GRIPPER)
+        gripper = ep.static.get(eval_keys.GRIPPER)
         if gripper and gripper['signal'] in numeric_data:
             grip_ts, grip_vals = numeric_data[gripper['signal']]
             grip_keep = _decimation_indices(grip_ts, _URDF_ANIM_HZ)

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -26,8 +26,8 @@ from positronic.dataset.local_dataset import LocalDataset
 from positronic.dataset.signal import Kind
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.video import VideoSignal
-from positronic.drivers.roboarm.models import JOINT_NAMES, URDF
-from positronic.eval import JOINT_SIGNALS, MOUNTS, POSE_SIGNALS
+from positronic.drivers.roboarm import keys as roboarm_keys
+from positronic.eval import keys as eval_keys
 from positronic.utils.rerun_compat import flatten_numeric, log_series_styles, set_timeline_time
 
 # TODO: 3D visualization roles (pose_signals, joint_signals) are currently read from episode
@@ -175,8 +175,8 @@ _SINGULAR_JOINT_SIGNAL = 'joint_signal'
 
 
 def _collect_signal_groups(ep: Episode) -> EpisodeSignals:
-    pose_set = set(ep.static.get(POSE_SIGNALS, []))
-    joint_set = set(ep.static.get(JOINT_SIGNALS, []))
+    pose_set = set(ep.static.get(eval_keys.POSE_SIGNALS, []))
+    joint_set = set(ep.static.get(eval_keys.JOINT_SIGNALS, []))
     # TODO(#587): drop once the published PhAIL dataset carries the plural key. Its `static.json` has the
     # singular one baked in, so without this a released episode loses its arm model and joint names.
     if _SINGULAR_JOINT_SIGNAL in ep.static:
@@ -270,7 +270,7 @@ def _build_blueprint(signals: EpisodeSignals, ep: Episode) -> rrb.Blueprint:
 
 def _setup_series_names(signals: EpisodeSignals, ep: Episode) -> None:
     joint_set = set(signals.joints)
-    joint_names = ep.static.get(JOINT_NAMES)
+    joint_names = ep.static.get(roboarm_keys.JOINT_NAMES)
     pose_set = set(signals.poses)
     for key, dim in signals.plotted.items():
         is_joint_vel = key.endswith('.dq') and f'{key[: -len(".dq")]}.q' in joint_set
@@ -553,8 +553,8 @@ def _log_urdf_robot(
     ep: Episode, joint_sig: str, numeric_data: dict[str, tuple[np.ndarray, np.ndarray]], drainer: _BinaryStreamDrainer
 ) -> Iterator[bytes]:
     """Log the episode's robot model, its joints animated by `joint_sig`."""
-    joint_names = ep.static.get(JOINT_NAMES)
-    urdf_str = ep.static.get(URDF)
+    joint_names = ep.static.get(roboarm_keys.JOINT_NAMES)
+    urdf_str = ep.static.get(roboarm_keys.URDF)
     meshes = ep.static.get('meshes')
     if not (joint_names and urdf_str and meshes):
         return
@@ -564,7 +564,7 @@ def _log_urdf_robot(
             f'{joint_sig} carries {q_vals.shape[1]} angles for {len(joint_names)} model joints; skipping its model'
         )
         return
-    mount = ep.static.get(MOUNTS, {}).get(joint_sig)
+    mount = ep.static.get(eval_keys.MOUNTS, {}).get(joint_sig)
     namespace = f'{joint_sig}.'
     prefix = f'/3d/robot/{joint_sig}'
 

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -9,6 +9,7 @@ import pytest
 
 from positronic import keys
 from positronic.dataset.local_dataset import DiskEpisode, DiskEpisodeWriter
+from positronic.eval import JOINT_SIGNALS
 from positronic.server import dataset_utils
 from positronic.server.dataset_utils import (
     _MAX_PLOTTED_WIDTH,
@@ -56,7 +57,7 @@ def test_wide_signal_still_reaches_the_3d_view(tmp_path):
 
 def test_every_joint_signal_the_episode_records_is_collected(tmp_path):
     widths = {'robot_state.left.q': 6, 'robot_state.right.q': 6, keys.GRIP: 1}
-    static = {keys.JOINT_SIGNALS: ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
+    static = {JOINT_SIGNALS: ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
 
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', widths, static))
 

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -9,7 +9,7 @@ import pytest
 
 from positronic import keys
 from positronic.dataset.local_dataset import DiskEpisode, DiskEpisodeWriter
-from positronic.eval import JOINT_SIGNALS
+from positronic.eval import keys as eval_keys
 from positronic.server import dataset_utils
 from positronic.server.dataset_utils import (
     _MAX_PLOTTED_WIDTH,
@@ -57,7 +57,7 @@ def test_wide_signal_still_reaches_the_3d_view(tmp_path):
 
 def test_every_joint_signal_the_episode_records_is_collected(tmp_path):
     widths = {'robot_state.left.q': 6, 'robot_state.right.q': 6, keys.GRIP: 1}
-    static = {JOINT_SIGNALS: ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
+    static = {eval_keys.JOINT_SIGNALS: ['robot_state.left.q', 'robot_state.right.q', 'robot_state.absent.q']}
 
     signals = _collect_signal_groups(_episode(tmp_path / 'ep', widths, static))
 

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -20,14 +20,6 @@ from positronic.drivers.roboarm import command as roboarm_command
 class EnvAdapter(ABC):
     """The mappings between the canonical embodiment contract and an env's raw wire payloads."""
 
-    def task_spec(self, selection: Any) -> Any:
-        """An eval's selection -> the spec the env resolves it against.
-
-        A benchmark selected in its own vocabulary — a task name, a category — needs no mapping and gets
-        this one. A benchmark naming a task on more than one axis maps the eval's keys onto its own.
-        """
-        return selection
-
     @abstractmethod
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """The env's own task records -> one trial params dict per task; the mirror of ``reset_token``.

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -1,10 +1,10 @@
 """The ``EnvAdapter`` interface: the per-benchmark canonical<->raw mappings, on the client side.
 
 ``RemoteEnvControlSystem`` is a dumb translator — it moves data between pimm signals and this adapter.
-The adapter is the smart half: it turns the Harness's commands into the env's raw action (owning what to
-hold between them), maps raw observations back to canonical signals — policy-facing and privileged
-ground-truth kept separate — and reads the terminal. Each benchmark ships one adapter (``vendors/``-style);
-the native ``MujocoSim`` fixture is the reference.
+The adapter is the smart half: it maps the env's own task records into trial params, turns the Harness's
+commands into the env's raw action (owning what to hold between them), maps raw observations back to
+canonical signals — policy-facing and privileged ground-truth kept separate — and reads the terminal. Each
+benchmark ships one adapter (``vendors/``-style); the native ``MujocoSim`` fixture is the reference.
 """
 
 from abc import ABC, abstractmethod
@@ -19,6 +19,22 @@ from positronic.drivers.roboarm import command as roboarm_command
 
 class EnvAdapter(ABC):
     """The mappings between the canonical embodiment contract and an env's raw wire payloads."""
+
+    def task_spec(self, selection: Any) -> Any:
+        """An eval's selection -> the spec the env resolves it against.
+
+        A benchmark selected in its own vocabulary — a task name, a category — needs no mapping and gets
+        this one. A benchmark naming a task on more than one axis maps the eval's keys onto its own.
+        """
+        return selection
+
+    @abstractmethod
+    def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """The env's own task records -> one trial params dict per task; the mirror of ``reset_token``.
+
+        An eval builds its sweep from these. Each dict carries what a trial of that task needs: what names
+        the task, and the seconds the benchmark gives its episode where the benchmark budgets one.
+        """
 
     @abstractmethod
     def reset_token(self, params: dict[str, Any]) -> Any:
@@ -107,7 +123,7 @@ class WireCommandAdapter(EnvAdapter):
     joint positions, or per-step joint deltas) plus the gripper closure into one payload.
     All action *encoding* — how the tagged command becomes the env's native action — stays server-side with
     the env's own model. Subclasses implement ``_reset_token`` (the base clears the per-trial command state
-    around it) and keep the observation and terminal mappings to themselves.
+    around it) and keep the task, observation and terminal mappings to themselves.
     """
 
     def __init__(self, env_control_frame: geom.Transform3D | None = None):

--- a/positronic/simulator/env_server/adapter.py
+++ b/positronic/simulator/env_server/adapter.py
@@ -22,11 +22,7 @@ class EnvAdapter(ABC):
 
     @abstractmethod
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """The env's own task records -> one trial params dict per task; the mirror of ``reset_token``.
-
-        An eval builds its sweep from these. Each dict carries what a trial of that task needs: what names
-        the task, and the seconds the benchmark gives its episode where the benchmark budgets one.
-        """
+        """The env's own task records -> one trial params dict per task; the mirror of ``reset_token``."""
 
     @abstractmethod
     def reset_token(self, params: dict[str, Any]) -> Any:

--- a/positronic/simulator/env_server/client.py
+++ b/positronic/simulator/env_server/client.py
@@ -1,4 +1,4 @@
-"""Synchronous client for the env server: the lockstep ``reset``/``step``/``close`` round-trips.
+"""Synchronous client for the env server: the lockstep ``tasks``/``reset``/``step``/``close`` round-trips.
 
 Positronic-free (``websockets`` + the wire codec). ``RemoteEnvControlSystem`` wraps this as a pimm
 control system; tests use it directly to compare a socket rollout against an in-process one.
@@ -22,7 +22,7 @@ _CLOSE_ACK_TIMEOUT = 5.0
 
 
 class EnvConnection:
-    """One websocket to an ``EnvServer``, opened with retry. ``reset``/``step`` block on the round-trip.
+    """One websocket to an ``EnvServer``, opened with retry. Every command blocks on the round-trip.
 
     There is no handshake: the first ``reset`` constructs the env server-side and returns
     ``{'obs', 'meta', 'control_dt'}``.
@@ -45,6 +45,9 @@ class EnvConnection:
                     raise type(e)(f'{e} (connecting to {host}:{port})') from e
                 time.sleep(backoff)
                 backoff = min(backoff * 2, 5.0)
+
+    def tasks(self, spec: Any) -> list[dict[str, Any]]:
+        return self._request({'cmd': 'tasks', 'spec': spec})['tasks']
 
     def reset(self, token: Any) -> dict[str, Any]:
         return self._request({'cmd': 'reset', 'token': token})

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -70,14 +70,13 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
             self._cleanup.callback(self._conn.close)
         return self._conn
 
-    def tasks(self, selection: Any) -> list[dict[str, Any]]:
-        """The tasks the env has for ``selection``, as the trial params an eval builds its sweep from."""
+    def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
+        """The tasks the env has for ``spec``, as the trial params an eval builds its sweep from."""
         try:
-            records = self._connect().tasks(self._adapter.task_spec(selection))
-            params = self._adapter.task_params(records)
+            params = self._adapter.task_params(self._connect().tasks(spec))
             if not params:
                 # A sweep of no trials writes nothing and ends at once, which reads as a run that succeeded.
-                raise ValueError(f'the env has no task for {selection!r}')
+                raise ValueError(f'the env has no task for {spec!r}')
             return params
         except BaseException:
             # An eval lists its tasks on the first turn of the world, and the scheduler enters ``run`` — the

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -16,7 +16,8 @@ from typing import Any
 import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.serializers import Serializers
-from positronic.eval import ROBOT_STATIC_META, SCENE, Command, Embodiment, Observation
+from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.adapter import EnvAdapter
 from positronic.simulator.env_server.client import EnvConnection
 
@@ -170,7 +171,7 @@ def remote_franka_embodiment(
         observations=observations,
         commands=commands,
         # A remote env readies its own robot when it draws the scene; the proxy has no lever of its own
-        prepare_handlers={SCENE: proxy.env_reset},
+        prepare_handlers={eval_keys.SCENE: proxy.env_reset},
         static_meta={**ROBOT_STATIC_META, **(static_meta or {})},
         meta_source=proxy.robot_meta,
         control_systems=(proxy,),

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -57,6 +57,35 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
         assert self._meta is not None, 'meta read before the first reset'
         return self._meta
 
+    def _connect(self) -> EnvConnection:
+        """The connection to the env server, started and opened on the first call.
+
+        Deferred so positronic can wire the World before the subprocess spawns; whichever of ``tasks`` and
+        ``reset`` runs first starts the server. The connection closes before the server (registered last),
+        so a rollout never races the server's teardown.
+        """
+        if self._conn is None:
+            host, port = self._cleanup.enter_context(self._serve)
+            self._conn = EnvConnection(host, port)
+            self._cleanup.callback(self._conn.close)
+        return self._conn
+
+    def tasks(self, selection: Any) -> list[dict[str, Any]]:
+        """The tasks the env has for ``selection``, as the trial params an eval builds its sweep from."""
+        try:
+            records = self._connect().tasks(self._adapter.task_spec(selection))
+            params = self._adapter.task_params(records)
+            if not params:
+                # A sweep of no trials writes nothing and ends at once, which reads as a run that succeeded.
+                raise ValueError(f'the env has no task for {selection!r}')
+            return params
+        except BaseException:
+            # An eval lists its tasks on the first turn of the world, and the scheduler enters ``run`` — the
+            # only other place that closes the server — later in that same turn. So a listing that raises
+            # stops the server itself; nothing else can.
+            self._cleanup.close()
+            raise
+
     def reset(self, params: dict[str, Any]) -> None:
         """Re-randomize the env from the trial's params and publish the scene it draws.
 
@@ -64,16 +93,10 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
         model, a full observation payload and a non-terminal ``done``. Stale commands queued while inactive
         are dropped so the first step doesn't apply them.
         """
-        if self._conn is None:
-            # Start the server and connect on the first reset, not at construction, so positronic can wire the
-            # World before the subprocess spawns. The connection closes before the server (registered last), so a
-            # rollout never races the server's teardown.
-            host, port = self._cleanup.enter_context(self._serve)
-            self._conn = EnvConnection(host, port)
-            self._cleanup.callback(self._conn.close)
+        conn = self._connect()
         for _, receiver in self.commands.items():
             receiver.read()
-        self._frame = self._conn.reset(self._adapter.reset_token(params))
+        self._frame = conn.reset(self._adapter.reset_token(params))
         self._meta = self._frame['meta']
         self._active = True
         self.robot_meta.emit(self._frame['robot_meta'])
@@ -107,7 +130,7 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
                         with telemetry.span(telemetry_keys.SPAN_MATERIALIZE):
                             self._emit_payload(self._frame['obs'])
         finally:
-            # Closes the connection then the server, in that order (reverse of acquisition); a no-op if no reset
+            # Closes the connection then the server, in that order (reverse of acquisition); a no-op if nothing
             # ever connected.
             self._cleanup.close()
 

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -60,9 +60,8 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
     def _connect(self) -> EnvConnection:
         """The connection to the env server, started and opened on the first call.
 
-        Deferred so positronic can wire the World before the subprocess spawns; whichever of ``tasks`` and
-        ``reset`` runs first starts the server. The connection closes before the server (registered last),
-        so a rollout never races the server's teardown.
+        Deferred so positronic can wire the World before the subprocess spawns. The connection closes before
+        the server (registered last), so a rollout never races the server's teardown.
         """
         if self._conn is None:
             host, port = self._cleanup.enter_context(self._serve)
@@ -79,9 +78,8 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
                 raise ValueError(f'the env has no task for {spec!r}')
             return params
         except BaseException:
-            # An eval lists its tasks on the first turn of the world, and the scheduler enters ``run`` — the
-            # only other place that closes the server — later in that same turn. So a listing that raises
-            # stops the server itself; nothing else can.
+            # An eval lists its tasks before the scheduler enters ``run``, whose teardown is the only other place
+            # that closes the server. So a listing that raises stops the server itself.
             self._cleanup.close()
             raise
 

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -16,7 +16,7 @@ from typing import Any
 import pimm
 from positronic import keys, telemetry, telemetry_keys
 from positronic.dataset.serializers import Serializers
-from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Observation
+from positronic.eval import ROBOT_STATIC_META, SCENE, Command, Embodiment, Observation
 from positronic.simulator.env_server.adapter import EnvAdapter
 from positronic.simulator.env_server.client import EnvConnection
 
@@ -170,7 +170,7 @@ def remote_franka_embodiment(
         observations=observations,
         commands=commands,
         # A remote env readies its own robot when it draws the scene; the proxy has no lever of its own
-        prepare_handlers={keys.SCENE: proxy.env_reset},
+        prepare_handlers={SCENE: proxy.env_reset},
         static_meta={**ROBOT_STATIC_META, **(static_meta or {})},
         meta_source=proxy.robot_meta,
         control_systems=(proxy,),

--- a/positronic/simulator/env_server/proxy.py
+++ b/positronic/simulator/env_server/proxy.py
@@ -79,8 +79,7 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
                 raise ValueError(f'the env has no task for {spec!r}')
             return params
         except BaseException:
-            # An eval lists its tasks before the scheduler enters ``run``, whose teardown is the only other place
-            # that closes the server. So a listing that raises stops the server itself.
+            # The listing runs before ``run``, so its failure is the only path that closes the server.
             self._cleanup.close()
             raise
 
@@ -111,25 +110,19 @@ class RemoteEnvControlSystem(pimm.ControlSystem):
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         try:
             while not should_stop.value:
-                # The proxy is the eval's sole time-master: it sleeps one control period every turn —
-                # stepping, resetting, or idle between trials alike. Before the first reset the env's
-                # ``control_dt`` is unknown, so it paces at ``_IDLE_DT`` until reset reports the real one.
+                # The proxy paces every turn; ``control_dt`` is known only once a reset ran.
                 yield pimm.Sleep(self._frame['control_dt'] if self._frame is not None else _IDLE_DT)
                 if (call := next(self.env_reset.incoming(), None)) is not None:
                     with pimm.calls.raise_to(call):
                         self.reset(dict(call.request or {}))
                         call.set_result(None)
                 elif self._active:
-                    # ``env.step`` spans the whole client-observed step; ``materialize`` nests the client-side
-                    # observation assembly (shared-memory image allocation + camera copies) inside it, so the
-                    # reduce can split materialisation out of the wire cost.
+                    # The materialize span nests inside the step span, so a reduce can split the two costs.
                     with telemetry.span(telemetry_keys.SPAN_ENV_STEP):
                         self._frame = self._step_env()
                         with telemetry.span(telemetry_keys.SPAN_MATERIALIZE):
                             self._emit_payload(self._frame['obs'])
         finally:
-            # Closes the connection then the server, in that order (reverse of acquisition); a no-op if nothing
-            # ever connected.
             self._cleanup.close()
 
     def _step_env(self) -> dict[str, Any]:

--- a/positronic/simulator/env_server/server.py
+++ b/positronic/simulator/env_server/server.py
@@ -44,11 +44,14 @@ class EnvProtocol(ABC):
     """
 
     @abstractmethod
-    def tasks(self, spec: Any) -> list[dict[str, Any]]:
-        """The benchmark's own task records for an opaque spec (a task name, a category, a suite, ``'all'``).
+    def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
+        """The benchmark's task records for a spec: the selection arguments an eval binds.
 
-        Each record is plain data in the benchmark's own vocabulary — the task's name, the seconds it gives an
-        episode — which the client's ``EnvAdapter`` maps into trial params. An unknown spec raises.
+        Each key narrows one axis, and an absent key does not narrow that axis. The keys are the eval
+        config's own parameter names, so a rename there breaks this method. An unknown value raises.
+
+        Each record is plain data in the benchmark's own vocabulary, which the client's ``EnvAdapter`` maps
+        into trial params. Every record carries ``name``: the id of one task, the same on every run.
         """
 
     @abstractmethod

--- a/positronic/simulator/env_server/server.py
+++ b/positronic/simulator/env_server/server.py
@@ -45,13 +45,11 @@ class EnvProtocol(ABC):
 
     @abstractmethod
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
-        """The benchmark's task records for a spec: the selection arguments an eval binds.
+        """The benchmark's task records for ``spec``: the selection arguments an eval binds, keyed by the eval
+        config's own parameter names.
 
-        Each key narrows one axis, and an absent key does not narrow that axis. The keys are the eval
-        config's own parameter names, so a rename there breaks this method. An unknown value raises.
-
-        Each record is plain data in the benchmark's own vocabulary, which the client's ``EnvAdapter`` maps
-        into trial params. Every record carries ``name``: the id of one task, the same on every run.
+        An absent key does not narrow that axis; an unknown value raises. Every record carries ``name``, the id
+        of one task.
         """
 
     @abstractmethod

--- a/positronic/simulator/env_server/server.py
+++ b/positronic/simulator/env_server/server.py
@@ -1,4 +1,4 @@
-"""The dumb remote env-server: a benchmark env behind ``reset``/``step``/``close`` over websockets.
+"""The dumb remote env-server: a benchmark env behind ``tasks``/``reset``/``step``/``close`` over websockets.
 
 Positronic-free by contract — it depends only on ``websockets``, plus the wire codec and the
 ``EnvProtocol`` an env implements. A benchmark runs this in its own isolated interpreter (where
@@ -11,6 +11,7 @@ re-randomizes it; ``control_dt`` rides every observation (``reset`` and each ``s
 may even vary its control period per step. Heavy construction is the env's own concern (cache it).
 
 Protocol (msgpack frames, see ``protocol``):
+  client ``{'cmd': 'tasks', 'spec': ...}``    -> server ``{'tasks': [{...}, ...]}``
   client ``{'cmd': 'reset', 'token': ...}``   -> server ``{'obs', 'meta', 'robot_meta', 'control_dt'}``
   client ``{'cmd': 'step', 'action': {...}}`` -> server ``{'obs', 'done', 'control_dt'}``
   client ``{'cmd': 'close'}``                 -> server ``{'ok': True}``
@@ -35,12 +36,20 @@ logger = logging.getLogger(__name__)
 
 
 class EnvProtocol(ABC):
-    """A benchmark env behind the three methods the server exposes; the wire contract, positronic-free.
+    """A benchmark env behind the four methods the server exposes; the wire contract, positronic-free.
 
-    ``reset`` and ``step`` exchange raw plain-data dicts (numpy arrays + scalars) — the canonical<->raw
+    ``tasks``, ``reset`` and ``step`` exchange raw plain data (numpy arrays + scalars) — the canonical<->raw
     mapping is the client's ``EnvAdapter``, never the server's. Heavy, per-task construction is the
     env's own concern (cache it, keyed by the token's structural part); the protocol has no build phase.
     """
+
+    @abstractmethod
+    def tasks(self, spec: Any) -> list[dict[str, Any]]:
+        """The benchmark's own task records for an opaque spec (a task name, a category, a suite, ``'all'``).
+
+        Each record is plain data in the benchmark's own vocabulary — the task's name, the seconds it gives an
+        episode — which the client's ``EnvAdapter`` maps into trial params. An unknown spec raises.
+        """
 
     @abstractmethod
     def reset(self, token: Any) -> dict[str, Any]:
@@ -95,6 +104,8 @@ class EnvServer:
                     case 'close':
                         connection.send(encode({'ok': True}))
                         return
+                    case 'tasks':
+                        result = {'tasks': self._env.tasks(msg['spec'])}
                     case 'reset':
                         result = self._env.reset(msg['token'])
                     case 'step':

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -4,7 +4,7 @@ This is the duplicated, test-only remote copy of the production native path (in-
 ``stack_cubes`` stays the real one), and the reference ``WireCommandAdapter`` env — it decodes the
 same tagged command dialect the real benchmarks speak, with no OSC/axis-angle quirks. ``MujocoEnv``
 drives ``MujocoSim.run()`` directly, binding local pipes to its ports the way ``World.start`` does,
-and exposes it as the gym-style ``reset``/``step`` the server serves. ``make_mujoco_env`` builds it;
+and exposes it as the ``tasks``/``reset``/``step``/``close`` the server serves. ``make_mujoco_env`` builds it;
 ``StackCubesAdapter`` is the client-side mapping.
 """
 
@@ -32,6 +32,9 @@ _ROTMAT = geom.Rotation.Representation.ROTATION_MATRIX
 # Logical observation name -> the model camera the sim renders.
 CAMERAS = {keys.EXTERIOR_IMAGE: 'agentview'}
 
+# The one scene this fixture serves.
+SCENE_NAME = 'stack_cubes'
+
 
 class _NeverStop(pimm.SignalReceiver):
     """A ``should_stop`` that never fires — ``MujocoEnv`` drives the sim loop tick by tick instead."""
@@ -41,7 +44,7 @@ class _NeverStop(pimm.SignalReceiver):
 
 
 class MujocoEnv(EnvProtocol):
-    """A ``MujocoSim`` behind the gym-style env protocol, driving its ``run()`` loop one tick at a time.
+    """A ``MujocoSim`` behind the env protocol, driving its ``run()`` loop one tick at a time.
 
     Binding local pipes to the sim's ports (the wiring ``World.start`` performs) lets ``step`` inject a
     raw action and pump the fused per-tick loop, then read the post-step signals back. The control
@@ -96,6 +99,11 @@ class MujocoEnv(EnvProtocol):
             'cameras': {name: recv.read().data.array.copy() for name, recv in self._camera_recvs.items()},
             'sim_state': dict(self._sim_state_recv.read().data),
         }
+
+    def tasks(self, spec: Any) -> list[dict[str, Any]]:
+        if spec != SCENE_NAME:
+            raise ValueError(f'MujocoEnv serves {SCENE_NAME!r}, not {spec!r}')
+        return [{'name': SCENE_NAME}]
 
     def reset(self, token: Any) -> dict[str, Any]:
         # Close the prior generator before rebuilding the scene, so its ``run`` cleanup tears down the old
@@ -161,6 +169,9 @@ class StackCubesAdapter(WireCommandAdapter):
     def __init__(self, camera_dict: dict[str, str]):
         super().__init__()
         self._camera_dict = camera_dict  # logical observation name -> the env's model camera name
+
+    def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [{keys.EVAL_TASK: record['name']} for record in records]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
         return params.get(keys.EVAL_SEED)

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -20,7 +20,7 @@ import positronic.cfg.simulator
 from pimm.world import LocalQueueEmitter, LocalQueueReceiver, VirtualClock
 from positronic import geom, keys
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.eval import Eval, Observation, Task
+from positronic.eval import EVAL_SEED, EVAL_TASK, Eval, Observation, Task
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.env_server.server import EnvProtocol
@@ -173,10 +173,10 @@ class StackCubesAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the env's model camera name
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return [{keys.EVAL_TASK: record['name']} for record in records]
+        return [{EVAL_TASK: record['name']} for record in records]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
-        return params.get(keys.EVAL_SEED)
+        return params.get(EVAL_SEED)
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         state = MujocoFrankaState()

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -20,7 +20,8 @@ import positronic.cfg.simulator
 from pimm.world import LocalQueueEmitter, LocalQueueReceiver, VirtualClock
 from positronic import geom, keys
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.eval import EVAL_SEED, EVAL_TASK, Eval, Observation, Task
+from positronic.eval import Eval, Observation, Task
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem, remote_franka_embodiment
 from positronic.simulator.env_server.server import EnvProtocol
@@ -173,10 +174,10 @@ class StackCubesAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the env's model camera name
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return [{EVAL_TASK: record['name']} for record in records]
+        return [{eval_keys.TASK: record['name']} for record in records]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
-        return params.get(EVAL_SEED)
+        return params.get(eval_keys.SEED)
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         state = MujocoFrankaState()

--- a/positronic/simulator/env_server/tests/mujoco_env.py
+++ b/positronic/simulator/env_server/tests/mujoco_env.py
@@ -100,10 +100,12 @@ class MujocoEnv(EnvProtocol):
             'sim_state': dict(self._sim_state_recv.read().data),
         }
 
-    def tasks(self, spec: Any) -> list[dict[str, Any]]:
-        if spec != SCENE_NAME:
-            raise ValueError(f'MujocoEnv serves {SCENE_NAME!r}, not {spec!r}')
-        return [{'name': SCENE_NAME}]
+    def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
+        selection = spec.get('task', SCENE_NAME)
+        names = [selection] if isinstance(selection, str) else list(selection)
+        if any(name != SCENE_NAME for name in names):
+            raise ValueError(f'MujocoEnv serves {SCENE_NAME!r}, not {names}')
+        return [{'name': name} for name in names]
 
     def reset(self, token: Any) -> dict[str, Any]:
         # Close the prior generator before rebuilding the scene, so its ``run`` cleanup tears down the old

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -19,7 +19,7 @@ from positronic.cli.eval.run import main
 from positronic.dataset import Episode
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.eval import Task
+from positronic.eval import EVAL_EMBODIMENT, EVAL_SEED, EVAL_SUCCESS, EVAL_TASK, EVAL_TERMINATED, EVAL_UNIVERSE, Task
 from positronic.policy import Policy, Session
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.layers import ChunkedSchedule
@@ -295,10 +295,10 @@ class _CountdownEnv(EnvProtocol):
 
 class _CountdownAdapter(EnvAdapter):
     def task_params(self, records):
-        return [{keys.EVAL_TASK: record['name']} for record in records]
+        return [{EVAL_TASK: record['name']} for record in records]
 
     def reset_token(self, params):
-        return params.get(keys.EVAL_SEED)
+        return params.get(EVAL_SEED)
 
     def action(self, commands):
         return {}
@@ -310,7 +310,7 @@ class _CountdownAdapter(EnvAdapter):
         return {}
 
     def terminal(self, result):
-        return {keys.EVAL_SUCCESS: True} if result['done'] else None
+        return {EVAL_SUCCESS: True} if result['done'] else None
 
 
 @pytest.mark.timeout(60.0)
@@ -322,9 +322,9 @@ def test_the_proxy_connects_on_a_tasks_call_before_any_reset():
         obs_rx = world.pair(proxy.observations['value'])
         world.start([proxy])
 
-        assert proxy.tasks({'task': _COUNTDOWN}) == [{keys.EVAL_TASK: _COUNTDOWN}]
+        assert proxy.tasks({'task': _COUNTDOWN}) == [{EVAL_TASK: _COUNTDOWN}]
 
-        proxy.reset({keys.EVAL_SEED: 0})
+        proxy.reset({EVAL_SEED: 0})
         np.testing.assert_array_equal(obs_rx.value, np.zeros(7))
 
 
@@ -370,7 +370,7 @@ def test_proxy_publishes_the_reset_frame_then_free_runs():
         scheduler = world.start([proxy])
         drive_scheduler(scheduler, steps=2)  # inactive: the proxy paces time without an env
 
-        proxy.reset({keys.EVAL_SEED: 0})
+        proxy.reset({EVAL_SEED: 0})
         np.testing.assert_array_equal(obs_rx.read().data, np.zeros(7))
         assert done_rx.read().data == {}
 
@@ -388,7 +388,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
         task = Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=1.0)
         scheduler = world.start([proxy])
 
-        proxy.reset({keys.EVAL_SEED: 0})
+        proxy.reset({EVAL_SEED: 0})
         assert task.instruction == 'countdown'  # resolved live off the cached reset meta
         drive_scheduler(scheduler, steps=4)  # the env steps, each ``step`` omitting meta ...
         assert task.instruction == 'countdown'  # ... yet the reset-scoped cache holds
@@ -402,7 +402,7 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     host, port = env_server
     with pos3.mirror():
         ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
-        trial = number_trials([(replace(next(iter(ev.tasks())), timeout_sec=0.1), {keys.EVAL_SEED: 100})])[0]
+        trial = number_trials([(replace(next(iter(ev.tasks())), timeout_sec=0.1), {EVAL_SEED: 100})])[0]
         policy = StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0)
         main(
             policy=ChunkedSchedule().wrap(policy),
@@ -414,10 +414,10 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     assert len(ds) == 1
     episode = ds[0]
     assert isinstance(episode, Episode)
-    assert episode.static[keys.EVAL_TERMINATED] is False
-    assert keys.EVAL_SUCCESS not in episode.static
-    assert episode.static[keys.EVAL_UNIVERSE] == 'sim'
-    assert episode.static[keys.EVAL_EMBODIMENT] == 'remote.mujoco.franka'
+    assert episode.static[EVAL_TERMINATED] is False
+    assert EVAL_SUCCESS not in episode.static
+    assert episode.static[EVAL_UNIVERSE] == 'sim'
+    assert episode.static[EVAL_EMBODIMENT] == 'remote.mujoco.franka'
     assert episode.static['scene_xml'].startswith('<mujoco')
     signals = episode.signals
     assert keys.EXTERIOR_IMAGE in signals
@@ -477,7 +477,7 @@ def test_full_chunk_executes_between_replans(env_server, tmp_path):
     with pos3.mirror():
         ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
         task = replace(next(iter(ev.tasks())), timeout_sec=20 * control_dt)
-        trial = number_trials([(task, {keys.EVAL_SEED: 100})])[0]
+        trial = number_trials([(task, {EVAL_SEED: 100})])[0]
         main(policy=policy, evals=[replace(ev, tasks=partial(iter, [trial]))], output_dir=str(tmp_path))
 
     grip = LocalDataset(tmp_path)[0].signals['target_grip']

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -19,7 +19,8 @@ from positronic.cli.eval.run import main
 from positronic.dataset import Episode
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.eval import EVAL_EMBODIMENT, EVAL_SEED, EVAL_SUCCESS, EVAL_TASK, EVAL_TERMINATED, EVAL_UNIVERSE, Task
+from positronic.eval import Task
+from positronic.eval import keys as eval_keys
 from positronic.policy import Policy, Session
 from positronic.policy.codec import ActionTimestamp
 from positronic.policy.layers import ChunkedSchedule
@@ -295,10 +296,10 @@ class _CountdownEnv(EnvProtocol):
 
 class _CountdownAdapter(EnvAdapter):
     def task_params(self, records):
-        return [{EVAL_TASK: record['name']} for record in records]
+        return [{eval_keys.TASK: record['name']} for record in records]
 
     def reset_token(self, params):
-        return params.get(EVAL_SEED)
+        return params.get(eval_keys.SEED)
 
     def action(self, commands):
         return {}
@@ -310,7 +311,7 @@ class _CountdownAdapter(EnvAdapter):
         return {}
 
     def terminal(self, result):
-        return {EVAL_SUCCESS: True} if result['done'] else None
+        return {eval_keys.SUCCESS: True} if result['done'] else None
 
 
 @pytest.mark.timeout(60.0)
@@ -322,9 +323,9 @@ def test_the_proxy_connects_on_a_tasks_call_before_any_reset():
         obs_rx = world.pair(proxy.observations['value'])
         world.start([proxy])
 
-        assert proxy.tasks({'task': _COUNTDOWN}) == [{EVAL_TASK: _COUNTDOWN}]
+        assert proxy.tasks({'task': _COUNTDOWN}) == [{eval_keys.TASK: _COUNTDOWN}]
 
-        proxy.reset({EVAL_SEED: 0})
+        proxy.reset({eval_keys.SEED: 0})
         np.testing.assert_array_equal(obs_rx.value, np.zeros(7))
 
 
@@ -370,7 +371,7 @@ def test_proxy_publishes_the_reset_frame_then_free_runs():
         scheduler = world.start([proxy])
         drive_scheduler(scheduler, steps=2)  # inactive: the proxy paces time without an env
 
-        proxy.reset({EVAL_SEED: 0})
+        proxy.reset({eval_keys.SEED: 0})
         np.testing.assert_array_equal(obs_rx.read().data, np.zeros(7))
         assert done_rx.read().data == {}
 
@@ -388,7 +389,7 @@ def test_proxy_caches_reset_meta_as_live_instruction_source():
         task = Task(instruction_source=lambda: proxy.meta['task'], timeout_sec=1.0)
         scheduler = world.start([proxy])
 
-        proxy.reset({EVAL_SEED: 0})
+        proxy.reset({eval_keys.SEED: 0})
         assert task.instruction == 'countdown'  # resolved live off the cached reset meta
         drive_scheduler(scheduler, steps=4)  # the env steps, each ``step`` omitting meta ...
         assert task.instruction == 'countdown'  # ... yet the reset-scoped cache holds
@@ -402,7 +403,7 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     host, port = env_server
     with pos3.mirror():
         ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
-        trial = number_trials([(replace(next(iter(ev.tasks())), timeout_sec=0.1), {EVAL_SEED: 100})])[0]
+        trial = number_trials([(replace(next(iter(ev.tasks())), timeout_sec=0.1), {eval_keys.SEED: 100})])[0]
         policy = StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0)
         main(
             policy=ChunkedSchedule().wrap(policy),
@@ -414,10 +415,10 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     assert len(ds) == 1
     episode = ds[0]
     assert isinstance(episode, Episode)
-    assert episode.static[EVAL_TERMINATED] is False
-    assert EVAL_SUCCESS not in episode.static
-    assert episode.static[EVAL_UNIVERSE] == 'sim'
-    assert episode.static[EVAL_EMBODIMENT] == 'remote.mujoco.franka'
+    assert episode.static[eval_keys.TERMINATED] is False
+    assert eval_keys.SUCCESS not in episode.static
+    assert episode.static[eval_keys.UNIVERSE] == 'sim'
+    assert episode.static[eval_keys.EMBODIMENT] == 'remote.mujoco.franka'
     assert episode.static['scene_xml'].startswith('<mujoco')
     signals = episode.signals
     assert keys.EXTERIOR_IMAGE in signals
@@ -477,7 +478,7 @@ def test_full_chunk_executes_between_replans(env_server, tmp_path):
     with pos3.mirror():
         ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
         task = replace(next(iter(ev.tasks())), timeout_sec=20 * control_dt)
-        trial = number_trials([(task, {EVAL_SEED: 100})])[0]
+        trial = number_trials([(task, {eval_keys.SEED: 100})])[0]
         main(policy=policy, evals=[replace(ev, tasks=partial(iter, [trial]))], output_dir=str(tmp_path))
 
     grip = LocalDataset(tmp_path)[0].signals['target_grip']

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -30,7 +30,12 @@ from positronic.simulator.env_server.launcher import free_port
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
 from positronic.simulator.env_server.server import EnvProtocol
 from positronic.simulator.env_server.tests.conftest import serve_env
-from positronic.simulator.env_server.tests.mujoco_env import CAMERAS, make_mujoco_env, remote_stack_cubes_eval
+from positronic.simulator.env_server.tests.mujoco_env import (
+    CAMERAS,
+    SCENE_NAME,
+    make_mujoco_env,
+    remote_stack_cubes_eval,
+)
 from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.tests.testing_coutils import drive_scheduler
 
@@ -101,6 +106,18 @@ def test_transport_is_transparent(env_server):
         assert direct_step['control_dt'] == socket_step['control_dt']
 
 
+@pytest.mark.timeout(60.0)
+def test_the_env_answers_its_own_task_list(env_server):
+    """``tasks`` crosses like every other command: the env answers its own records, and a spec it does not
+    know raises server-side and reaches the client as an error."""
+    host, port = env_server
+    conn = EnvConnection(host, port)
+    assert conn.tasks(SCENE_NAME) == [{'name': SCENE_NAME}]
+    with pytest.raises(RuntimeError, match='nosuchscene'):
+        conn.tasks('nosuchscene')
+    conn.close()
+
+
 @contextmanager
 def _mute_server():
     """A peer that accepts the connection and then answers nothing, holding the socket open.
@@ -159,8 +176,8 @@ def test_a_pinned_control_mode_rides_the_wire():
 class TestEnvControlFrame:
     """An env measuring somewhere other than the embodiment's ``default`` gets commands re-expressed for it.
 
-    ``RobolabAdapter`` is the live case and has no test module of its own, so its round-trip lands here beside
-    the rest of the adapter's wire contract.
+    ``RobolabAdapter`` is the live case, and this file covers the adapter wire contract, so its frame
+    round-trip runs here.
     """
 
     frame = geom.Transform3D(np.array([0.0, 0.0, 0.1]), geom.Rotation.from_euler([0.0, 0.0, np.pi / 2]))
@@ -236,6 +253,10 @@ def test_cartesian_delta_matches_absolute_target():
     np.testing.assert_allclose(ee_idle, ee_delta, atol=1e-3)  # one-shot: idle ticks add no motion
 
 
+# The one task ``_CountdownEnv`` serves.
+_COUNTDOWN = 'countdown'
+
+
 class _CountdownEnv(EnvProtocol):
     """A degenerate env exercising the proxy's terminal and free-run paths without the real ``stack_cubes``
     wrapper. Obs encodes the step count (``reset`` is step 0, each ``step`` increments) so a reader can
@@ -246,9 +267,16 @@ class _CountdownEnv(EnvProtocol):
         self._control_dt = control_dt
         self._steps = 0
 
+    def tasks(self, spec):
+        if isinstance(spec, list):  # a selection of names, which names nothing when it is empty
+            return [{'name': name} for name in spec]
+        if spec != _COUNTDOWN:
+            raise ValueError(f'_CountdownEnv serves {_COUNTDOWN!r}, not {spec!r}')
+        return [{'name': _COUNTDOWN}]
+
     def reset(self, token):
         self._steps = 0
-        meta = {'task': 'countdown'}  # scene meta the env reports only at reset; ``step`` omits it
+        meta = {'task': _COUNTDOWN}  # scene meta the env reports only at reset; ``step`` omits it
         return {
             'obs': {'q': np.full(7, self._steps, dtype=np.float64)},
             'meta': meta,
@@ -266,6 +294,9 @@ class _CountdownEnv(EnvProtocol):
 
 
 class _CountdownAdapter(EnvAdapter):
+    def task_params(self, records):
+        return [{keys.EVAL_TASK: record['name']} for record in records]
+
     def reset_token(self, params):
         return params.get(keys.EVAL_SEED)
 
@@ -280,6 +311,53 @@ class _CountdownAdapter(EnvAdapter):
 
     def terminal(self, result):
         return {keys.EVAL_SUCCESS: True} if result['done'] else None
+
+
+@pytest.mark.timeout(60.0)
+def test_the_proxy_connects_on_a_tasks_call_before_any_reset():
+    """An eval asks the env what tasks it has before its first trial, so ``tasks`` is what starts the server
+    and opens the connection. The server serves one client, so the trial that follows proves it shares that
+    connection rather than opening a second one."""
+    with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
+        proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
+        obs_rx = world.pair(proxy.observations['value'])
+        world.start([proxy])
+
+        assert proxy.tasks(_COUNTDOWN) == [{keys.EVAL_TASK: _COUNTDOWN}]
+
+        proxy.reset({keys.EVAL_SEED: 0})
+        np.testing.assert_array_equal(obs_rx.value, np.zeros(7))
+
+
+@pytest.mark.timeout(60.0)
+def test_a_selection_naming_no_task_is_refused():
+    """A sweep of no trials writes nothing and ends at once, which a caller reads as a run that succeeded.
+    So a listing that comes back empty stops the run where the selection is still known."""
+    with serve_env(_CountdownEnv()) as (host, port):
+        proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
+        with pytest.raises(ValueError, match='no task'):
+            proxy.tasks([])
+
+
+@pytest.mark.timeout(60.0)
+def test_a_refused_listing_stops_the_server_it_started():
+    """The listing starts the server, and the scheduler enters ``run`` — whose teardown stops it — only later
+    in that same turn. So a spec the env refuses stops the server it just started."""
+    with serve_env(_CountdownEnv()) as address:
+        stopped = False
+
+        @contextmanager
+        def serve():
+            nonlocal stopped
+            try:
+                yield address
+            finally:
+                stopped = True
+
+        proxy = RemoteEnvControlSystem(_CountdownAdapter(), serve())
+        with pytest.raises(RuntimeError, match='nosuchtask'):
+            proxy.tasks('nosuchtask')
+        assert stopped, 'the server stayed up with nobody left to stop it'
 
 
 @pytest.mark.timeout(60.0)
@@ -327,7 +405,7 @@ def test_remote_eval_runs_to_timeout_without_done(env_server, tmp_path):
     host, port = env_server
     with pos3.mirror():
         ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
-        trial = number_trials(replace(next(iter(ev.tasks())), timeout_sec=0.1), [{keys.EVAL_SEED: 100}])[0]
+        trial = number_trials([(replace(next(iter(ev.tasks())), timeout_sec=0.1), {keys.EVAL_SEED: 100})])[0]
         policy = StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0)
         main(
             policy=ChunkedSchedule().wrap(policy),
@@ -401,7 +479,8 @@ def test_full_chunk_executes_between_replans(env_server, tmp_path):
     policy = (ChunkedSchedule() | ActionTimestamp(fps=1.0 / control_dt)).wrap(raw)
     with pos3.mirror():
         ev = remote_stack_cubes_eval(host, port, camera_dict=CAMERAS)
-        trial = number_trials(replace(next(iter(ev.tasks())), timeout_sec=20 * control_dt), [{keys.EVAL_SEED: 100}])[0]
+        task = replace(next(iter(ev.tasks())), timeout_sec=20 * control_dt)
+        trial = number_trials([(task, {keys.EVAL_SEED: 100})])[0]
         main(policy=policy, evals=[replace(ev, tasks=partial(iter, [trial]))], output_dir=str(tmp_path))
 
     grip = LocalDataset(tmp_path)[0].signals['target_grip']

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -108,8 +108,7 @@ def test_transport_is_transparent(env_server):
 
 @pytest.mark.timeout(60.0)
 def test_the_env_answers_its_own_task_list(env_server):
-    """``tasks`` crosses like every other command: the env answers its own records, and a spec it does not
-    know raises server-side and reaches the client as an error."""
+    """The env answers its own records, and a spec it does not know raises through to the client."""
     host, port = env_server
     conn = EnvConnection(host, port)
     assert conn.tasks({}) == [{'name': SCENE_NAME}]
@@ -316,9 +315,8 @@ class _CountdownAdapter(EnvAdapter):
 
 @pytest.mark.timeout(60.0)
 def test_the_proxy_connects_on_a_tasks_call_before_any_reset():
-    """An eval asks the env what tasks it has before its first trial, so ``tasks`` is what starts the server
-    and opens the connection. The server serves one client, so the trial that follows proves it shares that
-    connection rather than opening a second one."""
+    """``tasks`` runs before the first trial, so it starts the server; the reset that follows shares its
+    connection."""
     with serve_env(_CountdownEnv()) as (host, port), pimm.World(virtual_time=True) as world:
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
         obs_rx = world.pair(proxy.observations['value'])
@@ -332,8 +330,7 @@ def test_the_proxy_connects_on_a_tasks_call_before_any_reset():
 
 @pytest.mark.timeout(60.0)
 def test_a_selection_naming_no_task_is_refused():
-    """A sweep of no trials writes nothing and ends at once, which a caller reads as a run that succeeded.
-    So a listing that comes back empty stops the run where the selection is still known."""
+    """A sweep of no trials ends at once and reads as a run that succeeded, so an empty listing raises."""
     with serve_env(_CountdownEnv()) as (host, port):
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
         with pytest.raises(ValueError, match='no task'):
@@ -342,8 +339,7 @@ def test_a_selection_naming_no_task_is_refused():
 
 @pytest.mark.timeout(60.0)
 def test_a_refused_listing_stops_the_server_it_started():
-    """The listing starts the server, and the scheduler enters ``run`` — whose teardown stops it — only later
-    in that same turn. So a spec the env refuses stops the server it just started."""
+    """The scheduler enters ``run``, whose teardown stops the server, only after the listing."""
     with serve_env(_CountdownEnv()) as address:
         stopped = False
 

--- a/positronic/simulator/env_server/tests/test_remote_env.py
+++ b/positronic/simulator/env_server/tests/test_remote_env.py
@@ -112,9 +112,10 @@ def test_the_env_answers_its_own_task_list(env_server):
     know raises server-side and reaches the client as an error."""
     host, port = env_server
     conn = EnvConnection(host, port)
-    assert conn.tasks(SCENE_NAME) == [{'name': SCENE_NAME}]
+    assert conn.tasks({}) == [{'name': SCENE_NAME}]
+    assert conn.tasks({'task': SCENE_NAME}) == [{'name': SCENE_NAME}]
     with pytest.raises(RuntimeError, match='nosuchscene'):
-        conn.tasks('nosuchscene')
+        conn.tasks({'task': 'nosuchscene'})
     conn.close()
 
 
@@ -268,11 +269,11 @@ class _CountdownEnv(EnvProtocol):
         self._steps = 0
 
     def tasks(self, spec):
-        if isinstance(spec, list):  # a selection of names, which names nothing when it is empty
-            return [{'name': name} for name in spec]
-        if spec != _COUNTDOWN:
-            raise ValueError(f'_CountdownEnv serves {_COUNTDOWN!r}, not {spec!r}')
-        return [{'name': _COUNTDOWN}]
+        selection = spec.get('task', _COUNTDOWN)
+        names = [selection] if isinstance(selection, str) else list(selection)
+        if any(name != _COUNTDOWN for name in names):
+            raise ValueError(f'_CountdownEnv serves {_COUNTDOWN!r}, not {names}')
+        return [{'name': name} for name in names]
 
     def reset(self, token):
         self._steps = 0
@@ -323,7 +324,7 @@ def test_the_proxy_connects_on_a_tasks_call_before_any_reset():
         obs_rx = world.pair(proxy.observations['value'])
         world.start([proxy])
 
-        assert proxy.tasks(_COUNTDOWN) == [{keys.EVAL_TASK: _COUNTDOWN}]
+        assert proxy.tasks({'task': _COUNTDOWN}) == [{keys.EVAL_TASK: _COUNTDOWN}]
 
         proxy.reset({keys.EVAL_SEED: 0})
         np.testing.assert_array_equal(obs_rx.value, np.zeros(7))
@@ -336,7 +337,7 @@ def test_a_selection_naming_no_task_is_refused():
     with serve_env(_CountdownEnv()) as (host, port):
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), nullcontext((host, port)))
         with pytest.raises(ValueError, match='no task'):
-            proxy.tasks([])
+            proxy.tasks({'task': []})
 
 
 @pytest.mark.timeout(60.0)
@@ -356,7 +357,7 @@ def test_a_refused_listing_stops_the_server_it_started():
 
         proxy = RemoteEnvControlSystem(_CountdownAdapter(), serve())
         with pytest.raises(RuntimeError, match='nosuchtask'):
-            proxy.tasks('nosuchtask')
+            proxy.tasks({'task': 'nosuchtask'})
         assert stopped, 'the server stayed up with nobody left to stop it'
 
 

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -12,18 +12,10 @@ import numpy as np
 
 import pimm
 from positronic import geom, keys
-from positronic.eval import EVAL_SEED, EVAL_SUCCESS, EVAL_TASK
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.adapter import WireCommandAdapter
+from positronic.simulator.libero import keys as libero_keys
 from positronic.simulator.mujoco.sim import MujocoFrankaState
-
-# The scene a trial runs: the task, as ``task_params`` names it from the env's task records, plus the render
-# and control settings the eval config owns; ``_reset_token`` reads them back. The server caches an env by
-# ``(suite, task_id, camera_resolution, control_mode)``.
-EVAL_SUITE = 'eval.suite'
-EVAL_TASK_ID = 'eval.task_id'
-EVAL_CAMERA_RESOLUTION = 'eval.camera_resolution'
-EVAL_CONTROL_MODE = 'eval.control_mode'
-EVAL_SETTLE_STEPS = 'eval.settle_steps'
 
 
 class LiberoAdapter(WireCommandAdapter):
@@ -32,7 +24,10 @@ class LiberoAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return [{EVAL_TASK: r['name'], EVAL_SUITE: r['suite'], EVAL_TASK_ID: r['task_id']} for r in records]
+        return [
+            {eval_keys.TASK: r['name'], libero_keys.SUITE: r['suite'], libero_keys.TASK_ID: r['task_id']}
+            for r in records
+        ]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # The whole scene spec rides the trial params: the server caches its env by ``(suite, task_id,
@@ -41,12 +36,12 @@ class LiberoAdapter(WireCommandAdapter):
         # the hold-arm/open-gripper wait the server runs after a seeded reset so dropped objects settle before
         # the first observation (openpi's num_steps_wait dummy-action wait).
         return {
-            'suite': params[EVAL_SUITE],
-            'task_id': params[EVAL_TASK_ID],
-            'camera_resolution': params[EVAL_CAMERA_RESOLUTION],
-            'control_mode': params[EVAL_CONTROL_MODE],
-            'seed': params.get(EVAL_SEED),
-            'settle_steps': params[EVAL_SETTLE_STEPS],
+            'suite': params[libero_keys.SUITE],
+            'task_id': params[libero_keys.TASK_ID],
+            'camera_resolution': params[libero_keys.CAMERA_RESOLUTION],
+            'control_mode': params[libero_keys.CONTROL_MODE],
+            'seed': params.get(eval_keys.SEED),
+            'settle_steps': params[libero_keys.SETTLE_STEPS],
         }
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
@@ -70,4 +65,4 @@ class LiberoAdapter(WireCommandAdapter):
 
     def terminal(self, result: dict[str, Any]) -> dict[str, Any] | None:
         # ``done`` is LIBERO's success check rather than a step limit, so reaching it is the success.
-        return {EVAL_SUCCESS: True} if result['done'] else None
+        return {eval_keys.SUCCESS: True} if result['done'] else None

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -12,8 +12,18 @@ import numpy as np
 
 import pimm
 from positronic import geom, keys
+from positronic.eval import EVAL_SEED, EVAL_SUCCESS, EVAL_TASK
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
+
+# The scene a trial runs: the task, as ``task_params`` names it from the env's task records, plus the render
+# and control settings the eval config owns; ``_reset_token`` reads them back. The server caches an env by
+# ``(suite, task_id, camera_resolution, control_mode)``.
+EVAL_SUITE = 'eval.suite'
+EVAL_TASK_ID = 'eval.task_id'
+EVAL_CAMERA_RESOLUTION = 'eval.camera_resolution'
+EVAL_CONTROL_MODE = 'eval.control_mode'
+EVAL_SETTLE_STEPS = 'eval.settle_steps'
 
 
 class LiberoAdapter(WireCommandAdapter):
@@ -22,9 +32,7 @@ class LiberoAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return [
-            {keys.EVAL_TASK: r['name'], keys.EVAL_SUITE: r['suite'], keys.EVAL_TASK_ID: r['task_id']} for r in records
-        ]
+        return [{EVAL_TASK: r['name'], EVAL_SUITE: r['suite'], EVAL_TASK_ID: r['task_id']} for r in records]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # The whole scene spec rides the trial params: the server caches its env by ``(suite, task_id,
@@ -33,12 +41,12 @@ class LiberoAdapter(WireCommandAdapter):
         # the hold-arm/open-gripper wait the server runs after a seeded reset so dropped objects settle before
         # the first observation (openpi's num_steps_wait dummy-action wait).
         return {
-            'suite': params[keys.EVAL_SUITE],
-            'task_id': params[keys.EVAL_TASK_ID],
-            'camera_resolution': params[keys.EVAL_CAMERA_RESOLUTION],
-            'control_mode': params[keys.EVAL_CONTROL_MODE],
-            'seed': params.get(keys.EVAL_SEED),
-            'settle_steps': params[keys.EVAL_SETTLE_STEPS],
+            'suite': params[EVAL_SUITE],
+            'task_id': params[EVAL_TASK_ID],
+            'camera_resolution': params[EVAL_CAMERA_RESOLUTION],
+            'control_mode': params[EVAL_CONTROL_MODE],
+            'seed': params.get(EVAL_SEED),
+            'settle_steps': params[EVAL_SETTLE_STEPS],
         }
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
@@ -62,4 +70,4 @@ class LiberoAdapter(WireCommandAdapter):
 
     def terminal(self, result: dict[str, Any]) -> dict[str, Any] | None:
         # ``done`` is LIBERO's success check rather than a step limit, so reaching it is the success.
-        return {keys.EVAL_SUCCESS: True} if result['done'] else None
+        return {EVAL_SUCCESS: True} if result['done'] else None

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -22,8 +22,6 @@ class LiberoAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        # The env names the task and the eval config names how to render and control it, so a record maps to
-        # the scene keys that identify a task; the config's scene spec fills the rest of the reset token.
         return [
             {keys.EVAL_TASK: r['name'], keys.EVAL_SUITE: r['suite'], keys.EVAL_TASK_ID: r['task_id']} for r in records
         ]

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -21,15 +21,12 @@ class LiberoAdapter(WireCommandAdapter):
         super().__init__()
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
 
-    def task_spec(self, selection: dict[str, Any]) -> Any:
-        # LIBERO names a task on two axes, so an eval selects on both: one suite or a list of them, and one
-        # task id or ``None`` for every task of each suite.
-        return {'suite': selection[keys.EVAL_SUITE], 'task_id': selection[keys.EVAL_TASK_ID]}
-
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # The env names the task and the eval config names how to render and control it, so a record maps to
         # the scene keys that identify a task; the config's scene spec fills the rest of the reset token.
-        return [{keys.EVAL_SUITE: r['suite'], keys.EVAL_TASK_ID: r['task_id']} for r in records]
+        return [
+            {keys.EVAL_TASK: r['name'], keys.EVAL_SUITE: r['suite'], keys.EVAL_TASK_ID: r['task_id']} for r in records
+        ]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # The whole scene spec rides the trial params: the server caches its env by ``(suite, task_id,

--- a/positronic/simulator/libero/adapter.py
+++ b/positronic/simulator/libero/adapter.py
@@ -21,6 +21,16 @@ class LiberoAdapter(WireCommandAdapter):
         super().__init__()
         self._camera_dict = camera_dict  # logical observation name -> the LIBERO obs image key
 
+    def task_spec(self, selection: dict[str, Any]) -> Any:
+        # LIBERO names a task on two axes, so an eval selects on both: one suite or a list of them, and one
+        # task id or ``None`` for every task of each suite.
+        return {'suite': selection[keys.EVAL_SUITE], 'task_id': selection[keys.EVAL_TASK_ID]}
+
+    def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        # The env names the task and the eval config names how to render and control it, so a record maps to
+        # the scene keys that identify a task; the config's scene spec fills the rest of the reset token.
+        return [{keys.EVAL_SUITE: r['suite'], keys.EVAL_TASK_ID: r['task_id']} for r in records]
+
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # The whole scene spec rides the trial params: the server caches its env by ``(suite, task_id,
         # camera_resolution, control_mode)``, so one adapter + one server serve any mix of suites and tasks.

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -37,8 +37,7 @@ goal is solved to joints with damped-least-squares IK and a joint goal is turned
 forward kinematics, both on the MuJoCo site Jacobian OSC itself computes. The reset token carries the task spec
 (suite, task_id, camera resolution, control mode) plus the per-trial seed; the env builds that task on the first
 reset and caches it, rebuilding only when the spec changes. The seed selects a saved init-state and re-randomizes
-object positions; a ``None`` seed draws one at random. ``tasks`` reads the suites LIBERO registers, so the eval
-asks this server which tasks a selection holds instead of pinning a count of its own.
+object positions; a ``None`` seed draws one at random.
 """
 
 import argparse
@@ -116,9 +115,7 @@ class LiberoEnv(EnvProtocol):
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
         """The tasks ``spec`` selects: ``suite`` is one name or a list of them, ``task_id`` narrows to one.
 
-        A record names its task as the reset token does, by suite and index, and it carries the bddl name as
-        the id. That name holds across task orders, which the index does not. Reading the registry builds no
-        env, so the task the server holds stays.
+        The id is the bddl name: it holds across task orders, which the index does not.
         """
         suites = [spec['suite']] if isinstance(spec['suite'], str) else spec['suite']
         registry = benchmark.get_benchmark_dict()

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -114,25 +114,25 @@ class LiberoEnv(EnvProtocol):
         return self._env.env.robots[0].controller
 
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
-        """The tasks ``spec`` selects: ``suite`` is one name or a list of them, ``task_id`` one id or ``None``.
+        """The tasks ``spec`` selects: ``suite`` is one name or a list of them, ``task_id`` narrows to one.
 
-        A record names its task as the reset token does, by suite and index. Reading the registry builds no
+        A record names its task as the reset token does, by suite and index, and it carries the bddl name as
+        the id. That name holds across task orders, which the index does not. Reading the registry builds no
         env, so the task the server holds stays.
         """
         suites = [spec['suite']] if isinstance(spec['suite'], str) else spec['suite']
-        task_id = spec['task_id']
         registry = benchmark.get_benchmark_dict()
         records = []
         for suite_name in suites:
             if suite_name not in registry:
                 raise ValueError(f'LIBERO holds the suites {sorted(registry)}, not {suite_name!r}')
-            num_tasks = registry[suite_name]().get_num_tasks()
-            if task_id is None:
-                records += [{'suite': suite_name, 'task_id': i} for i in range(num_tasks)]
-            elif 0 <= task_id < num_tasks:
-                records.append({'suite': suite_name, 'task_id': task_id})
-            else:
-                raise ValueError(f'suite {suite_name!r} holds {num_tasks} tasks, so task_id {task_id} does not exist')
+            suite = registry[suite_name]()
+            num_tasks = suite.get_num_tasks()
+            ids = [spec['task_id']] if 'task_id' in spec else range(num_tasks)
+            for task_id in ids:
+                if not 0 <= task_id < num_tasks:
+                    raise ValueError(f'suite {suite_name!r} holds {num_tasks} tasks, so task_id {task_id} is none')
+                records.append({'suite': suite_name, 'task_id': task_id, 'name': suite.get_task(task_id).name})
         return records
 
     def _build(self, suite_name: str, task_id: int, camera_resolution: int, control_mode: str) -> None:

--- a/positronic/simulator/libero/env.py
+++ b/positronic/simulator/libero/env.py
@@ -37,7 +37,8 @@ goal is solved to joints with damped-least-squares IK and a joint goal is turned
 forward kinematics, both on the MuJoCo site Jacobian OSC itself computes. The reset token carries the task spec
 (suite, task_id, camera resolution, control mode) plus the per-trial seed; the env builds that task on the first
 reset and caches it, rebuilding only when the spec changes. The seed selects a saved init-state and re-randomizes
-object positions; a ``None`` seed draws one at random.
+object positions; a ``None`` seed draws one at random. ``tasks`` reads the suites LIBERO registers, so the eval
+asks this server which tasks a selection holds instead of pinning a count of its own.
 """
 
 import argparse
@@ -71,7 +72,7 @@ def _unpack_pose(vec: Any) -> tuple[np.ndarray, np.ndarray]:
 
 
 class LiberoEnv(EnvProtocol):
-    """A LIBERO task behind the gym-style ``reset``/``step``/``close`` the env server serves.
+    """A LIBERO task behind the ``tasks``/``reset``/``step``/``close`` the env server serves.
 
     Built from the reset token's task spec (suite, task_id, resolution, control mode) and cached; ``reset``
     rebuilds when the spec changes, then re-seeds and selects a saved init-state (drawing the seed when the token
@@ -111,6 +112,28 @@ class LiberoEnv(EnvProtocol):
     @property
     def _controller(self):
         return self._env.env.robots[0].controller
+
+    def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
+        """The tasks ``spec`` selects: ``suite`` is one name or a list of them, ``task_id`` one id or ``None``.
+
+        A record names its task as the reset token does, by suite and index. Reading the registry builds no
+        env, so the task the server holds stays.
+        """
+        suites = [spec['suite']] if isinstance(spec['suite'], str) else spec['suite']
+        task_id = spec['task_id']
+        registry = benchmark.get_benchmark_dict()
+        records = []
+        for suite_name in suites:
+            if suite_name not in registry:
+                raise ValueError(f'LIBERO holds the suites {sorted(registry)}, not {suite_name!r}')
+            num_tasks = registry[suite_name]().get_num_tasks()
+            if task_id is None:
+                records += [{'suite': suite_name, 'task_id': i} for i in range(num_tasks)]
+            elif 0 <= task_id < num_tasks:
+                records.append({'suite': suite_name, 'task_id': task_id})
+            else:
+                raise ValueError(f'suite {suite_name!r} holds {num_tasks} tasks, so task_id {task_id} does not exist')
+        return records
 
     def _build(self, suite_name: str, task_id: int, camera_resolution: int, control_mode: str) -> None:
         if self._env is not None:

--- a/positronic/simulator/libero/keys.py
+++ b/positronic/simulator/libero/keys.py
@@ -1,0 +1,10 @@
+"""The keys of a LIBERO scene: the task the eval config selects and the settings it owns."""
+
+# The scene a trial runs: the task, as ``task_params`` names it from the env's task records, plus the render
+# and control settings the eval config owns; ``_reset_token`` reads them back. The server caches an env by
+# ``(suite, task_id, camera_resolution, control_mode)``.
+SUITE = 'eval.suite'
+TASK_ID = 'eval.task_id'
+CAMERA_RESOLUTION = 'eval.camera_resolution'
+CONTROL_MODE = 'eval.control_mode'
+SETTLE_STEPS = 'eval.settle_steps'

--- a/positronic/simulator/libero/tests/test_e2e.py
+++ b/positronic/simulator/libero/tests/test_e2e.py
@@ -1,9 +1,10 @@
 """The LIBERO env-server e2e, as a pytest.
 
-It replays demo episodes from a tiny committed ``.npz`` fixture through the real env-server subprocess, which
-needs LIBERO's 3.10 interpreter and offscreen rendering. That is too heavy for the normal suite, so this path is
-kept out of the default ``testpaths``: the dedicated ``.github/workflows/libero-e2e.yaml`` lane runs it by
-explicit path (Linux software rendering, ``MUJOCO_GL=osmesa``); a plain ``uv run pytest`` never collects it.
+It drives the real env-server subprocess, which needs LIBERO's 3.10 interpreter and offscreen rendering: a demo
+replay from a tiny committed ``.npz`` fixture, and the task list the benchmark itself answers. That is too heavy
+for the normal suite, so this path is kept out of the default ``testpaths``: the dedicated
+``.github/workflows/libero-e2e.yaml`` lane runs it by explicit path (Linux software rendering,
+``MUJOCO_GL=osmesa``); a plain ``uv run pytest`` never collects it.
 
 The fixture is generated once on a LIBERO box::
 
@@ -20,7 +21,9 @@ import os
 
 import pytest
 
+from positronic.simulator.env_server.client import EnvConnection
 from positronic.simulator.libero.e2e import run_replay
+from positronic.simulator.libero.launcher import serve_libero
 
 _FIXTURE = os.path.join(os.path.dirname(__file__), 'libero_spatial_task0.npz')
 
@@ -33,3 +36,27 @@ _FIXTURE = os.path.join(os.path.dirname(__file__), 'libero_spatial_task0.npz')
 def test_demo_replay_reaches_success(command_mode):
     rate = run_replay(_FIXTURE, suite='libero_spatial', task_id=0, command_mode=command_mode)
     assert rate == 1.0, f'demo replay ({command_mode}) rate {rate:.2f} — every prerecorded demo must replay to success'
+
+
+@pytest.mark.timeout(900)
+def test_the_env_lists_the_tasks_a_spec_selects():
+    """The eval keeps no task count, so LIBERO's own registry is what a sweep is built from. This lane is the
+    only one that reaches it: positronic's interpreter cannot import LIBERO."""
+    with serve_libero() as (host, port):
+        conn = EnvConnection(host, port)
+        try:
+            records = conn.tasks({'suite': 'libero_spatial', 'task_id': None})
+            assert [r['task_id'] for r in records] == list(range(len(records)))
+            assert {r['suite'] for r in records} == {'libero_spatial'}
+
+            pinned = conn.tasks({'suite': 'libero_spatial', 'task_id': 3})
+            assert pinned == [{'suite': 'libero_spatial', 'task_id': 3}]
+
+            pair = conn.tasks({'suite': ['libero_spatial', 'libero_object'], 'task_id': None})
+            assert {r['suite'] for r in pair} == {'libero_spatial', 'libero_object'}
+
+            # A task nobody has: the server raises and the client re-raises, so a wrong selection stops the run.
+            with pytest.raises(RuntimeError):
+                conn.tasks({'suite': 'libero_spatial', 'task_id': 999})
+        finally:
+            conn.close()

--- a/positronic/simulator/libero/tests/test_e2e.py
+++ b/positronic/simulator/libero/tests/test_e2e.py
@@ -40,8 +40,7 @@ def test_demo_replay_reaches_success(command_mode):
 
 @pytest.mark.timeout(900)
 def test_the_env_lists_the_tasks_a_spec_selects():
-    """The eval keeps no task count, so LIBERO's own registry is what a sweep is built from. This lane is the
-    only one that reaches it: positronic's interpreter cannot import LIBERO."""
+    """A sweep is built from LIBERO's own registry, which only this lane reaches."""
     with serve_libero() as (host, port):
         conn = EnvConnection(host, port)
         try:
@@ -57,7 +56,6 @@ def test_the_env_lists_the_tasks_a_spec_selects():
             pair = conn.tasks({'suite': ['libero_spatial', 'libero_object']})
             assert {r['suite'] for r in pair} == {'libero_spatial', 'libero_object'}
 
-            # A task nobody has: the server raises and the client re-raises, so a wrong selection stops the run.
             with pytest.raises(RuntimeError):
                 conn.tasks({'suite': 'libero_spatial', 'task_id': 999})
         finally:

--- a/positronic/simulator/libero/tests/test_e2e.py
+++ b/positronic/simulator/libero/tests/test_e2e.py
@@ -45,14 +45,16 @@ def test_the_env_lists_the_tasks_a_spec_selects():
     with serve_libero() as (host, port):
         conn = EnvConnection(host, port)
         try:
-            records = conn.tasks({'suite': 'libero_spatial', 'task_id': None})
+            records = conn.tasks({'suite': 'libero_spatial'})
             assert [r['task_id'] for r in records] == list(range(len(records)))
             assert {r['suite'] for r in records} == {'libero_spatial'}
+            assert all(r['name'] for r in records), 'every record carries the id the episode records'
 
             pinned = conn.tasks({'suite': 'libero_spatial', 'task_id': 3})
-            assert pinned == [{'suite': 'libero_spatial', 'task_id': 3}]
+            assert [(r['suite'], r['task_id']) for r in pinned] == [('libero_spatial', 3)]
+            assert pinned[0]['name'] == records[3]['name'], 'the id does not move when the selection narrows'
 
-            pair = conn.tasks({'suite': ['libero_spatial', 'libero_object'], 'task_id': None})
+            pair = conn.tasks({'suite': ['libero_spatial', 'libero_object']})
             assert {r['suite'] for r in pair} == {'libero_spatial', 'libero_object'}
 
             # A task nobody has: the server raises and the client re-raises, so a wrong selection stops the run.

--- a/positronic/simulator/libero/tests/test_tasks.py
+++ b/positronic/simulator/libero/tests/test_tasks.py
@@ -1,8 +1,7 @@
 """Which tasks a LIBERO eval runs: the adapter maps the env's records, the config sweeps them.
 
-``RemoteEnvControlSystem.tasks`` is stubbed here, so the env, the socket and the adapter stay out of the
-config tests — a task list needs LIBERO's own 3.10 interpreter, which the normal suite has no access to. The
-adapter's own mapping is tested below, and ``test_e2e.py`` runs the same command against the real benchmark.
+``RemoteEnvControlSystem.tasks`` is stubbed, since a real task list needs LIBERO's 3.10 interpreter;
+``test_e2e.py`` runs the same command against the real benchmark.
 """
 
 from typing import Any
@@ -34,7 +33,6 @@ def asked(monkeypatch) -> list[Any]:
 
 
 def test_the_adapter_names_a_task_the_way_the_reset_token_does():
-    """A record carries the suite and the index, which is what the token needs to name the task again."""
     adapter = LiberoAdapter({keys.EXTERIOR_IMAGE: 'agentview_image'})
 
     params = adapter.task_params([{'suite': 'libero_goal', 'task_id': 4, 'name': 'KITCHEN_SCENE_open_the_drawer'}])
@@ -51,8 +49,8 @@ def test_the_adapter_names_a_task_the_way_the_reset_token_does():
 
 
 def test_the_env_answers_which_tasks_the_sweep_runs(asked):
-    """The sweep is asked for when the run starts, not when the config is built, so a live env reports its own
-    tasks. The render and control settings are the config's, and join each task the env names."""
+    """The sweep is asked for when the run starts, and the config's render and control settings join each task
+    the env names."""
     ev = libero_cfg.spatial.override(
         seed=7, trial_count=2, camera_resolution=64, control_mode='joint', settle_steps=3
     ).instantiate()
@@ -75,7 +73,6 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
 
 
 def test_a_pinned_task_id_reaches_the_env(asked):
-    """``--eval.task_id`` narrows the selection the env resolves, so only that task comes back."""
     ev = libero_cfg.spatial.override(task_id=3).instantiate()
 
     list(ev.tasks())
@@ -84,7 +81,6 @@ def test_a_pinned_task_id_reaches_the_env(asked):
 
 
 def test_a_suite_list_is_one_selection(asked):
-    """``all`` sweeps four suites in one run, so the env resolves them in one answer."""
     ev = libero_cfg.all.instantiate()
 
     list(ev.tasks())

--- a/positronic/simulator/libero/tests/test_tasks.py
+++ b/positronic/simulator/libero/tests/test_tasks.py
@@ -10,8 +10,16 @@ import pytest
 
 from positronic import keys
 from positronic.cfg.eval.sim import libero as libero_cfg
+from positronic.eval import EVAL_SEED, EVAL_TASK, SCENE
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
-from positronic.simulator.libero.adapter import LiberoAdapter
+from positronic.simulator.libero.adapter import (
+    EVAL_CAMERA_RESOLUTION,
+    EVAL_CONTROL_MODE,
+    EVAL_SETTLE_STEPS,
+    EVAL_SUITE,
+    EVAL_TASK_ID,
+    LiberoAdapter,
+)
 
 
 @pytest.fixture
@@ -22,11 +30,7 @@ def asked(monkeypatch) -> list[Any]:
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
         specs.append(spec)
         suites = [spec['suite']] if isinstance(spec['suite'], str) else spec['suite']
-        return [
-            {keys.EVAL_TASK: f'{suite}_{i}', keys.EVAL_SUITE: suite, keys.EVAL_TASK_ID: i}
-            for suite in suites
-            for i in (0, 1)
-        ]
+        return [{EVAL_TASK: f'{suite}_{i}', EVAL_SUITE: suite, EVAL_TASK_ID: i} for suite in suites for i in (0, 1)]
 
     monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
     return specs
@@ -37,13 +41,13 @@ def test_the_adapter_names_a_task_the_way_the_reset_token_does():
 
     params = adapter.task_params([{'suite': 'libero_goal', 'task_id': 4, 'name': 'KITCHEN_SCENE_open_the_drawer'}])
 
-    assert params[0][keys.EVAL_TASK] == 'KITCHEN_SCENE_open_the_drawer', 'the episode records this id'
+    assert params[0][EVAL_TASK] == 'KITCHEN_SCENE_open_the_drawer', 'the episode records this id'
 
     token = adapter.reset_token({
         **params[0],
-        keys.EVAL_CAMERA_RESOLUTION: 128,
-        keys.EVAL_CONTROL_MODE: 'ee',
-        keys.EVAL_SETTLE_STEPS: 0,
+        EVAL_CAMERA_RESOLUTION: 128,
+        EVAL_CONTROL_MODE: 'ee',
+        EVAL_SETTLE_STEPS: 0,
     })
     assert (token['suite'], token['task_id']) == ('libero_goal', 4)
 
@@ -59,16 +63,16 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
     trials = list(ev.tasks())
 
     assert asked == [{'suite': 'libero_spatial'}], 'an unbound task_id is absent, so the env narrows nothing'
-    scenes = [trial.prepare_args[keys.SCENE] for trial in trials]
-    assert [(scene[keys.EVAL_TASK_ID], scene[keys.EVAL_SEED]) for scene in scenes] == [(0, 7), (0, 8), (1, 7), (1, 8)]
+    scenes = [trial.prepare_args[SCENE] for trial in trials]
+    assert [(scene[EVAL_TASK_ID], scene[EVAL_SEED]) for scene in scenes] == [(0, 7), (0, 8), (1, 7), (1, 8)]
     assert scenes[0] == {
-        keys.EVAL_TASK: 'libero_spatial_0',
-        keys.EVAL_SUITE: 'libero_spatial',
-        keys.EVAL_TASK_ID: 0,
-        keys.EVAL_CAMERA_RESOLUTION: 64,
-        keys.EVAL_CONTROL_MODE: 'joint',
-        keys.EVAL_SETTLE_STEPS: 3,
-        keys.EVAL_SEED: 7,
+        EVAL_TASK: 'libero_spatial_0',
+        EVAL_SUITE: 'libero_spatial',
+        EVAL_TASK_ID: 0,
+        EVAL_CAMERA_RESOLUTION: 64,
+        EVAL_CONTROL_MODE: 'joint',
+        EVAL_SETTLE_STEPS: 3,
+        EVAL_SEED: 7,
     }
 
 

--- a/positronic/simulator/libero/tests/test_tasks.py
+++ b/positronic/simulator/libero/tests/test_tasks.py
@@ -1,0 +1,97 @@
+"""Which tasks a LIBERO eval runs: the adapter maps the env's records, the config sweeps them.
+
+``RemoteEnvControlSystem.tasks`` is stubbed here, so the env, the socket and the adapter stay out of the
+config tests — a task list needs LIBERO's own 3.10 interpreter, which the normal suite has no access to. The
+adapter's own mapping is tested below, and ``test_e2e.py`` runs the same command against the real benchmark.
+"""
+
+from typing import Any
+
+import pytest
+
+from positronic import keys
+from positronic.cfg.eval.sim import libero as libero_cfg
+from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
+from positronic.simulator.libero.adapter import LiberoAdapter
+
+
+@pytest.fixture
+def asked(monkeypatch) -> list[Any]:
+    """The selections the eval sends the proxy; every suite a selection names is answered with two tasks."""
+    specs: list[Any] = []
+
+    def tasks(self, selection: Any) -> list[dict[str, Any]]:
+        specs.append(selection)
+        suites = selection[keys.EVAL_SUITE]
+        suites = [suites] if isinstance(suites, str) else suites
+        return [{keys.EVAL_SUITE: suite, keys.EVAL_TASK_ID: i} for suite in suites for i in (0, 1)]
+
+    monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
+    return specs
+
+
+def test_the_adapter_spells_the_selection_in_the_envs_own_words():
+    """LIBERO names a task by suite and index, so the adapter owns both spellings of both axes and the eval
+    names neither."""
+    adapter = LiberoAdapter({keys.EXTERIOR_IMAGE: 'agentview_image'})
+
+    spec = adapter.task_spec({keys.EVAL_SUITE: 'libero_goal', keys.EVAL_TASK_ID: None})
+
+    assert spec == {'suite': 'libero_goal', 'task_id': None}
+
+
+def test_the_adapter_names_a_task_the_way_the_reset_token_does():
+    """A record carries the suite and the index, which is what the token needs to name the task again."""
+    adapter = LiberoAdapter({keys.EXTERIOR_IMAGE: 'agentview_image'})
+
+    params = adapter.task_params([{'suite': 'libero_goal', 'task_id': 4}])
+
+    token = adapter.reset_token({
+        **params[0],
+        keys.EVAL_CAMERA_RESOLUTION: 128,
+        keys.EVAL_CONTROL_MODE: 'ee',
+        keys.EVAL_SETTLE_STEPS: 0,
+    })
+    assert (token['suite'], token['task_id']) == ('libero_goal', 4)
+
+
+def test_the_env_answers_which_tasks_the_sweep_runs(asked):
+    """The sweep is asked for when the run starts, not when the config is built, so a live env reports its own
+    tasks. The render and control settings are the config's, and join each task the env names."""
+    ev = libero_cfg.spatial.override(
+        seed=7, trial_count=2, camera_resolution=64, control_mode='joint', settle_steps=3
+    ).instantiate()
+    assert asked == []
+
+    trials = list(ev.tasks())
+
+    assert asked == [{keys.EVAL_SUITE: 'libero_spatial', keys.EVAL_TASK_ID: None}]
+    scenes = [trial.prepare_args[keys.SCENE] for trial in trials]
+    assert [(scene[keys.EVAL_TASK_ID], scene[keys.EVAL_SEED]) for scene in scenes] == [(0, 7), (0, 8), (1, 7), (1, 8)]
+    assert scenes[0] == {
+        keys.EVAL_SUITE: 'libero_spatial',
+        keys.EVAL_TASK_ID: 0,
+        keys.EVAL_CAMERA_RESOLUTION: 64,
+        keys.EVAL_CONTROL_MODE: 'joint',
+        keys.EVAL_SETTLE_STEPS: 3,
+        keys.EVAL_SEED: 7,
+    }
+
+
+def test_a_pinned_task_id_reaches_the_env(asked):
+    """``--eval.task_id`` narrows the selection the env resolves, so only that task comes back."""
+    ev = libero_cfg.spatial.override(task_id=3).instantiate()
+
+    list(ev.tasks())
+
+    assert asked == [{keys.EVAL_SUITE: 'libero_spatial', keys.EVAL_TASK_ID: 3}]
+
+
+def test_a_suite_list_is_one_selection(asked):
+    """``all`` sweeps four suites in one run, so the env resolves them in one answer."""
+    ev = libero_cfg.all.instantiate()
+
+    list(ev.tasks())
+
+    suites = ['libero_spatial', 'libero_object', 'libero_goal', 'libero_10']
+    assert asked == [{keys.EVAL_SUITE: suites, keys.EVAL_TASK_ID: None}]

--- a/positronic/simulator/libero/tests/test_tasks.py
+++ b/positronic/simulator/libero/tests/test_tasks.py
@@ -10,16 +10,10 @@ import pytest
 
 from positronic import keys
 from positronic.cfg.eval.sim import libero as libero_cfg
-from positronic.eval import EVAL_SEED, EVAL_TASK, SCENE
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
-from positronic.simulator.libero.adapter import (
-    EVAL_CAMERA_RESOLUTION,
-    EVAL_CONTROL_MODE,
-    EVAL_SETTLE_STEPS,
-    EVAL_SUITE,
-    EVAL_TASK_ID,
-    LiberoAdapter,
-)
+from positronic.simulator.libero import keys as libero_keys
+from positronic.simulator.libero.adapter import LiberoAdapter
 
 
 @pytest.fixture
@@ -30,7 +24,11 @@ def asked(monkeypatch) -> list[Any]:
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
         specs.append(spec)
         suites = [spec['suite']] if isinstance(spec['suite'], str) else spec['suite']
-        return [{EVAL_TASK: f'{suite}_{i}', EVAL_SUITE: suite, EVAL_TASK_ID: i} for suite in suites for i in (0, 1)]
+        return [
+            {eval_keys.TASK: f'{suite}_{i}', libero_keys.SUITE: suite, libero_keys.TASK_ID: i}
+            for suite in suites
+            for i in (0, 1)
+        ]
 
     monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
     return specs
@@ -41,13 +39,13 @@ def test_the_adapter_names_a_task_the_way_the_reset_token_does():
 
     params = adapter.task_params([{'suite': 'libero_goal', 'task_id': 4, 'name': 'KITCHEN_SCENE_open_the_drawer'}])
 
-    assert params[0][EVAL_TASK] == 'KITCHEN_SCENE_open_the_drawer', 'the episode records this id'
+    assert params[0][eval_keys.TASK] == 'KITCHEN_SCENE_open_the_drawer', 'the episode records this id'
 
     token = adapter.reset_token({
         **params[0],
-        EVAL_CAMERA_RESOLUTION: 128,
-        EVAL_CONTROL_MODE: 'ee',
-        EVAL_SETTLE_STEPS: 0,
+        libero_keys.CAMERA_RESOLUTION: 128,
+        libero_keys.CONTROL_MODE: 'ee',
+        libero_keys.SETTLE_STEPS: 0,
     })
     assert (token['suite'], token['task_id']) == ('libero_goal', 4)
 
@@ -63,16 +61,16 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
     trials = list(ev.tasks())
 
     assert asked == [{'suite': 'libero_spatial'}], 'an unbound task_id is absent, so the env narrows nothing'
-    scenes = [trial.prepare_args[SCENE] for trial in trials]
-    assert [(scene[EVAL_TASK_ID], scene[EVAL_SEED]) for scene in scenes] == [(0, 7), (0, 8), (1, 7), (1, 8)]
+    scenes = [trial.prepare_args[eval_keys.SCENE] for trial in trials]
+    assert [(scene[libero_keys.TASK_ID], scene[eval_keys.SEED]) for scene in scenes] == [(0, 7), (0, 8), (1, 7), (1, 8)]
     assert scenes[0] == {
-        EVAL_TASK: 'libero_spatial_0',
-        EVAL_SUITE: 'libero_spatial',
-        EVAL_TASK_ID: 0,
-        EVAL_CAMERA_RESOLUTION: 64,
-        EVAL_CONTROL_MODE: 'joint',
-        EVAL_SETTLE_STEPS: 3,
-        EVAL_SEED: 7,
+        eval_keys.TASK: 'libero_spatial_0',
+        libero_keys.SUITE: 'libero_spatial',
+        libero_keys.TASK_ID: 0,
+        libero_keys.CAMERA_RESOLUTION: 64,
+        libero_keys.CONTROL_MODE: 'joint',
+        libero_keys.SETTLE_STEPS: 3,
+        eval_keys.SEED: 7,
     }
 
 

--- a/positronic/simulator/libero/tests/test_tasks.py
+++ b/positronic/simulator/libero/tests/test_tasks.py
@@ -17,34 +17,29 @@ from positronic.simulator.libero.adapter import LiberoAdapter
 
 @pytest.fixture
 def asked(monkeypatch) -> list[Any]:
-    """The selections the eval sends the proxy; every suite a selection names is answered with two tasks."""
+    """The specs the eval sends the proxy; every suite a spec names is answered with two tasks."""
     specs: list[Any] = []
 
-    def tasks(self, selection: Any) -> list[dict[str, Any]]:
-        specs.append(selection)
-        suites = selection[keys.EVAL_SUITE]
-        suites = [suites] if isinstance(suites, str) else suites
-        return [{keys.EVAL_SUITE: suite, keys.EVAL_TASK_ID: i} for suite in suites for i in (0, 1)]
+    def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
+        specs.append(spec)
+        suites = [spec['suite']] if isinstance(spec['suite'], str) else spec['suite']
+        return [
+            {keys.EVAL_TASK: f'{suite}_{i}', keys.EVAL_SUITE: suite, keys.EVAL_TASK_ID: i}
+            for suite in suites
+            for i in (0, 1)
+        ]
 
     monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
     return specs
-
-
-def test_the_adapter_spells_the_selection_in_the_envs_own_words():
-    """LIBERO names a task by suite and index, so the adapter owns both spellings of both axes and the eval
-    names neither."""
-    adapter = LiberoAdapter({keys.EXTERIOR_IMAGE: 'agentview_image'})
-
-    spec = adapter.task_spec({keys.EVAL_SUITE: 'libero_goal', keys.EVAL_TASK_ID: None})
-
-    assert spec == {'suite': 'libero_goal', 'task_id': None}
 
 
 def test_the_adapter_names_a_task_the_way_the_reset_token_does():
     """A record carries the suite and the index, which is what the token needs to name the task again."""
     adapter = LiberoAdapter({keys.EXTERIOR_IMAGE: 'agentview_image'})
 
-    params = adapter.task_params([{'suite': 'libero_goal', 'task_id': 4}])
+    params = adapter.task_params([{'suite': 'libero_goal', 'task_id': 4, 'name': 'KITCHEN_SCENE_open_the_drawer'}])
+
+    assert params[0][keys.EVAL_TASK] == 'KITCHEN_SCENE_open_the_drawer', 'the episode records this id'
 
     token = adapter.reset_token({
         **params[0],
@@ -65,10 +60,11 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
 
     trials = list(ev.tasks())
 
-    assert asked == [{keys.EVAL_SUITE: 'libero_spatial', keys.EVAL_TASK_ID: None}]
+    assert asked == [{'suite': 'libero_spatial'}], 'an unbound task_id is absent, so the env narrows nothing'
     scenes = [trial.prepare_args[keys.SCENE] for trial in trials]
     assert [(scene[keys.EVAL_TASK_ID], scene[keys.EVAL_SEED]) for scene in scenes] == [(0, 7), (0, 8), (1, 7), (1, 8)]
     assert scenes[0] == {
+        keys.EVAL_TASK: 'libero_spatial_0',
         keys.EVAL_SUITE: 'libero_spatial',
         keys.EVAL_TASK_ID: 0,
         keys.EVAL_CAMERA_RESOLUTION: 64,
@@ -84,7 +80,7 @@ def test_a_pinned_task_id_reaches_the_env(asked):
 
     list(ev.tasks())
 
-    assert asked == [{keys.EVAL_SUITE: 'libero_spatial', keys.EVAL_TASK_ID: 3}]
+    assert asked == [{'suite': 'libero_spatial', 'task_id': 3}]
 
 
 def test_a_suite_list_is_one_selection(asked):
@@ -94,4 +90,4 @@ def test_a_suite_list_is_one_selection(asked):
     list(ev.tasks())
 
     suites = ['libero_spatial', 'libero_object', 'libero_goal', 'libero_10']
-    assert asked == [{keys.EVAL_SUITE: suites, keys.EVAL_TASK_ID: None}]
+    assert asked == [{'suite': suites}]

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -13,7 +13,7 @@ from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.ik import qpos_from_site_pose
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.drivers.utils import Moves, MoveStatus
-from positronic.eval import EVAL_SEED
+from positronic.eval import keys as eval_keys
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
 
 logger = logging.getLogger(__name__)
@@ -180,7 +180,7 @@ class MujocoSim(pimm.ControlSystem):
                 redraw = next(self.env_reset.incoming(), None)
                 if redraw is not None:
                     with pimm.calls.raise_to(redraw):
-                        self.reset(dict(redraw.request or {}).get(EVAL_SEED))
+                        self.reset(dict(redraw.request or {}).get(eval_keys.SEED))
                         redraw.set_result(None)
 
                 command = self._moves.next_request()

--- a/positronic/simulator/mujoco/sim.py
+++ b/positronic/simulator/mujoco/sim.py
@@ -7,12 +7,13 @@ import mujoco as mj
 import numpy as np
 
 import pimm
-from positronic import geom, keys, telemetry, telemetry_keys
+from positronic import geom, telemetry, telemetry_keys
 from positronic.drivers.roboarm import RobotStatus, State
 from positronic.drivers.roboarm import command as roboarm_command
 from positronic.drivers.roboarm.ik import qpos_from_site_pose
 from positronic.drivers.roboarm.models import bundled_panda_model
 from positronic.drivers.utils import Moves, MoveStatus
+from positronic.eval import EVAL_SEED
 from positronic.simulator.mujoco.transforms import MujocoSceneTransform, load_spec, load_spec_from_file, np_seed
 
 logger = logging.getLogger(__name__)
@@ -179,7 +180,7 @@ class MujocoSim(pimm.ControlSystem):
                 redraw = next(self.env_reset.incoming(), None)
                 if redraw is not None:
                     with pimm.calls.raise_to(redraw):
-                        self.reset(dict(redraw.request or {}).get(keys.EVAL_SEED))
+                        self.reset(dict(redraw.request or {}).get(EVAL_SEED))
                         redraw.set_result(None)
 
                 command = self._moves.next_request()

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -23,6 +23,13 @@ class RobolabAdapter(WireCommandAdapter):
         super().__init__(DROID_EE_FRAME)
         self._camera_dict = camera_dict  # logical observation name -> the RoboLab obs image key
 
+    def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        # The env names the task and reports the budget RoboLab gives its episode; the eval config joins the
+        # instruction phrasing, which is the config's own and not the benchmark's.
+        return [
+            {keys.EVAL_TASK: record['name'], keys.EVAL_EPISODE_LENGTH: record['episode_length_s']} for record in records
+        ]
+
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # No seed rides the token: RoboLab's eval path has no seed hook, so a recorded seed would only mislead.
         return {'task': params[keys.EVAL_TASK], 'instruction_type': params[keys.EVAL_INSTRUCTION_TYPE]}

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -24,8 +24,6 @@ class RobolabAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the RoboLab obs image key
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        # The env names the task and reports the budget RoboLab gives its episode; the eval config joins the
-        # instruction phrasing, which is the config's own and not the benchmark's.
         return [
             {keys.EVAL_TASK: record['name'], keys.EVAL_EPISODE_LENGTH: record['episode_length_s']} for record in records
         ]

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -13,8 +13,14 @@ import numpy as np
 import pimm
 from positronic import geom, keys
 from positronic.drivers.roboarm.models import DROID_EE_FRAME
+from positronic.eval import EVAL_SUCCESS, EVAL_TASK
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
+
+# The seconds RoboLab gives an episode of this task; the eval config sets the trial's deadline from it.
+EVAL_EPISODE_LENGTH = 'eval.episode_length'
+# The phrasing of the instruction, which the eval config owns and ``_reset_token`` reads back.
+EVAL_INSTRUCTION_TYPE = 'eval.instruction_type'
 
 
 class RobolabAdapter(WireCommandAdapter):
@@ -24,13 +30,11 @@ class RobolabAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the RoboLab obs image key
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return [
-            {keys.EVAL_TASK: record['name'], keys.EVAL_EPISODE_LENGTH: record['episode_length_s']} for record in records
-        ]
+        return [{EVAL_TASK: record['name'], EVAL_EPISODE_LENGTH: record['episode_length_s']} for record in records]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # No seed rides the token: RoboLab's eval path has no seed hook, so a recorded seed would only mislead.
-        return {'task': params[keys.EVAL_TASK], 'instruction_type': params[keys.EVAL_INSTRUCTION_TYPE]}
+        return {'task': params[EVAL_TASK], 'instruction_type': params[EVAL_INSTRUCTION_TYPE]}
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         # The env reports the eef pose in the control frame IK drives; ``eef_quat`` is scalar-first (wxyz),
@@ -65,4 +69,4 @@ class RobolabAdapter(WireCommandAdapter):
     def terminal(self, result: dict[str, Any]) -> dict[str, Any] | None:
         # ``done`` covers termination and truncation, so the trial ends either way; ``success`` is True only
         # when the task's success condition fired, keeping timeouts honest.
-        return {keys.EVAL_SUCCESS: bool(result['success'])} if result['done'] else None
+        return {EVAL_SUCCESS: bool(result['success'])} if result['done'] else None

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -13,14 +13,10 @@ import numpy as np
 import pimm
 from positronic import geom, keys
 from positronic.drivers.roboarm.models import DROID_EE_FRAME
-from positronic.eval import EVAL_SUCCESS, EVAL_TASK
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.adapter import WireCommandAdapter
 from positronic.simulator.mujoco.sim import MujocoFrankaState
-
-# The seconds RoboLab gives an episode of this task; the eval config sets the trial's deadline from it.
-EVAL_EPISODE_LENGTH = 'eval.episode_length'
-# The phrasing of the instruction, which the eval config owns and ``_reset_token`` reads back.
-EVAL_INSTRUCTION_TYPE = 'eval.instruction_type'
+from positronic.simulator.robolab import keys as robolab_keys
 
 
 class RobolabAdapter(WireCommandAdapter):
@@ -30,11 +26,14 @@ class RobolabAdapter(WireCommandAdapter):
         self._camera_dict = camera_dict  # logical observation name -> the RoboLab obs image key
 
     def task_params(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return [{EVAL_TASK: record['name'], EVAL_EPISODE_LENGTH: record['episode_length_s']} for record in records]
+        return [
+            {eval_keys.TASK: record['name'], robolab_keys.EPISODE_LENGTH: record['episode_length_s']}
+            for record in records
+        ]
 
     def _reset_token(self, params: dict[str, Any]) -> Any:
         # No seed rides the token: RoboLab's eval path has no seed hook, so a recorded seed would only mislead.
-        return {'task': params[EVAL_TASK], 'instruction_type': params[EVAL_INSTRUCTION_TYPE]}
+        return {'task': params[eval_keys.TASK], 'instruction_type': params[robolab_keys.INSTRUCTION_TYPE]}
 
     def observations(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         # The env reports the eef pose in the control frame IK drives; ``eef_quat`` is scalar-first (wxyz),
@@ -69,4 +68,4 @@ class RobolabAdapter(WireCommandAdapter):
     def terminal(self, result: dict[str, Any]) -> dict[str, Any] | None:
         # ``done`` covers termination and truncation, so the trial ends either way; ``success`` is True only
         # when the task's success condition fired, keeping timeouts honest.
-        return {EVAL_SUCCESS: bool(result['success'])} if result['done'] else None
+        return {eval_keys.SUCCESS: bool(result['success'])} if result['done'] else None

--- a/positronic/simulator/robolab/e2e.py
+++ b/positronic/simulator/robolab/e2e.py
@@ -22,10 +22,10 @@ import argparse
 
 import numpy as np
 
-from positronic import keys
 from positronic.cfg.eval import spec
+from positronic.eval import EVAL_TASK
 from positronic.simulator.env_server.client import EnvConnection
-from positronic.simulator.robolab.adapter import RobolabAdapter
+from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 # Keep re-sending the last action after the log ends, matching RoboLab's own replay tail: the final placement
@@ -71,10 +71,10 @@ def _check_task_list(conn: EnvConnection, task: str) -> None:
     """Assert the server answers its own task list, as the adapter reads it."""
     adapter = RobolabAdapter({})
     params = adapter.task_params(conn.tasks(spec(task=task)))
-    assert [p[keys.EVAL_TASK] for p in params] == [task], f'{task} asked for, {params} answered'
-    assert params[0][keys.EVAL_EPISODE_LENGTH] > 0, f'{task} reports no episode budget, so a trial has no deadline'
+    assert [p[EVAL_TASK] for p in params] == [task], f'{task} asked for, {params} answered'
+    assert params[0][EVAL_EPISODE_LENGTH] > 0, f'{task} reports no episode budget, so a trial has no deadline'
     whole = adapter.task_params(conn.tasks({}))
-    assert task in {p[keys.EVAL_TASK] for p in whole}, f'{task} is missing from the whole benchmark'
+    assert task in {p[EVAL_TASK] for p in whole}, f'{task} is missing from the whole benchmark'
 
 
 def run_replay(fixture_path: str, *, task: str) -> float:

--- a/positronic/simulator/robolab/e2e.py
+++ b/positronic/simulator/robolab/e2e.py
@@ -23,6 +23,7 @@ import argparse
 import numpy as np
 
 from positronic import keys
+from positronic.cfg.eval import spec
 from positronic.simulator.env_server.client import EnvConnection
 from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
@@ -71,10 +72,10 @@ def _check_task_list(conn: EnvConnection, task: str) -> None:
     import RoboLab, so this is the only gate on ``tasks``; the number of tasks is RoboLab's own and nothing
     here pins it."""
     adapter = RobolabAdapter({})
-    params = adapter.task_params(conn.tasks(adapter.task_spec(task)))
+    params = adapter.task_params(conn.tasks(spec(task=task)))
     assert [p[keys.EVAL_TASK] for p in params] == [task], f'{task} asked for, {params} answered'
     assert params[0][keys.EVAL_EPISODE_LENGTH] > 0, f'{task} reports no episode budget, so a trial has no deadline'
-    whole = adapter.task_params(conn.tasks('all'))
+    whole = adapter.task_params(conn.tasks({}))
     assert task in {p[keys.EVAL_TASK] for p in whole}, f'{task} is missing from the whole benchmark'
 
 

--- a/positronic/simulator/robolab/e2e.py
+++ b/positronic/simulator/robolab/e2e.py
@@ -4,11 +4,11 @@
 positronic launches the env-server subprocess (RoboLab's own Isaac Lab interpreter) and replays a recorded
 demo's raw joint-position actions through the actual socket — the ``joint_pos`` path is a bit-identical
 passthrough to the 8-dim ``[q1..q7, gripper]`` action RoboLab's own replay feeds its jointpos env. The gate
-asserts the boundary mechanics: the exact-state reset lands the arm on the demo's opening joints, and every
-recorded action round-trips the socket without a wire error. Task success is reported but not asserted: the
-recording RoboLab ships at the pinned commit no longer reaches success under replay — its own
-``examples/run_recorded.py`` reproduces the failure on the same box — so a success oracle needs a
-policy-driven differential, not a demo log.
+asserts the boundary mechanics: the server answers its own task list, the exact-state reset lands the arm on
+the demo's opening joints, and every recorded action round-trips the socket without a wire error. Task
+success is reported but not asserted: the recording RoboLab ships at the pinned commit no longer reaches
+success under replay — its own ``examples/run_recorded.py`` reproduces the failure on the same box — so a
+success oracle needs a policy-driven differential, not a demo log.
 
 The demos come from a tiny committed ``.npz`` fixture — each demo's action log + initial scene state, not the
 multi-GB recording; ``make_fixture.py`` extracts it once from a RoboLab ``data.hdf5``. Run on a RoboLab-capable
@@ -22,7 +22,9 @@ import argparse
 
 import numpy as np
 
+from positronic import keys
 from positronic.simulator.env_server.client import EnvConnection
+from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 # Keep re-sending the last action after the log ends, matching RoboLab's own replay tail: the final placement
@@ -64,13 +66,26 @@ def _replay_episode(conn: EnvConnection, actions: np.ndarray, initial_state: dic
     return False
 
 
+def _check_task_list(conn: EnvConnection, task: str) -> None:
+    """Assert the server answers its own task list, as the adapter reads it. positronic's interpreter cannot
+    import RoboLab, so this is the only gate on ``tasks``; the number of tasks is RoboLab's own and nothing
+    here pins it."""
+    adapter = RobolabAdapter({})
+    params = adapter.task_params(conn.tasks(adapter.task_spec(task)))
+    assert [p[keys.EVAL_TASK] for p in params] == [task], f'{task} asked for, {params} answered'
+    assert params[0][keys.EVAL_EPISODE_LENGTH] > 0, f'{task} reports no episode budget, so a trial has no deadline'
+    whole = adapter.task_params(conn.tasks('all'))
+    assert task in {p[keys.EVAL_TASK] for p in whole}, f'{task} is missing from the whole benchmark'
+
+
 def run_replay(fixture_path: str, *, task: str) -> float:
-    """Replay every episode in ``fixture_path`` through the env server; return the success rate."""
+    """Check the task list, then replay every episode in ``fixture_path``; return the replay success rate."""
     episodes = _load_fixture(fixture_path)
     successes = 0
     with serve_robolab() as (host, port):
         conn = EnvConnection(host, port)
         try:
+            _check_task_list(conn, task)
             for i, (actions, initial_state) in enumerate(episodes):
                 ok = _replay_episode(conn, actions, initial_state, task)
                 successes += int(ok)

--- a/positronic/simulator/robolab/e2e.py
+++ b/positronic/simulator/robolab/e2e.py
@@ -23,9 +23,10 @@ import argparse
 import numpy as np
 
 from positronic.cfg.eval import spec
-from positronic.eval import EVAL_TASK
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.client import EnvConnection
-from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, RobolabAdapter
+from positronic.simulator.robolab import keys as robolab_keys
+from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 # Keep re-sending the last action after the log ends, matching RoboLab's own replay tail: the final placement
@@ -71,10 +72,10 @@ def _check_task_list(conn: EnvConnection, task: str) -> None:
     """Assert the server answers its own task list, as the adapter reads it."""
     adapter = RobolabAdapter({})
     params = adapter.task_params(conn.tasks(spec(task=task)))
-    assert [p[EVAL_TASK] for p in params] == [task], f'{task} asked for, {params} answered'
-    assert params[0][EVAL_EPISODE_LENGTH] > 0, f'{task} reports no episode budget, so a trial has no deadline'
+    assert [p[eval_keys.TASK] for p in params] == [task], f'{task} asked for, {params} answered'
+    assert params[0][robolab_keys.EPISODE_LENGTH] > 0, f'{task} reports no episode budget, so a trial has no deadline'
     whole = adapter.task_params(conn.tasks({}))
-    assert task in {p[EVAL_TASK] for p in whole}, f'{task} is missing from the whole benchmark'
+    assert task in {p[eval_keys.TASK] for p in whole}, f'{task} is missing from the whole benchmark'
 
 
 def run_replay(fixture_path: str, *, task: str) -> float:

--- a/positronic/simulator/robolab/e2e.py
+++ b/positronic/simulator/robolab/e2e.py
@@ -68,9 +68,7 @@ def _replay_episode(conn: EnvConnection, actions: np.ndarray, initial_state: dic
 
 
 def _check_task_list(conn: EnvConnection, task: str) -> None:
-    """Assert the server answers its own task list, as the adapter reads it. positronic's interpreter cannot
-    import RoboLab, so this is the only gate on ``tasks``; the number of tasks is RoboLab's own and nothing
-    here pins it."""
+    """Assert the server answers its own task list, as the adapter reads it."""
     adapter = RobolabAdapter({})
     params = adapter.task_params(conn.tasks(spec(task=task)))
     assert [p[keys.EVAL_TASK] for p in params] == [task], f'{task} asked for, {params} answered'

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -16,8 +16,7 @@ frame.
 
 The reset token carries the RoboLab env name and the instruction variant; the env builds that task on the
 first reset and caches it, rebuilding only when the key changes. There is no seed anywhere: RoboLab's eval
-path has no seed hook, so a recorded seed would only mislead. ``tasks`` reads RoboLab's own task metadata, so
-the eval asks this server which tasks a selection holds instead of pinning a table of its own.
+path has no seed hook, so a recorded seed would only mislead.
 """
 
 import argparse
@@ -116,12 +115,7 @@ def _load_robot_meta() -> dict[str, Any]:
 
 
 def _benchmark_tasks() -> dict[str, dict[str, Any]]:
-    """Every benchmark task by name: the seconds RoboLab gives an episode, and the categories it sits in.
-
-    Reads the metadata RoboLab ships beside its task classes, so it builds no env and registers nothing.
-    ``attributes`` names a task's fine-grained skills; the ones ``BENCHMARK_TASK_CATEGORIES`` maps become its
-    categories, and an attribute outside that map — a phrasing such as ``vague`` — carries no category.
-    """
+    """Every benchmark task by name: the seconds RoboLab gives an episode, and the categories it sits in."""
     with open(os.path.join(robolab.constants.TASK_DIR, '_metadata', 'task_metadata.json')) as f:
         entries = json.load(f)
     remap = robolab.constants.BENCHMARK_TASK_CATEGORIES
@@ -130,6 +124,7 @@ def _benchmark_tasks() -> dict[str, dict[str, Any]]:
         attributes = [a.strip() for a in entry['attributes'].split(',')]
         tasks[entry['task_name']] = {
             'episode_length_s': float(entry['episode_s']),
+            # An attribute outside the map, such as ``vague``, is a phrasing and no category.
             'categories': {remap[a] for a in attributes if a in remap},
         }
     return tasks
@@ -177,15 +172,11 @@ class RobolabEnv(EnvProtocol):
 
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
         """The tasks ``spec`` selects: ``task`` is one of RoboLab's categories, a task name, or a list of
-        names. Without a ``task`` the whole benchmark runs.
-
-        A record names its task as the reset token does, which is also the id, and reports the seconds
-        RoboLab gives its episode.
-        """
+        names. Without a ``task`` the whole benchmark runs."""
         benchmark = _benchmark_tasks()
         categories = set(robolab.constants.BENCHMARK_TASK_CATEGORIES.values())
         match spec.get('task'):
-            case None:  # no task narrows nothing, so the whole benchmark runs
+            case None:
                 names = list(benchmark)
             case str() as category if category in categories:
                 names = [name for name, task in benchmark.items() if category in task['categories']]

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -16,10 +16,12 @@ frame.
 
 The reset token carries the RoboLab env name and the instruction variant; the env builds that task on the
 first reset and caches it, rebuilding only when the key changes. There is no seed anywhere: RoboLab's eval
-path has no seed hook, so a recorded seed would only mislead.
+path has no seed hook, so a recorded seed would only mislead. ``tasks`` reads RoboLab's own task metadata, so
+the eval asks this server which tasks a selection holds instead of pinning a table of its own.
 """
 
 import argparse
+import json
 import os
 import tempfile
 from collections.abc import Callable
@@ -113,8 +115,28 @@ def _load_robot_meta() -> dict[str, Any]:
         return decode(f.read())
 
 
+def _benchmark_tasks() -> dict[str, dict[str, Any]]:
+    """Every benchmark task by name: the seconds RoboLab gives an episode, and the categories it sits in.
+
+    Reads the metadata RoboLab ships beside its task classes, so it builds no env and registers nothing.
+    ``attributes`` names a task's fine-grained skills; the ones ``BENCHMARK_TASK_CATEGORIES`` maps become its
+    categories, and an attribute outside that map — a phrasing such as ``vague`` — carries no category.
+    """
+    with open(os.path.join(robolab.constants.TASK_DIR, '_metadata', 'task_metadata.json')) as f:
+        entries = json.load(f)
+    remap = robolab.constants.BENCHMARK_TASK_CATEGORIES
+    tasks = {}
+    for entry in entries:
+        attributes = [a.strip() for a in entry['attributes'].split(',')]
+        tasks[entry['task_name']] = {
+            'episode_length_s': float(entry['episode_s']),
+            'categories': {remap[a] for a in attributes if a in remap},
+        }
+    return tasks
+
+
 class RobolabEnv(EnvProtocol):
-    """A RoboLab task behind the gym-style ``reset``/``step``/``close`` the env server serves.
+    """A RoboLab task behind the ``tasks``/``reset``/``step``/``close`` the env server serves.
 
     Built from the reset token's key (RoboLab env name, instruction variant) and cached; ``reset`` rebuilds
     when the key changes and re-randomizes the scene through RoboLab's own reset events, or restores an exact
@@ -152,6 +174,29 @@ class RobolabEnv(EnvProtocol):
                 return method(*args, **kwargs)
 
         return timed
+
+    def tasks(self, spec: Any) -> list[dict[str, Any]]:
+        """The tasks ``spec`` selects: ``'all'``, one of RoboLab's categories, a task name, or a list of names.
+
+        A record names its task as the reset token does, and reports the seconds RoboLab gives its episode.
+        """
+        benchmark = _benchmark_tasks()
+        categories = set(robolab.constants.BENCHMARK_TASK_CATEGORIES.values())
+        if not isinstance(spec, str):
+            names = list(spec)
+        elif spec == 'all':
+            names = list(benchmark)
+        elif spec in categories:
+            names = [name for name, task in benchmark.items() if spec in task['categories']]
+        else:
+            names = [spec]
+        unknown = [name for name in names if name not in benchmark]
+        if unknown:
+            raise ValueError(
+                f'RoboLab does not hold {unknown}; a spec is a task name, a list of names, '
+                f'one of {sorted(categories)}, or "all"'
+            )
+        return [{'name': name, 'episode_length_s': benchmark[name]['episode_length_s']} for name in names]
 
     def _build(self, task: str, instruction_type: str) -> None:
         if self._env is not None:

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -114,22 +114,6 @@ def _load_robot_meta() -> dict[str, Any]:
         return decode(f.read())
 
 
-def _benchmark_tasks() -> dict[str, dict[str, Any]]:
-    """Every benchmark task by name: the seconds RoboLab gives an episode, and the categories it sits in."""
-    with open(os.path.join(robolab.constants.TASK_DIR, '_metadata', 'task_metadata.json')) as f:
-        entries = json.load(f)
-    remap = robolab.constants.BENCHMARK_TASK_CATEGORIES
-    tasks = {}
-    for entry in entries:
-        attributes = [a.strip() for a in entry['attributes'].split(',')]
-        tasks[entry['task_name']] = {
-            'episode_length_s': float(entry['episode_s']),
-            # An attribute outside the map, such as ``vague``, is a phrasing and no category.
-            'categories': {remap[a] for a in attributes if a in remap},
-        }
-    return tasks
-
-
 class RobolabEnv(EnvProtocol):
     """A RoboLab task behind the ``tasks``/``reset``/``step``/``close`` the env server serves.
 
@@ -170,10 +154,26 @@ class RobolabEnv(EnvProtocol):
 
         return timed
 
+    @staticmethod
+    def _benchmark_tasks() -> dict[str, dict[str, Any]]:
+        """Every benchmark task by name: the seconds RoboLab gives an episode, and the categories it sits in."""
+        with open(os.path.join(robolab.constants.TASK_DIR, '_metadata', 'task_metadata.json')) as f:
+            entries = json.load(f)
+        remap = robolab.constants.BENCHMARK_TASK_CATEGORIES
+        tasks = {}
+        for entry in entries:
+            attributes = [a.strip() for a in entry['attributes'].split(',')]
+            tasks[entry['task_name']] = {
+                'episode_length_s': float(entry['episode_s']),
+                # An attribute outside the map, such as ``vague``, is a phrasing and no category.
+                'categories': {remap[a] for a in attributes if a in remap},
+            }
+        return tasks
+
     def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
         """The tasks ``spec`` selects: ``task`` is one of RoboLab's categories, a task name, or a list of
         names. Without a ``task`` the whole benchmark runs."""
-        benchmark = _benchmark_tasks()
+        benchmark = self._benchmark_tasks()
         categories = set(robolab.constants.BENCHMARK_TASK_CATEGORIES.values())
         match spec.get('task'):
             case None:

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -175,26 +175,28 @@ class RobolabEnv(EnvProtocol):
 
         return timed
 
-    def tasks(self, spec: Any) -> list[dict[str, Any]]:
-        """The tasks ``spec`` selects: ``'all'``, one of RoboLab's categories, a task name, or a list of names.
+    def tasks(self, spec: dict[str, Any]) -> list[dict[str, Any]]:
+        """The tasks ``spec`` selects: ``task`` is one of RoboLab's categories, a task name, or a list of
+        names. Without a ``task`` the whole benchmark runs.
 
-        A record names its task as the reset token does, and reports the seconds RoboLab gives its episode.
+        A record names its task as the reset token does, which is also the id, and reports the seconds
+        RoboLab gives its episode.
         """
         benchmark = _benchmark_tasks()
         categories = set(robolab.constants.BENCHMARK_TASK_CATEGORIES.values())
-        if not isinstance(spec, str):
-            names = list(spec)
-        elif spec == 'all':
-            names = list(benchmark)
-        elif spec in categories:
-            names = [name for name, task in benchmark.items() if spec in task['categories']]
-        else:
-            names = [spec]
+        match spec.get('task'):
+            case None:  # no task narrows nothing, so the whole benchmark runs
+                names = list(benchmark)
+            case str() as category if category in categories:
+                names = [name for name, task in benchmark.items() if category in task['categories']]
+            case str() as name:
+                names = [name]
+            case selection:
+                names = list(selection)
         unknown = [name for name in names if name not in benchmark]
         if unknown:
             raise ValueError(
-                f'RoboLab does not hold {unknown}; a spec is a task name, a list of names, '
-                f'one of {sorted(categories)}, or "all"'
+                f'RoboLab does not hold {unknown}; a task is a name, a list of names, or one of {sorted(categories)}'
             )
         return [{'name': name, 'episode_length_s': benchmark[name]['episode_length_s']} for name in names]
 

--- a/positronic/simulator/robolab/keys.py
+++ b/positronic/simulator/robolab/keys.py
@@ -1,0 +1,6 @@
+"""The keys of a RoboLab task record and of the trial params the eval config owns."""
+
+# The seconds RoboLab gives an episode of this task; the eval config sets the trial's deadline from it.
+EPISODE_LENGTH = 'eval.episode_length'
+# The phrasing of the instruction, which the eval config owns and ``_reset_token`` reads back.
+INSTRUCTION_TYPE = 'eval.instruction_type'

--- a/positronic/simulator/robolab/tests/test_tasks.py
+++ b/positronic/simulator/robolab/tests/test_tasks.py
@@ -10,9 +10,10 @@ import pytest
 
 from positronic import keys
 from positronic.cfg.eval.sim import robolab as robolab_cfg
-from positronic.eval import EVAL_TASK, EVAL_TRIAL_INDEX, SCENE
+from positronic.eval import keys as eval_keys
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
-from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, EVAL_INSTRUCTION_TYPE, RobolabAdapter
+from positronic.simulator.robolab import keys as robolab_keys
+from positronic.simulator.robolab.adapter import RobolabAdapter
 
 
 @pytest.fixture
@@ -23,8 +24,8 @@ def asked(monkeypatch) -> list[Any]:
     def tasks(self, selection: Any) -> list[dict[str, Any]]:
         specs.append(selection)
         return [
-            {EVAL_TASK: 'BananaInBowlTask', EVAL_EPISODE_LENGTH: 50.0},
-            {EVAL_TASK: 'CleanUpToysTask', EVAL_EPISODE_LENGTH: 300.0},
+            {eval_keys.TASK: 'BananaInBowlTask', robolab_keys.EPISODE_LENGTH: 50.0},
+            {eval_keys.TASK: 'CleanUpToysTask', robolab_keys.EPISODE_LENGTH: 300.0},
         ]
 
     monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
@@ -36,8 +37,8 @@ def test_the_adapter_names_a_task_the_way_the_reset_token_does():
 
     params = adapter.task_params([{'name': 'AnimalsInBinTask', 'episode_length_s': 90.0}])
 
-    assert params == [{EVAL_TASK: 'AnimalsInBinTask', EVAL_EPISODE_LENGTH: 90.0}]
-    token = adapter.reset_token({**params[0], EVAL_INSTRUCTION_TYPE: 'vague'})
+    assert params == [{eval_keys.TASK: 'AnimalsInBinTask', robolab_keys.EPISODE_LENGTH: 90.0}]
+    token = adapter.reset_token({**params[0], robolab_keys.INSTRUCTION_TYPE: 'vague'})
     assert token == {'task': 'AnimalsInBinTask', 'instruction_type': 'vague'}
 
 
@@ -50,10 +51,14 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
     trials = list(ev.tasks())
 
     assert asked == [{'task': 'visual'}]
-    scenes = [trial.prepare_args[SCENE] for trial in trials]
-    assert [scene[EVAL_TASK] for scene in scenes] == ['BananaInBowlTask'] * 2 + ['CleanUpToysTask'] * 2
-    assert [trial.meta[EVAL_TRIAL_INDEX] for trial in trials] == [0, 1, 2, 3]
-    assert scenes[0] == {EVAL_TASK: 'BananaInBowlTask', EVAL_EPISODE_LENGTH: 50.0, EVAL_INSTRUCTION_TYPE: 'specific'}
+    scenes = [trial.prepare_args[eval_keys.SCENE] for trial in trials]
+    assert [scene[eval_keys.TASK] for scene in scenes] == ['BananaInBowlTask'] * 2 + ['CleanUpToysTask'] * 2
+    assert [trial.meta[eval_keys.TRIAL_INDEX] for trial in trials] == [0, 1, 2, 3]
+    assert scenes[0] == {
+        eval_keys.TASK: 'BananaInBowlTask',
+        robolab_keys.EPISODE_LENGTH: 50.0,
+        robolab_keys.INSTRUCTION_TYPE: 'specific',
+    }
 
 
 def test_a_spec_that_names_no_task_narrows_nothing(asked):

--- a/positronic/simulator/robolab/tests/test_tasks.py
+++ b/positronic/simulator/robolab/tests/test_tasks.py
@@ -1,0 +1,86 @@
+"""Which tasks a RoboLab eval runs: the adapter maps the env's records, the config sweeps them.
+
+``RemoteEnvControlSystem.tasks`` is stubbed here, so the env, the socket and the adapter stay out of the
+config tests — reading RoboLab's task metadata needs its own Isaac Lab interpreter, which the normal suite
+has no access to. The adapter's own mapping is tested below, and ``e2e.py`` runs the same command against
+the real benchmark.
+"""
+
+from typing import Any
+
+import pytest
+
+from positronic import keys
+from positronic.cfg.eval.sim import robolab as robolab_cfg
+from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
+from positronic.simulator.robolab.adapter import RobolabAdapter
+
+
+@pytest.fixture
+def asked(monkeypatch) -> list[Any]:
+    """The selections the eval sends the proxy; every selection is answered with two tasks of different
+    budgets."""
+    specs: list[Any] = []
+
+    def tasks(self, selection: Any) -> list[dict[str, Any]]:
+        specs.append(selection)
+        return [
+            {keys.EVAL_TASK: 'BananaInBowlTask', keys.EVAL_EPISODE_LENGTH: 50.0},
+            {keys.EVAL_TASK: 'CleanUpToysTask', keys.EVAL_EPISODE_LENGTH: 300.0},
+        ]
+
+    monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
+    return specs
+
+
+def test_the_adapter_names_a_task_the_way_the_reset_token_does():
+    """A record carries the name and the budget, and the name is what the token needs to build the task."""
+    adapter = RobolabAdapter({keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera'})
+
+    params = adapter.task_params([{'name': 'AnimalsInBinTask', 'episode_length_s': 90.0}])
+
+    assert params == [{keys.EVAL_TASK: 'AnimalsInBinTask', keys.EVAL_EPISODE_LENGTH: 90.0}]
+    token = adapter.reset_token({**params[0], keys.EVAL_INSTRUCTION_TYPE: 'vague'})
+    assert token == {'task': 'AnimalsInBinTask', 'instruction_type': 'vague'}
+
+
+def test_the_env_answers_which_tasks_the_sweep_runs(asked):
+    """The sweep is asked for when the run starts, not when the config is built, so a live env reports its own
+    tasks. The instruction phrasing is the config's, and joins every task the env names."""
+    ev = robolab_cfg.visual.override(trial_count=2, instruction_type='specific').instantiate()
+    assert asked == []
+
+    trials = list(ev.tasks())
+
+    assert asked == ['visual']
+    scenes = [trial.prepare_args[keys.SCENE] for trial in trials]
+    assert [scene[keys.EVAL_TASK] for scene in scenes] == ['BananaInBowlTask'] * 2 + ['CleanUpToysTask'] * 2
+    assert [trial.meta[keys.EVAL_TRIAL_INDEX] for trial in trials] == [0, 1, 2, 3]
+    assert scenes[0] == {
+        keys.EVAL_TASK: 'BananaInBowlTask',
+        keys.EVAL_EPISODE_LENGTH: 50.0,
+        keys.EVAL_INSTRUCTION_TYPE: 'specific',
+    }
+
+
+def test_each_task_runs_under_the_budget_the_benchmark_gives_it(asked):
+    """RoboLab gives each task its own episode length and truncates there, so one deadline for the whole sweep
+    would cut a long task short."""
+    trials = list(robolab_cfg.benchmark.instantiate().tasks())
+
+    assert [trial.timeout_sec for trial in trials] == [60.0, 310.0]
+
+
+def test_a_pinned_timeout_overrides_every_task(asked):
+    """``--eval.timeout`` is one deadline for the whole sweep, whatever the benchmark budgets."""
+    trials = list(robolab_cfg.benchmark.override(timeout=12.0).instantiate().tasks())
+
+    assert [trial.timeout_sec for trial in trials] == [12.0, 12.0]
+
+
+def test_the_spec_reaches_the_env_unmapped(asked):
+    """A category is the benchmark's own vocabulary, so the env resolves it and positronic maps nothing."""
+    list(robolab_cfg.procedural.instantiate().tasks())
+    list(robolab_cfg.rubiks_cube_and_banana.instantiate().tasks())
+
+    assert asked == ['procedural', 'RubiksCubeAndBananaTask']

--- a/positronic/simulator/robolab/tests/test_tasks.py
+++ b/positronic/simulator/robolab/tests/test_tasks.py
@@ -52,7 +52,7 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
 
     trials = list(ev.tasks())
 
-    assert asked == ['visual']
+    assert asked == [{'task': 'visual'}]
     scenes = [trial.prepare_args[keys.SCENE] for trial in trials]
     assert [scene[keys.EVAL_TASK] for scene in scenes] == ['BananaInBowlTask'] * 2 + ['CleanUpToysTask'] * 2
     assert [trial.meta[keys.EVAL_TRIAL_INDEX] for trial in trials] == [0, 1, 2, 3]
@@ -61,6 +61,13 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
         keys.EVAL_EPISODE_LENGTH: 50.0,
         keys.EVAL_INSTRUCTION_TYPE: 'specific',
     }
+
+
+def test_a_spec_that_names_no_task_narrows_nothing(asked):
+    """The whole benchmark binds no task, so the spec carries no key and the env selects every task."""
+    list(robolab_cfg.benchmark.instantiate().tasks())
+
+    assert asked == [{}]
 
 
 def test_each_task_runs_under_the_budget_the_benchmark_gives_it(asked):
@@ -83,4 +90,4 @@ def test_the_spec_reaches_the_env_unmapped(asked):
     list(robolab_cfg.procedural.instantiate().tasks())
     list(robolab_cfg.rubiks_cube_and_banana.instantiate().tasks())
 
-    assert asked == ['procedural', 'RubiksCubeAndBananaTask']
+    assert asked == [{'task': 'procedural'}, {'task': 'RubiksCubeAndBananaTask'}]

--- a/positronic/simulator/robolab/tests/test_tasks.py
+++ b/positronic/simulator/robolab/tests/test_tasks.py
@@ -1,9 +1,7 @@
 """Which tasks a RoboLab eval runs: the adapter maps the env's records, the config sweeps them.
 
-``RemoteEnvControlSystem.tasks`` is stubbed here, so the env, the socket and the adapter stay out of the
-config tests — reading RoboLab's task metadata needs its own Isaac Lab interpreter, which the normal suite
-has no access to. The adapter's own mapping is tested below, and ``e2e.py`` runs the same command against
-the real benchmark.
+``RemoteEnvControlSystem.tasks`` is stubbed, since a real task list needs RoboLab's Isaac Lab interpreter;
+``e2e.py`` runs the same command against the real benchmark.
 """
 
 from typing import Any
@@ -18,8 +16,7 @@ from positronic.simulator.robolab.adapter import RobolabAdapter
 
 @pytest.fixture
 def asked(monkeypatch) -> list[Any]:
-    """The selections the eval sends the proxy; every selection is answered with two tasks of different
-    budgets."""
+    """The specs the eval sends the proxy; every spec is answered with two tasks of different budgets."""
     specs: list[Any] = []
 
     def tasks(self, selection: Any) -> list[dict[str, Any]]:
@@ -34,7 +31,6 @@ def asked(monkeypatch) -> list[Any]:
 
 
 def test_the_adapter_names_a_task_the_way_the_reset_token_does():
-    """A record carries the name and the budget, and the name is what the token needs to build the task."""
     adapter = RobolabAdapter({keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera'})
 
     params = adapter.task_params([{'name': 'AnimalsInBinTask', 'episode_length_s': 90.0}])
@@ -45,8 +41,8 @@ def test_the_adapter_names_a_task_the_way_the_reset_token_does():
 
 
 def test_the_env_answers_which_tasks_the_sweep_runs(asked):
-    """The sweep is asked for when the run starts, not when the config is built, so a live env reports its own
-    tasks. The instruction phrasing is the config's, and joins every task the env names."""
+    """The sweep is asked for when the run starts, and the config's instruction phrasing joins each task the
+    env names."""
     ev = robolab_cfg.visual.override(trial_count=2, instruction_type='specific').instantiate()
     assert asked == []
 
@@ -64,15 +60,13 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
 
 
 def test_a_spec_that_names_no_task_narrows_nothing(asked):
-    """The whole benchmark binds no task, so the spec carries no key and the env selects every task."""
     list(robolab_cfg.benchmark.instantiate().tasks())
 
     assert asked == [{}]
 
 
 def test_each_task_runs_under_the_budget_the_benchmark_gives_it(asked):
-    """RoboLab gives each task its own episode length and truncates there, so one deadline for the whole sweep
-    would cut a long task short."""
+    """One deadline for the whole sweep would cut a long task short."""
     trials = list(robolab_cfg.benchmark.instantiate().tasks())
 
     assert [trial.timeout_sec for trial in trials] == [60.0, 310.0]
@@ -86,7 +80,6 @@ def test_a_pinned_timeout_overrides_every_task(asked):
 
 
 def test_the_spec_reaches_the_env_unmapped(asked):
-    """A category is the benchmark's own vocabulary, so the env resolves it and positronic maps nothing."""
     list(robolab_cfg.procedural.instantiate().tasks())
     list(robolab_cfg.rubiks_cube_and_banana.instantiate().tasks())
 

--- a/positronic/simulator/robolab/tests/test_tasks.py
+++ b/positronic/simulator/robolab/tests/test_tasks.py
@@ -10,8 +10,9 @@ import pytest
 
 from positronic import keys
 from positronic.cfg.eval.sim import robolab as robolab_cfg
+from positronic.eval import EVAL_TASK, EVAL_TRIAL_INDEX, SCENE
 from positronic.simulator.env_server.proxy import RemoteEnvControlSystem
-from positronic.simulator.robolab.adapter import RobolabAdapter
+from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, EVAL_INSTRUCTION_TYPE, RobolabAdapter
 
 
 @pytest.fixture
@@ -22,8 +23,8 @@ def asked(monkeypatch) -> list[Any]:
     def tasks(self, selection: Any) -> list[dict[str, Any]]:
         specs.append(selection)
         return [
-            {keys.EVAL_TASK: 'BananaInBowlTask', keys.EVAL_EPISODE_LENGTH: 50.0},
-            {keys.EVAL_TASK: 'CleanUpToysTask', keys.EVAL_EPISODE_LENGTH: 300.0},
+            {EVAL_TASK: 'BananaInBowlTask', EVAL_EPISODE_LENGTH: 50.0},
+            {EVAL_TASK: 'CleanUpToysTask', EVAL_EPISODE_LENGTH: 300.0},
         ]
 
     monkeypatch.setattr(RemoteEnvControlSystem, 'tasks', tasks)
@@ -35,8 +36,8 @@ def test_the_adapter_names_a_task_the_way_the_reset_token_does():
 
     params = adapter.task_params([{'name': 'AnimalsInBinTask', 'episode_length_s': 90.0}])
 
-    assert params == [{keys.EVAL_TASK: 'AnimalsInBinTask', keys.EVAL_EPISODE_LENGTH: 90.0}]
-    token = adapter.reset_token({**params[0], keys.EVAL_INSTRUCTION_TYPE: 'vague'})
+    assert params == [{EVAL_TASK: 'AnimalsInBinTask', EVAL_EPISODE_LENGTH: 90.0}]
+    token = adapter.reset_token({**params[0], EVAL_INSTRUCTION_TYPE: 'vague'})
     assert token == {'task': 'AnimalsInBinTask', 'instruction_type': 'vague'}
 
 
@@ -49,14 +50,10 @@ def test_the_env_answers_which_tasks_the_sweep_runs(asked):
     trials = list(ev.tasks())
 
     assert asked == [{'task': 'visual'}]
-    scenes = [trial.prepare_args[keys.SCENE] for trial in trials]
-    assert [scene[keys.EVAL_TASK] for scene in scenes] == ['BananaInBowlTask'] * 2 + ['CleanUpToysTask'] * 2
-    assert [trial.meta[keys.EVAL_TRIAL_INDEX] for trial in trials] == [0, 1, 2, 3]
-    assert scenes[0] == {
-        keys.EVAL_TASK: 'BananaInBowlTask',
-        keys.EVAL_EPISODE_LENGTH: 50.0,
-        keys.EVAL_INSTRUCTION_TYPE: 'specific',
-    }
+    scenes = [trial.prepare_args[SCENE] for trial in trials]
+    assert [scene[EVAL_TASK] for scene in scenes] == ['BananaInBowlTask'] * 2 + ['CleanUpToysTask'] * 2
+    assert [trial.meta[EVAL_TRIAL_INDEX] for trial in trials] == [0, 1, 2, 3]
+    assert scenes[0] == {EVAL_TASK: 'BananaInBowlTask', EVAL_EPISODE_LENGTH: 50.0, EVAL_INSTRUCTION_TYPE: 'specific'}
 
 
 def test_a_spec_that_names_no_task_narrows_nothing(asked):

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -12,7 +12,7 @@ import pytest
 import pimm
 from positronic import keys
 from positronic.drivers import keyboard
-from positronic.eval import Embodiment, Task
+from positronic.eval import ARM, ENDED_BY_OPERATOR, GRIPPER, Embodiment, Task
 from positronic.inference import KeyboardOperator, real
 from positronic.policy import Policy
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler, scripted_driver
@@ -55,7 +55,7 @@ def _embodiment(simulated: bool = False) -> Embodiment:
         descriptor='stub',
         observations={},
         commands={},
-        prepare_handlers={keys.ARM: devices.arm, keys.GRIPPER: devices.gripper},
+        prepare_handlers={ARM: devices.arm, GRIPPER: devices.gripper},
         static_meta={},
         meta_source=None,
         control_systems=(devices,),
@@ -64,7 +64,7 @@ def _embodiment(simulated: bool = False) -> Embodiment:
 
 
 def _trial(instruction: str = 'stub') -> Callable[[], Task]:
-    prepare_args = {keys.ARM: 'start-pose', keys.GRIPPER: 0.0}
+    prepare_args = {ARM: 'start-pose', GRIPPER: 0.0}
     return partial(Task, instruction_source=instruction, timeout_sec=None, prepare_args=prepare_args)
 
 
@@ -130,7 +130,7 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, caplog):
 
     assert policy.observations, 'the episode never opened'
     assert policy.observations[0][keys.TASK] == 'pick up the cube'
-    assert keys.ENDED_BY_OPERATOR in caplog.text
+    assert ENDED_BY_OPERATOR in caplog.text
     assert policy.closed
 
 

--- a/positronic/tests/test_inference.py
+++ b/positronic/tests/test_inference.py
@@ -12,7 +12,8 @@ import pytest
 import pimm
 from positronic import keys
 from positronic.drivers import keyboard
-from positronic.eval import ARM, ENDED_BY_OPERATOR, GRIPPER, Embodiment, Task
+from positronic.eval import Embodiment, Task
+from positronic.eval import keys as eval_keys
 from positronic.inference import KeyboardOperator, real
 from positronic.policy import Policy
 from positronic.tests.testing_coutils import IdleSession, drive_scheduler, scripted_driver
@@ -55,7 +56,7 @@ def _embodiment(simulated: bool = False) -> Embodiment:
         descriptor='stub',
         observations={},
         commands={},
-        prepare_handlers={ARM: devices.arm, GRIPPER: devices.gripper},
+        prepare_handlers={eval_keys.ARM: devices.arm, eval_keys.GRIPPER: devices.gripper},
         static_meta={},
         meta_source=None,
         control_systems=(devices,),
@@ -64,7 +65,7 @@ def _embodiment(simulated: bool = False) -> Embodiment:
 
 
 def _trial(instruction: str = 'stub') -> Callable[[], Task]:
-    prepare_args = {ARM: 'start-pose', GRIPPER: 0.0}
+    prepare_args = {eval_keys.ARM: 'start-pose', eval_keys.GRIPPER: 0.0}
     return partial(Task, instruction_source=instruction, timeout_sec=None, prepare_args=prepare_args)
 
 
@@ -130,7 +131,7 @@ def test_a_keypress_opens_an_episode_and_another_ends_it(monkeypatch, caplog):
 
     assert policy.observations, 'the episode never opened'
     assert policy.observations[0][keys.TASK] == 'pick up the cube'
-    assert ENDED_BY_OPERATOR in caplog.text
+    assert eval_keys.ENDED_BY_OPERATOR in caplog.text
     assert policy.closed
 
 

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -19,23 +19,10 @@ from positronic.cli.eval.run import main
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.drivers.roboarm.models import URDF, bundled_panda_model
-from positronic.eval import (
-    EVAL_EMBODIMENT,
-    EVAL_SEED,
-    EVAL_SUCCESS,
-    EVAL_TERMINATED,
-    EVAL_TIMEOUT,
-    EVAL_TRIAL_INDEX,
-    EVAL_UNIVERSE,
-    ROBOT_STATIC_META,
-    SCENE,
-    Command,
-    Embodiment,
-    Eval,
-    Observation,
-    Task,
-)
+from positronic.drivers.roboarm import keys as roboarm_keys
+from positronic.drivers.roboarm.models import bundled_panda_model
+from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Task
+from positronic.eval import keys as eval_keys
 from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.tests.test_harness import RemoteStubPolicy, StubPolicy
 from positronic.simulator.env_server import telemetry as env_telemetry
@@ -96,7 +83,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
             timeout=0.4,
         )
         task = next(iter(ev.tasks()))
-        trials = number_trials([(task, {EVAL_SEED: 100 + i}) for i in range(2)])
+        trials = number_trials([(task, {eval_keys.SEED: 100 + i}) for i in range(2)])
         main(
             policy=ChunkedSchedule().wrap(policy),
             evals=[replace(ev, tasks=partial(iter, trials))],
@@ -108,12 +95,12 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     assert len(ds) == 2
 
     episode = ds[0]
-    assert episode.static[EVAL_TERMINATED] is False
-    assert episode.static[EVAL_TRIAL_INDEX] == 0
-    assert episode.static[EVAL_SEED] == 100
-    assert episode.static[EVAL_UNIVERSE] == 'sim'
-    assert episode.static[EVAL_EMBODIMENT] == 'mujoco.franka'
-    assert episode.static[EVAL_TIMEOUT] == 0.4
+    assert episode.static[eval_keys.TERMINATED] is False
+    assert episode.static[eval_keys.TRIAL_INDEX] == 0
+    assert episode.static[eval_keys.SEED] == 100
+    assert episode.static[eval_keys.UNIVERSE] == 'sim'
+    assert episode.static[eval_keys.EMBODIMENT] == 'mujoco.franka'
+    assert episode.static[eval_keys.TIMEOUT] == 0.4
     # The post-loader scene description rides robot_meta into static: with eval.seed it makes
     # the episode self-contained for downstream scoring and faithful replay.
     assert episode.static['scene_xml'].startswith('<mujoco')
@@ -205,7 +192,7 @@ class _CountdownProducer(pimm.ControlSystem):
                 self._steps += 1
                 self._emit_obs()
                 if self._done_after is not None and self._steps >= self._done_after:
-                    self.done.emit({EVAL_SUCCESS: True})
+                    self.done.emit({eval_keys.SUCCESS: True})
                     self._active = False
 
 
@@ -214,7 +201,7 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float) -> Eval:
         descriptor='test.countdown',
         observations={'value': Observation(producer.observations['value'], None)},
         commands={keys.ROBOT_COMMAND: Command(producer.commands[keys.ROBOT_COMMAND], Serializers.robot_command)},
-        prepare_handlers={SCENE: producer.env_reset},
+        prepare_handlers={eval_keys.SCENE: producer.env_reset},
         static_meta=dict(ROBOT_STATIC_META),
         meta_source=producer.robot_meta,
         control_systems=(producer,),
@@ -232,7 +219,7 @@ def test_every_trial_records_from_its_own_reset(tmp_path):
     first sample."""
     ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35)
     task = next(iter(ev.tasks()))
-    trials = number_trials([(task, {EVAL_SEED: i}) for i in range(2)])
+    trials = number_trials([(task, {eval_keys.SEED: i}) for i in range(2)])
     with pos3.mirror():
         main(
             policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
@@ -304,7 +291,7 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     """[harness + recorder + sim] with no MuJoCo: a trial ends early when the producer's ``done`` fires,
     recording ``eval.terminated`` True and the delivered payload into the episode's static data."""
     ev = _countdown_eval(_CountdownProducer(done_after=4), timeout=15.0)
-    trial = number_trials([(next(iter(ev.tasks())), {EVAL_SEED: 100})])[0]
+    trial = number_trials([(next(iter(ev.tasks())), {eval_keys.SEED: 100})])[0]
     with pos3.mirror():
         main(
             policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
@@ -315,9 +302,9 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
     episode = ds[0]
-    assert episode.static[EVAL_TERMINATED] is True
-    assert episode.static[EVAL_SUCCESS] is True  # the delivered ``done`` payload lands in static data
-    assert episode.static[EVAL_EMBODIMENT] == 'test.countdown'
+    assert episode.static[eval_keys.TERMINATED] is True
+    assert episode.static[eval_keys.SUCCESS] is True  # the delivered ``done`` payload lands in static data
+    assert episode.static[eval_keys.EMBODIMENT] == 'test.countdown'
     # The terminal frame (the step where ``done`` fired) is recorded, not dropped by STOP closing the writer.
     values = [v for v, _ in episode.signals['value']]
     assert values[-1][0] == 4.0
@@ -411,7 +398,7 @@ def test_recorded_urdf_matches_sim_kinematics():
         model = spec.compile()
         return model, mj.MjData(model)
 
-    root = ET.fromstring(bundled_panda_model()[URDF])  # drop meshes so the URDF compiles file-free
+    root = ET.fromstring(bundled_panda_model()[roboarm_keys.URDF])  # drop meshes so the URDF compiles file-free
     for link in root.findall('.//link'):
         for el in link.findall('visual') + link.findall('collision'):
             link.remove(el)

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -19,8 +19,23 @@ from positronic.cli.eval.run import main
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.dataset.serializers import Serializers
 from positronic.drivers.roboarm import command as roboarm_command
-from positronic.drivers.roboarm.models import bundled_panda_model
-from positronic.eval import ROBOT_STATIC_META, Command, Embodiment, Eval, Observation, Task
+from positronic.drivers.roboarm.models import URDF, bundled_panda_model
+from positronic.eval import (
+    EVAL_EMBODIMENT,
+    EVAL_SEED,
+    EVAL_SUCCESS,
+    EVAL_TERMINATED,
+    EVAL_TIMEOUT,
+    EVAL_TRIAL_INDEX,
+    EVAL_UNIVERSE,
+    ROBOT_STATIC_META,
+    SCENE,
+    Command,
+    Embodiment,
+    Eval,
+    Observation,
+    Task,
+)
 from positronic.policy.layers import ChunkedSchedule
 from positronic.policy.tests.test_harness import RemoteStubPolicy, StubPolicy
 from positronic.simulator.env_server import telemetry as env_telemetry
@@ -81,7 +96,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
             timeout=0.4,
         )
         task = next(iter(ev.tasks()))
-        trials = number_trials([(task, {keys.EVAL_SEED: 100 + i}) for i in range(2)])
+        trials = number_trials([(task, {EVAL_SEED: 100 + i}) for i in range(2)])
         main(
             policy=ChunkedSchedule().wrap(policy),
             evals=[replace(ev, tasks=partial(iter, trials))],
@@ -93,12 +108,12 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     assert len(ds) == 2
 
     episode = ds[0]
-    assert episode.static[keys.EVAL_TERMINATED] is False
-    assert episode.static[keys.EVAL_TRIAL_INDEX] == 0
-    assert episode.static[keys.EVAL_SEED] == 100
-    assert episode.static[keys.EVAL_UNIVERSE] == 'sim'
-    assert episode.static[keys.EVAL_EMBODIMENT] == 'mujoco.franka'
-    assert episode.static[keys.EVAL_TIMEOUT] == 0.4
+    assert episode.static[EVAL_TERMINATED] is False
+    assert episode.static[EVAL_TRIAL_INDEX] == 0
+    assert episode.static[EVAL_SEED] == 100
+    assert episode.static[EVAL_UNIVERSE] == 'sim'
+    assert episode.static[EVAL_EMBODIMENT] == 'mujoco.franka'
+    assert episode.static[EVAL_TIMEOUT] == 0.4
     # The post-loader scene description rides robot_meta into static: with eval.seed it makes
     # the episode self-contained for downstream scoring and faithful replay.
     assert episode.static['scene_xml'].startswith('<mujoco')
@@ -118,7 +133,7 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
     # bit-reproducible from a fresh reset on the same seed. A stale step from the prior trial's run loop
     # bleeding in would record a post-step state instead.
     # TODO: the reference is a bare reset because no config asks for a starting arm pose. A task that sets
-    # ``keys.ARM`` in ``prepare_args`` moves the arm before the episode opens, and the reference needs the
+    # ``ARM`` in ``prepare_args`` moves the arm before the episode opens, and the reference needs the
     # same move.
     for i, seed in enumerate((100, 101)):
         reference = MujocoSim(
@@ -190,7 +205,7 @@ class _CountdownProducer(pimm.ControlSystem):
                 self._steps += 1
                 self._emit_obs()
                 if self._done_after is not None and self._steps >= self._done_after:
-                    self.done.emit({keys.EVAL_SUCCESS: True})
+                    self.done.emit({EVAL_SUCCESS: True})
                     self._active = False
 
 
@@ -199,7 +214,7 @@ def _countdown_eval(producer: _CountdownProducer, timeout: float) -> Eval:
         descriptor='test.countdown',
         observations={'value': Observation(producer.observations['value'], None)},
         commands={keys.ROBOT_COMMAND: Command(producer.commands[keys.ROBOT_COMMAND], Serializers.robot_command)},
-        prepare_handlers={keys.SCENE: producer.env_reset},
+        prepare_handlers={SCENE: producer.env_reset},
         static_meta=dict(ROBOT_STATIC_META),
         meta_source=producer.robot_meta,
         control_systems=(producer,),
@@ -217,7 +232,7 @@ def test_every_trial_records_from_its_own_reset(tmp_path):
     first sample."""
     ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35)
     task = next(iter(ev.tasks()))
-    trials = number_trials([(task, {keys.EVAL_SEED: i}) for i in range(2)])
+    trials = number_trials([(task, {EVAL_SEED: i}) for i in range(2)])
     with pos3.mirror():
         main(
             policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
@@ -289,7 +304,7 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     """[harness + recorder + sim] with no MuJoCo: a trial ends early when the producer's ``done`` fires,
     recording ``eval.terminated`` True and the delivered payload into the episode's static data."""
     ev = _countdown_eval(_CountdownProducer(done_after=4), timeout=15.0)
-    trial = number_trials([(next(iter(ev.tasks())), {keys.EVAL_SEED: 100})])[0]
+    trial = number_trials([(next(iter(ev.tasks())), {EVAL_SEED: 100})])[0]
     with pos3.mirror():
         main(
             policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
@@ -300,9 +315,9 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     ds = LocalDataset(tmp_path)
     assert len(ds) == 1
     episode = ds[0]
-    assert episode.static[keys.EVAL_TERMINATED] is True
-    assert episode.static[keys.EVAL_SUCCESS] is True  # the delivered ``done`` payload lands in static data
-    assert episode.static[keys.EVAL_EMBODIMENT] == 'test.countdown'
+    assert episode.static[EVAL_TERMINATED] is True
+    assert episode.static[EVAL_SUCCESS] is True  # the delivered ``done`` payload lands in static data
+    assert episode.static[EVAL_EMBODIMENT] == 'test.countdown'
     # The terminal frame (the step where ``done`` fired) is recorded, not dropped by STOP closing the writer.
     values = [v for v, _ in episode.signals['value']]
     assert values[-1][0] == 4.0
@@ -396,7 +411,7 @@ def test_recorded_urdf_matches_sim_kinematics():
         model = spec.compile()
         return model, mj.MjData(model)
 
-    root = ET.fromstring(bundled_panda_model()[keys.URDF])  # drop meshes so the URDF compiles file-free
+    root = ET.fromstring(bundled_panda_model()[URDF])  # drop meshes so the URDF compiles file-free
     for link in root.findall('.//link'):
         for el in link.findall('visual') + link.findall('collision'):
             link.remove(el)

--- a/positronic/tests/test_inference_integration.py
+++ b/positronic/tests/test_inference_integration.py
@@ -80,7 +80,8 @@ def test_sim_emits_commands_and_records_dataset(tmp_path, monkeypatch):  # noqa:
             instruction='integration-test',
             timeout=0.4,
         )
-        trials = number_trials(next(iter(ev.tasks())), [{keys.EVAL_SEED: 100 + i} for i in range(2)])
+        task = next(iter(ev.tasks()))
+        trials = number_trials([(task, {keys.EVAL_SEED: 100 + i}) for i in range(2)])
         main(
             policy=ChunkedSchedule().wrap(policy),
             evals=[replace(ev, tasks=partial(iter, trials))],
@@ -215,7 +216,8 @@ def test_every_trial_records_from_its_own_reset(tmp_path):
     producer quickly between trials, so a stray step from the previous trial would show up as a non-zero
     first sample."""
     ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.35)
-    trials = number_trials(next(iter(ev.tasks())), [{keys.EVAL_SEED: i} for i in range(2)])
+    task = next(iter(ev.tasks()))
+    trials = number_trials([(task, {keys.EVAL_SEED: i}) for i in range(2)])
     with pos3.mirror():
         main(
             policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),
@@ -238,7 +240,8 @@ def test_timing_writes_telemetry_sidecars(tmp_path):
     and the machine-load stats stream records at least one sample. record.io parenting proves the episode span
     stays in flight while the recorder commits STOP."""
     ev = _countdown_eval(_CountdownProducer(control_dt=0.01), timeout=0.2)
-    trials = number_trials(next(iter(ev.tasks())), [{}, {}])
+    task = next(iter(ev.tasks()))
+    trials = number_trials([(task, {}), (task, {})])
     with pos3.mirror():
         main(
             policy=ChunkedSchedule().wrap(
@@ -286,7 +289,7 @@ def test_countdown_terminates_on_done_records_payload(tmp_path):
     """[harness + recorder + sim] with no MuJoCo: a trial ends early when the producer's ``done`` fires,
     recording ``eval.terminated`` True and the delivered payload into the episode's static data."""
     ev = _countdown_eval(_CountdownProducer(done_after=4), timeout=15.0)
-    trial = number_trials(next(iter(ev.tasks())), [{keys.EVAL_SEED: 100}])[0]
+    trial = number_trials([(next(iter(ev.tasks())), {keys.EVAL_SEED: 100})])[0]
     with pos3.mirror():
         main(
             policy=StubPolicy(command=roboarm_command.JointPosition(np.zeros(7)), target_grip=0.0),

--- a/positronic/tests/test_keys.py
+++ b/positronic/tests/test_keys.py
@@ -19,6 +19,7 @@ _GUARDED = {
     keys.EVAL_UNIVERSE,
     keys.EVAL_EMBODIMENT,
     keys.EVAL_TIMEOUT,
+    keys.EVAL_EPISODE_LENGTH,
     keys.EVAL_SEED,
     keys.EVAL_TRIAL_INDEX,
     keys.EVAL_TRIAL_COUNT,

--- a/positronic/tests/test_keys.py
+++ b/positronic/tests/test_keys.py
@@ -1,33 +1,10 @@
 import ast
-import inspect
 from pathlib import Path
 
-from positronic import eval as eval_keys
 from positronic import keys
-from positronic.drivers.roboarm import models
-from positronic.eval import (
-    EVAL_CHARGE_INFERENCE_TIME,
-    EVAL_EMBODIMENT,
-    EVAL_SEED,
-    EVAL_SUCCESS,
-    EVAL_TASK,
-    EVAL_TERMINATED,
-    EVAL_TIMEOUT,
-    EVAL_TRIAL_COUNT,
-    EVAL_TRIAL_INDEX,
-    EVAL_UNIVERSE,
-)
-from positronic.policy import base
-from positronic.simulator.libero import adapter as libero
-from positronic.simulator.libero.adapter import (
-    EVAL_CAMERA_RESOLUTION,
-    EVAL_CONTROL_MODE,
-    EVAL_SETTLE_STEPS,
-    EVAL_SUITE,
-    EVAL_TASK_ID,
-)
-from positronic.simulator.robolab import adapter as robolab
-from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, EVAL_INSTRUCTION_TYPE
+from positronic.eval import keys as eval_keys
+from positronic.simulator.libero import keys as libero_keys
+from positronic.simulator.robolab import keys as robolab_keys
 
 # Namespaced raw wire keys that denote an observation signal, and the keys a trial records — the params it
 # runs under and the verdict it ends on — wherever they appear as a string literal. Writing any of these as a
@@ -39,23 +16,23 @@ _GUARDED = {
     keys.EE_POSE,
     keys.WRIST_IMAGE,
     keys.EXTERIOR_IMAGE,
-    EVAL_SUCCESS,
-    EVAL_TERMINATED,
-    EVAL_CHARGE_INFERENCE_TIME,
-    EVAL_UNIVERSE,
-    EVAL_EMBODIMENT,
-    EVAL_TIMEOUT,
-    EVAL_EPISODE_LENGTH,
-    EVAL_SEED,
-    EVAL_TRIAL_INDEX,
-    EVAL_TRIAL_COUNT,
-    EVAL_SUITE,
-    EVAL_TASK_ID,
-    EVAL_CAMERA_RESOLUTION,
-    EVAL_CONTROL_MODE,
-    EVAL_SETTLE_STEPS,
-    EVAL_TASK,
-    EVAL_INSTRUCTION_TYPE,
+    eval_keys.SUCCESS,
+    eval_keys.TERMINATED,
+    eval_keys.CHARGE_INFERENCE_TIME,
+    eval_keys.UNIVERSE,
+    eval_keys.EMBODIMENT,
+    eval_keys.TIMEOUT,
+    robolab_keys.EPISODE_LENGTH,
+    eval_keys.SEED,
+    eval_keys.TRIAL_INDEX,
+    eval_keys.TRIAL_COUNT,
+    libero_keys.SUITE,
+    libero_keys.TASK_ID,
+    libero_keys.CAMERA_RESOLUTION,
+    libero_keys.CONTROL_MODE,
+    libero_keys.SETTLE_STEPS,
+    eval_keys.TASK,
+    robolab_keys.INSTRUCTION_TYPE,
     keys.OBS_TIME_NS,
     keys.WALL_TIME_NS,
 }
@@ -65,9 +42,8 @@ _GUARDED = {
 
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 _REPO_ROOT = _PACKAGE_ROOT.parent
-_KEYS_MODULE = _PACKAGE_ROOT / 'keys.py'
-# The modules that define the guarded keys; each spells its own values once.
-_KEY_MODULES = {Path(inspect.getfile(m)).resolve() for m in (keys, eval_keys, models, base, libero, robolab)}
+# Every ``keys.py`` defines the keys of its package; it is the one place a value is spelled.
+_KEY_MODULES = sorted(_PACKAGE_ROOT.rglob('keys.py'))
 # First-party trees whose Python consumes the wire and must import the constants rather than
 # re-spell the literals — the package itself and the repo's `utilities/` scripts.
 _GUARDED_ROOTS = (_PACKAGE_ROOT, _REPO_ROOT / 'utilities')
@@ -93,14 +69,14 @@ def test_no_guarded_key_literals():
     assert not offenders, f'Guarded key literals found — import the constant from its module:\n{listing}'
 
 
-def test_keys_module_imports_nothing():
-    # `positronic.keys` must stay a dependency-free leaf so an out-of-repo consumer can depend on it
-    # alone, without dragging in the rest of positronic (or its optional torch/lerobot deps). Any
-    # import statement appearing here breaks that contract.
-    tree = ast.parse(_KEYS_MODULE.read_text(), filename=str(_KEYS_MODULE))
+def test_keys_modules_import_nothing():
+    # A keys module must stay a dependency-free leaf so an out-of-repo consumer can depend on it alone,
+    # without dragging in the rest of positronic (or its optional torch/lerobot deps). Any import statement
+    # appearing in one breaks that contract.
     imports = [
-        f'{_KEYS_MODULE.relative_to(_PACKAGE_ROOT.parent)}:{node.lineno}'
-        for node in ast.walk(tree)
+        f'{path.relative_to(_REPO_ROOT)}:{node.lineno}'
+        for path in _KEY_MODULES
+        for node in ast.walk(ast.parse(path.read_text(), filename=str(path)))
         if isinstance(node, (ast.Import, ast.ImportFrom))
     ]
-    assert not imports, '`positronic.keys` must import nothing (dependency-free leaf module):\n' + '\n'.join(imports)
+    assert not imports, 'A keys module must import nothing (dependency-free leaf module):\n' + '\n'.join(imports)

--- a/positronic/tests/test_keys.py
+++ b/positronic/tests/test_keys.py
@@ -1,35 +1,61 @@
 import ast
+import inspect
 from pathlib import Path
 
+from positronic import eval as eval_keys
 from positronic import keys
+from positronic.drivers.roboarm import models
+from positronic.eval import (
+    EVAL_CHARGE_INFERENCE_TIME,
+    EVAL_EMBODIMENT,
+    EVAL_SEED,
+    EVAL_SUCCESS,
+    EVAL_TASK,
+    EVAL_TERMINATED,
+    EVAL_TIMEOUT,
+    EVAL_TRIAL_COUNT,
+    EVAL_TRIAL_INDEX,
+    EVAL_UNIVERSE,
+)
+from positronic.policy import base
+from positronic.simulator.libero import adapter as libero
+from positronic.simulator.libero.adapter import (
+    EVAL_CAMERA_RESOLUTION,
+    EVAL_CONTROL_MODE,
+    EVAL_SETTLE_STEPS,
+    EVAL_SUITE,
+    EVAL_TASK_ID,
+)
+from positronic.simulator.robolab import adapter as robolab
+from positronic.simulator.robolab.adapter import EVAL_EPISODE_LENGTH, EVAL_INSTRUCTION_TYPE
 
 # Namespaced raw wire keys that denote an observation signal, and the keys a trial records — the params it
 # runs under and the verdict it ends on — wherever they appear as a string literal. Writing any of these as a
 # bare literal instead of importing the constant is what this guard forbids — the value must live once, in
-# `positronic.keys`, so a rename stays a single-site change.
+# the module that owns it, so a rename stays a single-site change.
 _GUARDED = {
     keys.JOINTS,
     keys.JOINT_VEL,
     keys.EE_POSE,
     keys.WRIST_IMAGE,
     keys.EXTERIOR_IMAGE,
-    keys.EVAL_SUCCESS,
-    keys.EVAL_TERMINATED,
-    keys.EVAL_CHARGE_INFERENCE_TIME,
-    keys.EVAL_UNIVERSE,
-    keys.EVAL_EMBODIMENT,
-    keys.EVAL_TIMEOUT,
-    keys.EVAL_EPISODE_LENGTH,
-    keys.EVAL_SEED,
-    keys.EVAL_TRIAL_INDEX,
-    keys.EVAL_TRIAL_COUNT,
-    keys.EVAL_SUITE,
-    keys.EVAL_TASK_ID,
-    keys.EVAL_CAMERA_RESOLUTION,
-    keys.EVAL_CONTROL_MODE,
-    keys.EVAL_SETTLE_STEPS,
-    keys.EVAL_TASK,
-    keys.EVAL_INSTRUCTION_TYPE,
+    EVAL_SUCCESS,
+    EVAL_TERMINATED,
+    EVAL_CHARGE_INFERENCE_TIME,
+    EVAL_UNIVERSE,
+    EVAL_EMBODIMENT,
+    EVAL_TIMEOUT,
+    EVAL_EPISODE_LENGTH,
+    EVAL_SEED,
+    EVAL_TRIAL_INDEX,
+    EVAL_TRIAL_COUNT,
+    EVAL_SUITE,
+    EVAL_TASK_ID,
+    EVAL_CAMERA_RESOLUTION,
+    EVAL_CONTROL_MODE,
+    EVAL_SETTLE_STEPS,
+    EVAL_TASK,
+    EVAL_INSTRUCTION_TYPE,
     keys.OBS_TIME_NS,
     keys.WALL_TIME_NS,
 }
@@ -40,6 +66,8 @@ _GUARDED = {
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 _REPO_ROOT = _PACKAGE_ROOT.parent
 _KEYS_MODULE = _PACKAGE_ROOT / 'keys.py'
+# The modules that define the guarded keys; each spells its own values once.
+_KEY_MODULES = {Path(inspect.getfile(m)).resolve() for m in (keys, eval_keys, models, base, libero, robolab)}
 # First-party trees whose Python consumes the wire and must import the constants rather than
 # re-spell the literals — the package itself and the repo's `utilities/` scripts.
 _GUARDED_ROOTS = (_PACKAGE_ROOT, _REPO_ROOT / 'utilities')
@@ -55,14 +83,14 @@ def test_no_guarded_key_literals():
     offenders = []
     for root in _GUARDED_ROOTS:
         for path in sorted(root.rglob('*.py')):
-            if path == _KEYS_MODULE:
+            if path in _KEY_MODULES:
                 continue
             tree = ast.parse(path.read_text(), filename=str(path))
             for value, lineno in _str_literals(tree):
                 if value in _GUARDED:
                     offenders.append(f'{path.relative_to(_REPO_ROOT)}:{lineno}: {value!r}')
     listing = '\n'.join(offenders)
-    assert not offenders, f'Guarded key literals found — import the constant from `positronic.keys`:\n{listing}'
+    assert not offenders, f'Guarded key literals found — import the constant from its module:\n{listing}'
 
 
 def test_keys_module_imports_nothing():

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -17,10 +17,10 @@ from huggingface_hub import snapshot_download
 from websockets.exceptions import ConnectionClosed
 
 from pimm.logging import init_logging
-from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Codec, Layer, Policy, Session
+from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME, TYPE
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.spec import ModelSource, remote
 from positronic.utils.checkpoints import list_checkpoints
@@ -359,11 +359,11 @@ class DreamZeroSource(ModelSource):
     def meta(self, model_id: str) -> dict[str, Any]:
         checkpoint_path = self._checkpoint_path(model_id)
         return {
-            keys.TYPE: 'dreamzero',
+            TYPE: 'dreamzero',
             'backbone': self._backbone,
             'num_gpus': self._num_gpus,
-            keys.CHECKPOINT_PATH: checkpoint_path,
-            keys.EXPERIMENT_NAME: _experiment_name(checkpoint_path),
+            CHECKPOINT_PATH: checkpoint_path,
+            EXPERIMENT_NAME: _experiment_name(checkpoint_path),
         }
 
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -20,7 +20,7 @@ from pimm.logging import init_logging
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready
 from positronic.policy import Codec, Layer, Policy, Session
-from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME, TYPE
+from positronic.policy import keys as policy_keys
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.spec import ModelSource, remote
 from positronic.utils.checkpoints import list_checkpoints
@@ -359,11 +359,11 @@ class DreamZeroSource(ModelSource):
     def meta(self, model_id: str) -> dict[str, Any]:
         checkpoint_path = self._checkpoint_path(model_id)
         return {
-            TYPE: 'dreamzero',
+            policy_keys.TYPE: 'dreamzero',
             'backbone': self._backbone,
             'num_gpus': self._num_gpus,
-            CHECKPOINT_PATH: checkpoint_path,
-            EXPERIMENT_NAME: _experiment_name(checkpoint_path),
+            policy_keys.CHECKPOINT_PATH: checkpoint_path,
+            policy_keys.EXPERIMENT_NAME: _experiment_name(checkpoint_path),
         }
 
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -17,7 +17,7 @@ from positronic.offboard.client import DEFAULT_INFER_TIMEOUT
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready, warmup
 from positronic.policy import Policy, Session
-from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME, TYPE
+from positronic.policy import keys as policy_keys
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
@@ -223,7 +223,7 @@ class Gr00tPolicy(Policy):
 
     def __init__(self, groot: Gr00tSubprocess, checkpoint_path: str):
         self._groot = groot
-        self._meta = {CHECKPOINT_PATH: checkpoint_path}
+        self._meta = {policy_keys.CHECKPOINT_PATH: checkpoint_path}
 
     def new_session(self, context=None, rt=None):
         self._groot.client.reset()
@@ -337,9 +337,9 @@ class Gr00tSource(ModelSource):
 
     def meta(self, model_id: str) -> dict[str, Any]:
         return {
-            TYPE: 'groot',
+            policy_keys.TYPE: 'groot',
             'modality_config': self.modality_config,
-            EXPERIMENT_NAME: self.checkpoints_dir.split('/')[-1] or '',
+            policy_keys.EXPERIMENT_NAME: self.checkpoints_dir.split('/')[-1] or '',
         }
 
 

--- a/positronic/vendors/gr00t/server.py
+++ b/positronic/vendors/gr00t/server.py
@@ -13,11 +13,11 @@ import pos3
 import zmq
 
 from pimm.logging import init_logging
-from positronic import keys
 from positronic.offboard.client import DEFAULT_INFER_TIMEOUT
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready, warmup
 from positronic.policy import Policy, Session
+from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME, TYPE
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
@@ -223,7 +223,7 @@ class Gr00tPolicy(Policy):
 
     def __init__(self, groot: Gr00tSubprocess, checkpoint_path: str):
         self._groot = groot
-        self._meta = {keys.CHECKPOINT_PATH: checkpoint_path}
+        self._meta = {CHECKPOINT_PATH: checkpoint_path}
 
     def new_session(self, context=None, rt=None):
         self._groot.client.reset()
@@ -337,9 +337,9 @@ class Gr00tSource(ModelSource):
 
     def meta(self, model_id: str) -> dict[str, Any]:
         return {
-            keys.TYPE: 'groot',
+            TYPE: 'groot',
             'modality_config': self.modality_config,
-            keys.EXPERIMENT_NAME: self.checkpoints_dir.split('/')[-1] or '',
+            EXPERIMENT_NAME: self.checkpoints_dir.split('/')[-1] or '',
         }
 
 

--- a/positronic/vendors/lerobot/policy.py
+++ b/positronic/vendors/lerobot/policy.py
@@ -6,8 +6,8 @@ from lerobot.configs.policies import PreTrainedConfig
 from lerobot.configs.types import FeatureType
 from lerobot.policies.factory import get_policy_class, make_pre_post_processors
 
-from positronic import keys
 from positronic.policy import Policy, Session
+from positronic.policy.base import TYPE
 from positronic.policy.observation import TASK_FIELD
 
 
@@ -95,7 +95,7 @@ class LerobotPolicy(Policy):
         policy_cls = get_policy_class(config.type)
         self._policy = policy_cls.from_pretrained(checkpoint_path).to(self._device)
         self._preprocessor, self._postprocessor = make_pre_post_processors(config, pretrained_path=checkpoint_path)
-        self._meta = {**(extra_meta or {}), keys.TYPE: config.type}
+        self._meta = {**(extra_meta or {}), TYPE: config.type}
 
     @property
     def config(self) -> PreTrainedConfig:

--- a/positronic/vendors/lerobot/policy.py
+++ b/positronic/vendors/lerobot/policy.py
@@ -7,7 +7,7 @@ from lerobot.configs.types import FeatureType
 from lerobot.policies.factory import get_policy_class, make_pre_post_processors
 
 from positronic.policy import Policy, Session
-from positronic.policy.base import TYPE
+from positronic.policy import keys as policy_keys
 from positronic.policy.observation import TASK_FIELD
 
 
@@ -95,7 +95,7 @@ class LerobotPolicy(Policy):
         policy_cls = get_policy_class(config.type)
         self._policy = policy_cls.from_pretrained(checkpoint_path).to(self._device)
         self._preprocessor, self._postprocessor = make_pre_post_processors(config, pretrained_path=checkpoint_path)
-        self._meta = {**(extra_meta or {}), TYPE: config.type}
+        self._meta = {**(extra_meta or {}), policy_keys.TYPE: config.type}
 
     @property
     def config(self) -> PreTrainedConfig:

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -7,10 +7,10 @@ import configuronic as cfn
 import pos3
 
 from pimm.logging import init_logging
-from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, warmup
 from positronic.policy import Codec, Policy
+from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, Pipeline, remote
@@ -46,12 +46,12 @@ class LerobotSource(ModelSource):
         local = run_with_progress(
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress
         )
-        policy = LerobotPolicy(str(local), self.device, extra_meta={keys.CHECKPOINT_PATH: checkpoint_path})
+        policy = LerobotPolicy(str(local), self.device, extra_meta={CHECKPOINT_PATH: checkpoint_path})
         warmup(policy, warm_observation(policy.config), on_progress)
         return policy
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'device': self.device, keys.EXPERIMENT_NAME: self.experiment_name}
+        return {'device': self.device, EXPERIMENT_NAME: self.experiment_name}
 
 
 lerobot_source = cfn.Config(LerobotSource, checkpoint=None, device=None)

--- a/positronic/vendors/lerobot/server.py
+++ b/positronic/vendors/lerobot/server.py
@@ -10,7 +10,7 @@ from pimm.logging import init_logging
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, warmup
 from positronic.policy import Codec, Policy
-from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME
+from positronic.policy import keys as policy_keys
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, Pipeline, remote
@@ -46,12 +46,12 @@ class LerobotSource(ModelSource):
         local = run_with_progress(
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress
         )
-        policy = LerobotPolicy(str(local), self.device, extra_meta={CHECKPOINT_PATH: checkpoint_path})
+        policy = LerobotPolicy(str(local), self.device, extra_meta={policy_keys.CHECKPOINT_PATH: checkpoint_path})
         warmup(policy, warm_observation(policy.config), on_progress)
         return policy
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'device': self.device, EXPERIMENT_NAME: self.experiment_name}
+        return {'device': self.device, policy_keys.EXPERIMENT_NAME: self.experiment_name}
 
 
 lerobot_source = cfn.Config(LerobotSource, checkpoint=None, device=None)

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -12,10 +12,9 @@ from lerobot.constants import CHECKPOINTS_DIR, PRETRAINED_MODEL_DIR
 from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.pretrained import PreTrainedPolicy
 
-from positronic import keys
 from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
-from positronic.policy.base import Answer, Runtime
+from positronic.policy.base import CHECKPOINT_PATH, TYPE, Answer, Runtime
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.observation import TASK_FIELD
 from positronic.policy.spec import PolicySource, inline
@@ -149,7 +148,7 @@ def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None
     if n_action_steps is not None:
         policy.config.n_action_steps = n_action_steps
 
-    return LerobotPolicy(policy, device, extra_meta={keys.TYPE: 'act', keys.CHECKPOINT_PATH: checkpoint_dir})
+    return LerobotPolicy(policy, device, extra_meta={TYPE: 'act', CHECKPOINT_PATH: checkpoint_dir})
 
 
 @cfn.config(

--- a/positronic/vendors/lerobot_0_3_3/policy.py
+++ b/positronic/vendors/lerobot_0_3_3/policy.py
@@ -14,7 +14,8 @@ from lerobot.policies.pretrained import PreTrainedPolicy
 
 from positronic.cfg import codecs
 from positronic.policy import Codec, Policy, Session
-from positronic.policy.base import CHECKPOINT_PATH, TYPE, Answer, Runtime
+from positronic.policy import keys as policy_keys
+from positronic.policy.base import Answer, Runtime
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.observation import TASK_FIELD
 from positronic.policy.spec import PolicySource, inline
@@ -148,7 +149,9 @@ def act(checkpoints_dir: str, checkpoint: str | None, n_action_steps: int | None
     if n_action_steps is not None:
         policy.config.n_action_steps = n_action_steps
 
-    return LerobotPolicy(policy, device, extra_meta={TYPE: 'act', CHECKPOINT_PATH: checkpoint_dir})
+    return LerobotPolicy(
+        policy, device, extra_meta={policy_keys.TYPE: 'act', policy_keys.CHECKPOINT_PATH: checkpoint_dir}
+    )
 
 
 @cfn.config(

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -10,10 +10,10 @@ from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.pretrained import PreTrainedPolicy
 
 from pimm.logging import init_logging
-from positronic import keys
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, warmup
 from positronic.policy import Codec, Policy
+from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME, TYPE
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
@@ -68,13 +68,13 @@ class LerobotSource(ModelSource):
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress
         )
         backbone = self._policy_factory(str(local))
-        meta = {keys.TYPE: self._model_type, keys.CHECKPOINT_PATH: checkpoint_path}
+        meta = {TYPE: self._model_type, CHECKPOINT_PATH: checkpoint_path}
         policy = LerobotPolicy(backbone, self._device, extra_meta=meta)
         warmup(policy, warm_observation(backbone.config), on_progress)
         return policy
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'device': self._device, keys.EXPERIMENT_NAME: self._experiment_name}
+        return {'device': self._device, EXPERIMENT_NAME: self._experiment_name}
 
 
 lerobot_source = cfn.Config(LerobotSource, policy_factory=act)

--- a/positronic/vendors/lerobot_0_3_3/server.py
+++ b/positronic/vendors/lerobot_0_3_3/server.py
@@ -13,7 +13,7 @@ from pimm.logging import init_logging
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, warmup
 from positronic.policy import Codec, Policy
-from positronic.policy.base import CHECKPOINT_PATH, EXPERIMENT_NAME, TYPE
+from positronic.policy import keys as policy_keys
 from positronic.policy.codec import RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
@@ -68,13 +68,13 @@ class LerobotSource(ModelSource):
             lambda: pos3.download(checkpoint_path), f'Downloading checkpoint {model_id}', on_progress
         )
         backbone = self._policy_factory(str(local))
-        meta = {TYPE: self._model_type, CHECKPOINT_PATH: checkpoint_path}
+        meta = {policy_keys.TYPE: self._model_type, policy_keys.CHECKPOINT_PATH: checkpoint_path}
         policy = LerobotPolicy(backbone, self._device, extra_meta=meta)
         warmup(policy, warm_observation(backbone.config), on_progress)
         return policy
 
     def meta(self, model_id: str) -> dict[str, Any]:
-        return {'device': self._device, EXPERIMENT_NAME: self._experiment_name}
+        return {'device': self._device, policy_keys.EXPERIMENT_NAME: self._experiment_name}
 
 
 lerobot_source = cfn.Config(LerobotSource, policy_factory=act)

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -4,8 +4,8 @@ import numpy as np
 import torch
 from transformers import AutoModelForImageTextToText, AutoProcessor
 
-from positronic import keys
 from positronic.policy import Policy, Session
+from positronic.policy.base import TYPE
 from positronic.vendors import molmoact2
 
 # The three views and the 8-D ``[joint_positions(7), grip(1)]`` state of the DROID action space this vendor
@@ -64,7 +64,7 @@ class MolmoAct2Policy(Policy):
         ).eval()
         self._norm_tag = norm_tag
         self._num_steps = num_steps
-        self._meta = {keys.TYPE: 'molmoact2', 'norm_tag': norm_tag}
+        self._meta = {TYPE: 'molmoact2', 'norm_tag': norm_tag}
 
     def new_session(self, context=None, rt=None) -> Session:
         return _MolmoAct2Session(self._model, self._processor, self._norm_tag, self._num_steps, self._meta)

--- a/positronic/vendors/molmoact2/policy.py
+++ b/positronic/vendors/molmoact2/policy.py
@@ -5,7 +5,7 @@ import torch
 from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from positronic.policy import Policy, Session
-from positronic.policy.base import TYPE
+from positronic.policy import keys as policy_keys
 from positronic.vendors import molmoact2
 
 # The three views and the 8-D ``[joint_positions(7), grip(1)]`` state of the DROID action space this vendor
@@ -64,7 +64,7 @@ class MolmoAct2Policy(Policy):
         ).eval()
         self._norm_tag = norm_tag
         self._num_steps = num_steps
-        self._meta = {TYPE: 'molmoact2', 'norm_tag': norm_tag}
+        self._meta = {policy_keys.TYPE: 'molmoact2', 'norm_tag': norm_tag}
 
     def new_session(self, context=None, rt=None) -> Session:
         return _MolmoAct2Session(self._model, self._processor, self._norm_tag, self._num_steps, self._meta)

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -15,7 +15,7 @@ from positronic import geom
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready, warmup
 from positronic.policy import Codec, Policy, Session
-from positronic.policy.base import CHECKPOINT_PATH, CONFIG_NAME, EXPERIMENT_NAME, TYPE
+from positronic.policy import keys as policy_keys
 from positronic.policy.codec import ChangeEEFrame, RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
@@ -235,10 +235,12 @@ class OpenpiSource(ModelSource):
 
     def meta(self, model_id: str) -> dict[str, Any]:
         return {
-            TYPE: 'openpi',
-            CONFIG_NAME: self.config_name,
-            CHECKPOINT_PATH: self.checkpoints_dir if self._passthrough else f'{self.checkpoints_dir}/{model_id}',
-            EXPERIMENT_NAME: self.checkpoints_dir.rsplit('/', 1)[-1],
+            policy_keys.TYPE: 'openpi',
+            policy_keys.CONFIG_NAME: self.config_name,
+            policy_keys.CHECKPOINT_PATH: self.checkpoints_dir
+            if self._passthrough
+            else f'{self.checkpoints_dir}/{model_id}',
+            policy_keys.EXPERIMENT_NAME: self.checkpoints_dir.rsplit('/', 1)[-1],
         }
 
 

--- a/positronic/vendors/openpi/server.py
+++ b/positronic/vendors/openpi/server.py
@@ -11,10 +11,11 @@ import pos3
 from openpi_client.websocket_client_policy import WebsocketClientPolicy
 
 from pimm.logging import init_logging
-from positronic import geom, keys
+from positronic import geom
 from positronic.offboard.server import serve
 from positronic.offboard.server_utils import run_with_progress, wait_for_subprocess_ready, warmup
 from positronic.policy import Codec, Policy, Session
+from positronic.policy.base import CHECKPOINT_PATH, CONFIG_NAME, EXPERIMENT_NAME, TYPE
 from positronic.policy.codec import ChangeEEFrame, RestrictImageSize
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.spec import ModelSource, remote
@@ -234,10 +235,10 @@ class OpenpiSource(ModelSource):
 
     def meta(self, model_id: str) -> dict[str, Any]:
         return {
-            keys.TYPE: 'openpi',
-            keys.CONFIG_NAME: self.config_name,
-            keys.CHECKPOINT_PATH: self.checkpoints_dir if self._passthrough else f'{self.checkpoints_dir}/{model_id}',
-            keys.EXPERIMENT_NAME: self.checkpoints_dir.rsplit('/', 1)[-1],
+            TYPE: 'openpi',
+            CONFIG_NAME: self.config_name,
+            CHECKPOINT_PATH: self.checkpoints_dir if self._passthrough else f'{self.checkpoints_dir}/{model_id}',
+            EXPERIMENT_NAME: self.checkpoints_dir.rsplit('/', 1)[-1],
         }
 
 

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -11,7 +11,7 @@ from positronic.cfg.eval.real.tasks import SCISSORS_TASK, SPOONS_TASK, TOWELS_TA
 from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
-from positronic.eval import EVAL_CHARGE_INFERENCE_TIME
+from positronic.eval import keys as eval_keys
 
 # --- Metadata Templates ---
 
@@ -142,7 +142,7 @@ class FakeGenerator(pimm.ControlSystem):
                 'eval.tote_placement': random.choice(['left', 'right']),
                 'eval.external_camera': random.choices(['left', 'right', 'NA'], [5, 5, 1])[0],
                 'inference.policy_fps': self.fps,
-                EVAL_CHARGE_INFERENCE_TIME: False,
+                eval_keys.CHARGE_INFERENCE_TIME: False,
                 **self.policy_meta,
             }
 

--- a/utilities/fake_dataset_generator.py
+++ b/utilities/fake_dataset_generator.py
@@ -11,6 +11,7 @@ from positronic.cfg.eval.real.tasks import SCISSORS_TASK, SPOONS_TASK, TOWELS_TA
 from positronic.dataset.ds_writer_agent import DsWriterAgent, DsWriterCommand, TimeMode
 from positronic.dataset.local_dataset import LocalDatasetWriter
 from positronic.dataset.serializers import Serializers
+from positronic.eval import EVAL_CHARGE_INFERENCE_TIME
 
 # --- Metadata Templates ---
 
@@ -141,7 +142,7 @@ class FakeGenerator(pimm.ControlSystem):
                 'eval.tote_placement': random.choice(['left', 'right']),
                 'eval.external_camera': random.choices(['left', 'right', 'NA'], [5, 5, 1])[0],
                 'inference.policy_fps': self.fps,
-                keys.EVAL_CHARGE_INFERENCE_TIME: False,
+                EVAL_CHARGE_INFERENCE_TIME: False,
                 **self.policy_meta,
             }
 


### PR DESCRIPTION
## Summary

positronic held two hand-copied benchmark task tables: RoboLab's 120 tasks (name -> categories +
`episode_length_s`) and LIBERO's task count per suite. Both were pinned by hand against a commit, and both
went stale when the pin moved. This deletes them and asks the benchmark instead.

- The env-server protocol gains a fourth command, `tasks(spec)`, beside `reset`, `step` and `close`. The
  server stays positronic-free: it answers raw records in the benchmark's own vocabulary, and refuses a
  selection it does not hold with the names it does.
- `spec(**selection)` in `cfg.eval` turns the arguments an eval binds into the spec the env resolves; an
  unbound argument is absent. RoboLab binds `task` (a name, a list of names, a category, or `None` for the
  whole benchmark); LIBERO binds `suite` and, when pinned, `task_id`.
- `EnvAdapter.task_params` turns the answered records into trial params, the mirror of `reset_token`. Each
  trial records the task it ran under `eval.task`.
- `RemoteEnvControlSystem.tasks` starts the server and connects, sharing the lazy connect that `reset` uses.
  Each eval config asks when the run starts, which is where `Eval.tasks` already runs.
- Each RoboLab task carries its own deadline, taken from the benchmark's `episode_length_s`. The single
  maximum backstop over the whole sweep is gone; `--eval.timeout` still pins one deadline for every task.
- `number_trials` takes `(task, params)` pairs, so one sweep can run tasks that differ. Trial numbering still
  runs across the whole sweep.

## Keys move to the package that owns them

The task records gave each benchmark keys of its own, and `positronic/keys.py` was the wrong home for them:
it would have had to know the sims. So every key group now lives in its package's own `keys` module, and
`positronic/keys.py` keeps only the embodiment wire:

- `eval.keys` — what a trial readies, the conditions it runs under and the verdict it ends on (`SUCCESS`,
  `SEED`, `TASK`, ...), without the `EVAL_` prefix. `positronic/eval.py` becomes the `positronic/eval/`
  package to hold it.
- `simulator.libero.keys`, `simulator.robolab.keys` — each benchmark's scene and task keys.
- `drivers.roboarm.keys` — the robot model an episode carries (`URDF`, `JOINT_NAMES`, `CONTROL_FRAME`,
  `EE_FRAME`).
- `policy.keys` — what a policy reports about itself; `offboard.keys` — the server's own handshake entries.

Every `keys` module is an import-free leaf; a consumer imports it as `from <package> import keys as
<pkg>_keys`. String values are unchanged, so recorded datasets read as before. `test_keys.py` guards every
`keys.py` for that and forbids the guarded literals everywhere else.

## Cost this accepts

A RoboLab run boots Isaac Sim before it knows its task list, and a wrong task name, suite or category now
fails after that boot instead of at the command line. Each env answers with the valid names, and a selection
that names no task is refused rather than run as a sweep of nothing.

## Test plan

- `uv run --locked pytest` — 1732 passed, 8 skipped.
- `uv run --locked ruff check .` and `ruff format --check .` — clean; basedpyright clean on every changed file.
- Neither benchmark's env server runs in this environment, so `LiberoEnv.tasks` and `RobolabEnv.tasks` are
  covered by the gated lanes: a case in `libero/tests/test_e2e.py` (LIBERO's 3.10 interpreter) and the
  task-list gate in `robolab/e2e.py` (Isaac Lab). Neither asserts a task count.
- `RobolabEnv.tasks` was checked against the pinned RoboLab checkout offline: the whole benchmark reproduces
  the deleted 120-entry table exactly — same names, same episode lengths — and the three categories give
  84/42/34 memberships, matching the deleted table set for set.

## Note for a reviewer

The task-selection tests went into `positronic/simulator/{libero,robolab}/tests/test_tasks.py`. Nothing
fitted them: the eval configs under `positronic/cfg/eval/` have no test module, and `positronic/cfg/tests/`
mirrors only the top-level cfg modules. The gap is real and reaches you rather than being absorbed here.
