### PR TITLE
Fix the 2F-85 coupler to its driver, so one gripper draws

### DIFF
--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -109,8 +109,6 @@ _ROBOTIQ_2F85 = [
     # ``franka_robotiq_2f_85_flattened.usd`` as 18.17mm along the flange Z and +90deg about it.
     _UrdfRow(DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
 ]
-# A fixed joint keeps its rest pose, so ``grip`` does not drive it.
-_2F85_GRIP_ACTUATED_JOINTS = [row.joint for row in _ROBOTIQ_2F85 if row.joint and row.axis]
 
 
 def _build_2f85_elements() -> list[ET.Element]:
@@ -138,6 +136,10 @@ def _build_2f85_elements() -> list[ET.Element]:
             ET.SubElement(joint_el, 'limit', effort='10', velocity='2', lower='-1.6', upper='0.9')
         elements += [link_el, joint_el]
     return elements
+
+
+# A fixed joint keeps its rest pose, so ``grip`` does not drive it.
+_2F85_GRIP_ACTUATED_JOINTS = [row.joint for row in _ROBOTIQ_2F85 if row.joint and row.axis]
 
 
 @lru_cache(maxsize=1)

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -82,11 +82,9 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
 
 
 # Rows: (link, parent, joint | None, origin xyz, origin rpy, axis | None, mesh | None, visual xyz | None).
-# A row with an axis is a revolute joint whose axis sign sets its closing direction, so one positive
-# ``grip`` drives the 4-bar: driver and spring_link swing the finger in (+X), follower counter-rotates
-# (-X) to keep the pad parallel. FOOTGUN: the coupler is fixed, because the real linkage pins it to the
-# follower and a URDF tree cannot close that loop — give it an axis and the outer link hangs 19 mm out
-# at full grip. Rows without an axis are fixed; rows without a mesh are pure frames, carrying no visual.
+# An axis makes a revolute joint whose sign sets its closing direction; a row without one is fixed, and
+# a row without a mesh is a pure frame. FOOTGUN: the coupler is fixed. Give it an axis and the outer
+# link hangs 19 mm out at full grip.
 _ROBOTIQ_2F85 = [
     ('gripper_base_mount', FLANGE_LINK, None, '0 0 0.007', _2F85_MOUNT_RPY, None, 'base_mount.stl', None),
     ('gripper_base', 'gripper_base_mount', None, '0 0 0.0038', '0 0 -1.5707963268', None, 'base.stl', None),

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -32,7 +32,7 @@ DROID_EE_FRAME = geom.Transform3D(np.array([0.0, 0.0, -0.085225977]), geom.Rotat
 _2F85_MOUNT_RPY = '0 0 0.7853981634'
 
 
-class _Row(NamedTuple):
+class _UrdfRow(NamedTuple):
     """One link, and the joint that attaches it to its parent.
 
     ``axis`` names a revolute joint and its sign sets the closing direction; without one the joint is
@@ -49,12 +49,12 @@ class _Row(NamedTuple):
     visual_xyz: str | None
 
 
-def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_Row]:
+def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_UrdfRow]:
     """One 2F-85 finger as URDF rows. ``sign`` mirrors the y-offsets and ``base_rpy`` (180deg Z on the
     left) mirrors the motion, so one positive ``grip`` closes both fingers. The follower rotates about
     an anchor offset from its body, carried as the follower mesh's visual origin."""
     return [
-        _Row(
+        _UrdfRow(
             f'{side}_driver',
             'gripper_base',
             f'{side}_driver_joint',
@@ -64,7 +64,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_Row]:
             'driver.stl',
             None,
         ),
-        _Row(
+        _UrdfRow(
             f'{side}_coupler',
             f'{side}_driver',
             f'{side}_coupler_joint',
@@ -74,7 +74,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_Row]:
             'coupler.stl',
             None,
         ),
-        _Row(
+        _UrdfRow(
             f'{side}_spring_link',
             'gripper_base',
             f'{side}_spring_link_joint',
@@ -84,7 +84,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_Row]:
             'spring_link.stl',
             None,
         ),
-        _Row(
+        _UrdfRow(
             f'{side}_follower',
             f'{side}_spring_link',
             f'{side}_follower_joint',
@@ -94,20 +94,20 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_Row]:
             'follower.stl',
             '0 0.018 -0.0065',
         ),
-        _Row(f'{side}_pad', f'{side}_follower', None, '0 -0.0009 0.00702', '0 0 0', None, 'pad.stl', None),
-        _Row(f'{side}_silicone_pad', f'{side}_pad', None, '0 0 0', '0 0 0', None, 'silicone_pad.stl', None),
+        _UrdfRow(f'{side}_pad', f'{side}_follower', None, '0 -0.0009 0.00702', '0 0 0', None, 'pad.stl', None),
+        _UrdfRow(f'{side}_silicone_pad', f'{side}_pad', None, '0 0 0', '0 0 0', None, 'silicone_pad.stl', None),
     ]
 
 
-# FOOTGUN: the coupler is fixed. Give it an axis and the outer link hangs 19 mm out at full grip.
+# The coupler stays fixed: given an axis, the outer link hangs 19 mm out at full grip.
 _ROBOTIQ_2F85 = [
-    _Row('gripper_base_mount', FLANGE_LINK, None, '0 0 0.007', _2F85_MOUNT_RPY, None, 'base_mount.stl', None),
-    _Row('gripper_base', 'gripper_base_mount', None, '0 0 0.0038', '0 0 -1.5707963268', None, 'base.stl', None),
+    _UrdfRow('gripper_base_mount', FLANGE_LINK, None, '0 0 0.007', _2F85_MOUNT_RPY, None, 'base_mount.stl', None),
+    _UrdfRow('gripper_base', 'gripper_base_mount', None, '0 0 0.0038', '0 0 -1.5707963268', None, 'base.stl', None),
     *_2f85_finger('right', 1, '0 0 0'),
     *_2f85_finger('left', -1, '0 0 3.1415926536'),
     # RoboLab's ``eef_frame`` (``Robotiq_2F_85/base_link`` ∘ ``EEF_OFFSET_ROT``), measured off its DROID USD
     # ``franka_robotiq_2f_85_flattened.usd`` as 18.17mm along the flange Z and +90deg about it.
-    _Row(DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
+    _UrdfRow(DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
 ]
 # A fixed joint keeps its rest pose, so ``grip`` does not drive it.
 _2F85_GRIP_ACTUATED_JOINTS = [row.joint for row in _ROBOTIQ_2F85 if row.joint and row.axis]
@@ -128,8 +128,8 @@ def _build_2f85_elements() -> list[ET.Element]:
             if row.visual_xyz is not None:
                 ET.SubElement(visual, 'origin', xyz=row.visual_xyz, rpy='0 0 0')
             ET.SubElement(ET.SubElement(visual, 'geometry'), 'mesh', filename=row.mesh)
-        name = row.joint or f'{row.link}_fixed'
-        joint_el = ET.Element('joint', name=name, type='revolute' if row.axis else 'fixed')
+        joint_name = row.joint or f'{row.link}_fixed'
+        joint_el = ET.Element('joint', name=joint_name, type='revolute' if row.axis else 'fixed')
         ET.SubElement(joint_el, 'origin', xyz=row.xyz, rpy=row.rpy)
         ET.SubElement(joint_el, 'parent', link=row.parent)
         ET.SubElement(joint_el, 'child', link=row.link)

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -52,7 +52,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
             f'{side}_coupler_joint',
             '0 0.0315 -0.0041',
             '0 0 0',
-            '-1 0 0',
+            None,
             'coupler.stl',
             None,
         ),
@@ -83,9 +83,10 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
 
 # Rows: (link, parent, joint | None, origin xyz, origin rpy, axis | None, mesh | None, visual xyz | None).
 # A row with an axis is a revolute joint whose axis sign sets its closing direction, so one positive
-# ``grip`` drives the whole 4-bar: driver/spring_link swing the finger in (+X), coupler/follower
-# counter-rotate (-X) to keep the pad parallel. Rows without an axis are fixed; rows without a mesh are pure
-# frames, carrying no visual.
+# ``grip`` drives the 4-bar: driver and spring_link swing the finger in (+X), follower counter-rotates
+# (-X) to keep the pad parallel. FOOTGUN: the coupler is fixed, because the real linkage pins it to the
+# follower and a URDF tree cannot close that loop — give it an axis and the outer link hangs 19 mm out
+# at full grip. Rows without an axis are fixed; rows without a mesh are pure frames, carrying no visual.
 _ROBOTIQ_2F85 = [
     ('gripper_base_mount', FLANGE_LINK, None, '0 0 0.007', _2F85_MOUNT_RPY, None, 'base_mount.stl', None),
     ('gripper_base', 'gripper_base_mount', None, '0 0 0.0038', '0 0 -1.5707963268', None, 'base.stl', None),
@@ -95,7 +96,8 @@ _ROBOTIQ_2F85 = [
     # ``franka_robotiq_2f_85_flattened.usd`` as 18.17mm along the flange Z and +90deg about it.
     (DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
 ]
-_ROBOTIQ_2F85_JOINTS = [row[2] for row in _ROBOTIQ_2F85 if row[2]]
+# The joints ``grip`` actuates: a named joint that also has an axis. A fixed one keeps its rest pose.
+_ROBOTIQ_2F85_JOINTS = [row[2] for row in _ROBOTIQ_2F85 if row[2] and row[5]]
 
 
 def _build_2f85_elements() -> list[ET.Element]:

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -109,7 +109,7 @@ _ROBOTIQ_2F85 = [
     # ``franka_robotiq_2f_85_flattened.usd`` as 18.17mm along the flange Z and +90deg about it.
     _Row(DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
 ]
-# A fixed joint keeps its rest pose, so it is not one ``grip`` drives.
+# A fixed joint keeps its rest pose, so ``grip`` does not drive it.
 _2F85_GRIP_ACTUATED_JOINTS = [row.joint for row in _ROBOTIQ_2F85 if row.joint and row.axis]
 
 

--- a/positronic/drivers/roboarm/models.py
+++ b/positronic/drivers/roboarm/models.py
@@ -5,6 +5,7 @@ real arm and the live franka driver."""
 import xml.etree.ElementTree as ET
 from functools import lru_cache
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 
@@ -31,12 +32,29 @@ DROID_EE_FRAME = geom.Transform3D(np.array([0.0, 0.0, -0.085225977]), geom.Rotat
 _2F85_MOUNT_RPY = '0 0 0.7853981634'
 
 
-def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
+class _Row(NamedTuple):
+    """One link, and the joint that attaches it to its parent.
+
+    ``axis`` names a revolute joint and its sign sets the closing direction; without one the joint is
+    fixed. ``mesh`` absent makes the link a pure frame, carrying no visual.
+    """
+
+    link: str
+    parent: str
+    joint: str | None
+    xyz: str
+    rpy: str
+    axis: str | None
+    mesh: str | None
+    visual_xyz: str | None
+
+
+def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[_Row]:
     """One 2F-85 finger as URDF rows. ``sign`` mirrors the y-offsets and ``base_rpy`` (180deg Z on the
     left) mirrors the motion, so one positive ``grip`` closes both fingers. The follower rotates about
     an anchor offset from its body, carried as the follower mesh's visual origin."""
     return [
-        (
+        _Row(
             f'{side}_driver',
             'gripper_base',
             f'{side}_driver_joint',
@@ -46,7 +64,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
             'driver.stl',
             None,
         ),
-        (
+        _Row(
             f'{side}_coupler',
             f'{side}_driver',
             f'{side}_coupler_joint',
@@ -56,7 +74,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
             'coupler.stl',
             None,
         ),
-        (
+        _Row(
             f'{side}_spring_link',
             'gripper_base',
             f'{side}_spring_link_joint',
@@ -66,7 +84,7 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
             'spring_link.stl',
             None,
         ),
-        (
+        _Row(
             f'{side}_follower',
             f'{side}_spring_link',
             f'{side}_follower_joint',
@@ -76,49 +94,47 @@ def _2f85_finger(side: str, sign: int, base_rpy: str) -> list[tuple]:
             'follower.stl',
             '0 0.018 -0.0065',
         ),
-        (f'{side}_pad', f'{side}_follower', None, '0 -0.0009 0.00702', '0 0 0', None, 'pad.stl', None),
-        (f'{side}_silicone_pad', f'{side}_pad', None, '0 0 0', '0 0 0', None, 'silicone_pad.stl', None),
+        _Row(f'{side}_pad', f'{side}_follower', None, '0 -0.0009 0.00702', '0 0 0', None, 'pad.stl', None),
+        _Row(f'{side}_silicone_pad', f'{side}_pad', None, '0 0 0', '0 0 0', None, 'silicone_pad.stl', None),
     ]
 
 
-# Rows: (link, parent, joint | None, origin xyz, origin rpy, axis | None, mesh | None, visual xyz | None).
-# An axis makes a revolute joint whose sign sets its closing direction; a row without one is fixed, and
-# a row without a mesh is a pure frame. FOOTGUN: the coupler is fixed. Give it an axis and the outer
-# link hangs 19 mm out at full grip.
+# FOOTGUN: the coupler is fixed. Give it an axis and the outer link hangs 19 mm out at full grip.
 _ROBOTIQ_2F85 = [
-    ('gripper_base_mount', FLANGE_LINK, None, '0 0 0.007', _2F85_MOUNT_RPY, None, 'base_mount.stl', None),
-    ('gripper_base', 'gripper_base_mount', None, '0 0 0.0038', '0 0 -1.5707963268', None, 'base.stl', None),
+    _Row('gripper_base_mount', FLANGE_LINK, None, '0 0 0.007', _2F85_MOUNT_RPY, None, 'base_mount.stl', None),
+    _Row('gripper_base', 'gripper_base_mount', None, '0 0 0.0038', '0 0 -1.5707963268', None, 'base.stl', None),
     *_2f85_finger('right', 1, '0 0 0'),
     *_2f85_finger('left', -1, '0 0 3.1415926536'),
     # RoboLab's ``eef_frame`` (``Robotiq_2F_85/base_link`` ∘ ``EEF_OFFSET_ROT``), measured off its DROID USD
     # ``franka_robotiq_2f_85_flattened.usd`` as 18.17mm along the flange Z and +90deg about it.
-    (DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
+    _Row(DROID_EEF_LINK, FLANGE_LINK, None, '0 0 0.01817402261', '0 0 1.5707963268', None, None, None),
 ]
-# The joints ``grip`` actuates: a named joint that also has an axis. A fixed one keeps its rest pose.
-_ROBOTIQ_2F85_JOINTS = [row[2] for row in _ROBOTIQ_2F85 if row[2] and row[5]]
+# A fixed joint keeps its rest pose, so it is not one ``grip`` drives.
+_2F85_GRIP_ACTUATED_JOINTS = [row.joint for row in _ROBOTIQ_2F85 if row.joint and row.axis]
 
 
 def _build_2f85_elements() -> list[ET.Element]:
     elements = []
-    for link, parent, joint, xyz, rpy, axis, mesh, visual_xyz in _ROBOTIQ_2F85:
-        link_el = ET.Element('link', name=link)
+    for row in _ROBOTIQ_2F85:
+        link_el = ET.Element('link', name=row.link)
         # A nominal inertial keeps each link a valid MuJoCo moving body: ik._prepare_spec strips the
         # visuals and compiles the URDF, which rejects zero-inertia bodies. IK is kinematic and the
         # viewer ignores inertials, so the magnitude is arbitrary.
         inertial = ET.SubElement(link_el, 'inertial')
         ET.SubElement(inertial, 'mass', value='0.01')
         ET.SubElement(inertial, 'inertia', ixx='1e-5', iyy='1e-5', izz='1e-5', ixy='0', ixz='0', iyz='0')
-        if mesh is not None:
+        if row.mesh is not None:
             visual = ET.SubElement(link_el, 'visual')
-            if visual_xyz is not None:
-                ET.SubElement(visual, 'origin', xyz=visual_xyz, rpy='0 0 0')
-            ET.SubElement(ET.SubElement(visual, 'geometry'), 'mesh', filename=mesh)
-        joint_el = ET.Element('joint', name=joint or f'{link}_fixed', type='revolute' if axis else 'fixed')
-        ET.SubElement(joint_el, 'origin', xyz=xyz, rpy=rpy)
-        ET.SubElement(joint_el, 'parent', link=parent)
-        ET.SubElement(joint_el, 'child', link=link)
-        if axis is not None:
-            ET.SubElement(joint_el, 'axis', xyz=axis)
+            if row.visual_xyz is not None:
+                ET.SubElement(visual, 'origin', xyz=row.visual_xyz, rpy='0 0 0')
+            ET.SubElement(ET.SubElement(visual, 'geometry'), 'mesh', filename=row.mesh)
+        name = row.joint or f'{row.link}_fixed'
+        joint_el = ET.Element('joint', name=name, type='revolute' if row.axis else 'fixed')
+        ET.SubElement(joint_el, 'origin', xyz=row.xyz, rpy=row.rpy)
+        ET.SubElement(joint_el, 'parent', link=row.parent)
+        ET.SubElement(joint_el, 'child', link=row.link)
+        if row.axis is not None:
+            ET.SubElement(joint_el, 'axis', xyz=row.axis)
             ET.SubElement(joint_el, 'limit', effort='10', velocity='2', lower='-1.6', upper='0.9')
         elements += [link_el, joint_el]
     return elements
@@ -134,7 +150,7 @@ def _bundled_robotiq_2f85() -> dict:
     return {
         'subtree': subtree,
         'meshes': {f.name: f.read_bytes() for f in sorted(mesh_dir.glob('*.stl'))},
-        roboarm_keys.GRIPPER: {'signal': keys.GRIP, 'joints': _ROBOTIQ_2F85_JOINTS, 'travel': 0.8},
+        roboarm_keys.GRIPPER: {'signal': keys.GRIP, 'joints': _2F85_GRIP_ACTUATED_JOINTS, 'travel': 0.8},
     }
 
 


### PR DESCRIPTION
## What

A Robotiq 2F-85 now draws as one gripper in the dataset viewer. The coupler becomes a fixed joint, and the gripper spec's joint list holds the joints `grip` actuates.

The rows of the 2F-85 table gain named fields, so the joint and the axis are read by name rather than by position.

## Why

The viewer drives every joint the spec names to one value, `clip(grip, 0, 1) * travel`, and takes direction from each joint's axis sign (`server/dataset_utils.py`). The coupler's axis is `-1 0 0`, so it held at absolute 0 while its driver rotated to +45.8 degrees at full grip. The outer link stayed where the open finger was while the inner finger travelled inboard, so a closed gripper drew two forked bodies hanging outboard of the pads. A founder reported it as "we have 2 grippers", and by eye that is what it looks like.

The real linkage pins the coupler to the follower. That is a loop, and a URDF tree cannot express it — the recorded model carries no `mimic` tags and could not carry this one anyway. Holding the coupler rigid to its driver closes the loop: with driver, coupler and spring-link at the same angle and the follower counter-rotating, both routes to the pin agree at every grip, the two knuckle bars stay parallel, and the pad translates without rotating. That is how a 2F-85 is built.

Teaching the viewer the four-bar relation instead puts one gripper's kinematics into a generic viewer, and the tree structure cannot tell the coupler from the follower — both are distal joints on another gripper link. Driving only the two driver joints leaves the spring link and follower at rest, so the pads never move and the jaw stops opening at all.

Selecting the actuated joints needs the joint and the axis together, and on a positional tuple that reads `row[2] and row[5]`, which makes every consumer re-derive the schema. `_Row` carries it once, and `_2F85_GRIP_ACTUATED_JOINTS` says what the list holds now that the couplers are not in it.

## Verification

Measured across the stroke, on a real episode's recorded `grip`:

- Loop-closure error falls from **19.01 mm to 0.00 mm**. Solved by least squares for the pin offsets that keep the loop closed; holding the coupler rigid with its driver leaves no residual.
- The jaw gap still runs **98.6 mm to 13.0 mm** — 85.6 mm of travel against the 2F-85's 85 mm specification, so `travel: 0.8` was always calibrated correctly.
- Rendered before and after. At grip 0.9 the couplers hang free outboard of the closed pads; with the coupler fixed, one assembled gripper. Setting the coupler to 0 and omitting it from the actuated list render pixel-identically.
- A founder validated the result visually in the dataset viewer.
- The named-field change moves no behaviour: six actuated joints, the coupler fixed, the built URDF identical. `positronic/drivers/roboarm/tests` 61 pass; ruff, ruff format and basedpyright pass on the changed file.

The error scales with grip, so an episode whose gripper never actuates looks correct either way.

## Two things left as they are

`'signal'`, `'joints'` and `'travel'` are the gripper spec's own schema: written here and read in `server/dataset_utils.py`, with no owner either side imports. That is a contract worth a constant, and it predates this change — giving it one touches the viewer, which is not this fix's business.

`gripper.joints` is read from each episode's own `static.json`, so this repairs new recordings only. Episodes recorded since the 2F-85 was bundled keep the eight-joint list and keep drawing the old way. Whether to rewrite that field in recorded data is a separate decision, tracked as Positronic-Robotics/internal#970.

<!-- opened-by: posi-agent -->
