### PR TITLE
Render the viewer under a prefix and export it as static files

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5348,30 +5348,6 @@
                 }
             },
             {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 52,

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5404,22 +5404,6 @@
                 }
             },
             {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 33,

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5374,14 +5374,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 59,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 52,
                     "endColumn": 58,
                     "lineCount": 1

--- a/positronic/cfg/analysis.py
+++ b/positronic/cfg/analysis.py
@@ -399,6 +399,7 @@ def stacking_episodes_table():
     return {
         '__index__': C(label='#', format='%d'),
         '__duration__': C(label='Duration', format='%.2f sec'),
+        'model': C(label='Model', filter=True, display=False),
         'checkpoint': C(label='CKPT', filter=True),
         'success': C(
             label='Pass',
@@ -845,6 +846,7 @@ def phail_episodes_table():
         'model': C(label='Model', filter=True),
         'variant': C(label='Variant', filter=True),
         'eval.object': C(label='Task', filter=True),
+        'equipment': C(label='Equipment', filter=True, display=False),
         'started': C(label='Started', format='%Y-%m-%d %H:%M'),
         'units': C(label='Units', align='right'),
         'uph': C(label='UPH', subtitle='Units Per Hour', format='%.1f', default='-', align='right'),

--- a/positronic/cfg/tests/test_analysis.py
+++ b/positronic/cfg/tests/test_analysis.py
@@ -1,5 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from positronic.cfg import analysis
 from positronic.cfg.analysis import ckpt
 from positronic.dataset.episode import EpisodeContainer
+from positronic.server.positronic_server import app_state_restored, configure_tables
+
+
+@pytest.mark.parametrize(
+    ('flat', 'groups'),
+    [
+        (analysis.episodes_table, {'checkpoints': analysis.checkpoint_table}),
+        (analysis.stacking_episodes_table, {'checkpoints': analysis.stacking_checkpoint_table}),
+        (analysis.phail_episodes_table, {'leaderboard': analysis.phail_leaderboard}),
+    ],
+)
+def test_every_server_group_key_and_filter_is_a_flat_table_column(flat, groups):
+    """A group table's View link filters the flat table on its group keys and filters, so each is a flat column.
+
+    A hidden column counts, so `model` on stacking and `equipment` on phail filter without a visible column.
+    """
+    group_tables = {name: cfg.instantiate() for name, cfg in groups.items()}
+    with app_state_restored():
+        configure_tables(
+            root='',
+            cache_dir=Path(),
+            ep_table_cfg=flat(),
+            group_tables=group_tables,
+            home_page=None,
+            max_resolution=64,
+            max_hz=0,
+        )
 
 
 def test_ckpt_act_resolves_comment_example_path():

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -1,9 +1,7 @@
 """Write the viewer for one dataset as static files.
 
 The app is composed in this process and read with a test client, so the export holds what the
-server answers. A page lands at `<route>/index.html`, an API response at `api/<route>.json`, a group
-table as one file per filter set with `index.json` beside them, and a recording or a download under
-`build/<build_id>/` when a build id is given.
+server answers. A page lands at `<route>/index.html` and an API response at `api/<route>.json`.
 """
 
 import itertools
@@ -40,11 +38,12 @@ from positronic.server.positronic_server import (
 
 logger = logging.getLogger(__name__)
 
-# What a page, an API response and a group table's files are written as. A page is a directory
-# with an index file, so a static host answers `episode/3` with it.
+# A page is a directory with an index file, so a static host answers `episode/3` with it.
 PAGE_FILE = 'index.html'
 API_DIR = 'api'
+# The recordings and the downloads sit under `build/<build_id>/`, a path a rebuild never rewrites.
 BUILD_DIR = 'build'
+# A group table is one file per filter set, and the index beside them says which file holds which.
 GROUP_INDEX_FILE = 'index.json'
 UNFILTERED_FILE = 'all.json'
 # The app's own assets, at the server root, so every export a host serves shares one copy.
@@ -161,7 +160,7 @@ def _write_group(client: TestClient, out: _Output, name: str) -> None:
     out.write(f'{route}/{GROUP_INDEX_FILE}', listing, 'application/json')
 
 
-# What the viewer ships and `mimetypes` does not answer for on every box.
+# `mimetypes` answers for neither on every box.
 _CONTENT_TYPE_BY_SUFFIX = {'.wasm': 'application/wasm', '.rrd': 'application/octet-stream'}
 
 

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -8,6 +8,7 @@ import itertools
 import json
 import logging
 import mimetypes
+import os
 import re
 import shutil
 import tempfile
@@ -108,29 +109,41 @@ class GroupFile:
     file: str
 
 
-class _PortableTree:
-    """The paths written so far, as any host or filesystem the tree lands on holds them.
+def _path_max(directory: Path) -> int:
+    """The longest path, its end mark included, the filesystem under `directory` takes; read off the nearest
+    ancestor that exists."""
+    existing = next(candidate for candidate in (directory, *directory.parents) if candidate.exists())
+    return os.pathconf(existing, 'PC_PATH_MAX')
 
-    A path past a host's key limit is refused. So is a component Windows reads as a device or trims, and a
-    path that folds onto a file written before, or onto a directory above one, or whose own directory folds
-    onto a file: the export writes one tree, wherever it lands.
+
+class _PortableTree:
+    """The paths written so far under `directory`, as any host or filesystem the tree lands on holds them.
+
+    A path past a host's key limit is refused, and so is one past the local filesystem's path limit with
+    `directory` in front. So is a component Windows reads as a device or trims, and a path that folds onto
+    a file written before, or onto a directory above one, or whose own directory folds onto a file.
     """
 
-    def __init__(self):
+    def __init__(self, directory: Path):
+        self._directory = directory
+        self._path_max = _path_max(directory)
         self._files: set[PurePosixPath] = set()
         self._directories: set[PurePosixPath] = set()
 
-    def add(self, path: str) -> None:
-        if len(path.encode()) > MAX_PATH_BYTES:
-            raise ValueError(f'{path!r} is past the {MAX_PATH_BYTES}-byte key limit of a host')
-        folded = PurePosixPath(path.casefold())
+    def add(self, path: PurePosixPath) -> None:
+        if len(str(path).encode()) > MAX_PATH_BYTES:
+            raise ValueError(f'{path} is past the {MAX_PATH_BYTES}-byte key limit of a host')
+        local = self._directory.joinpath(*path.parts)
+        if len(os.fsencode(local)) >= self._path_max:
+            raise ValueError(f'{local} is past the {self._path_max}-byte path limit of its filesystem')
+        folded = PurePosixPath(str(path).casefold())
         for part in folded.parts:
             if part.partition('.')[0] in _WINDOWS_DEVICES or part.endswith('.'):
-                raise ValueError(f'{path!r} has a component Windows reads as a device or trims, {part!r}')
+                raise ValueError(f'{path} has a component Windows reads as a device or trims, {part!r}')
         directories = [parent for parent in folded.parents if parent.parts]
         taken = folded in self._files or folded in self._directories
         if taken or any(directory in self._files for directory in directories):
-            raise ValueError(f'{path!r} is one file with another the export writes on a filesystem that folds case')
+            raise ValueError(f'{path} is one file with another the export writes on a filesystem that folds case')
         self._files.add(folded)
         self._directories.update(directories)
 
@@ -139,7 +152,7 @@ class _Output:
     def __init__(self, directory: Path):
         self.directory = directory
         self.files: list[ExportedFile] = []
-        self._tree = _PortableTree()
+        self._tree = _PortableTree(directory)
 
     def target(self, path: str) -> Path:
         """The file `path` is written to; a path that would land outside the directory, or that a host or a
@@ -147,7 +160,7 @@ class _Output:
         relative = PurePosixPath(path)
         if relative.is_absolute() or '\\' in path or '..' in relative.parts:
             raise ValueError(f'{path!r} would land outside {self.directory}')
-        self._tree.add(path)
+        self._tree.add(relative)
         return self.directory.joinpath(*relative.parts)
 
     def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
@@ -353,17 +366,19 @@ def _filter_sets_by_group(
     return sets_by_group
 
 
-def _refuse_unportable_paths(group_names: Iterable[str], episodes: Iterable[_EpisodeFiles], build_id: str) -> None:
+def _refuse_unportable_paths(
+    out: _Output, group_names: Iterable[str], episodes: Iterable[_EpisodeFiles], build_id: str
+) -> None:
     """Refuse a group directory or a large file that a host or a filesystem does not hold as it is, before a write.
 
     Past `configure_tables`, every group name is one segment the route builder spells.
     """
-    named = _PortableTree()
+    named = _PortableTree(out.directory)
     for name in group_names:
-        named.add(group_link(name))
+        named.add(PurePosixPath(group_link(name)))
     for files in episodes:
         for link in files.links:
-            named.add(_on_disk(link, build_id))
+            named.add(PurePosixPath(_on_disk(link, build_id)))
 
 
 def export_static(
@@ -421,7 +436,7 @@ def export_static(
             max_hz=max_hz,
         )
         configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
-        _refuse_unportable_paths(group_tables or {}, episodes, build_id)
+        _refuse_unportable_paths(out, group_tables or {}, episodes, build_id)
         install_dataset(shown)
         client = TestClient(app)
         group_names = list(group_tables or {})

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -164,7 +164,7 @@ def _episode_links(dataset: Dataset, index: int) -> list[str]:
 
 
 def _write_pages(
-    client: TestClient, out: _Output, group_names: list[str], dataset: Dataset, build_id: str
+    client: TestClient, out: _Output, group_names: list[str], episode_links: list[list[str]], build_id: str
 ) -> list[str]:
     """Write every page, and give back the recording and download links the episode pages held."""
     body, content_type = _fetch(client, '/')
@@ -173,10 +173,9 @@ def _write_pages(
         body, content_type = _fetch(client, f'/{route}')
         out.write(f'{route}/{PAGE_FILE}', body, content_type)
     links = []
-    for index in range(len(dataset)):
+    for index, page_links in enumerate(episode_links):
         body, content_type = _fetch(client, f'/{episode_link(index)}')
         page = body.decode()
-        page_links = _episode_links(dataset, index)
         if not all(any(node in page for node in _link_nodes(link)) for link in page_links):
             raise RuntimeError(f'episode page {index} does not carry every link the export expects')
         moved = large_file_links_under(page, page_links, build_id)
@@ -275,6 +274,7 @@ def export_static(
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
+    episode_links = [_episode_links(shown, index) for index in range(len(shown))]
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         configure_tables(
             root=get_dataset_root(dataset) or 'unknown_dataset',
@@ -290,7 +290,7 @@ def export_static(
         client = TestClient(app)
         group_names = list(group_tables or {})
 
-        links = _write_pages(client, out, group_names, shown, build_id)
+        links = _write_pages(client, out, group_names, episode_links, build_id)
         for route in _whole_api_routes():
             body, content_type = _fetch(client, f'/{route}')
             out.write(f'{route}.json', body, content_type)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -47,6 +47,7 @@ from positronic.server.positronic_server import (
     filter_spelling,
     group_api_link,
     group_link,
+    has_download,
     install_dataset,
     normalized_base_href,
 )
@@ -116,8 +117,8 @@ class _PortableTree:
     """
 
     def __init__(self):
-        self._files: set[str] = set()
-        self._directories: set[str] = set()
+        self._files: set[PurePosixPath] = set()
+        self._directories: set[PurePosixPath] = set()
 
     def add(self, path: str) -> None:
         if len(path.encode()) > MAX_PATH_BYTES:
@@ -126,11 +127,11 @@ class _PortableTree:
         for part in folded.parts:
             if part.partition('.')[0] in _WINDOWS_DEVICES or part.endswith('.'):
                 raise ValueError(f'{path!r} has a component Windows reads as a device or trims, {part!r}')
-        directories = [str(parent) for parent in folded.parents if str(parent) != '.']
-        taken = str(folded) in self._files or str(folded) in self._directories
+        directories = [parent for parent in folded.parents if parent.parts]
+        taken = folded in self._files or folded in self._directories
         if taken or any(directory in self._files for directory in directories):
             raise ValueError(f'{path!r} is one file with another the export writes on a filesystem that folds case')
-        self._files.add(str(folded))
+        self._files.add(folded)
         self._directories.update(directories)
 
 
@@ -323,7 +324,7 @@ def _aligned(full: Dataset, shown: Dataset) -> Dataset:
                 f'full_dataset episode {index} has uid {full_episode.meta[META_UID]!r} and dataset has '
                 f'{shown_episode.meta[META_UID]!r}'
             )
-        missing = set(download_paths(shown_episode.static)) - set(download_paths(full_episode.static))
+        missing = [path for path in download_paths(shown_episode.static) if not has_download(full_episode.static, path)]
         if missing:
             path = '/'.join(min(missing))
             raise ValueError(f'full_dataset episode {index} has no download at {path!r}, which dataset links')

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -147,10 +147,6 @@ def _link_nodes(link: str) -> list[str]:
     return [f'appUrl({spelling})', f'{_page_spelling(DOWNLOAD_LINK)}: {spelling}']
 
 
-def _carries(page: str, link: str) -> bool:
-    return any(node in page for node in _link_nodes(link))
-
-
 def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> str:
     """`html` with each of `links`, in the nodes a page carries them, moved under `build/<build_id>/`."""
     if not build_id:
@@ -181,7 +177,7 @@ def _write_pages(
         body, content_type = _fetch(client, f'/{episode_link(index)}')
         page = body.decode()
         page_links = _episode_links(dataset, index)
-        if not all(_carries(page, link) for link in page_links):
+        if not all(any(node in page for node in _link_nodes(link)) for link in page_links):
             raise RuntimeError(f'episode page {index} does not carry every link the export expects')
         moved = large_file_links_under(page, page_links, build_id)
         out.write(f'{episode_link(index)}/{PAGE_FILE}', moved.encode(), content_type)
@@ -265,9 +261,8 @@ def export_static(
     """Write the viewer for `dataset` under `out_dir` and give back every file written.
 
     The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
-    when given, which holds the same episodes in the same order: the recording builder reads an
-    episode's robot model out of its static values, so a caller that hides static values from the
-    pages passes the unhidden dataset here. `assets` writes the app's own scripts, styles and viewer
+    when given, which holds the same episodes in the same order; the recording builder reads an
+    episode's robot model out of its static values. `assets` writes the app's own scripts, styles and viewer
     under `static/`, which the pages request at the host root, so it goes with the root base href
     only; an export under a prefix shares the host's copy. An export holds the app's state for its
     duration, so a second export in the process waits for it.

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -325,8 +325,12 @@ def export_static(
     refused, as the directory holds the first.
     """
     out = _Output(Path(out_dir))
-    if cache_dir is not None and Path(cache_dir).resolve().is_relative_to(out.directory.resolve()):
-        raise ValueError(f'cache_dir {cache_dir} lies inside {out.directory}; the cache stays outside the export')
+    if cache_dir is not None:
+        cache, output = Path(cache_dir).resolve(), out.directory.resolve()
+        if cache.is_relative_to(output) or output.is_relative_to(cache):
+            raise ValueError(
+                f'cache_dir {cache_dir} and out_dir {out.directory} overlap; the cache stays outside the export'
+            )
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -30,6 +30,7 @@ from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
     DOWNLOAD_LINK,
+    MAX_COMPONENT_BYTES,
     GroupTableConfig,
     TableConfig,
     app,
@@ -70,9 +71,9 @@ _BUILD_ID = re.compile(r'[A-Za-z0-9_-]*')
 
 
 def validated_build_id(value: str) -> str:
-    """`value` when a path and a page can carry it as it is; empty names no build."""
-    if not _BUILD_ID.fullmatch(value):
-        raise ValueError(f'build_id must match {_BUILD_ID.pattern!r}, got {value!r}')
+    """`value` when a path, a file name and a page can carry it as it is; empty names no build."""
+    if not _BUILD_ID.fullmatch(value) or len(value) > MAX_COMPONENT_BYTES:
+        raise ValueError(f'build_id must match {_BUILD_ID.pattern!r} within {MAX_COMPONENT_BYTES} bytes, got {value!r}')
     return value
 
 
@@ -395,7 +396,11 @@ def main(
     Args:
         dataset: Dataset to export
         out_dir: Directory the files are written under; it is created
-        ep_table_cfg, max_resolution, max_hz, group_tables, home_page: As `positronic-server` takes them
+        ep_table_cfg: Columns of the episode table, by static key
+        max_resolution: Long side an episode's videos are re-encoded down to
+        max_hz: Rate an episode's numeric signals are thinned to; 0 keeps every sample
+        group_tables: Grouped tables, by name
+        home_page: The group table served at the root, or None for the episodes
         base_href: Path at the host root the export is served under
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -94,11 +94,15 @@ class _Output:
         self.directory = directory
         self.files: list[ExportedFile] = []
 
-    def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
+    def target(self, path: str) -> Path:
+        """The file `path` is written to; a path that would land outside the directory is refused."""
         relative = PurePosixPath(path)
         if relative.is_absolute() or '\\' in path or '..' in relative.parts:
             raise ValueError(f'{path!r} would land outside {self.directory}')
-        target = self.directory.joinpath(*relative.parts)
+        return self.directory.joinpath(*relative.parts)
+
+    def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
+        target = self.target(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
         written = ExportedFile(PurePosixPath(path), content_type, len(body))
@@ -165,14 +169,13 @@ def _episode_links(dataset: Dataset, index: int) -> list[str]:
 
 def _write_pages(
     client: TestClient, out: _Output, group_names: list[str], episode_links: list[list[str]], build_id: str
-) -> list[str]:
-    """Write every page, and give back the recording and download links the episode pages held."""
+) -> None:
+    """Write every page; an episode page carries its links moved under the build."""
     body, content_type = _fetch(client, '/')
     out.write(PAGE_FILE, body, content_type)
     for route in (episodes_link(), *(group_link(name) for name in group_names)):
         body, content_type = _fetch(client, f'/{route}')
         out.write(f'{route}/{PAGE_FILE}', body, content_type)
-    links = []
     for index, page_links in enumerate(episode_links):
         body, content_type = _fetch(client, f'/{episode_link(index)}')
         page = body.decode()
@@ -180,8 +183,6 @@ def _write_pages(
             raise RuntimeError(f'episode page {index} does not carry every link the export expects')
         moved = large_file_links_under(page, page_links, build_id)
         out.write(f'{episode_link(index)}/{PAGE_FILE}', moved.encode(), content_type)
-        links.extend(page_links)
-    return links
 
 
 def _write_group(client: TestClient, out: _Output, name: str, sets: Iterable[dict[str, str]]) -> None:
@@ -264,18 +265,23 @@ def export_static(
     episode's robot model out of its static values. `assets` writes the app's own scripts, styles and viewer
     under `static/`, which the pages request at the host root, so it goes with the root base href
     only; an export under a prefix shares the host's copy. An export holds the app's state for its
-    duration, so a second export in the process waits for it.
+    duration, so a second export in the process waits for it; one into the same directory is then
+    refused, as the directory holds the first.
     """
     out = _Output(Path(out_dir))
-    if out.directory.exists() and any(out.directory.iterdir()):
-        raise ValueError(f'{out.directory} is not empty; an export goes into a new or an empty directory')
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episode_links = [_episode_links(shown, index) for index in range(len(shown))]
+    large_files = [(link, _large_file_path(unquote(link), build_id)) for links in episode_links for link in links]
+    for _, path in large_files:
+        out.target(path)  # a name the writer refuses stops the export before a page is written
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
+        # Under the lock, so a second export into the directory of a running one finds it full.
+        if out.directory.exists() and any(out.directory.iterdir()):
+            raise ValueError(f'{out.directory} is not empty; an export goes into a new or an empty directory')
         configure_tables(
             root=get_dataset_root(dataset) or 'unknown_dataset',
             cache_dir=Path(cache_dir) if cache_dir else Path(scratch),
@@ -290,7 +296,7 @@ def export_static(
         client = TestClient(app)
         group_names = list(group_tables or {})
 
-        links = _write_pages(client, out, group_names, episode_links, build_id)
+        _write_pages(client, out, group_names, episode_links, build_id)
         for route in _whole_api_routes():
             body, content_type = _fetch(client, f'/{route}')
             out.write(f'{route}.json', body, content_type)
@@ -298,9 +304,9 @@ def export_static(
             _write_group(client, out, name, filter_sets(_filter_values(shown, cfg.group_filter_keys)))
 
         install_dataset(full)
-        for link in links:
+        for link, path in large_files:
             body, content_type = _fetch(client, f'/{link}')
-            out.write(_large_file_path(unquote(link), build_id), body, content_type)
+            out.write(path, body, content_type)
     if assets:
         _write_assets(out)
     logger.info('wrote %d files under %s', len(out.files), out_dir)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -27,6 +27,7 @@ from positronic.dataset import CachedDataset, Dataset, Episode
 from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
+    DOWNLOAD_LINK,
     FILTER_VALUES,
     GROUP_FILTERS,
     GroupTableConfig,
@@ -38,6 +39,7 @@ from positronic.server.positronic_server import (
     default_table,
     download_paths,
     install_dataset,
+    normalized_base_href,
 )
 
 logger = logging.getLogger(__name__)
@@ -88,9 +90,9 @@ class _Output:
 
     def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
         relative = PurePosixPath(path)
-        if relative.is_absolute() or '..' in relative.parts:
+        if relative.is_absolute() or '\\' in path or '..' in relative.parts:
             raise ValueError(f'{path!r} would land outside {self.directory}')
-        target = self.directory / path
+        target = self.directory.joinpath(*relative.parts)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
         written = ExportedFile(PurePosixPath(path), content_type, len(body))
@@ -126,12 +128,23 @@ def _page_spelling(link: str) -> str:
     return str(htmlsafe_json_dumps(link))
 
 
+def _link_nodes(link: str) -> list[str]:
+    """The nodes of an episode page that carry `link`: the recording's `appUrl(...)` call, a download's field."""
+    spelling = _page_spelling(link)
+    return [f'appUrl({spelling})', f'{_page_spelling(DOWNLOAD_LINK)}: {spelling}']
+
+
+def _carries(page: str, link: str) -> bool:
+    return any(node in page for node in _link_nodes(link))
+
+
 def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> str:
-    """`html` with each of `links`, as a page spells them, moved under `build/<build_id>/`."""
+    """`html` with each of `links`, in the nodes a page carries them, moved under `build/<build_id>/`."""
     if not build_id:
         return html
     for link in links:
-        html = html.replace(_page_spelling(link), _page_spelling(_large_file_path(link, build_id)))
+        for node, moved in zip(_link_nodes(link), _link_nodes(_large_file_path(link, build_id)), strict=True):
+            html = html.replace(node, moved)
     return html
 
 
@@ -156,7 +169,7 @@ def _write_pages(
         body, content_type = _fetch(client, f'/episode/{index}')
         page = body.decode()
         page_links = _episode_links(dataset, index)
-        if any(_page_spelling(link) not in page for link in page_links):
+        if not all(_carries(page, link) for link in page_links):
             raise RuntimeError(f'episode page {index} does not carry every link the export expects')
         moved = large_file_links_under(page, page_links, build_id)
         out.write(f'episode/{index}/{PAGE_FILE}', moved.encode(), content_type)
@@ -243,12 +256,15 @@ def export_static(
     when given, which holds the same episodes in the same order: the recording builder reads an
     episode's robot model out of its static values, so a caller that hides static values from the
     pages passes the unhidden dataset here. `assets` writes the app's own scripts, styles and viewer
-    under `static/`, which every export at one host shares. An export holds the app's state for its
+    under `static/`, which the pages request at the host root, so it goes with the root base href
+    only; an export under a prefix shares the host's copy. An export holds the app's state for its
     duration, so a second export in the process waits for it.
     """
     out = _Output(Path(out_dir))
     if out.directory.exists() and any(out.directory.iterdir()):
         raise ValueError(f'{out.directory} is not empty; an export goes into a new or an empty directory')
+    if assets and normalized_base_href(base_href) != '/':
+        raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
@@ -309,7 +325,7 @@ def main(
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives
         build_id: Names one build; the recordings and the downloads are written under `build/<build_id>/`
-        assets: Whether to write the app's own assets under `static/`
+        assets: Whether to write the app's own assets under `static/`; with the root base href only
     """
     written = export_static(
         dataset,

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -63,6 +63,19 @@ GROUP_INDEX_FILE = 'index.json'
 UNFILTERED_FILE = 'all.json'
 # A group table is one file per filter set some episode satisfies, up to 2^k per episode for k filter keys.
 MAX_FILTER_KEYS_PER_GROUP = 6
+# Each file of a group table is one read of the whole dataset.
+MAX_FILTER_SETS_PER_GROUP = 1024
+# The object key limit of an S3-style host; with an output directory in front it stays within a filesystem's path limit.
+MAX_PATH_BYTES = 1024
+# Windows reads these as devices, with or without a suffix, and trims a trailing dot off a name.
+_WINDOWS_DEVICES = frozenset([
+    'con',
+    'prn',
+    'aux',
+    'nul',
+    *(f'com{n}' for n in range(1, 10)),
+    *(f'lpt{n}' for n in range(1, 10)),
+])
 # The app's own assets, at the server root, so every export a host serves shares one copy.
 ASSET_DIR = 'static'
 
@@ -94,11 +107,12 @@ class GroupFile:
     file: str
 
 
-class _CaseInsensitiveTree:
-    """The paths written so far, as a filesystem that folds case holds them.
+class _PortableTree:
+    """The paths written so far, as any host or filesystem the tree lands on holds them.
 
-    A path that folds onto a file written before, or onto a directory above one, or whose own directory folds
-    onto a file, is refused: the export writes one tree, whatever filesystem it lands on.
+    A path past a host's key limit is refused. So is a component Windows reads as a device or trims, and a
+    path that folds onto a file written before, or onto a directory above one, or whose own directory folds
+    onto a file: the export writes one tree, wherever it lands.
     """
 
     def __init__(self):
@@ -106,7 +120,12 @@ class _CaseInsensitiveTree:
         self._directories: set[str] = set()
 
     def add(self, path: str) -> None:
+        if len(path.encode()) > MAX_PATH_BYTES:
+            raise ValueError(f'{path!r} is past the {MAX_PATH_BYTES}-byte key limit of a host')
         folded = PurePosixPath(path.casefold())
+        for part in folded.parts:
+            if part.partition('.')[0] in _WINDOWS_DEVICES or part.endswith('.'):
+                raise ValueError(f'{path!r} has a component Windows reads as a device or trims, {part!r}')
         directories = [str(parent) for parent in folded.parents if str(parent) != '.']
         taken = str(folded) in self._files or str(folded) in self._directories
         if taken or any(directory in self._files for directory in directories):
@@ -119,11 +138,11 @@ class _Output:
     def __init__(self, directory: Path):
         self.directory = directory
         self.files: list[ExportedFile] = []
-        self._tree = _CaseInsensitiveTree()
+        self._tree = _PortableTree()
 
     def target(self, path: str) -> Path:
-        """The file `path` is written to; a path that would land outside the directory, or on another file
-        once case is folded, is refused."""
+        """The file `path` is written to; a path that would land outside the directory, or that a host or a
+        filesystem the tree lands on does not hold as it is, is refused."""
         relative = PurePosixPath(path)
         if relative.is_absolute() or '\\' in path or '..' in relative.parts:
             raise ValueError(f'{path!r} would land outside {self.directory}')
@@ -311,21 +330,34 @@ def _aligned(full: Dataset, shown: Dataset) -> Dataset:
     return full
 
 
-def _check_filter_keys(group_tables: dict[str, GroupTableConfig] | None) -> None:
+def _filter_sets_by_group(
+    dataset: Dataset, group_tables: dict[str, GroupTableConfig] | None
+) -> dict[str, list[dict[str, str]]]:
+    """The filter sets each group table gets a file for; a group past either bound is refused before a write."""
+    sets_by_group: dict[str, list[dict[str, str]]] = {}
     for name, cfg in (group_tables or {}).items():
         if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
             raise ValueError(
                 f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
                 f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
             )
+        sets = filter_sets(_filter_values(dataset, cfg.group_filter_keys))
+        if len(sets) > MAX_FILTER_SETS_PER_GROUP:
+            raise ValueError(
+                f'group table {name!r} has {len(sets)} filter sets and an export reads the dataset once per set, '
+                f'so a group table takes at most {MAX_FILTER_SETS_PER_GROUP}; a filter key with a value per episode '
+                f'is the usual cause'
+            )
+        sets_by_group[name] = sets
+    return sets_by_group
 
 
-def _refuse_folded_collisions(group_names: Iterable[str], episodes: Iterable[_EpisodeFiles], build_id: str) -> None:
-    """Refuse a group directory or a large file that another folds onto, before a write.
+def _refuse_unportable_paths(group_names: Iterable[str], episodes: Iterable[_EpisodeFiles], build_id: str) -> None:
+    """Refuse a group directory or a large file that a host or a filesystem does not hold as it is, before a write.
 
     Past `configure_tables`, every group name is one segment the route builder spells.
     """
-    named = _CaseInsensitiveTree()
+    named = _PortableTree()
     for name in group_names:
         named.add(group_link(name))
     for files in episodes:
@@ -371,8 +403,8 @@ def export_static(
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
-    _check_filter_keys(group_tables)
     shown = CachedDataset(dataset)
+    sets_by_group = _filter_sets_by_group(shown, group_tables)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_files(shown, index) for index in range(len(shown))]
     with app_state_restored(), tempfile.TemporaryDirectory(dir=scratch_dir) as scratch:
@@ -389,7 +421,7 @@ def export_static(
             max_hz=max_hz,
         )
         configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
-        _refuse_folded_collisions(group_tables or {}, episodes, build_id)
+        _refuse_unportable_paths(group_tables or {}, episodes, build_id)
         install_dataset(shown)
         client = TestClient(app)
         group_names = list(group_tables or {})
@@ -398,8 +430,8 @@ def export_static(
         for route in _whole_api_routes():
             body, content_type = _fetch(client, f'/{route}')
             out.write(f'{route}.json', body, content_type)
-        for name, cfg in (group_tables or {}).items():
-            _write_group(client, out, name, filter_sets(_filter_values(shown, cfg.group_filter_keys)))
+        for name, sets in sets_by_group.items():
+            _write_group(client, out, name, sets)
 
         install_dataset(full)
         for files in episodes:

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -8,9 +8,10 @@ import itertools
 import json
 import logging
 import mimetypes
+import re
 import tempfile
-from collections.abc import Iterator
-from dataclasses import dataclass
+from collections.abc import Iterable, Iterator
+from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import cast
 
@@ -52,6 +53,16 @@ ASSET_DIR = 'static'
 # The routes whose responses a page reads whole. `episodes` is filtered in the browser.
 _WHOLE_API_ROUTES = ('dataset_info', 'dataset_status', 'episodes')
 
+# The `secrets.token_urlsafe` alphabet: a build id is a path segment and sits inside a script string.
+_BUILD_ID = re.compile(r'[A-Za-z0-9_-]*')
+
+
+def validated_build_id(value: str) -> str:
+    """`value` when a path and a page can carry it as it is; empty names no build."""
+    if not _BUILD_ID.fullmatch(value):
+        raise ValueError(f'build_id must match {_BUILD_ID.pattern!r}, got {value!r}')
+    return value
+
 
 @dataclass(frozen=True)
 class ExportedFile:
@@ -72,11 +83,11 @@ class GroupFile:
 
 class _Output:
     def __init__(self, directory: Path):
-        self._directory = directory
+        self.directory = directory
         self.files: list[ExportedFile] = []
 
     def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
-        target = self._directory / path
+        target = self.directory / path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
         written = ExportedFile(PurePosixPath(path), content_type, len(body))
@@ -112,21 +123,29 @@ def filter_sets(response: dict) -> Iterator[dict[str, str]]:
         yield {key: value for key, value in zip(keys, chosen, strict=True) if value is not None}
 
 
-def large_file_links_under(html: str, build_id: str) -> str:
-    """`html` with every recording and download link moved under `build/<build_id>/`."""
+def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> str:
+    """`html` with each of `links`, a quoted script string, moved under `build/<build_id>/`."""
     if not build_id:
         return html
-    prefix = f'{BUILD_DIR}/{build_id}/'
-    return html.replace('"api/episode_rrd/', f'"{prefix}api/episode_rrd/').replace(
-        '"api/episode/', f'"{prefix}api/episode/'
-    )
+    for link in links:
+        html = html.replace(f'"{link}"', f'"{BUILD_DIR}/{build_id}/{link}"')
+    return html
 
 
 def _large_file_path(link: str, build_id: str) -> str:
     return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
 
 
-def _write_pages(client: TestClient, out: _Output, group_names: list[str], count: int, build_id: str) -> list[str]:
+def _episode_links(dataset: Dataset, index: int) -> list[str]:
+    """The recording and the downloads an episode page links, as the page spells them."""
+    static = cast(Episode, dataset[index]).static
+    downloads = (f'{API_DIR}/episode/{index}/static/{field}' for field in download_paths(static))
+    return [f'{API_DIR}/episode_rrd/{index}', *downloads]
+
+
+def _write_pages(
+    client: TestClient, out: _Output, group_names: list[str], dataset: Dataset, build_id: str
+) -> list[str]:
     """Write every page, and give back the recording and download links the episode pages held."""
     body, content_type = _fetch(client, '/')
     out.write(PAGE_FILE, body, content_type)
@@ -134,15 +153,15 @@ def _write_pages(client: TestClient, out: _Output, group_names: list[str], count
         body, content_type = _fetch(client, f'/{route}')
         out.write(f'{route}/{PAGE_FILE}', body, content_type)
     links = []
-    for index in range(count):
+    for index in range(len(dataset)):
         body, content_type = _fetch(client, f'/episode/{index}')
         page = body.decode()
-        moved = large_file_links_under(page, build_id)
-        rrd_link = f'{API_DIR}/episode_rrd/{index}'
-        if build_id and rrd_link not in page:
-            raise RuntimeError(f'episode page {index} carries no recording link to move under the build')
+        page_links = _episode_links(dataset, index)
+        if any(f'"{link}"' not in page for link in page_links):
+            raise RuntimeError(f'episode page {index} does not carry every link the export expects')
+        moved = large_file_links_under(page, page_links, build_id)
         out.write(f'episode/{index}/{PAGE_FILE}', moved.encode(), content_type)
-        links.append(rrd_link)
+        links.extend(page_links)
     return links
 
 
@@ -156,7 +175,7 @@ def _write_group(client: TestClient, out: _Output, name: str) -> None:
         entry = GroupFile(params, f'{number}.json')
         out.write(f'{route}/{entry.file}', filtered, filtered_type)
         index.append(entry)
-    listing = json.dumps([{'params': entry.params, 'file': entry.file} for entry in index]).encode()
+    listing = json.dumps([asdict(entry) for entry in index]).encode()
     out.write(f'{route}/{GROUP_INDEX_FILE}', listing, 'application/json')
 
 
@@ -203,6 +222,9 @@ def export_static(
     the app's own scripts, styles and viewer under `static/`, which every export at one host shares.
     """
     out = _Output(Path(out_dir))
+    if out.directory.exists() and any(out.directory.iterdir()):
+        raise ValueError(f'{out.directory} is not empty; an export goes into a new or an empty directory')
+    validated_build_id(build_id)
     shown = CachedDataset(dataset)
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         configure_tables(
@@ -219,7 +241,7 @@ def export_static(
         client = TestClient(app)
         group_names = list(group_tables or {})
 
-        links = _write_pages(client, out, group_names, len(shown), build_id)
+        links = _write_pages(client, out, group_names, shown, build_id)
         for route in _WHOLE_API_ROUTES:
             body, content_type = _fetch(client, f'/{API_DIR}/{route}')
             out.write(f'{API_DIR}/{route}.json', body, content_type)
@@ -227,9 +249,6 @@ def export_static(
             _write_group(client, out, name)
 
         install_dataset(CachedDataset(full_dataset) if full_dataset is not None else shown)
-        for index in range(len(shown)):
-            static = cast(Episode, shown[index]).static
-            links.extend(f'{API_DIR}/episode/{index}/static/{field}' for field in download_paths(static))
         for link in links:
             body, content_type = _fetch(client, f'/{link}')
             out.write(_large_file_path(link, build_id), body, content_type)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -271,6 +271,20 @@ def _aligned(full: Dataset, shown: Dataset) -> Dataset:
     return full
 
 
+def _check_targets(out: _Output, episodes: list[_EpisodeFiles], build_id: str) -> None:
+    """Refuse, before a write, a large file the writer cannot place: a name it refuses, two names on one file, a file
+    in another file's directory."""
+    targets: dict[Path, str] = {}
+    for link in (link for files in episodes for link in files.links):
+        target = out.target(_on_disk(link, build_id))
+        if targets.setdefault(target, link) != link:
+            raise ValueError(f'{link!r} and {targets[target]!r} would be written to one file, {target}')
+    for target, link in targets.items():
+        for parent in target.parents:
+            if parent in targets:
+                raise ValueError(f'{link!r} needs {targets[parent]!r} to be a directory, and it is a file')
+
+
 def export_static(
     dataset: Dataset,
     out_dir: Path,
@@ -295,23 +309,21 @@ def export_static(
     episode's robot model out of its static values. A recording is copied from the cache file the server
     serves, so no recording is held in memory whole. `assets` writes the app's own scripts, styles and viewer
     under `static/`, which the pages request at the host root, so it goes with the root base href
-    only; an export under a prefix shares the host's copy. An export holds the app's state for its
+    only; an export under a prefix shares the host's copy. `cache_dir`, when given, lies outside
+    `out_dir`: the recordings are built there and copied in. An export holds the app's state for its
     duration, so a second export in the process waits for it; one into the same directory is then
     refused, as the directory holds the first.
     """
     out = _Output(Path(out_dir))
+    if cache_dir is not None and Path(cache_dir).resolve().is_relative_to(out.directory.resolve()):
+        raise ValueError(f'cache_dir {cache_dir} lies inside {out.directory}; the cache stays outside the export')
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_files(shown, index) for index in range(len(shown))]
-    targets: dict[Path, str] = {}
-    for link in (link for files in episodes for link in files.links):
-        # A name the writer refuses, or two names for one file, stops the export before a write.
-        target = out.target(_on_disk(link, build_id))
-        if targets.setdefault(target, link) != link:
-            raise ValueError(f'{link!r} and {targets[target]!r} would be written to one file, {target}')
+    _check_targets(out, episodes, build_id)
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.
         if out.directory.exists() and any(out.directory.iterdir()):

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -12,7 +12,7 @@ import os
 import re
 import shutil
 import tempfile
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import cast
@@ -39,7 +39,9 @@ from positronic.server.positronic_server import (
     configure_pages,
     configure_tables,
     default_table,
+    download_at,
     download_link,
+    download_metadata,
     download_paths,
     episode_link,
     episode_rrd_link,
@@ -48,7 +50,6 @@ from positronic.server.positronic_server import (
     filter_spelling,
     group_api_link,
     group_link,
-    has_download,
     install_dataset,
     normalized_base_href,
 )
@@ -69,6 +70,8 @@ MAX_FILTER_KEYS_PER_GROUP = 6
 MAX_FILTER_SETS_PER_GROUP = 1024
 # The object key limit of an S3-style host.
 MAX_PATH_BYTES = 1024
+# Windows holds a path within `MAX_PATH` characters, its end mark included, unless a machine opts into long paths.
+_WINDOWS_PATH_MAX = 260
 # Windows reads these as devices, with or without a suffix, and trims a trailing dot off a name.
 _WINDOWS_DEVICES = frozenset([
     'con',
@@ -110,18 +113,20 @@ class GroupFile:
 
 
 def _path_max(directory: Path) -> int:
-    """The longest path, its end mark included, the filesystem under `directory` takes; read off the nearest
-    ancestor that exists."""
+    """The longest path, its end mark included, the filesystem under `directory` takes: read off the nearest
+    ancestor that exists where the platform reports it, and Windows' `MAX_PATH` where it does not."""
+    if not hasattr(os, 'pathconf'):
+        return _WINDOWS_PATH_MAX
     existing = next(candidate for candidate in (directory, *directory.parents) if candidate.exists())
     return os.pathconf(existing, 'PC_PATH_MAX')
 
 
 class _PortableTree:
-    """The paths written so far under `directory`, as any host or filesystem the tree lands on holds them.
+    """The paths the export writes under `directory`, as any host or filesystem the tree lands on holds them.
 
     A path past a host's key limit is refused, and so is one past the local filesystem's path limit with
     `directory` in front. So is a component Windows reads as a device or trims, and a path that folds onto
-    a file written before, or onto a directory above one, or whose own directory folds onto a file.
+    a file added before, or onto a directory above one, or whose own directory folds onto a file.
     """
 
     def __init__(self, directory: Path):
@@ -149,37 +154,55 @@ class _PortableTree:
 
 
 class _Output:
+    """The files the export writes under `directory`: every path is planned before the first write, and a write
+    of a path outside the plan is refused."""
+
     def __init__(self, directory: Path):
         self.directory = directory
         self.files: list[ExportedFile] = []
         self._tree = _PortableTree(directory)
+        self._planned: set[str] = set()
 
-    def target(self, path: str) -> Path:
-        """The file `path` is written to; a path that would land outside the directory, or that a host or a
-        filesystem the tree lands on does not hold as it is, is refused."""
-        relative = PurePosixPath(path)
-        if relative.is_absolute() or '\\' in path or '..' in relative.parts:
-            raise ValueError(f'{path!r} would land outside {self.directory}')
-        self._tree.add(relative)
-        return self.directory.joinpath(*relative.parts)
+    def plan(self, paths: Iterable[str]) -> None:
+        """Register every path the export writes; one that would land outside the directory, or that a host or a
+        filesystem the tree lands on does not hold as it is, is refused here, before a write."""
+        for path in paths:
+            relative = PurePosixPath(path)
+            if relative.is_absolute() or '\\' in path or '..' in relative.parts:
+                raise ValueError(f'{path!r} would land outside {self.directory}')
+            self._tree.add(relative)
+            self._planned.add(path)
 
     def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
-        target = self.target(path)
+        target = self._target(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
         return self._record(path, content_type, len(body))
 
     def copy(self, path: str, source: Path) -> ExportedFile:
         """Copy the file at `source` to `path` without holding it in memory."""
-        target = self.target(path)
+        target = self._target(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, target)
         return self._record(path, asset_content_type(source), target.stat().st_size)
+
+    def _target(self, path: str) -> Path:
+        if path not in self._planned:
+            raise ValueError(f'{path!r} is not in the export plan')
+        return self.directory.joinpath(*PurePosixPath(path).parts)
 
     def _record(self, path: str, content_type: str, size: int) -> ExportedFile:
         written = ExportedFile(PurePosixPath(path), content_type, size)
         self.files.append(written)
         return written
+
+
+@dataclass(frozen=True)
+class _Planned:
+    """One file the export writes at `path`; `write` writes it, once the app serves the dataset it reads."""
+
+    path: str
+    write: Callable[[_Output], ExportedFile]
 
 
 def _fetch(client: TestClient, path: str, params: dict[str, str] | None = None) -> tuple[bytes, str]:
@@ -188,11 +211,14 @@ def _fetch(client: TestClient, path: str, params: dict[str, str] | None = None) 
     return response.content, response.headers.get('content-type', '')
 
 
-def _filter_values(dataset: Dataset, keys: Iterable[str]) -> Iterator[dict[str, str]]:
-    """Each episode's values on the filter `keys`, as a filter spells them; an absent value is left out."""
-    for episode in dataset:
-        spelled = ((key, filter_spelling(cast(Episode, episode).static.get(key))) for key in keys)
-        yield {key: value for key, value in spelled if value is not None}
+def _fetched(client: TestClient, route: str, path: str, params: dict[str, str] | None = None) -> _Planned:
+    """The response of `route`, read with `params`, written at `path`."""
+    return _Planned(path, lambda out: out.write(path, *_fetch(client, route, params)))
+
+
+def _copied(path: str, source: Path) -> _Planned:
+    """The file at `source`, copied to `path`."""
+    return _Planned(path, lambda out: out.copy(path, source))
 
 
 def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, str]]:
@@ -208,14 +234,39 @@ def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, s
     return [dict(chosen) for chosen in sorted(satisfied, key=lambda chosen: (len(chosen), chosen))]
 
 
+def _filter_values(dataset: Dataset, keys: Iterable[str]) -> Iterator[dict[str, str]]:
+    """Each episode's values on the filter `keys`, as a filter spells them; an absent value is left out."""
+    for episode in dataset:
+        spelled = ((key, filter_spelling(cast(Episode, episode).static.get(key))) for key in keys)
+        yield {key: value for key, value in spelled if value is not None}
+
+
+def _filter_sets_by_group(
+    dataset: Dataset, group_tables: dict[str, GroupTableConfig] | None
+) -> dict[str, list[dict[str, str]]]:
+    """The filter sets each group table gets a file for; a group past either bound is refused before a write."""
+    sets_by_group: dict[str, list[dict[str, str]]] = {}
+    for name, cfg in (group_tables or {}).items():
+        if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
+            raise ValueError(
+                f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
+                f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
+            )
+        sets = filter_sets(_filter_values(dataset, cfg.group_filter_keys))
+        if len(sets) > MAX_FILTER_SETS_PER_GROUP:
+            raise ValueError(
+                f'group table {name!r} has {len(sets)} filter sets and an export reads the dataset once per set, '
+                f'so a group table takes at most {MAX_FILTER_SETS_PER_GROUP}; a filter key with a value per episode '
+                f'is the usual cause'
+            )
+        sets_by_group[name] = sets
+    return sets_by_group
+
+
 def _large_file_path(link: str, build_id: str) -> str:
-    return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
-
-
-def _on_disk(link: str, build_id: str) -> str:
     """Where the file a large-file `link` names is written: its segments as a directory tree, each keeping the
     encoded spelling the browser asks it by, under the build."""
-    return _large_file_path(link, build_id)
+    return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
 
 
 def _page_spelling(link: str) -> str:
@@ -246,54 +297,71 @@ def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> st
 
 
 @dataclass(frozen=True)
-class _EpisodeFiles:
+class _EpisodeLinks:
     """The large files one episode page links, as the page spells them."""
 
     index: int
-    recording: str
-    downloads: list[str]
-
-    @property
-    def links(self) -> list[str]:
-        return [self.recording, *self.downloads]
+    recording_link: str
+    download_links: list[str]
 
 
-def _episode_files(dataset: Dataset, index: int) -> _EpisodeFiles:
+def _episode_links(dataset: Dataset, index: int) -> _EpisodeLinks:
     static = cast(Episode, dataset[index]).static
     downloads = [download_link(index, field) for field in download_paths(static)]
-    return _EpisodeFiles(index, episode_rrd_link(index), downloads)
+    return _EpisodeLinks(index, episode_rrd_link(index), downloads)
 
 
-def _write_pages(
-    client: TestClient, out: _Output, group_names: list[str], episodes: list[_EpisodeFiles], build_id: str
-) -> None:
-    """Write every page; an episode page carries its links moved under the build."""
-    body, content_type = _fetch(client, '/')
-    out.write(PAGE_FILE, body, content_type)
-    for route in (episodes_link(), *(group_link(name) for name in group_names)):
+def _episode_page(client: TestClient, links: _EpisodeLinks, build_id: str) -> _Planned:
+    """The page of one episode, with its links moved under the build."""
+    route = episode_link(links.index)
+    path = f'{route}/{PAGE_FILE}'
+    every = [links.recording_link, *links.download_links]
+
+    def write(out: _Output) -> ExportedFile:
         body, content_type = _fetch(client, f'/{route}')
-        out.write(f'{route}/{PAGE_FILE}', body, content_type)
-    for files in episodes:
-        body, content_type = _fetch(client, f'/{episode_link(files.index)}')
         page = body.decode()
-        if not all(any(node in page for node in _link_nodes(link)) for link in files.links):
-            raise RuntimeError(f'episode page {files.index} does not carry every link the export expects')
-        moved = large_file_links_under(page, files.links, build_id)
-        out.write(f'{episode_link(files.index)}/{PAGE_FILE}', moved.encode(), content_type)
+        if not all(any(node in page for node in _link_nodes(link)) for link in every):
+            raise RuntimeError(f'episode page {links.index} does not carry every link the export expects')
+        return out.write(path, large_file_links_under(page, every, build_id).encode(), content_type)
+
+    return _Planned(path, write)
 
 
-def _write_group(client: TestClient, out: _Output, name: str, sets: Iterable[dict[str, str]]) -> None:
+def _page_writes(
+    client: TestClient, group_names: Iterable[str], episodes: Iterable[_EpisodeLinks], build_id: str
+) -> list[_Planned]:
+    """Every page."""
+    routes = [episodes_link(), *(group_link(name) for name in group_names)]
+    return [
+        _fetched(client, '/', PAGE_FILE),
+        *(_fetched(client, f'/{route}', f'{route}/{PAGE_FILE}') for route in routes),
+        *(_episode_page(client, links, build_id) for links in episodes),
+    ]
+
+
+def _group_writes(client: TestClient, name: str, sets: Iterable[dict[str, str]]) -> list[_Planned]:
+    """One file per filter set of the group table `name`, and the index naming them."""
     route = group_api_link(name)
-    body, content_type = _fetch(client, f'/{route}')
-    index = [GroupFile({}, UNFILTERED_FILE)]
-    out.write(f'{route}/{UNFILTERED_FILE}', body, content_type)
-    for number, params in enumerate((chosen for chosen in sets if chosen), start=1):
-        filtered, filtered_type = _fetch(client, f'/{route}', params)
-        entry = GroupFile(params, f'{number}.json')
-        out.write(f'{route}/{entry.file}', filtered, filtered_type)
-        index.append(entry)
+    filtered = (chosen for chosen in sets if chosen)
+    index = [GroupFile({}, UNFILTERED_FILE), *(GroupFile(params, f'{n}.json') for n, params in enumerate(filtered, 1))]
     listing = json.dumps([asdict(entry) for entry in index]).encode()
-    out.write(f'{route}/{GROUP_INDEX_FILE}', listing, 'application/json')
+    return [
+        *(_fetched(client, f'/{route}', f'{route}/{entry.file}', entry.params) for entry in index),
+        _Planned(
+            f'{route}/{GROUP_INDEX_FILE}',
+            lambda out: out.write(f'{route}/{GROUP_INDEX_FILE}', listing, 'application/json'),
+        ),
+    ]
+
+
+def _large_file_writes(client: TestClient, links: _EpisodeLinks, build_id: str) -> list[_Planned]:
+    """The recording and the downloads of one episode, under the build; the recording is copied from the file the
+    app builds, the downloads are read through the client."""
+    recording = _large_file_path(links.recording_link, build_id)
+    return [
+        _Planned(recording, lambda out: out.copy(recording, episode_rrd_path(links.index))),
+        *(_fetched(client, f'/{link}', _large_file_path(link, build_id)) for link in links.download_links),
+    ]
 
 
 # `mimetypes` answers for neither on every box.
@@ -307,11 +375,11 @@ def asset_content_type(path: Path) -> str:
     return mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
 
 
-def _write_assets(out: _Output) -> None:
+def _asset_writes() -> list[_Planned]:
+    """The app's own scripts, styles and viewer, under `static/`."""
     static_dir = Path(__file__).resolve().parent / ASSET_DIR
-    for path in sorted(p for p in static_dir.rglob('*') if p.is_file()):
-        relative = path.relative_to(static_dir).as_posix()
-        out.write(f'{ASSET_DIR}/{relative}', path.read_bytes(), asset_content_type(path))
+    files = sorted(p for p in static_dir.rglob('*') if p.is_file())
+    return [_copied(f'{ASSET_DIR}/{file.relative_to(static_dir).as_posix()}', file) for file in files]
 
 
 def _whole_api_routes() -> list[str]:
@@ -327,7 +395,8 @@ def _whole_api_routes() -> list[str]:
 
 
 def _aligned(full: Dataset, shown: Dataset) -> Dataset:
-    """`full`, once it holds the episodes of `shown` at the same indexes, by uid, with every download `shown` links."""
+    """`full`, once it holds the episodes of `shown` at the same indexes, by uid, with every download `shown` links,
+    of the type and the size the page reports beside the link."""
     if len(full) != len(shown):
         raise ValueError(f'full_dataset holds {len(full)} episodes and dataset holds {len(shown)}')
     for index in range(len(shown)):
@@ -337,48 +406,20 @@ def _aligned(full: Dataset, shown: Dataset) -> Dataset:
                 f'full_dataset episode {index} has uid {full_episode.meta[META_UID]!r} and dataset has '
                 f'{shown_episode.meta[META_UID]!r}'
             )
-        missing = [path for path in download_paths(shown_episode.static) if not has_download(full_episode.static, path)]
-        if missing:
-            path = '/'.join(min(missing))
-            raise ValueError(f'full_dataset episode {index} has no download at {path!r}, which dataset links')
+        for path in download_paths(shown_episode.static):
+            linked = download_metadata(cast(bytes | str, download_at(shown_episode.static, path)))
+            held = download_at(full_episode.static, path)
+            if held is None:
+                raise ValueError(
+                    f'full_dataset episode {index} has no download at {"/".join(path)!r}, which dataset links'
+                )
+            if download_metadata(held) != linked:
+                raise ValueError(
+                    f'full_dataset episode {index} holds {download_metadata(held).type} of size '
+                    f'{download_metadata(held).size} at {"/".join(path)!r}, and dataset links {linked.type} of size '
+                    f'{linked.size}'
+                )
     return full
-
-
-def _filter_sets_by_group(
-    dataset: Dataset, group_tables: dict[str, GroupTableConfig] | None
-) -> dict[str, list[dict[str, str]]]:
-    """The filter sets each group table gets a file for; a group past either bound is refused before a write."""
-    sets_by_group: dict[str, list[dict[str, str]]] = {}
-    for name, cfg in (group_tables or {}).items():
-        if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
-            raise ValueError(
-                f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
-                f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
-            )
-        sets = filter_sets(_filter_values(dataset, cfg.group_filter_keys))
-        if len(sets) > MAX_FILTER_SETS_PER_GROUP:
-            raise ValueError(
-                f'group table {name!r} has {len(sets)} filter sets and an export reads the dataset once per set, '
-                f'so a group table takes at most {MAX_FILTER_SETS_PER_GROUP}; a filter key with a value per episode '
-                f'is the usual cause'
-            )
-        sets_by_group[name] = sets
-    return sets_by_group
-
-
-def _refuse_unportable_paths(
-    out: _Output, group_names: Iterable[str], episodes: Iterable[_EpisodeFiles], build_id: str
-) -> None:
-    """Refuse a group directory or a large file that a host or a filesystem does not hold as it is, before a write.
-
-    Past `configure_tables`, every group name is one segment the route builder spells.
-    """
-    named = _PortableTree(out.directory)
-    for name in group_names:
-        named.add(PurePosixPath(group_link(name)))
-    for files in episodes:
-        for link in files.links:
-            named.add(PurePosixPath(_on_disk(link, build_id)))
 
 
 def export_static(
@@ -421,7 +462,7 @@ def export_static(
     shown = CachedDataset(dataset)
     sets_by_group = _filter_sets_by_group(shown, group_tables)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
-    episodes = [_episode_files(shown, index) for index in range(len(shown))]
+    episodes = [_episode_links(shown, index) for index in range(len(shown))]
     with app_state_restored(), tempfile.TemporaryDirectory(dir=scratch_dir) as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.
         if out.directory.exists() and any(out.directory.iterdir()):
@@ -436,26 +477,27 @@ def export_static(
             max_hz=max_hz,
         )
         configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
-        _refuse_unportable_paths(out, group_tables or {}, episodes, build_id)
-        install_dataset(shown)
         client = TestClient(app)
-        group_names = list(group_tables or {})
+        # Past `configure_tables`, every group name is one segment the route builders spell.
+        pages = [
+            *_page_writes(client, sets_by_group, episodes, build_id),
+            *(_fetched(client, f'/{route}', f'{route}.json') for route in _whole_api_routes()),
+            *itertools.chain.from_iterable(_group_writes(client, name, sets) for name, sets in sets_by_group.items()),
+        ]
+        large_files = list(
+            itertools.chain.from_iterable(_large_file_writes(client, links, build_id) for links in episodes)
+        )
+        asset_files = _asset_writes() if assets else []
+        out.plan(planned.path for planned in (*pages, *large_files, *asset_files))
 
-        _write_pages(client, out, group_names, episodes, build_id)
-        for route in _whole_api_routes():
-            body, content_type = _fetch(client, f'/{route}')
-            out.write(f'{route}.json', body, content_type)
-        for name, sets in sets_by_group.items():
-            _write_group(client, out, name, sets)
-
+        install_dataset(shown)
+        for planned in pages:
+            planned.write(out)
         install_dataset(full)
-        for files in episodes:
-            out.copy(_on_disk(files.recording, build_id), episode_rrd_path(files.index))
-            for link in files.downloads:
-                body, content_type = _fetch(client, f'/{link}')
-                out.write(_on_disk(link, build_id), body, content_type)
-    if assets:
-        _write_assets(out)
+        for planned in large_files:
+            planned.write(out)
+    for planned in asset_files:
+        planned.write(out)
     logger.info('wrote %d files under %s', len(out.files), out_dir)
     return out.files
 

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -17,11 +17,14 @@ from typing import cast
 
 import configuronic as cfn
 import pos3
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from jinja2.utils import htmlsafe_json_dumps
 
 import positronic.cfg.ds
 from pimm.logging import init_logging
 from positronic.dataset import CachedDataset, Dataset, Episode
+from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
     FILTER_VALUES,
@@ -49,9 +52,6 @@ GROUP_INDEX_FILE = 'index.json'
 UNFILTERED_FILE = 'all.json'
 # The app's own assets, at the server root, so every export a host serves shares one copy.
 ASSET_DIR = 'static'
-
-# The routes whose responses a page reads whole. `episodes` is filtered in the browser.
-_WHOLE_API_ROUTES = ('dataset_info', 'dataset_status', 'episodes')
 
 # The `secrets.token_urlsafe` alphabet: a build id is a path segment and sits inside a script string.
 _BUILD_ID = re.compile(r'[A-Za-z0-9_-]*')
@@ -87,6 +87,9 @@ class _Output:
         self.files: list[ExportedFile] = []
 
     def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
+        relative = PurePosixPath(path)
+        if relative.is_absolute() or '..' in relative.parts:
+            raise ValueError(f'{path!r} would land outside {self.directory}')
         target = self.directory / path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
@@ -101,39 +104,35 @@ def _fetch(client: TestClient, path: str, params: dict[str, str] | None = None) 
     return response.content, response.headers.get('content-type', '')
 
 
-def _filter_values(response: dict, key: str) -> list[str]:
-    """The values a group's filter offers, as the page sends them.
-
-    None is left out: the server compares a filter against an episode's own value, and no query
-    matches a value that is absent.
-    """
-    values = response.get(GROUP_FILTERS, {}).get(key, {}).get(FILTER_VALUES, [])
-    return sorted(str(value) for value in values if value is not None)
-
-
 def filter_sets(response: dict) -> Iterator[dict[str, str]]:
     """Every filter set a group page can ask for, the empty one first.
 
     Each key offers its values and the choice of not filtering on it, so k keys of v values each
     give (v+1)^k sets.
     """
-    keys = sorted(response.get(GROUP_FILTERS, {}))
-    options = [[None, *_filter_values(response, key)] for key in keys]
+    filters = response.get(GROUP_FILTERS, {})
+    keys = sorted(filters)
+    options = [[None, *filters[key][FILTER_VALUES]] for key in keys]
     for chosen in itertools.product(*options):
         yield {key: value for key, value in zip(keys, chosen, strict=True) if value is not None}
 
 
+def _large_file_path(link: str, build_id: str) -> str:
+    return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
+
+
+def _page_spelling(link: str) -> str:
+    """`link` as a page carries it: a quoted JSON string, escaped as Jinja's `tojson` writes one."""
+    return str(htmlsafe_json_dumps(link))
+
+
 def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> str:
-    """`html` with each of `links`, a quoted script string, moved under `build/<build_id>/`."""
+    """`html` with each of `links`, as a page spells them, moved under `build/<build_id>/`."""
     if not build_id:
         return html
     for link in links:
-        html = html.replace(f'"{link}"', f'"{BUILD_DIR}/{build_id}/{link}"')
+        html = html.replace(_page_spelling(link), _page_spelling(_large_file_path(link, build_id)))
     return html
-
-
-def _large_file_path(link: str, build_id: str) -> str:
-    return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
 
 
 def _episode_links(dataset: Dataset, index: int) -> list[str]:
@@ -157,7 +156,7 @@ def _write_pages(
         body, content_type = _fetch(client, f'/episode/{index}')
         page = body.decode()
         page_links = _episode_links(dataset, index)
-        if any(f'"{link}"' not in page for link in page_links):
+        if any(_page_spelling(link) not in page for link in page_links):
             raise RuntimeError(f'episode page {index} does not carry every link the export expects')
         moved = large_file_links_under(page, page_links, build_id)
         out.write(f'episode/{index}/{PAGE_FILE}', moved.encode(), content_type)
@@ -197,6 +196,30 @@ def _write_assets(out: _Output) -> None:
         out.write(f'{ASSET_DIR}/{relative}', path.read_bytes(), asset_content_type(path))
 
 
+def _whole_api_routes() -> list[str]:
+    """The API routes a page reads whole: every GET under `api/` that takes no path parameter.
+
+    The flat episode table is one of them; a static page filters it in the browser.
+    """
+    return [
+        route.path.removeprefix('/')
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.path.startswith(f'/{API_DIR}/') and not route.param_convertors
+    ]
+
+
+def _aligned(full: Dataset, shown: Dataset) -> Dataset:
+    """`full`, once it holds the episodes of `shown` at the same indexes, by uid."""
+    if len(full) != len(shown):
+        raise ValueError(f'full_dataset holds {len(full)} episodes and dataset holds {len(shown)}')
+    for index in range(len(shown)):
+        full_uid = cast(Episode, full[index]).meta[META_UID]
+        shown_uid = cast(Episode, shown[index]).meta[META_UID]
+        if full_uid != shown_uid:
+            raise ValueError(f'full_dataset episode {index} has uid {full_uid!r} and dataset has {shown_uid!r}')
+    return full
+
+
 def export_static(
     dataset: Dataset,
     out_dir: Path,
@@ -217,15 +240,18 @@ def export_static(
     """Write the viewer for `dataset` under `out_dir` and give back every file written.
 
     The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
-    when given: the recording builder reads an episode's robot model out of its static values, so a
-    caller that hides static values from the pages passes the unhidden dataset here. `assets` writes
-    the app's own scripts, styles and viewer under `static/`, which every export at one host shares.
+    when given, which holds the same episodes in the same order: the recording builder reads an
+    episode's robot model out of its static values, so a caller that hides static values from the
+    pages passes the unhidden dataset here. `assets` writes the app's own scripts, styles and viewer
+    under `static/`, which every export at one host shares. An export holds the app's state for its
+    duration, so a second export in the process waits for it.
     """
     out = _Output(Path(out_dir))
     if out.directory.exists() and any(out.directory.iterdir()):
         raise ValueError(f'{out.directory} is not empty; an export goes into a new or an empty directory')
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
+    full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         configure_tables(
             root=get_dataset_root(dataset) or 'unknown_dataset',
@@ -242,13 +268,13 @@ def export_static(
         group_names = list(group_tables or {})
 
         links = _write_pages(client, out, group_names, shown, build_id)
-        for route in _WHOLE_API_ROUTES:
-            body, content_type = _fetch(client, f'/{API_DIR}/{route}')
-            out.write(f'{API_DIR}/{route}.json', body, content_type)
+        for route in _whole_api_routes():
+            body, content_type = _fetch(client, f'/{route}')
+            out.write(f'{route}.json', body, content_type)
         for name in group_names:
             _write_group(client, out, name)
 
-        install_dataset(CachedDataset(full_dataset) if full_dataset is not None else shown)
+        install_dataset(full)
         for link in links:
             body, content_type = _fetch(client, f'/{link}')
             out.write(_large_file_path(link, build_id), body, content_type)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -1,0 +1,294 @@
+"""Write the viewer for one dataset as static files.
+
+The app is composed in this process and read with a test client, so the export holds what the
+server answers. A page lands at `<route>/index.html`, an API response at `api/<route>.json`, a group
+table as one file per filter set with `index.json` beside them, and a recording or a download under
+`build/<build_id>/` when a build id is given.
+"""
+
+import itertools
+import json
+import logging
+import mimetypes
+import tempfile
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+import configuronic as cfn
+import pos3
+from fastapi.testclient import TestClient
+
+import positronic.cfg.ds
+from pimm.logging import init_logging
+from positronic.dataset import CachedDataset, Dataset, Episode
+from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
+from positronic.server.positronic_server import (
+    FILTER_VALUES,
+    GROUP_FILTERS,
+    GroupTableConfig,
+    TableConfig,
+    app,
+    app_state_restored,
+    configure_pages,
+    configure_tables,
+    default_table,
+    download_paths,
+    install_dataset,
+)
+
+logger = logging.getLogger(__name__)
+
+# What a page, an API response and a group table's files are written as. A page is a directory
+# with an index file, so a static host answers `episode/3` with it.
+PAGE_FILE = 'index.html'
+API_DIR = 'api'
+BUILD_DIR = 'build'
+GROUP_INDEX_FILE = 'index.json'
+UNFILTERED_FILE = 'all.json'
+# The app's own assets, at the server root, so every export a host serves shares one copy.
+ASSET_DIR = 'static'
+
+# The routes whose responses a page reads whole. `episodes` is filtered in the browser.
+_WHOLE_API_ROUTES = ('dataset_info', 'dataset_status', 'episodes')
+
+
+@dataclass(frozen=True)
+class ExportedFile:
+    """One file the export wrote, at `path` under the output directory."""
+
+    path: PurePosixPath
+    content_type: str
+    size: int
+
+
+@dataclass(frozen=True)
+class GroupFile:
+    """One file of a group table: the filter set it was read with, and its name beside the index."""
+
+    params: dict[str, str]
+    file: str
+
+
+class _Output:
+    def __init__(self, directory: Path):
+        self._directory = directory
+        self.files: list[ExportedFile] = []
+
+    def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
+        target = self._directory / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(body)
+        written = ExportedFile(PurePosixPath(path), content_type, len(body))
+        self.files.append(written)
+        return written
+
+
+def _fetch(client: TestClient, path: str, params: dict[str, str] | None = None) -> tuple[bytes, str]:
+    response = client.get(path, params=params or {})
+    response.raise_for_status()
+    return response.content, response.headers.get('content-type', '')
+
+
+def _filter_values(response: dict, key: str) -> list[str]:
+    """The values a group's filter offers, as the page sends them.
+
+    None is left out: the server compares a filter against an episode's own value, and no query
+    matches a value that is absent.
+    """
+    values = response.get(GROUP_FILTERS, {}).get(key, {}).get(FILTER_VALUES, [])
+    return sorted(str(value) for value in values if value is not None)
+
+
+def filter_sets(response: dict) -> Iterator[dict[str, str]]:
+    """Every filter set a group page can ask for, the empty one first.
+
+    Each key offers its values and the choice of not filtering on it, so k keys of v values each
+    give (v+1)^k sets.
+    """
+    keys = sorted(response.get(GROUP_FILTERS, {}))
+    options = [[None, *_filter_values(response, key)] for key in keys]
+    for chosen in itertools.product(*options):
+        yield {key: value for key, value in zip(keys, chosen, strict=True) if value is not None}
+
+
+def large_file_links_under(html: str, build_id: str) -> str:
+    """`html` with every recording and download link moved under `build/<build_id>/`."""
+    if not build_id:
+        return html
+    prefix = f'{BUILD_DIR}/{build_id}/'
+    return html.replace('"api/episode_rrd/', f'"{prefix}api/episode_rrd/').replace(
+        '"api/episode/', f'"{prefix}api/episode/'
+    )
+
+
+def _large_file_path(link: str, build_id: str) -> str:
+    return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
+
+
+def _write_pages(client: TestClient, out: _Output, group_names: list[str], count: int, build_id: str) -> list[str]:
+    """Write every page, and give back the recording and download links the episode pages held."""
+    body, content_type = _fetch(client, '/')
+    out.write(PAGE_FILE, body, content_type)
+    for route in ('episodes', *(f'groups/{name}' for name in group_names)):
+        body, content_type = _fetch(client, f'/{route}')
+        out.write(f'{route}/{PAGE_FILE}', body, content_type)
+    links = []
+    for index in range(count):
+        body, content_type = _fetch(client, f'/episode/{index}')
+        page = body.decode()
+        moved = large_file_links_under(page, build_id)
+        rrd_link = f'{API_DIR}/episode_rrd/{index}'
+        if build_id and rrd_link not in page:
+            raise RuntimeError(f'episode page {index} carries no recording link to move under the build')
+        out.write(f'episode/{index}/{PAGE_FILE}', moved.encode(), content_type)
+        links.append(rrd_link)
+    return links
+
+
+def _write_group(client: TestClient, out: _Output, name: str) -> None:
+    route = f'{API_DIR}/groups/{name}'
+    body, content_type = _fetch(client, f'/{route}')
+    index = [GroupFile({}, UNFILTERED_FILE)]
+    out.write(f'{route}/{UNFILTERED_FILE}', body, content_type)
+    for number, params in enumerate((chosen for chosen in filter_sets(json.loads(body)) if chosen), start=1):
+        filtered, filtered_type = _fetch(client, f'/{route}', params)
+        entry = GroupFile(params, f'{number}.json')
+        out.write(f'{route}/{entry.file}', filtered, filtered_type)
+        index.append(entry)
+    listing = json.dumps([{'params': entry.params, 'file': entry.file} for entry in index]).encode()
+    out.write(f'{route}/{GROUP_INDEX_FILE}', listing, 'application/json')
+
+
+# What the viewer ships and `mimetypes` does not answer for on every box.
+_CONTENT_TYPE_BY_SUFFIX = {'.wasm': 'application/wasm', '.rrd': 'application/octet-stream'}
+
+
+def asset_content_type(path: Path) -> str:
+    """The `Content-Type` an asset file is served under."""
+    if path.suffix in _CONTENT_TYPE_BY_SUFFIX:
+        return _CONTENT_TYPE_BY_SUFFIX[path.suffix]
+    return mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
+
+
+def _write_assets(out: _Output) -> None:
+    static_dir = Path(__file__).resolve().parent / ASSET_DIR
+    for path in sorted(p for p in static_dir.rglob('*') if p.is_file()):
+        relative = path.relative_to(static_dir).as_posix()
+        out.write(f'{ASSET_DIR}/{relative}', path.read_bytes(), asset_content_type(path))
+
+
+def export_static(
+    dataset: Dataset,
+    out_dir: Path,
+    *,
+    ep_table_cfg: TableConfig | None = None,
+    group_tables: dict[str, GroupTableConfig] | None = None,
+    home_page: str | None = None,
+    max_resolution: int = DEFAULT_MAX_RESOLUTION,
+    max_hz: float = DEFAULT_MAX_HZ,
+    base_href: str = '/',
+    title: str = '',
+    show_paths: bool = False,
+    build_id: str = '',
+    full_dataset: Dataset | None = None,
+    assets: bool = True,
+    cache_dir: Path | None = None,
+) -> list[ExportedFile]:
+    """Write the viewer for `dataset` under `out_dir` and give back every file written.
+
+    The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
+    when given: the recording builder reads an episode's robot model out of its static values, so a
+    caller that hides static values from the pages passes the unhidden dataset here. `assets` writes
+    the app's own scripts, styles and viewer under `static/`, which every export at one host shares.
+    """
+    out = _Output(Path(out_dir))
+    shown = CachedDataset(dataset)
+    with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
+        configure_tables(
+            root=get_dataset_root(dataset) or 'unknown_dataset',
+            cache_dir=Path(cache_dir) if cache_dir else Path(scratch),
+            ep_table_cfg=ep_table_cfg,
+            group_tables=group_tables,
+            home_page=home_page,
+            max_resolution=max_resolution,
+            max_hz=max_hz,
+        )
+        configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
+        install_dataset(shown)
+        client = TestClient(app)
+        group_names = list(group_tables or {})
+
+        links = _write_pages(client, out, group_names, len(shown), build_id)
+        for route in _WHOLE_API_ROUTES:
+            body, content_type = _fetch(client, f'/{API_DIR}/{route}')
+            out.write(f'{API_DIR}/{route}.json', body, content_type)
+        for name in group_names:
+            _write_group(client, out, name)
+
+        install_dataset(CachedDataset(full_dataset) if full_dataset is not None else shown)
+        for index in range(len(shown)):
+            static = cast(Episode, shown[index]).static
+            links.extend(f'{API_DIR}/episode/{index}/static/{field}' for field in download_paths(static))
+        for link in links:
+            body, content_type = _fetch(client, f'/{link}')
+            out.write(_large_file_path(link, build_id), body, content_type)
+    if assets:
+        _write_assets(out)
+    logger.info('wrote %d files under %s', len(out.files), out_dir)
+    return out.files
+
+
+@cfn.config(dataset=positronic.cfg.ds.local_all, ep_table_cfg=default_table, group_tables=None)
+def main(
+    dataset: Dataset,
+    out_dir: str,
+    ep_table_cfg: TableConfig | None,
+    max_resolution: int = DEFAULT_MAX_RESOLUTION,
+    max_hz: float = DEFAULT_MAX_HZ,
+    group_tables: dict[str, GroupTableConfig] | None = None,
+    home_page: str | None = None,
+    base_href: str = '/',
+    title: str = '',
+    show_paths: bool = False,
+    build_id: str = '',
+    assets: bool = True,
+):
+    """Write the viewer for a Dataset as static files, for any static host.
+
+    Args:
+        dataset: Dataset to export
+        out_dir: Directory the files are written under; it is created
+        ep_table_cfg, max_resolution, max_hz, group_tables, home_page: As `positronic-server` takes them
+        base_href: Path at the host root the export is served under
+        title: Header text; the dataset root when empty
+        show_paths: Whether the pages report where the dataset lives
+        build_id: Names one build; the recordings and the downloads are written under `build/<build_id>/`
+        assets: Whether to write the app's own assets under `static/`
+    """
+    written = export_static(
+        dataset,
+        Path(out_dir).expanduser(),
+        ep_table_cfg=ep_table_cfg,
+        group_tables=group_tables,
+        home_page=home_page,
+        max_resolution=max_resolution,
+        max_hz=max_hz,
+        base_href=base_href,
+        title=title,
+        show_paths=show_paths,
+        build_id=build_id,
+        assets=assets,
+    )
+    logging.info(f'{len(written)} files, {sum(file.size for file in written) / 1e6:.1f} MB, under {out_dir}')
+
+
+@pos3.with_mirror()
+def _internal_main():
+    init_logging()
+    cfn.cli(main)
+
+
+if __name__ == '__main__':
+    _internal_main()

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -306,9 +306,12 @@ def export_static(
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_files(shown, index) for index in range(len(shown))]
-    for files in episodes:
-        for link in files.links:
-            out.target(_on_disk(link, build_id))  # a name the writer refuses stops the export before a write
+    targets: dict[Path, str] = {}
+    for link in (link for files in episodes for link in files.links):
+        # A name the writer refuses, or two names for one file, stops the export before a write.
+        target = out.target(_on_disk(link, build_id))
+        if targets.setdefault(target, link) != link:
+            raise ValueError(f'{link!r} and {targets[target]!r} would be written to one file, {target}')
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.
         if out.directory.exists() and any(out.directory.iterdir()):

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -60,6 +60,8 @@ BUILD_DIR = 'build'
 # A group table is one file per filter set, and the index beside them says which file holds which.
 GROUP_INDEX_FILE = 'index.json'
 UNFILTERED_FILE = 'all.json'
+# A group table is one file per filter set some episode satisfies, up to 2^k per episode for k filter keys.
+MAX_FILTER_KEYS_PER_GROUP = 6
 # The app's own assets, at the server root, so every export a host serves shares one copy.
 ASSET_DIR = 'static'
 
@@ -267,15 +269,30 @@ def _whole_api_routes() -> list[str]:
 
 
 def _aligned(full: Dataset, shown: Dataset) -> Dataset:
-    """`full`, once it holds the episodes of `shown` at the same indexes, by uid."""
+    """`full`, once it holds the episodes of `shown` at the same indexes, by uid, with every download `shown` links."""
     if len(full) != len(shown):
         raise ValueError(f'full_dataset holds {len(full)} episodes and dataset holds {len(shown)}')
     for index in range(len(shown)):
-        full_uid = cast(Episode, full[index]).meta[META_UID]
-        shown_uid = cast(Episode, shown[index]).meta[META_UID]
-        if full_uid != shown_uid:
-            raise ValueError(f'full_dataset episode {index} has uid {full_uid!r} and dataset has {shown_uid!r}')
+        full_episode, shown_episode = cast(Episode, full[index]), cast(Episode, shown[index])
+        if full_episode.meta[META_UID] != shown_episode.meta[META_UID]:
+            raise ValueError(
+                f'full_dataset episode {index} has uid {full_episode.meta[META_UID]!r} and dataset has '
+                f'{shown_episode.meta[META_UID]!r}'
+            )
+        missing = set(download_paths(shown_episode.static)) - set(download_paths(full_episode.static))
+        if missing:
+            path = '/'.join(min(missing))
+            raise ValueError(f'full_dataset episode {index} has no download at {path!r}, which dataset links')
     return full
+
+
+def _check_filter_keys(group_tables: dict[str, GroupTableConfig] | None) -> None:
+    for name, cfg in (group_tables or {}).items():
+        if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
+            raise ValueError(
+                f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
+                f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
+            )
 
 
 def export_static(
@@ -313,6 +330,7 @@ def export_static(
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
+    _check_filter_keys(group_tables)
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_files(shown, index) for index in range(len(shown))]

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -94,16 +94,40 @@ class GroupFile:
     file: str
 
 
+class _CaseInsensitiveTree:
+    """The paths written so far, as a filesystem that folds case holds them.
+
+    A path that folds onto a file written before, or onto a directory above one, or whose own directory folds
+    onto a file, is refused: the export writes one tree, whatever filesystem it lands on.
+    """
+
+    def __init__(self):
+        self._files: set[str] = set()
+        self._directories: set[str] = set()
+
+    def add(self, path: str) -> None:
+        folded = PurePosixPath(path.casefold())
+        directories = [str(parent) for parent in folded.parents if str(parent) != '.']
+        taken = str(folded) in self._files or str(folded) in self._directories
+        if taken or any(directory in self._files for directory in directories):
+            raise ValueError(f'{path!r} is one file with another the export writes on a filesystem that folds case')
+        self._files.add(str(folded))
+        self._directories.update(directories)
+
+
 class _Output:
     def __init__(self, directory: Path):
         self.directory = directory
         self.files: list[ExportedFile] = []
+        self._tree = _CaseInsensitiveTree()
 
     def target(self, path: str) -> Path:
-        """The file `path` is written to; a path that would land outside the directory is refused."""
+        """The file `path` is written to; a path that would land outside the directory, or on another file
+        once case is folded, is refused."""
         relative = PurePosixPath(path)
         if relative.is_absolute() or '\\' in path or '..' in relative.parts:
             raise ValueError(f'{path!r} would land outside {self.directory}')
+        self._tree.add(path)
         return self.directory.joinpath(*relative.parts)
 
     def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
@@ -296,6 +320,19 @@ def _check_filter_keys(group_tables: dict[str, GroupTableConfig] | None) -> None
             )
 
 
+def _refuse_folded_collisions(group_names: Iterable[str], episodes: Iterable[_EpisodeFiles], build_id: str) -> None:
+    """Refuse a group directory or a large file that another folds onto, before a write.
+
+    Past `configure_tables`, every group name is one segment the route builder spells.
+    """
+    named = _CaseInsensitiveTree()
+    for name in group_names:
+        named.add(group_link(name))
+    for files in episodes:
+        for link in files.links:
+            named.add(_on_disk(link, build_id))
+
+
 def export_static(
     dataset: Dataset,
     out_dir: Path,
@@ -311,27 +348,26 @@ def export_static(
     build_id: str = '',
     full_dataset: Dataset | None = None,
     assets: bool = True,
-    cache_dir: Path | None = None,
+    scratch_dir: Path | None = None,
 ) -> list[ExportedFile]:
     """Write the viewer for `dataset` under `out_dir` and give back every file written.
 
     The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
     when given, which holds the same episodes in the same order; the recording builder reads an
-    episode's robot model out of its static values. A recording is copied from the cache file the server
-    serves, so no recording is held in memory whole. `assets` writes the app's own scripts, styles and viewer
-    under `static/`, which the pages request at the host root, so it goes with the root base href
-    only; an export under a prefix shares the host's copy. `cache_dir`, when given, lies outside
-    `out_dir`: the recordings are built there and copied in. An export holds the app's state for its
-    duration, so a second export in the process waits for it; one into the same directory is then
-    refused, as the directory holds the first.
+    episode's robot model out of its static values. The recordings are built in a directory of this
+    export's own under `scratch_dir`, the system's temporary directory when None, and copied in from
+    there, so no recording is held in memory whole and no export reads another's; the directory is
+    removed at the end. `assets` writes the app's own scripts, styles and viewer under `static/`, which
+    the pages request at the host root, so it goes with the root base href only; an export under a
+    prefix shares the host's copy. An export holds the app's state for its duration, so a second
+    export in the process waits for it; one into the same directory is then refused, as the directory
+    holds the first.
     """
     out = _Output(Path(out_dir))
-    if cache_dir is not None:
-        cache, output = Path(cache_dir).resolve(), out.directory.resolve()
-        if cache.is_relative_to(output) or output.is_relative_to(cache):
-            raise ValueError(
-                f'cache_dir {cache_dir} and out_dir {out.directory} overlap; the cache stays outside the export'
-            )
+    if scratch_dir is not None and Path(scratch_dir).resolve().is_relative_to(out.directory.resolve()):
+        raise ValueError(
+            f'scratch_dir {scratch_dir} lies inside out_dir {out.directory}; the recordings are built beside it'
+        )
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
@@ -339,13 +375,13 @@ def export_static(
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_files(shown, index) for index in range(len(shown))]
-    with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
+    with app_state_restored(), tempfile.TemporaryDirectory(dir=scratch_dir) as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.
         if out.directory.exists() and any(out.directory.iterdir()):
             raise ValueError(f'{out.directory} is not empty; an export goes into a new or an empty directory')
         configure_tables(
             root=get_dataset_root(dataset) or 'unknown_dataset',
-            cache_dir=Path(cache_dir) if cache_dir else Path(scratch),
+            cache_dir=Path(scratch),
             ep_table_cfg=ep_table_cfg,
             group_tables=group_tables,
             home_page=home_page,
@@ -353,6 +389,7 @@ def export_static(
             max_hz=max_hz,
         )
         configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
+        _refuse_folded_collisions(group_tables or {}, episodes, build_id)
         install_dataset(shown)
         client = TestClient(app)
         group_names = list(group_tables or {})

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -10,10 +10,11 @@ import logging
 import mimetypes
 import re
 import tempfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import cast
+from urllib.parse import unquote
 
 import configuronic as cfn
 import pos3
@@ -28,8 +29,6 @@ from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
     DOWNLOAD_LINK,
-    FILTER_VALUES,
-    GROUP_FILTERS,
     GroupTableConfig,
     TableConfig,
     app,
@@ -37,7 +36,14 @@ from positronic.server.positronic_server import (
     configure_pages,
     configure_tables,
     default_table,
+    download_link,
     download_paths,
+    episode_link,
+    episode_rrd_link,
+    episodes_link,
+    filter_spelling,
+    group_api_link,
+    group_link,
     install_dataset,
     normalized_base_href,
 )
@@ -106,17 +112,24 @@ def _fetch(client: TestClient, path: str, params: dict[str, str] | None = None) 
     return response.content, response.headers.get('content-type', '')
 
 
-def filter_sets(response: dict) -> Iterator[dict[str, str]]:
-    """Every filter set a group page can ask for, the empty one first.
+def _filter_values(dataset: Dataset, keys: Iterable[str]) -> Iterator[dict[str, str]]:
+    """Each episode's values on the filter `keys`, as a filter spells them; an absent value is left out."""
+    for episode in dataset:
+        spelled = ((key, filter_spelling(cast(Episode, episode).static.get(key))) for key in keys)
+        yield {key: value for key, value in spelled if value is not None}
 
-    Each key offers its values and the choice of not filtering on it, so k keys of v values each
-    give (v+1)^k sets.
+
+def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, str]]:
+    """Every filter set some episode satisfies, the empty one first.
+
+    An episode satisfies each subset of its own values, so k filter keys give at most 2^k sets per
+    episode, and a set no episode satisfies gets no file.
     """
-    filters = response.get(GROUP_FILTERS, {})
-    keys = sorted(filters)
-    options = [[None, *filters[key][FILTER_VALUES]] for key in keys]
-    for chosen in itertools.product(*options):
-        yield {key: value for key, value in zip(keys, chosen, strict=True) if value is not None}
+    satisfied: set[tuple[tuple[str, str], ...]] = set()
+    for values in episode_values:
+        items = sorted(values.items())
+        satisfied.update(chosen for n in range(len(items) + 1) for chosen in itertools.combinations(items, n))
+    return [dict(chosen) for chosen in sorted(satisfied, key=lambda chosen: (len(chosen), chosen))]
 
 
 def _large_file_path(link: str, build_id: str) -> str:
@@ -151,8 +164,7 @@ def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> st
 def _episode_links(dataset: Dataset, index: int) -> list[str]:
     """The recording and the downloads an episode page links, as the page spells them."""
     static = cast(Episode, dataset[index]).static
-    downloads = (f'{API_DIR}/episode/{index}/static/{field}' for field in download_paths(static))
-    return [f'{API_DIR}/episode_rrd/{index}', *downloads]
+    return [episode_rrd_link(index), *(download_link(index, field) for field in download_paths(static))]
 
 
 def _write_pages(
@@ -161,28 +173,28 @@ def _write_pages(
     """Write every page, and give back the recording and download links the episode pages held."""
     body, content_type = _fetch(client, '/')
     out.write(PAGE_FILE, body, content_type)
-    for route in ('episodes', *(f'groups/{name}' for name in group_names)):
+    for route in (episodes_link(), *(group_link(name) for name in group_names)):
         body, content_type = _fetch(client, f'/{route}')
         out.write(f'{route}/{PAGE_FILE}', body, content_type)
     links = []
     for index in range(len(dataset)):
-        body, content_type = _fetch(client, f'/episode/{index}')
+        body, content_type = _fetch(client, f'/{episode_link(index)}')
         page = body.decode()
         page_links = _episode_links(dataset, index)
         if not all(_carries(page, link) for link in page_links):
             raise RuntimeError(f'episode page {index} does not carry every link the export expects')
         moved = large_file_links_under(page, page_links, build_id)
-        out.write(f'episode/{index}/{PAGE_FILE}', moved.encode(), content_type)
+        out.write(f'{episode_link(index)}/{PAGE_FILE}', moved.encode(), content_type)
         links.extend(page_links)
     return links
 
 
-def _write_group(client: TestClient, out: _Output, name: str) -> None:
-    route = f'{API_DIR}/groups/{name}'
+def _write_group(client: TestClient, out: _Output, name: str, sets: Iterable[dict[str, str]]) -> None:
+    route = group_api_link(name)
     body, content_type = _fetch(client, f'/{route}')
     index = [GroupFile({}, UNFILTERED_FILE)]
     out.write(f'{route}/{UNFILTERED_FILE}', body, content_type)
-    for number, params in enumerate((chosen for chosen in filter_sets(json.loads(body)) if chosen), start=1):
+    for number, params in enumerate((chosen for chosen in sets if chosen), start=1):
         filtered, filtered_type = _fetch(client, f'/{route}', params)
         entry = GroupFile(params, f'{number}.json')
         out.write(f'{route}/{entry.file}', filtered, filtered_type)
@@ -287,13 +299,13 @@ def export_static(
         for route in _whole_api_routes():
             body, content_type = _fetch(client, f'/{route}')
             out.write(f'{route}.json', body, content_type)
-        for name in group_names:
-            _write_group(client, out, name)
+        for name, cfg in (group_tables or {}).items():
+            _write_group(client, out, name, filter_sets(_filter_values(shown, cfg.group_filter_keys)))
 
         install_dataset(full)
         for link in links:
             body, content_type = _fetch(client, f'/{link}')
-            out.write(_large_file_path(link, build_id), body, content_type)
+            out.write(_large_file_path(unquote(link), build_id), body, content_type)
     if assets:
         _write_assets(out)
     logger.info('wrote %d files under %s', len(out.files), out_dir)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -1,7 +1,7 @@
 """Write the viewer for one dataset as static files.
 
-The app is composed in this process and read with a test client, so the export holds what the
-server answers. A page lands at `<route>/index.html` and an API response at `api/<route>.json`.
+The app is composed in this process and read with a test client. A page lands at
+`<route>/index.html` and an API response at `api/<route>.json`.
 """
 
 import itertools
@@ -66,7 +66,7 @@ UNFILTERED_FILE = 'all.json'
 MAX_FILTER_KEYS_PER_GROUP = 6
 # Each file of a group table is one read of the whole dataset.
 MAX_FILTER_SETS_PER_GROUP = 1024
-# The object key limit of an S3-style host; with an output directory in front it stays within a filesystem's path limit.
+# The object key limit of an S3-style host.
 MAX_PATH_BYTES = 1024
 # Windows reads these as devices, with or without a suffix, and trims a trailing dot off a name.
 _WINDOWS_DEVICES = frozenset([
@@ -388,13 +388,12 @@ def export_static(
     The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
     when given, which holds the same episodes in the same order; the recording builder reads an
     episode's robot model out of its static values. The recordings are built in a directory of this
-    export's own under `scratch_dir`, the system's temporary directory when None, and copied in from
-    there, so no recording is held in memory whole and no export reads another's; the directory is
-    removed at the end. `assets` writes the app's own scripts, styles and viewer under `static/`, which
-    the pages request at the host root, so it goes with the root base href only; an export under a
-    prefix shares the host's copy. An export holds the app's state for its duration, so a second
-    export in the process waits for it; one into the same directory is then refused, as the directory
-    holds the first.
+    export's own under `scratch_dir`, the system's temporary directory when None, copied in from
+    there, and the directory is removed at the end. `assets` writes the app's own scripts, styles
+    and viewer under `static/`, which the pages request at the host root, so it goes with the root
+    base href only; an export under a prefix shares the host's copy. An export holds the app's state
+    for its duration, so a second export in the process waits for it; one into the same directory is
+    then refused, as the directory holds the first.
     """
     out = _Output(Path(out_dir))
     if scratch_dir is not None and Path(scratch_dir).resolve().is_relative_to(out.directory.resolve()):

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import cast
+from urllib.parse import quote
 
 import configuronic as cfn
 import pos3
@@ -168,13 +169,19 @@ def _link_nodes(link: str) -> list[str]:
     return [f'appUrl({spelling})', f'{_page_spelling(DOWNLOAD_LINK)}: {spelling}']
 
 
+def _host_spelling(path: str) -> str:
+    """The path a browser asks a static host for the file at `path`: a host percent-decodes a request path once
+    before it looks the file up, so each `%` of the file's own name is escaped."""
+    return quote(path, safe='/')
+
+
 def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> str:
-    """`html` with each of `links`, in the nodes a page carries them, moved under `build/<build_id>/`."""
-    if not build_id:
-        return html
+    """`html` with each of `links`, in the nodes a page carries them, moved under `build/<build_id>/` and
+    spelled as a static host resolves them to the files on disk."""
     for link in links:
-        for node, moved in zip(_link_nodes(link), _link_nodes(_large_file_path(link, build_id)), strict=True):
-            html = html.replace(node, moved)
+        moved = _host_spelling(_large_file_path(link, build_id))
+        for node, moved_node in zip(_link_nodes(link), _link_nodes(moved), strict=True):
+            html = html.replace(node, moved_node)
     return html
 
 

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -9,6 +9,7 @@ import json
 import logging
 import mimetypes
 import re
+import shutil
 import tempfile
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import asdict, dataclass
@@ -40,6 +41,7 @@ from positronic.server.positronic_server import (
     download_paths,
     episode_link,
     episode_rrd_link,
+    episode_rrd_path,
     episodes_link,
     filter_spelling,
     group_api_link,
@@ -105,7 +107,17 @@ class _Output:
         target = self.target(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
-        written = ExportedFile(PurePosixPath(path), content_type, len(body))
+        return self._record(path, content_type, len(body))
+
+    def copy(self, path: str, source: Path) -> ExportedFile:
+        """Copy the file at `source` to `path` without holding it in memory."""
+        target = self.target(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+        return self._record(path, asset_content_type(source), target.stat().st_size)
+
+    def _record(self, path: str, content_type: str, size: int) -> ExportedFile:
+        written = ExportedFile(PurePosixPath(path), content_type, size)
         self.files.append(written)
         return written
 
@@ -140,6 +152,11 @@ def _large_file_path(link: str, build_id: str) -> str:
     return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
 
 
+def _on_disk(link: str, build_id: str) -> str:
+    """Where the file a large-file `link` names is written: the decoded link, under the build."""
+    return _large_file_path(unquote(link), build_id)
+
+
 def _page_spelling(link: str) -> str:
     """`link` as a page carries it: a quoted JSON string, escaped as Jinja's `tojson` writes one."""
     return str(htmlsafe_json_dumps(link))
@@ -161,14 +178,27 @@ def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> st
     return html
 
 
-def _episode_links(dataset: Dataset, index: int) -> list[str]:
-    """The recording and the downloads an episode page links, as the page spells them."""
+@dataclass(frozen=True)
+class _EpisodeFiles:
+    """The large files one episode page links, as the page spells them."""
+
+    index: int
+    recording: str
+    downloads: list[str]
+
+    @property
+    def links(self) -> list[str]:
+        return [self.recording, *self.downloads]
+
+
+def _episode_files(dataset: Dataset, index: int) -> _EpisodeFiles:
     static = cast(Episode, dataset[index]).static
-    return [episode_rrd_link(index), *(download_link(index, field) for field in download_paths(static))]
+    downloads = [download_link(index, field) for field in download_paths(static)]
+    return _EpisodeFiles(index, episode_rrd_link(index), downloads)
 
 
 def _write_pages(
-    client: TestClient, out: _Output, group_names: list[str], episode_links: list[list[str]], build_id: str
+    client: TestClient, out: _Output, group_names: list[str], episodes: list[_EpisodeFiles], build_id: str
 ) -> None:
     """Write every page; an episode page carries its links moved under the build."""
     body, content_type = _fetch(client, '/')
@@ -176,13 +206,13 @@ def _write_pages(
     for route in (episodes_link(), *(group_link(name) for name in group_names)):
         body, content_type = _fetch(client, f'/{route}')
         out.write(f'{route}/{PAGE_FILE}', body, content_type)
-    for index, page_links in enumerate(episode_links):
-        body, content_type = _fetch(client, f'/{episode_link(index)}')
+    for files in episodes:
+        body, content_type = _fetch(client, f'/{episode_link(files.index)}')
         page = body.decode()
-        if not all(any(node in page for node in _link_nodes(link)) for link in page_links):
-            raise RuntimeError(f'episode page {index} does not carry every link the export expects')
-        moved = large_file_links_under(page, page_links, build_id)
-        out.write(f'{episode_link(index)}/{PAGE_FILE}', moved.encode(), content_type)
+        if not all(any(node in page for node in _link_nodes(link)) for link in files.links):
+            raise RuntimeError(f'episode page {files.index} does not carry every link the export expects')
+        moved = large_file_links_under(page, files.links, build_id)
+        out.write(f'{episode_link(files.index)}/{PAGE_FILE}', moved.encode(), content_type)
 
 
 def _write_group(client: TestClient, out: _Output, name: str, sets: Iterable[dict[str, str]]) -> None:
@@ -262,7 +292,8 @@ def export_static(
 
     The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
     when given, which holds the same episodes in the same order; the recording builder reads an
-    episode's robot model out of its static values. `assets` writes the app's own scripts, styles and viewer
+    episode's robot model out of its static values. A recording is copied from the cache file the server
+    serves, so no recording is held in memory whole. `assets` writes the app's own scripts, styles and viewer
     under `static/`, which the pages request at the host root, so it goes with the root base href
     only; an export under a prefix shares the host's copy. An export holds the app's state for its
     duration, so a second export in the process waits for it; one into the same directory is then
@@ -274,10 +305,10 @@ def export_static(
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
-    episode_links = [_episode_links(shown, index) for index in range(len(shown))]
-    large_files = [(link, _large_file_path(unquote(link), build_id)) for links in episode_links for link in links]
-    for _, path in large_files:
-        out.target(path)  # a name the writer refuses stops the export before a page is written
+    episodes = [_episode_files(shown, index) for index in range(len(shown))]
+    for files in episodes:
+        for link in files.links:
+            out.target(_on_disk(link, build_id))  # a name the writer refuses stops the export before a write
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.
         if out.directory.exists() and any(out.directory.iterdir()):
@@ -296,7 +327,7 @@ def export_static(
         client = TestClient(app)
         group_names = list(group_tables or {})
 
-        _write_pages(client, out, group_names, episode_links, build_id)
+        _write_pages(client, out, group_names, episodes, build_id)
         for route in _whole_api_routes():
             body, content_type = _fetch(client, f'/{route}')
             out.write(f'{route}.json', body, content_type)
@@ -304,9 +335,11 @@ def export_static(
             _write_group(client, out, name, filter_sets(_filter_values(shown, cfg.group_filter_keys)))
 
         install_dataset(full)
-        for link, path in large_files:
-            body, content_type = _fetch(client, f'/{link}')
-            out.write(path, body, content_type)
+        for files in episodes:
+            out.copy(_on_disk(files.recording, build_id), episode_rrd_path(files.index))
+            for link in files.downloads:
+                body, content_type = _fetch(client, f'/{link}')
+                out.write(_on_disk(link, build_id), body, content_type)
     if assets:
         _write_assets(out)
     logger.info('wrote %d files under %s', len(out.files), out_dir)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -15,7 +15,6 @@ from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import cast
-from urllib.parse import unquote
 
 import configuronic as cfn
 import pos3
@@ -153,8 +152,9 @@ def _large_file_path(link: str, build_id: str) -> str:
 
 
 def _on_disk(link: str, build_id: str) -> str:
-    """Where the file a large-file `link` names is written: the decoded link, under the build."""
-    return _large_file_path(unquote(link), build_id)
+    """Where the file a large-file `link` names is written: its segments as a directory tree, each keeping the
+    encoded spelling the browser asks it by, under the build."""
+    return _large_file_path(link, build_id)
 
 
 def _page_spelling(link: str) -> str:
@@ -271,20 +271,6 @@ def _aligned(full: Dataset, shown: Dataset) -> Dataset:
     return full
 
 
-def _check_targets(out: _Output, episodes: list[_EpisodeFiles], build_id: str) -> None:
-    """Refuse, before a write, a large file the writer cannot place: a name it refuses, two names on one file, a file
-    in another file's directory."""
-    targets: dict[Path, str] = {}
-    for link in (link for files in episodes for link in files.links):
-        target = out.target(_on_disk(link, build_id))
-        if targets.setdefault(target, link) != link:
-            raise ValueError(f'{link!r} and {targets[target]!r} would be written to one file, {target}')
-    for target, link in targets.items():
-        for parent in target.parents:
-            if parent in targets:
-                raise ValueError(f'{link!r} needs {targets[parent]!r} to be a directory, and it is a file')
-
-
 def export_static(
     dataset: Dataset,
     out_dir: Path,
@@ -323,7 +309,6 @@ def export_static(
     shown = CachedDataset(dataset)
     full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_files(shown, index) for index in range(len(shown))]
-    _check_targets(out, episodes, build_id)
     with app_state_restored(), tempfile.TemporaryDirectory() as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.
         if out.directory.exists() and any(out.directory.iterdir()):

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -73,8 +73,8 @@ MAX_FILTER_KEYS_PER_GROUP = 6
 MAX_FILTER_SETS_PER_GROUP = 1024
 # The object key limit of an S3-style host.
 MAX_KEY_BYTES = 1024
-# A platform that reports no path limit is Windows, whose `MAX_PATH` counts UTF-16 units, the end mark included,
-# unless a machine opts into long paths.
+# Windows reports no path limit; its `MAX_PATH` counts UTF-16 units, the end mark included, unless a machine opts
+# into long paths.
 _REPORTS_PATH_MAX = hasattr(os, 'pathconf')
 _WINDOWS_PATH_MAX = 260
 # Windows reads these as devices, with or without a suffix, and trims a trailing dot off a name.

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -67,7 +67,7 @@ API_DIR = 'api'
 BUILD_DIR = 'build'
 # The file of a group table read with no filter, beside the index that names it.
 UNFILTERED_FILE = 'all.json'
-# A group table is one file per filter set some episode satisfies, up to 2^k per episode for k filter keys.
+# An episode satisfies up to 2^k filter sets for k filter keys.
 MAX_FILTER_KEYS_PER_GROUP = 6
 # Each file of a group table is one read of the whole dataset.
 MAX_FILTER_SETS_PER_GROUP = 1024

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -114,6 +114,17 @@ def _path_max(directory: Path) -> int:
     return os.pathconf(existing, 'PC_PATH_MAX')
 
 
+# `mimetypes` answers for neither on every box.
+_CONTENT_TYPE_BY_SUFFIX = {'.wasm': 'application/wasm', '.rrd': 'application/octet-stream'}
+
+
+def asset_content_type(path: Path) -> str:
+    """The `Content-Type` an asset file is served under."""
+    if path.suffix in _CONTENT_TYPE_BY_SUFFIX:
+        return _CONTENT_TYPE_BY_SUFFIX[path.suffix]
+    return mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
+
+
 class _Output:
     """The files the export writes under `directory`, as any host or filesystem holds them.
 
@@ -199,8 +210,9 @@ def _planned_fetch(
     return _Planned(path, reads, lambda out: out.write(path, *_fetch(client, route, params)))
 
 
-def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, str]]:
-    """Every non-empty filter set some episode satisfies, the shortest first.
+def filter_sets(episode_values: Iterable[Mapping[str, str]], most: int) -> list[dict[str, str]]:
+    """Every non-empty filter set some episode satisfies, the shortest first; more than `most` of them is
+    refused at the episode that passes the count, before the rest are read.
 
     An episode satisfies each subset of its own values, so k filter keys give at most 2^k sets per
     episode, and a set no episode satisfies gets no file.
@@ -209,6 +221,8 @@ def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, s
     for values in episode_values:
         items = sorted(values.items())
         satisfied.update(chosen for n in range(1, len(items) + 1) for chosen in itertools.combinations(items, n))
+        if len(satisfied) > most:
+            raise ValueError(f'more than {most} filter sets; a filter key with a value per episode is the usual cause')
     return [dict(chosen) for chosen in sorted(satisfied, key=lambda chosen: (len(chosen), chosen))]
 
 
@@ -232,14 +246,13 @@ def _filter_sets_by_group(
             }
             for episode in dataset
         )
-        sets = filter_sets(episode_values)
-        if len(sets) + 1 > MAX_FILTER_SETS_PER_GROUP:
+        try:
+            # One of the files is the unfiltered one.
+            sets_by_group[name] = filter_sets(episode_values, MAX_FILTER_SETS_PER_GROUP - 1)
+        except ValueError as past_bound:
             raise ValueError(
-                f'group table {name!r} has {len(sets) + 1} filter sets and an export reads the dataset once per set, '
-                f'so a group table takes at most {MAX_FILTER_SETS_PER_GROUP}; a filter key with a value per episode '
-                f'is the usual cause'
-            )
-        sets_by_group[name] = sets
+                f'group table {name!r} has {past_bound}; an export reads the dataset once per set'
+            ) from None
     return sets_by_group
 
 
@@ -343,17 +356,6 @@ def _large_file_plans(client: TestClient, reads: Dataset, links: _EpisodeLinks, 
         _Planned(recording, reads, lambda out: out.copy(recording, episode_rrd_path(links.index))),
         *(_planned_fetch(client, f'/{link}', path, reads) for link, path in downloads),
     ]
-
-
-# `mimetypes` answers for neither on every box.
-_CONTENT_TYPE_BY_SUFFIX = {'.wasm': 'application/wasm', '.rrd': 'application/octet-stream'}
-
-
-def asset_content_type(path: Path) -> str:
-    """The `Content-Type` an asset file is served under."""
-    if path.suffix in _CONTENT_TYPE_BY_SUFFIX:
-        return _CONTENT_TYPE_BY_SUFFIX[path.suffix]
-    return mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
 
 
 def _asset_files() -> list[tuple[PurePosixPath, Path]]:

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -237,36 +237,6 @@ def filter_sets(episode_values: Iterable[Mapping[str, str]], most: int) -> list[
     return [dict(chosen) for chosen in sorted(satisfied, key=lambda chosen: (len(chosen), chosen))]
 
 
-def _filter_sets_by_group(
-    dataset: Dataset, group_tables: dict[str, GroupTableConfig] | None
-) -> dict[str, list[dict[str, str]]]:
-    """The non-empty filter sets each group table gets a file for; a group past either bound is refused."""
-    sets_by_group: dict[str, list[dict[str, str]]] = {}
-    for name, cfg in (group_tables or {}).items():
-        if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
-            raise ValueError(
-                f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
-                f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
-            )
-        # Each episode's values on the group's filter keys, as a filter spells them; an absent value is left out.
-        episode_values = (
-            {
-                key: spelling
-                for key in cfg.group_filter_keys
-                if (spelling := filter_spelling(cast(Episode, episode).static.get(key))) is not None
-            }
-            for episode in dataset
-        )
-        try:
-            # One of the files is the unfiltered one.
-            sets_by_group[name] = filter_sets(episode_values, MAX_FILTER_SETS_PER_GROUP - 1)
-        except ValueError as past_bound:
-            raise ValueError(
-                f'group table {name!r} has {past_bound}; an export reads the dataset once per set'
-            ) from None
-    return sets_by_group
-
-
 def _large_file_path(link: str, build_id: str) -> PurePosixPath:
     """Where the file a large-file `link` names is written: its segments as a directory tree, each keeping the
     encoded spelling the browser asks it by, under the build."""
@@ -424,6 +394,36 @@ def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
             install_dataset(planned.reads)
             serving = planned.reads
         planned.write(out)
+
+
+def _filter_sets_by_group(
+    dataset: Dataset, group_tables: dict[str, GroupTableConfig] | None
+) -> dict[str, list[dict[str, str]]]:
+    """The non-empty filter sets each group table gets a file for; a group past either bound is refused."""
+    sets_by_group: dict[str, list[dict[str, str]]] = {}
+    for name, cfg in (group_tables or {}).items():
+        if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
+            raise ValueError(
+                f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
+                f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
+            )
+        # Each episode's values on the group's filter keys, as a filter spells them; an absent value is left out.
+        episode_values = (
+            {
+                key: spelling
+                for key in cfg.group_filter_keys
+                if (spelling := filter_spelling(cast(Episode, episode).static.get(key))) is not None
+            }
+            for episode in dataset
+        )
+        try:
+            # One of the files is the unfiltered one.
+            sets_by_group[name] = filter_sets(episode_values, MAX_FILTER_SETS_PER_GROUP - 1)
+        except ValueError as past_bound:
+            raise ValueError(
+                f'group table {name!r} has {past_bound}; an export reads the dataset once per set'
+            ) from None
+    return sets_by_group
 
 
 def export_static(

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -12,7 +12,7 @@ import os
 import re
 import shutil
 import tempfile
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import cast
@@ -121,57 +121,43 @@ def _path_max(directory: Path) -> int:
     return os.pathconf(existing, 'PC_PATH_MAX')
 
 
-class _PortableTree:
-    """The paths the export writes under `directory`, as any host or filesystem the tree lands on holds them.
-
-    A path past a host's key limit is refused, and so is one past the local filesystem's path limit with
-    `directory` in front. So is a component Windows reads as a device or trims, and a path that folds onto
-    a file added before, or onto a directory above one, or whose own directory folds onto a file.
-    """
-
-    def __init__(self, directory: Path):
-        self._directory = directory
-        self._path_max = _path_max(directory)
-        self._files: set[PurePosixPath] = set()
-        self._directories: set[PurePosixPath] = set()
-
-    def add(self, path: PurePosixPath) -> None:
-        if len(str(path).encode()) > MAX_PATH_BYTES:
-            raise ValueError(f'{path} is past the {MAX_PATH_BYTES}-byte key limit of a host')
-        local = self._directory.joinpath(*path.parts)
-        if len(os.fsencode(local)) >= self._path_max:
-            raise ValueError(f'{local} is past the {self._path_max}-byte path limit of its filesystem')
-        folded = PurePosixPath(str(path).casefold())
-        for part in folded.parts:
-            if part.partition('.')[0] in _WINDOWS_DEVICES or part.endswith('.'):
-                raise ValueError(f'{path} has a component Windows reads as a device or trims, {part!r}')
-        directories = [parent for parent in folded.parents if parent.parts]
-        taken = folded in self._files or folded in self._directories
-        if taken or any(directory in self._files for directory in directories):
-            raise ValueError(f'{path} is one file with another the export writes on a filesystem that folds case')
-        self._files.add(folded)
-        self._directories.update(directories)
-
-
 class _Output:
-    """The files the export writes under `directory`: every path is planned before the first write, and a write
-    of a path outside the plan is refused."""
+    """The files the export writes under `directory`, as any host or filesystem holds them.
+
+    Every path is planned before the first write. A path past a host's key limit is refused, and so is one
+    past the local filesystem's path limit with `directory` in front. So is a component Windows reads as a
+    device or trims, and a path that folds onto a file planned before, or onto a directory above one, or
+    whose own directory folds onto a file.
+    """
 
     def __init__(self, directory: Path):
         # Absolute, so a path is measured with the working directory in front, as the filesystem measures it.
         self.directory = directory.absolute()
         self.files: list[ExportedFile] = []
-        self._tree = _PortableTree(self.directory)
-        self._planned: set[PurePosixPath] = set()
+        self._path_max = _path_max(self.directory)
+        self._folded_files: set[PurePosixPath] = set()
+        self._folded_directories: set[PurePosixPath] = set()
 
     def plan(self, paths: Iterable[PurePosixPath]) -> None:
-        """Register every path the export writes; one that would land outside the directory, or that a host or a
-        filesystem the tree lands on does not hold as it is, is refused here, before a write."""
+        """Register every path the export writes, before the first write."""
         for path in paths:
             if path.is_absolute() or '\\' in str(path) or '..' in path.parts:
                 raise ValueError(f'{path} would land outside {self.directory}')
-            self._tree.add(path)
-            self._planned.add(path)
+            if len(str(path).encode()) > MAX_PATH_BYTES:
+                raise ValueError(f'{path} is past the {MAX_PATH_BYTES}-byte key limit of a host')
+            local = self._target(path)
+            if len(os.fsencode(local)) >= self._path_max:
+                raise ValueError(f'{local} is past the {self._path_max}-byte path limit of its filesystem')
+            folded = PurePosixPath(str(path).casefold())
+            for part in folded.parts:
+                if part.partition('.')[0] in _WINDOWS_DEVICES or part.endswith('.'):
+                    raise ValueError(f'{path} has a component Windows reads as a device or trims, {part!r}')
+            directories = [parent for parent in folded.parents if parent.parts]
+            taken = folded in self._folded_files or folded in self._folded_directories
+            if taken or any(directory in self._folded_files for directory in directories):
+                raise ValueError(f'{path} is one file with another the export writes on a filesystem that folds case')
+            self._folded_files.add(folded)
+            self._folded_directories.update(directories)
 
     def write(self, path: PurePosixPath, body: bytes, content_type: str) -> ExportedFile:
         target = self._target(path)
@@ -187,8 +173,6 @@ class _Output:
         return self._record(path, asset_content_type(source), target.stat().st_size)
 
     def _target(self, path: PurePosixPath) -> Path:
-        if path not in self._planned:
-            raise ValueError(f'{path} is not in the export plan')
         return self.directory.joinpath(*path.parts)
 
     def _record(self, path: PurePosixPath, content_type: str, size: int) -> ExportedFile:
@@ -230,7 +214,7 @@ def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
 
 
 def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, str]]:
-    """Every filter set some episode satisfies, the empty one first.
+    """Every non-empty filter set some episode satisfies, the shortest first.
 
     An episode satisfies each subset of its own values, so k filter keys give at most 2^k sets per
     episode, and a set no episode satisfies gets no file.
@@ -238,21 +222,14 @@ def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, s
     satisfied: set[tuple[tuple[str, str], ...]] = set()
     for values in episode_values:
         items = sorted(values.items())
-        satisfied.update(chosen for n in range(len(items) + 1) for chosen in itertools.combinations(items, n))
+        satisfied.update(chosen for n in range(1, len(items) + 1) for chosen in itertools.combinations(items, n))
     return [dict(chosen) for chosen in sorted(satisfied, key=lambda chosen: (len(chosen), chosen))]
-
-
-def _filter_values(dataset: Dataset, keys: Iterable[str]) -> Iterator[dict[str, str]]:
-    """Each episode's values on the filter `keys`, as a filter spells them; an absent value is left out."""
-    for episode in dataset:
-        spelled = ((key, filter_spelling(cast(Episode, episode).static.get(key))) for key in keys)
-        yield {key: value for key, value in spelled if value is not None}
 
 
 def _filter_sets_by_group(
     dataset: Dataset, group_tables: dict[str, GroupTableConfig] | None
 ) -> dict[str, list[dict[str, str]]]:
-    """The filter sets each group table gets a file for; a group past either bound is refused before a write."""
+    """The non-empty filter sets each group table gets a file for; a group past either bound is refused."""
     sets_by_group: dict[str, list[dict[str, str]]] = {}
     for name, cfg in (group_tables or {}).items():
         if len(cfg.group_filter_keys) > MAX_FILTER_KEYS_PER_GROUP:
@@ -260,10 +237,19 @@ def _filter_sets_by_group(
                 f'group table {name!r} has {len(cfg.group_filter_keys)} filter keys; an export writes up to 2^k '
                 f'files per episode, so a group table takes at most {MAX_FILTER_KEYS_PER_GROUP}'
             )
-        sets = filter_sets(_filter_values(dataset, cfg.group_filter_keys))
-        if len(sets) > MAX_FILTER_SETS_PER_GROUP:
+        # Each episode's values on the group's filter keys, as a filter spells them; an absent value is left out.
+        episode_values = (
+            {
+                key: spelling
+                for key in cfg.group_filter_keys
+                if (spelling := filter_spelling(cast(Episode, episode).static.get(key))) is not None
+            }
+            for episode in dataset
+        )
+        sets = filter_sets(episode_values)
+        if len(sets) + 1 > MAX_FILTER_SETS_PER_GROUP:
             raise ValueError(
-                f'group table {name!r} has {len(sets)} filter sets and an export reads the dataset once per set, '
+                f'group table {name!r} has {len(sets) + 1} filter sets and an export reads the dataset once per set, '
                 f'so a group table takes at most {MAX_FILTER_SETS_PER_GROUP}; a filter key with a value per episode '
                 f'is the usual cause'
             )
@@ -350,8 +336,7 @@ def _page_plans(
 def _group_plans(client: TestClient, reads: Dataset, name: str, sets: Iterable[dict[str, str]]) -> list[_Planned]:
     """The plans to write one file per filter set of the group table `name`, and the index naming them."""
     route = PurePosixPath(group_api_link(name))
-    filtered = (chosen for chosen in sets if chosen)
-    index = [GroupFile({}, UNFILTERED_FILE), *(GroupFile(params, f'{n}.json') for n, params in enumerate(filtered, 1))]
+    index = [GroupFile({}, UNFILTERED_FILE), *(GroupFile(params, f'{n}.json') for n, params in enumerate(sets, 1))]
     listing = json.dumps([asdict(entry) for entry in index]).encode()
     return [
         *(_planned_fetch(client, f'/{route}', route / entry.file, reads, entry.params) for entry in index),

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -30,6 +30,7 @@ from positronic.dataset import CachedDataset, Dataset, Episode
 from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
+    ASSET_ROUTE,
     DOWNLOAD_LINK,
     GROUP_INDEX_FILE,
     MAX_COMPONENT_BYTES,
@@ -82,8 +83,6 @@ _WINDOWS_DEVICES = frozenset([
     *(f'com{n}' for n in range(1, 10)),
     *(f'lpt{n}' for n in range(1, 10)),
 ])
-# The app's own assets, at the server root, so every export a host serves shares one copy.
-ASSET_DIR = 'static'
 
 # The `secrets.token_urlsafe` alphabet: a build id is a path segment and sits inside a script string.
 _BUILD_ID = re.compile(r'[A-Za-z0-9_-]*')
@@ -117,15 +116,17 @@ def _path_max(directory: Path) -> int:
 class _Output:
     """The files the export writes under `directory`, as any host or filesystem holds them.
 
-    Every path is planned before the first write. A path past a host's key limit is refused, and so is one
-    past the local filesystem's path limit with `directory` in front. So is a component Windows reads as a
+    Every path is planned before the first write. A path past a host's key limit with `key_prefix`, the
+    base href, in front is refused, and so is one past the local filesystem's path limit with `directory`
+    in front. So is a component Windows reads as a
     device or trims, and a path that folds onto a file planned before, or onto a directory above one, or
     whose own directory folds onto a file.
     """
 
-    def __init__(self, directory: Path):
+    def __init__(self, directory: Path, key_prefix: str = ''):
         # Absolute, so a path is measured with the working directory in front, as the filesystem measures it.
         self.directory = directory.absolute()
+        self._key_prefix = key_prefix
         self.files: list[ExportedFile] = []
         self._path_max = _path_max(self.directory)
         self._folded_files: set[PurePosixPath] = set()
@@ -136,8 +137,9 @@ class _Output:
         for path in paths:
             if path.is_absolute() or '\\' in str(path) or '..' in path.parts:
                 raise ValueError(f'{path} would land outside {self.directory}')
-            if len(str(path).encode()) > MAX_PATH_BYTES:
-                raise ValueError(f'{path} is past the {MAX_PATH_BYTES}-byte key limit of a host')
+            key = self._key_prefix + str(path)
+            if len(key.encode()) > MAX_PATH_BYTES:
+                raise ValueError(f'{key} is past the {MAX_PATH_BYTES}-byte key limit of a host')
             local = self._target(path)
             if len(os.fsencode(local)) >= self._path_max:
                 raise ValueError(f'{local} is past the {self._path_max}-byte path limit of its filesystem')
@@ -365,9 +367,9 @@ def asset_content_type(path: Path) -> str:
 
 def _asset_files() -> list[tuple[PurePosixPath, Path]]:
     """The app's own scripts, styles and viewer, each with its path under `static/`."""
-    static_dir = Path(__file__).resolve().parent / ASSET_DIR
+    static_dir = Path(__file__).resolve().parent / ASSET_ROUTE
     files = sorted(p for p in static_dir.rglob('*') if p.is_file())
-    return [(PurePosixPath(ASSET_DIR) / file.relative_to(static_dir).as_posix(), file) for file in files]
+    return [(PurePosixPath(ASSET_ROUTE) / file.relative_to(static_dir).as_posix(), file) for file in files]
 
 
 def _whole_api_routes() -> list[str]:
@@ -439,7 +441,7 @@ def export_static(
     for its duration, so a second export in the process waits for it; one into the same directory is
     then refused, as the directory holds the first.
     """
-    out = _Output(Path(out_dir))
+    out = _Output(Path(out_dir), normalized_base_href(base_href).removeprefix('/'))
     if scratch_dir is not None and Path(scratch_dir).resolve().is_relative_to(out.directory.resolve()):
         raise ValueError(
             f'scratch_dir {scratch_dir} lies inside out_dir {out.directory}; the recordings are built beside it'

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -135,7 +135,7 @@ def _path_length(path: Path) -> int:
 class _Output:
     """The files the export writes under `directory`, as any host or filesystem holds them.
 
-    Every path is planned before the first write, and `plan` refuses:
+    Every path is planned before the first write, a write of a path outside the plan is refused, and `plan` refuses:
     - a key past a host's limit, with `key_prefix`, the base href, in front;
     - a local path past the filesystem's limit, with `directory` in front;
     - a component Windows reads as a device or trims;
@@ -148,6 +148,7 @@ class _Output:
         self._key_prefix = key_prefix
         self.files: list[ExportedFile] = []
         self._path_max = _path_max(self.directory)
+        self._planned: set[PurePosixPath] = set()
         self._folded_files: set[PurePosixPath] = set()
         self._folded_directories: set[PurePosixPath] = set()
 
@@ -159,7 +160,7 @@ class _Output:
             key = self._key_prefix + str(path)
             if len(key.encode()) > MAX_KEY_BYTES:
                 raise ValueError(f'{key} is past the {MAX_KEY_BYTES}-byte key limit of a host')
-            local = self._target(path)
+            local = self.directory.joinpath(*path.parts)
             if _path_length(local) >= self._path_max:
                 raise ValueError(f'{local} is past the path limit of its filesystem, {self._path_max}')
             folded = PurePosixPath(str(path).casefold())
@@ -172,6 +173,7 @@ class _Output:
                 raise ValueError(f'{path} is one file with another the export writes on a filesystem that folds case')
             self._folded_files.add(folded)
             self._folded_directories.update(directories)
+            self._planned.add(path)
 
     def write(self, path: PurePosixPath, body: bytes, content_type: str) -> ExportedFile:
         target = self._target(path)
@@ -187,6 +189,8 @@ class _Output:
         return self._record(path, asset_content_type(source), target.stat().st_size)
 
     def _target(self, path: PurePosixPath) -> Path:
+        if path not in self._planned:
+            raise ValueError(f'{path} is not in the export plan')
         return self.directory.joinpath(*path.parts)
 
     def _record(self, path: PurePosixPath, content_type: str, size: int) -> ExportedFile:

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -72,8 +72,10 @@ MAX_FILTER_KEYS_PER_GROUP = 6
 # Each file of a group table is one read of the whole dataset.
 MAX_FILTER_SETS_PER_GROUP = 1024
 # The object key limit of an S3-style host.
-MAX_PATH_BYTES = 1024
-# Windows holds a path within `MAX_PATH` characters, its end mark included, unless a machine opts into long paths.
+MAX_KEY_BYTES = 1024
+# A platform that reports no path limit is Windows, whose `MAX_PATH` counts UTF-16 units, the end mark included,
+# unless a machine opts into long paths.
+_REPORTS_PATH_MAX = hasattr(os, 'pathconf')
 _WINDOWS_PATH_MAX = 260
 # Windows reads these as devices, with or without a suffix, and trims a trailing dot off a name.
 _WINDOWS_DEVICES = frozenset([
@@ -119,10 +121,15 @@ def asset_content_type(path: Path) -> str:
 def _path_max(directory: Path) -> int:
     """The longest path, its end mark included, the filesystem under `directory` takes: read off the nearest
     ancestor that exists where the platform reports it, and Windows' `MAX_PATH` where it does not."""
-    if not hasattr(os, 'pathconf'):
+    if not _REPORTS_PATH_MAX:
         return _WINDOWS_PATH_MAX
     existing = next(candidate for candidate in (directory, *directory.parents) if candidate.exists())
     return os.pathconf(existing, 'PC_PATH_MAX')
+
+
+def _path_length(path: Path) -> int:
+    """`path` as its filesystem's limit counts it: bytes, or UTF-16 units under Windows' `MAX_PATH`."""
+    return len(os.fsencode(path)) if _REPORTS_PATH_MAX else len(str(path).encode('utf-16-le')) // 2
 
 
 class _Output:
@@ -150,11 +157,11 @@ class _Output:
             if path.is_absolute() or '\\' in str(path) or '..' in path.parts:
                 raise ValueError(f'{path} would land outside {self.directory}')
             key = self._key_prefix + str(path)
-            if len(key.encode()) > MAX_PATH_BYTES:
-                raise ValueError(f'{key} is past the {MAX_PATH_BYTES}-byte key limit of a host')
+            if len(key.encode()) > MAX_KEY_BYTES:
+                raise ValueError(f'{key} is past the {MAX_KEY_BYTES}-byte key limit of a host')
             local = self._target(path)
-            if len(os.fsencode(local)) >= self._path_max:
-                raise ValueError(f'{local} is past the {self._path_max}-byte path limit of its filesystem')
+            if _path_length(local) >= self._path_max:
+                raise ValueError(f'{local} is past the path limit of its filesystem, {self._path_max}')
             folded = PurePosixPath(str(path).casefold())
             for part in folded.parts:
                 if part.partition('.')[0] in _WINDOWS_DEVICES or part.endswith('.'):
@@ -256,10 +263,10 @@ def _filter_sets_by_group(
     return sets_by_group
 
 
-def _large_file_path(link: str, build_id: str) -> str:
+def _large_file_path(link: str, build_id: str) -> PurePosixPath:
     """Where the file a large-file `link` names is written: its segments as a directory tree, each keeping the
     encoded spelling the browser asks it by, under the build."""
-    return f'{BUILD_DIR}/{build_id}/{link}' if build_id else link
+    return PurePosixPath(BUILD_DIR, build_id, link) if build_id else PurePosixPath(link)
 
 
 def _page_spelling(link: str) -> str:
@@ -283,7 +290,7 @@ def large_file_links_under(html: str, links: Iterable[str], build_id: str) -> st
     """`html` with each of `links`, in the nodes a page carries them, moved under `build/<build_id>/` and
     spelled as a static host resolves them to the files on disk."""
     for link in links:
-        moved = _host_spelling(_large_file_path(link, build_id))
+        moved = _host_spelling(str(_large_file_path(link, build_id)))
         for node, moved_node in zip(_link_nodes(link), _link_nodes(moved), strict=True):
             html = html.replace(node, moved_node)
     return html
@@ -350,8 +357,8 @@ def _group_plans(client: TestClient, reads: Dataset, name: str, sets: Iterable[d
 def _large_file_plans(client: TestClient, reads: Dataset, links: _EpisodeLinks, build_id: str) -> list[_Planned]:
     """The plans to write the recording and the downloads of one episode, under the build; the recording is copied
     from the file the app builds, the downloads are read through the client."""
-    recording = PurePosixPath(_large_file_path(links.recording_link, build_id))
-    downloads = [(link, PurePosixPath(_large_file_path(link, build_id))) for link in links.download_links]
+    recording = _large_file_path(links.recording_link, build_id)
+    downloads = [(link, _large_file_path(link, build_id)) for link in links.download_links]
     return [
         _Planned(recording, reads, lambda out: out.copy(recording, episode_rrd_path(links.index))),
         *(_planned_fetch(client, f'/{link}', path, reads) for link, path in downloads),

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -31,6 +31,7 @@ from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
     API_FILE_SUFFIX,
+    API_ROUTE,
     ASSET_ROUTE,
     DOWNLOAD_LINK,
     GROUP_INDEX_FILE,
@@ -62,7 +63,6 @@ logger = logging.getLogger(__name__)
 
 # A page is a directory with an index file, so a static host answers `episode/3` with it.
 PAGE_FILE = 'index.html'
-API_DIR = 'api'
 # The recordings and the downloads sit under `build/<build_id>/`, a path a rebuild never rewrites.
 BUILD_DIR = 'build'
 # The file of a group table read with no filter, beside the index that names it.
@@ -105,15 +105,6 @@ class ExportedFile:
     size: int
 
 
-def _path_max(directory: Path) -> int:
-    """The longest path, its end mark included, the filesystem under `directory` takes: read off the nearest
-    ancestor that exists where the platform reports it, and Windows' `MAX_PATH` where it does not."""
-    if not hasattr(os, 'pathconf'):
-        return _WINDOWS_PATH_MAX
-    existing = next(candidate for candidate in (directory, *directory.parents) if candidate.exists())
-    return os.pathconf(existing, 'PC_PATH_MAX')
-
-
 # `mimetypes` answers for neither on every box.
 _CONTENT_TYPE_BY_SUFFIX = {'.wasm': 'application/wasm', '.rrd': 'application/octet-stream'}
 
@@ -123,6 +114,15 @@ def asset_content_type(path: Path) -> str:
     if path.suffix in _CONTENT_TYPE_BY_SUFFIX:
         return _CONTENT_TYPE_BY_SUFFIX[path.suffix]
     return mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
+
+
+def _path_max(directory: Path) -> int:
+    """The longest path, its end mark included, the filesystem under `directory` takes: read off the nearest
+    ancestor that exists where the platform reports it, and Windows' `MAX_PATH` where it does not."""
+    if not hasattr(os, 'pathconf'):
+        return _WINDOWS_PATH_MAX
+    existing = next(candidate for candidate in (directory, *directory.parents) if candidate.exists())
+    return os.pathconf(existing, 'PC_PATH_MAX')
 
 
 class _Output:
@@ -366,14 +366,14 @@ def _asset_files() -> list[tuple[PurePosixPath, Path]]:
 
 
 def _whole_api_routes() -> list[str]:
-    """The API routes a page reads whole: every GET under `api/` that takes no path parameter.
+    """The API routes a page reads whole: every GET under the API segment that takes no path parameter.
 
     The flat episode table is one of them; a static page filters it in the browser.
     """
     return [
         route.path.removeprefix('/')
         for route in app.routes
-        if isinstance(route, APIRoute) and route.path.startswith(f'/{API_DIR}/') and not route.param_convertors
+        if isinstance(route, APIRoute) and route.path.startswith(f'/{API_ROUTE}/') and not route.param_convertors
     ]
 
 

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -128,11 +128,11 @@ def _path_max(directory: Path) -> int:
 class _Output:
     """The files the export writes under `directory`, as any host or filesystem holds them.
 
-    Every path is planned before the first write. A path past a host's key limit with `key_prefix`, the
-    base href, in front is refused, and so is one past the local filesystem's path limit with `directory`
-    in front. So is a component Windows reads as a
-    device or trims, and a path that folds onto a file planned before, or onto a directory above one, or
-    whose own directory folds onto a file.
+    Every path is planned before the first write, and `plan` refuses:
+    - a key past a host's limit, with `key_prefix`, the base href, in front;
+    - a local path past the filesystem's limit, with `directory` in front;
+    - a component Windows reads as a device or trims;
+    - a path that folds onto a planned file or onto a directory above one, or whose directory folds onto a file.
     """
 
     def __init__(self, directory: Path, key_prefix: str = ''):

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -48,9 +48,9 @@ from positronic.server.positronic_server import (
     download_link,
     download_metadata,
     download_paths,
+    ensure_episode_rrd,
     episode_link,
     episode_rrd_link,
-    episode_rrd_path,
     episodes_link,
     filter_spelling,
     group_api_link,
@@ -334,7 +334,7 @@ def _large_file_plans(client: TestClient, reads: Dataset, links: _EpisodeLinks, 
     recording = _large_file_path(links.recording_link, build_id)
     downloads = [(link, _large_file_path(link, build_id)) for link in links.download_links]
     return [
-        _Planned(recording, reads, lambda out: out.copy(recording, episode_rrd_path(links.index))),
+        _Planned(recording, reads, lambda out: out.copy(recording, ensure_episode_rrd(links.index))),
         *(_planned_fetch(client, f'/{link}', path, reads) for link, path in downloads),
     ]
 
@@ -358,7 +358,7 @@ def _whole_api_routes() -> list[str]:
     ]
 
 
-def _aligned(full: Dataset, shown: Dataset) -> Dataset:
+def _full_checked_against(full: Dataset, shown: Dataset) -> Dataset:
     """`full`, once it holds the episodes of `shown` at the same indexes, by uid, with every download `shown` links,
     of the type and the size the page reports beside the link."""
     if len(full) != len(shown):
@@ -465,7 +465,7 @@ def export_static(
     validated_build_id(build_id)
     shown = CachedDataset(dataset)
     sets_by_group = _filter_sets_by_group(shown, group_tables)
-    full = _aligned(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
+    full = _full_checked_against(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
     episodes = [_episode_links(shown, index) for index in range(len(shown))]
     with app_state_restored(), tempfile.TemporaryDirectory(dir=scratch_dir) as scratch:
         # Under the lock, so a second export into the directory of a running one finds it full.

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -31,7 +31,9 @@ from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
     DOWNLOAD_LINK,
+    GROUP_INDEX_FILE,
     MAX_COMPONENT_BYTES,
+    GroupFile,
     GroupTableConfig,
     TableConfig,
     app,
@@ -61,8 +63,7 @@ PAGE_FILE = 'index.html'
 API_DIR = 'api'
 # The recordings and the downloads sit under `build/<build_id>/`, a path a rebuild never rewrites.
 BUILD_DIR = 'build'
-# A group table is one file per filter set, and the index beside them says which file holds which.
-GROUP_INDEX_FILE = 'index.json'
+# The file of a group table read with no filter, beside the index that names it.
 UNFILTERED_FILE = 'all.json'
 # A group table is one file per filter set some episode satisfies, up to 2^k per episode for k filter keys.
 MAX_FILTER_KEYS_PER_GROUP = 6
@@ -102,14 +103,6 @@ class ExportedFile:
     path: PurePosixPath
     content_type: str
     size: int
-
-
-@dataclass(frozen=True)
-class GroupFile:
-    """One file of a group table: the filter set it was read with, and its name beside the index."""
-
-    params: dict[str, str]
-    file: str
 
 
 def _path_max(directory: Path) -> int:

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -158,50 +158,51 @@ class _Output:
     of a path outside the plan is refused."""
 
     def __init__(self, directory: Path):
-        self.directory = directory
+        # Absolute, so a path is measured with the working directory in front, as the filesystem measures it.
+        self.directory = directory.absolute()
         self.files: list[ExportedFile] = []
-        self._tree = _PortableTree(directory)
-        self._planned: set[str] = set()
+        self._tree = _PortableTree(self.directory)
+        self._planned: set[PurePosixPath] = set()
 
-    def plan(self, paths: Iterable[str]) -> None:
+    def plan(self, paths: Iterable[PurePosixPath]) -> None:
         """Register every path the export writes; one that would land outside the directory, or that a host or a
         filesystem the tree lands on does not hold as it is, is refused here, before a write."""
         for path in paths:
-            relative = PurePosixPath(path)
-            if relative.is_absolute() or '\\' in path or '..' in relative.parts:
-                raise ValueError(f'{path!r} would land outside {self.directory}')
-            self._tree.add(relative)
+            if path.is_absolute() or '\\' in str(path) or '..' in path.parts:
+                raise ValueError(f'{path} would land outside {self.directory}')
+            self._tree.add(path)
             self._planned.add(path)
 
-    def write(self, path: str, body: bytes, content_type: str) -> ExportedFile:
+    def write(self, path: PurePosixPath, body: bytes, content_type: str) -> ExportedFile:
         target = self._target(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(body)
         return self._record(path, content_type, len(body))
 
-    def copy(self, path: str, source: Path) -> ExportedFile:
+    def copy(self, path: PurePosixPath, source: Path) -> ExportedFile:
         """Copy the file at `source` to `path` without holding it in memory."""
         target = self._target(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, target)
         return self._record(path, asset_content_type(source), target.stat().st_size)
 
-    def _target(self, path: str) -> Path:
+    def _target(self, path: PurePosixPath) -> Path:
         if path not in self._planned:
-            raise ValueError(f'{path!r} is not in the export plan')
-        return self.directory.joinpath(*PurePosixPath(path).parts)
+            raise ValueError(f'{path} is not in the export plan')
+        return self.directory.joinpath(*path.parts)
 
-    def _record(self, path: str, content_type: str, size: int) -> ExportedFile:
-        written = ExportedFile(PurePosixPath(path), content_type, size)
+    def _record(self, path: PurePosixPath, content_type: str, size: int) -> ExportedFile:
+        written = ExportedFile(path, content_type, size)
         self.files.append(written)
         return written
 
 
 @dataclass(frozen=True)
 class _Planned:
-    """One file the export writes at `path`; `write` writes it, once the app serves the dataset it reads."""
+    """One file the export writes at `path`; `write` writes it while the app serves `reads`."""
 
-    path: str
+    path: PurePosixPath
+    reads: Dataset
     write: Callable[[_Output], ExportedFile]
 
 
@@ -211,14 +212,21 @@ def _fetch(client: TestClient, path: str, params: dict[str, str] | None = None) 
     return response.content, response.headers.get('content-type', '')
 
 
-def _fetched(client: TestClient, route: str, path: str, params: dict[str, str] | None = None) -> _Planned:
-    """The response of `route`, read with `params`, written at `path`."""
-    return _Planned(path, lambda out: out.write(path, *_fetch(client, route, params)))
+def _planned_fetch(
+    client: TestClient, route: str, path: PurePosixPath, reads: Dataset, params: dict[str, str] | None = None
+) -> _Planned:
+    """The plan to write the response of `route`, read with `params` while the app serves `reads`, at `path`."""
+    return _Planned(path, reads, lambda out: out.write(path, *_fetch(client, route, params)))
 
 
-def _copied(path: str, source: Path) -> _Planned:
-    """The file at `source`, copied to `path`."""
-    return _Planned(path, lambda out: out.copy(path, source))
+def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
+    """Write each of `plans` with the app serving the dataset it reads."""
+    serving: Dataset | None = None
+    for planned in plans:
+        if planned.reads is not serving:
+            install_dataset(planned.reads)
+            serving = planned.reads
+        planned.write(out)
 
 
 def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, str]]:
@@ -311,10 +319,10 @@ def _episode_links(dataset: Dataset, index: int) -> _EpisodeLinks:
     return _EpisodeLinks(index, episode_rrd_link(index), downloads)
 
 
-def _episode_page(client: TestClient, links: _EpisodeLinks, build_id: str) -> _Planned:
-    """The page of one episode, with its links moved under the build."""
+def _episode_page(client: TestClient, reads: Dataset, links: _EpisodeLinks, build_id: str) -> _Planned:
+    """The plan to write the page of one episode, with its links moved under the build."""
     route = episode_link(links.index)
-    path = f'{route}/{PAGE_FILE}'
+    path = PurePosixPath(route) / PAGE_FILE
     every = [links.recording_link, *links.download_links]
 
     def write(out: _Output) -> ExportedFile:
@@ -324,43 +332,45 @@ def _episode_page(client: TestClient, links: _EpisodeLinks, build_id: str) -> _P
             raise RuntimeError(f'episode page {links.index} does not carry every link the export expects')
         return out.write(path, large_file_links_under(page, every, build_id).encode(), content_type)
 
-    return _Planned(path, write)
+    return _Planned(path, reads, write)
 
 
-def _page_writes(
-    client: TestClient, group_names: Iterable[str], episodes: Iterable[_EpisodeLinks], build_id: str
+def _page_plans(
+    client: TestClient, reads: Dataset, group_names: Iterable[str], episodes: Iterable[_EpisodeLinks], build_id: str
 ) -> list[_Planned]:
-    """Every page."""
+    """The plans to write every page."""
     routes = [episodes_link(), *(group_link(name) for name in group_names)]
     return [
-        _fetched(client, '/', PAGE_FILE),
-        *(_fetched(client, f'/{route}', f'{route}/{PAGE_FILE}') for route in routes),
-        *(_episode_page(client, links, build_id) for links in episodes),
+        _planned_fetch(client, '/', PurePosixPath(PAGE_FILE), reads),
+        *(_planned_fetch(client, f'/{route}', PurePosixPath(route) / PAGE_FILE, reads) for route in routes),
+        *(_episode_page(client, reads, links, build_id) for links in episodes),
     ]
 
 
-def _group_writes(client: TestClient, name: str, sets: Iterable[dict[str, str]]) -> list[_Planned]:
-    """One file per filter set of the group table `name`, and the index naming them."""
-    route = group_api_link(name)
+def _group_plans(client: TestClient, reads: Dataset, name: str, sets: Iterable[dict[str, str]]) -> list[_Planned]:
+    """The plans to write one file per filter set of the group table `name`, and the index naming them."""
+    route = PurePosixPath(group_api_link(name))
     filtered = (chosen for chosen in sets if chosen)
     index = [GroupFile({}, UNFILTERED_FILE), *(GroupFile(params, f'{n}.json') for n, params in enumerate(filtered, 1))]
     listing = json.dumps([asdict(entry) for entry in index]).encode()
     return [
-        *(_fetched(client, f'/{route}', f'{route}/{entry.file}', entry.params) for entry in index),
+        *(_planned_fetch(client, f'/{route}', route / entry.file, reads, entry.params) for entry in index),
         _Planned(
-            f'{route}/{GROUP_INDEX_FILE}',
-            lambda out: out.write(f'{route}/{GROUP_INDEX_FILE}', listing, 'application/json'),
+            route / GROUP_INDEX_FILE,
+            reads,
+            lambda out: out.write(route / GROUP_INDEX_FILE, listing, 'application/json'),
         ),
     ]
 
 
-def _large_file_writes(client: TestClient, links: _EpisodeLinks, build_id: str) -> list[_Planned]:
-    """The recording and the downloads of one episode, under the build; the recording is copied from the file the
-    app builds, the downloads are read through the client."""
-    recording = _large_file_path(links.recording_link, build_id)
+def _large_file_plans(client: TestClient, reads: Dataset, links: _EpisodeLinks, build_id: str) -> list[_Planned]:
+    """The plans to write the recording and the downloads of one episode, under the build; the recording is copied
+    from the file the app builds, the downloads are read through the client."""
+    recording = PurePosixPath(_large_file_path(links.recording_link, build_id))
+    downloads = [(link, PurePosixPath(_large_file_path(link, build_id))) for link in links.download_links]
     return [
-        _Planned(recording, lambda out: out.copy(recording, episode_rrd_path(links.index))),
-        *(_fetched(client, f'/{link}', _large_file_path(link, build_id)) for link in links.download_links),
+        _Planned(recording, reads, lambda out: out.copy(recording, episode_rrd_path(links.index))),
+        *(_planned_fetch(client, f'/{link}', path, reads) for link, path in downloads),
     ]
 
 
@@ -375,11 +385,11 @@ def asset_content_type(path: Path) -> str:
     return mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
 
 
-def _asset_writes() -> list[_Planned]:
-    """The app's own scripts, styles and viewer, under `static/`."""
+def _asset_files() -> list[tuple[PurePosixPath, Path]]:
+    """The app's own scripts, styles and viewer, each with its path under `static/`."""
     static_dir = Path(__file__).resolve().parent / ASSET_DIR
     files = sorted(p for p in static_dir.rglob('*') if p.is_file())
-    return [_copied(f'{ASSET_DIR}/{file.relative_to(static_dir).as_posix()}', file) for file in files]
+    return [(PurePosixPath(ASSET_DIR) / file.relative_to(static_dir).as_posix(), file) for file in files]
 
 
 def _whole_api_routes() -> list[str]:
@@ -479,25 +489,22 @@ def export_static(
         configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
         client = TestClient(app)
         # Past `configure_tables`, every group name is one segment the route builders spell.
-        pages = [
-            *_page_writes(client, sets_by_group, episodes, build_id),
-            *(_fetched(client, f'/{route}', f'{route}.json') for route in _whole_api_routes()),
-            *itertools.chain.from_iterable(_group_writes(client, name, sets) for name, sets in sets_by_group.items()),
+        plans = [
+            *_page_plans(client, shown, sets_by_group, episodes, build_id),
+            *(
+                _planned_fetch(client, f'/{route}', PurePosixPath(f'{route}.json'), shown)
+                for route in _whole_api_routes()
+            ),
+            *itertools.chain.from_iterable(
+                _group_plans(client, shown, name, sets) for name, sets in sets_by_group.items()
+            ),
+            *itertools.chain.from_iterable(_large_file_plans(client, full, links, build_id) for links in episodes),
         ]
-        large_files = list(
-            itertools.chain.from_iterable(_large_file_writes(client, links, build_id) for links in episodes)
-        )
-        asset_files = _asset_writes() if assets else []
-        out.plan(planned.path for planned in (*pages, *large_files, *asset_files))
-
-        install_dataset(shown)
-        for planned in pages:
-            planned.write(out)
-        install_dataset(full)
-        for planned in large_files:
-            planned.write(out)
-    for planned in asset_files:
-        planned.write(out)
+        asset_files = _asset_files() if assets else []
+        out.plan(itertools.chain((planned.path for planned in plans), (path for path, _ in asset_files)))
+        _write_serving(out, plans)
+    for path, file in asset_files:
+        out.copy(path, file)
     logger.info('wrote %d files under %s', len(out.files), out_dir)
     return out.files
 

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -30,6 +30,7 @@ from positronic.dataset import CachedDataset, Dataset, Episode
 from positronic.dataset.episode import META_UID
 from positronic.server.dataset_utils import DEFAULT_MAX_HZ, DEFAULT_MAX_RESOLUTION, get_dataset_root
 from positronic.server.positronic_server import (
+    API_FILE_SUFFIX,
     ASSET_ROUTE,
     DOWNLOAD_LINK,
     GROUP_INDEX_FILE,
@@ -196,16 +197,6 @@ def _planned_fetch(
 ) -> _Planned:
     """The plan to write the response of `route`, read with `params` while the app serves `reads`, at `path`."""
     return _Planned(path, reads, lambda out: out.write(path, *_fetch(client, route, params)))
-
-
-def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
-    """Write each of `plans` with the app serving the dataset it reads."""
-    serving: Dataset | None = None
-    for planned in plans:
-        if planned.reads is not serving:
-            install_dataset(planned.reads)
-            serving = planned.reads
-        planned.write(out)
 
 
 def filter_sets(episode_values: Iterable[Mapping[str, str]]) -> list[dict[str, str]]:
@@ -412,6 +403,16 @@ def _aligned(full: Dataset, shown: Dataset) -> Dataset:
     return full
 
 
+def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
+    """Write each of `plans` with the app serving the dataset it reads."""
+    serving: Dataset | None = None
+    for planned in plans:
+        if planned.reads is not serving:
+            install_dataset(planned.reads)
+            serving = planned.reads
+        planned.write(out)
+
+
 def export_static(
     dataset: Dataset,
     out_dir: Path,
@@ -472,7 +473,7 @@ def export_static(
         plans = [
             *_page_plans(client, shown, sets_by_group, episodes, build_id),
             *(
-                _planned_fetch(client, f'/{route}', PurePosixPath(f'{route}.json'), shown)
+                _planned_fetch(client, f'/{route}', PurePosixPath(route + API_FILE_SUFFIX), shown)
                 for route in _whole_api_routes()
             ),
             *itertools.chain.from_iterable(

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -93,13 +93,13 @@ def require_dataset(func):
     return wrapper
 
 
-_MAX_COMPONENT_BYTES = 200
+MAX_COMPONENT_BYTES = 200
 
 
 def _path_component(value: str) -> str:
     """``value`` as one filename component, injectively and within any filesystem's name limit."""
     encoded = quote(value, safe='')
-    if len(encoded.encode()) <= _MAX_COMPONENT_BYTES:
+    if len(encoded.encode()) <= MAX_COMPONENT_BYTES:
         return encoded
     # A digest is never read back as an encoded value: `quote` escapes '='.
     return '=' + hashlib.sha256(value.encode()).hexdigest()
@@ -183,7 +183,7 @@ def _download_segment(key: str) -> str:
     if key in ('', '.', '..'):
         raise ValueError(f'a static value with a key {key!r} has no link a browser keeps')
     encoded = quote(key, safe='')
-    if len(encoded.encode()) > _MAX_COMPONENT_BYTES:
+    if len(encoded.encode()) > MAX_COMPONENT_BYTES:
         raise ValueError(
             f'a static value with a key of {len(encoded.encode())} encoded bytes has no link a file is named by'
         )
@@ -330,7 +330,7 @@ def app_state_restored() -> Iterator[None]:
             _api_cache.clear()
 
 
-# The field of a static value's sidebar entry that holds its download link, as `app.js` reads it.
+# The field of a static value's sidebar entry that holds its download link.
 DOWNLOAD_LINK = '__download__'
 
 
@@ -721,7 +721,7 @@ def _recording_chunks_cached(episode_id: int, cache_path: Path) -> Iterator[byte
 
 
 def episode_rrd_path(episode_id: int) -> Path:
-    """The file the recording route serves for `episode_id`, built when the cache holds none."""
+    """The complete cached recording of `episode_id`, built when the cache holds none."""
     cache_path = _recording_cache_path(episode_id)
     if not cache_path.exists():
         for _ in _recording_chunks_cached(episode_id, cache_path):
@@ -871,8 +871,11 @@ def configure_tables(
     """
     episode_columns = set(ep_table_cfg or {})
     for name, cfg in (group_tables or {}).items():
-        if not name or name in ('.', '..') or quote(name, safe='') != name:
-            raise ValueError(f'a group name is one URL path segment (letters, digits, "_", "-", "."), got {name!r}')
+        if not name or name in ('.', '..') or quote(name, safe='') != name or len(name) > MAX_COMPONENT_BYTES:
+            raise ValueError(
+                f'a group name is one URL path segment of at most {MAX_COMPONENT_BYTES} letters, digits, "_", "-" '
+                f'and ".", got {name!r}'
+            )
         group_keys = (cfg.group_keys,) if isinstance(cfg.group_keys, str) else cfg.group_keys
         for key in (*group_keys, *cfg.group_filter_keys):
             if key not in episode_columns:

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -5,6 +5,7 @@ import hashlib
 import ipaddress
 import logging
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -18,7 +19,7 @@ from datetime import datetime
 from functools import wraps
 from pathlib import Path
 from typing import Any, cast
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import configuronic as cfn
 import pos3
@@ -150,8 +151,8 @@ def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str
 
     - `params` is None: `<path>.json`, for an endpoint the export writes whole.
     - `params` is a mapping: `<path>/<query>.json`, for one it writes a file per filter set for.
-      The query holds the parameters that carry a value, sorted by key and percent-encoded, and
-      an empty query is named `all`.
+      The query holds the parameters that carry a value, percent-encoded and then sorted, and
+      an empty query is named `all`. Sorting the encoded pair compares ASCII in every language.
     - A query past the byte budget becomes a digest of itself, which no filesystem's name limit
       rejects. A digest is hexadecimal, so it can never read as a query or as `all`.
 
@@ -159,8 +160,10 @@ def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str
     """
     if params is None:
         return f'{path}.json'
-    pairs = sorted((key, value) for key, value in params.items() if value)
-    query = '&'.join(f'{quote(k, safe=_QUERY_SAFE)}={quote(v, safe=_QUERY_SAFE)}' for k, v in pairs)
+    pairs = sorted(
+        f'{quote(key, safe=_QUERY_SAFE)}={quote(value, safe=_QUERY_SAFE)}' for key, value in params.items() if value
+    )
+    query = '&'.join(pairs)
     if len(query.encode()) > _MAX_COMPONENT_BYTES:
         query = hashlib.sha256(query.encode()).hexdigest()[:_QUERY_DIGEST_CHARS]
     return f'{path}/{query or _UNFILTERED_NAME}.json'
@@ -242,12 +245,26 @@ def static_export_url_path(path: str, params: Mapping[str, str] | None = None) -
 def normalized_base_href(value: str) -> str:
     """`value` with the trailing slash a relative link needs.
 
-    A base href starts at the server root. A relative one resolves against each page's own URL, so
-    a page under `/episode/0` would reach a different prefix than the root page reaches.
+    Only a path at the server root: a relative one, a netloc, a query or a fragment each send a
+    relative link somewhere other than the prefix.
     """
-    if not value.startswith('/'):
-        raise ValueError(f"base_href must start at the server root ('/'), got {value!r}")
-    return value if value.endswith('/') else value + '/'
+    parts = urlsplit(value)
+    if parts.scheme or parts.netloc or parts.query or parts.fragment or not parts.path.startswith('/'):
+        raise ValueError(f'base_href must be a path at the server root and nothing else, got {value!r}')
+    return parts.path if parts.path.endswith('/') else parts.path + '/'
+
+
+_BUILD_ID = re.compile(r'[A-Za-z0-9_-]*')
+
+
+def validated_build_id(value: str) -> str:
+    """`value` when it holds only what `secrets.token_urlsafe` produces; empty names no build.
+
+    A `?` or a `#` would turn the rest of the URL path into a query or a fragment.
+    """
+    if not _BUILD_ID.fullmatch(value):
+        raise ValueError(f'build_id must match {_BUILD_ID.pattern!r}, got {value!r}')
+    return value
 
 
 def _cacheable_api_path(suffix: str) -> str:
@@ -255,7 +272,7 @@ def _cacheable_api_path(suffix: str) -> str:
 
     Only an export writes such a file: a live server serves no `build/…` route.
     """
-    build_id = str(app_state['build_id'])
+    build_id = validated_build_id(str(app_state['build_id']))
     if app_state['static_export'] and build_id:
         return f'build/{build_id}/api/{suffix}'
     return f'api/{suffix}'
@@ -780,12 +797,12 @@ def main(
                 },
             }
         group_tables: Mapping of group name to GroupTableConfig
-        base_href: Path every page link and API call resolves against
+        base_href: Path at the server root that every page link and API call resolves against
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives
         static_export: Whether the pages ask for the file names a static export writes
-        build_id: Names one build. With static_export, the episode RRD and the static-field
-            downloads sit under it
+        build_id: Names one build, in the `secrets.token_urlsafe` alphabet. With static_export,
+            the episode RRD and the static-field downloads sit under it
     """
     root = get_dataset_root(dataset) or 'unknown_dataset'
     deb_level = logging.DEBUG if debug else logging.INFO
@@ -805,7 +822,7 @@ def main(
     app_state['title'] = title
     app_state['show_paths'] = show_paths
     app_state['static_export'] = static_export
-    app_state['build_id'] = build_id
+    app_state['build_id'] = validated_build_id(build_id)
 
     if reset_cache and cache_root.exists():
         logging.info(f'Clearing RRD cache directory: {cache_root.resolve()}')

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -135,7 +135,7 @@ async def cache_rerun_assets(request: Request, call_next):
 
 
 # The field a group table's response carries its filters under, and the field of each filter
-# holding its values. The export reads them back to write one file per filter set.
+# holding its values.
 GROUP_FILTERS = 'group_filters'
 FILTER_VALUES = 'values'
 
@@ -163,8 +163,13 @@ def episode_rrd_link(episode_id: int) -> str:
 
 
 def download_link(episode_id: int, field_path: str) -> str:
-    """The download's path; the field path is percent-encoded, so a `?`, a `#` or a space stays in the path."""
-    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=quote(field_path, safe='/'))
+    """The download's path; the field path is one percent-encoded segment, so a `?`, a `/` or a space stays in it.
+
+    A browser reads a segment of dots as a step in the path, encoded or not, so `.` and `..` are refused.
+    """
+    if field_path in ('.', '..'):
+        raise ValueError(f'a static value named {field_path!r} has no link a browser keeps')
+    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=quote(field_path, safe=''))
 
 
 def group_link(name: str) -> str:
@@ -800,7 +805,7 @@ def configure_tables(
 ) -> None:
     """Set what the tables show and how a recording is built; see `main` for what each value does."""
     for name in group_tables or {}:
-        if name in ('.', '..') or quote(name, safe='') != name:
+        if not name or name in ('.', '..') or quote(name, safe='') != name:
             raise ValueError(f'a group name is one URL path segment (letters, digits, "_", "-", "."), got {name!r}')
     if home_page and home_page not in (group_tables or {}):
         raise ValueError(f'home_page {home_page!r} names no group table; the tables are {sorted(group_tables or {})}')

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from functools import wraps
 from pathlib import Path
 from typing import Any, cast
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote, unquote, urlsplit
 
 import configuronic as cfn
 import pos3
@@ -246,11 +246,14 @@ def normalized_base_href(value: str) -> str:
     """`value` with the trailing slash a relative link needs.
 
     Only a path at the server root: a relative one, a netloc, a query or a fragment each send a
-    relative link somewhere other than the prefix.
+    relative link somewhere other than the prefix. A browser resolves a dot segment and a backslash
+    before it reads the `<base>`, so a path holding one names a different prefix than it shows.
     """
     parts = urlsplit(value)
     if parts.scheme or parts.netloc or parts.query or parts.fragment or not parts.path.startswith('/'):
         raise ValueError(f'base_href must be a path at the server root and nothing else, got {value!r}')
+    if '\\' in parts.path or any(unquote(segment) in ('.', '..') for segment in parts.path.split('/')):
+        raise ValueError(f'base_href must hold no dot segment and no backslash, got {value!r}')
     return parts.path if parts.path.endswith('/') else parts.path + '/'
 
 
@@ -265,6 +268,21 @@ def validated_build_id(value: str) -> str:
     if not _BUILD_ID.fullmatch(value):
         raise ValueError(f'build_id must match {_BUILD_ID.pattern!r}, got {value!r}')
     return value
+
+
+def configure_pages(
+    *, base_href: str = '/', title: str = '', show_paths: bool = True, static_export: bool = False, build_id: str = ''
+) -> None:
+    """Set where the pages are served and what they show; see `main` for what each value does.
+
+    The one place the five values enter `app_state`, so a crawler in another repository names no
+    key of it and gets the same checks the command line does.
+    """
+    app_state['base_href'] = normalized_base_href(base_href)
+    app_state['title'] = title
+    app_state['show_paths'] = show_paths
+    app_state['static_export'] = static_export
+    app_state['build_id'] = validated_build_id(build_id)
 
 
 def _cacheable_api_path(suffix: str) -> str:
@@ -818,11 +836,9 @@ def main(
     app_state['max_resolution'] = max_resolution
     app_state['max_hz'] = max_hz
     app_state['home_page'] = home_page
-    app_state['base_href'] = normalized_base_href(base_href)
-    app_state['title'] = title
-    app_state['show_paths'] = show_paths
-    app_state['static_export'] = static_export
-    app_state['build_id'] = validated_build_id(build_id)
+    configure_pages(
+        base_href=base_href, title=title, show_paths=show_paths, static_export=static_export, build_id=build_id
+    )
 
     if reset_cache and cache_root.exists():
         logging.info(f'Clearing RRD cache directory: {cache_root.resolve()}')

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -141,6 +141,9 @@ _QUERY_SAFE = "!*'()"
 # The name an empty filter set takes, which the export writer and the browser must spell alike.
 _UNFILTERED_NAME = 'all'
 
+# A digest stands in for a query over the byte budget; app.js spells both numbers too.
+_QUERY_DIGEST_CHARS = 16
+
 
 def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str:
     """The file name a static export writes an API response to.
@@ -149,6 +152,8 @@ def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str
     - `params` is a mapping: `<path>/<query>.json`, for one it writes a file per filter set for.
       The query holds the parameters that carry a value, sorted by key and percent-encoded, and
       an empty query is named `all`.
+    - A query past the byte budget becomes a digest of itself, which no filesystem's name limit
+      rejects. A digest is hexadecimal, so it can never read as a query or as `all`.
 
     `app.js` builds the same name.
     """
@@ -156,6 +161,8 @@ def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str
         return f'{path}.json'
     pairs = sorted((key, value) for key, value in params.items() if value)
     query = '&'.join(f'{quote(k, safe=_QUERY_SAFE)}={quote(v, safe=_QUERY_SAFE)}' for k, v in pairs)
+    if len(query.encode()) > _MAX_COMPONENT_BYTES:
+        query = hashlib.sha256(query.encode()).hexdigest()[:_QUERY_DIGEST_CHARS]
     return f'{path}/{query or _UNFILTERED_NAME}.json'
 
 
@@ -192,13 +199,11 @@ def _page_context() -> dict[str, Any]:
         # Episodes is home, insert at beginning
         nav_items.insert(0, {'name': 'episodes', 'url': '.', 'label': 'Episodes'})
 
-    base_href = str(app_state['base_href'])
     return {
         'nav_items': nav_items,
         'home_page': home_page,
         'episodes_url': episodes_url,
-        # A base href without a trailing slash loses its last segment when a relative link resolves.
-        'base_href': base_href if base_href.endswith('/') else base_href + '/',
+        'base_href': normalized_base_href(str(app_state['base_href'])),
         'title': str(app_state['title']) if app_state['title'] else _shown_root(),
         'show_paths': app_state['show_paths'],
         'static_export': app_state['static_export'],
@@ -232,6 +237,17 @@ def static_export_url_path(path: str, params: Mapping[str, str] | None = None) -
     is reached by escaping its own `%` again.
     """
     return static_export_key(path, params).replace('%', '%25')
+
+
+def normalized_base_href(value: str) -> str:
+    """`value` with the trailing slash a relative link needs.
+
+    A base href starts at the server root. A relative one resolves against each page's own URL, so
+    a page under `/episode/0` would reach a different prefix than the root page reaches.
+    """
+    if not value.startswith('/'):
+        raise ValueError(f"base_href must start at the server root ('/'), got {value!r}")
+    return value if value.endswith('/') else value + '/'
 
 
 def _cacheable_api_path(suffix: str) -> str:
@@ -280,7 +296,7 @@ async def episode_viewer(request: Request, episode_id: int):
         {
             'episode_id': episode_id,
             'num_episodes': len(ds),
-            'rerun_version': rr.__version__,
+            'viewer_path': f'/static/rerun/{rr.__version__}/index.html',
             'task': episode.static.get(keys.TASK, None),
             'rrd_path': _cacheable_api_path(f'episode_rrd/{episode_id}'),
             'episode_path': meta.get(META_PATH),
@@ -785,7 +801,7 @@ def main(
     app_state['max_resolution'] = max_resolution
     app_state['max_hz'] = max_hz
     app_state['home_page'] = home_page
-    app_state['base_href'] = base_href
+    app_state['base_href'] = normalized_base_href(base_href)
     app_state['title'] = title
     app_state['show_paths'] = show_paths
     app_state['static_export'] = static_export

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -890,7 +890,6 @@ def main(
     base_href: str = '/',
     title: str = '',
     show_paths: bool = True,
-    static_export: bool = False,
 ):
     """Visualize a Dataset with Rerun.
 
@@ -941,7 +940,6 @@ def main(
         base_href: Path at the server root that every page link and API call resolves against
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives
-        static_export: Whether the pages ask for the file names a static export writes
     """
     root = get_dataset_root(dataset) or 'unknown_dataset'
     deb_level = logging.DEBUG if debug else logging.INFO
@@ -958,7 +956,7 @@ def main(
         max_resolution=max_resolution,
         max_hz=max_hz,
     )
-    configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=static_export)
+    configure_pages(base_href=base_href, title=title, show_paths=show_paths)
     app_state['loading_state'] = True
 
     if reset_cache and cache_root.exists():

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -190,16 +190,9 @@ def _download_segment(key: str) -> str:
     return encoded
 
 
-# The object key limit of an S3-style host; with an output directory in front it stays within a filesystem's path limit.
-_MAX_DOWNLOAD_PATH_BYTES = 1024
-
-
 def _download_path(field_path: tuple[str, ...]) -> str:
     """`field_path` as the segments of a download link, one percent-encoded segment per key."""
-    encoded = '/'.join(_download_segment(key) for key in field_path)
-    if len(encoded.encode()) > _MAX_DOWNLOAD_PATH_BYTES:
-        raise ValueError(f'a static value at a path of {len(encoded.encode())} encoded bytes has no link a host keeps')
-    return encoded
+    return '/'.join(_download_segment(key) for key in field_path)
 
 
 def download_link(episode_id: int, field_path: tuple[str, ...]) -> str:
@@ -354,8 +347,7 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
     """The key path of every static value an episode page links as a download; a list item by its index.
 
     Each key is one URL segment, so distinct paths never share a link. A key that makes no segment —
-    empty, `.`, `..`, or past a file name's limit once encoded — is refused, and so is a path past a
-    host's key limit.
+    empty, `.`, `..`, or past a file name's limit once encoded — is refused.
     """
     for key_path, _ in _downloads(static, ()):
         _download_path(key_path)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import threading
 from collections import defaultdict
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -255,20 +255,16 @@ def is_download(value: object) -> bool:
     return isinstance(value, bytes) or (isinstance(value, str) and len(value) > 1024)
 
 
-def download_paths(static: Mapping[str, Any], path: str = '') -> Iterator[str]:
-    """The field path of every static value an episode page links as a download."""
-    for key, value in static.items():
-        field_path = f'{path}.{key}' if path else key
-        if is_download(value):
-            yield field_path
-        elif isinstance(value, dict):
-            yield from download_paths(value, field_path)
-        elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, dict):
-                    yield from download_paths(item, field_path)
-                elif is_download(item):
-                    yield field_path
+def download_paths(value: object, path: str = '') -> Iterator[str]:
+    """The field path of every static value an episode page links as a download; a list item by its index."""
+    if is_download(value):
+        yield path
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield from download_paths(item, f'{path}.{key}' if path else key)
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from download_paths(item, f'{path}.{index}' if path else str(index))
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -297,7 +293,7 @@ async def episode_viewer(request: Request, episode_id: int):
         if isinstance(obj, dict):
             return {k: _make_serializable(v, f'{path}.{k}' if path else k) for k, v in obj.items()}
         if isinstance(obj, list):
-            return [_make_serializable(v, path) for v in obj]
+            return [_make_serializable(v, f'{path}.{i}' if path else str(i)) for i, v in enumerate(obj)]
         return obj
 
     return templates.TemplateResponse(
@@ -499,7 +495,8 @@ async def api_groups(request: Request, suffix: str):  # noqa: C901
         for filter_key in cfg.group_filter_keys:
             group_filters[filter_key][FILTER_VALUES].add(episode.static.get(filter_key))
         # Apply filters for grouping
-        match = all(episode.static[key] == value for key, value in active_filters.items())
+        # A query carries a string, and the page offers the value as one.
+        match = all(str(episode.static.get(key)) == value for key, value in active_filters.items())
         if match:
             groups[_group_id(episode, group_keys)].append(episode)
 
@@ -532,6 +529,34 @@ async def api_dataset_status():
     }
 
 
+def _static_field(static: dict, field_path: str) -> object:
+    """The value at a dotted path into `static`, or an HTTP 404.
+
+    A dict key is matched greedily, so a key holding a dot (`link0.stl`) is found; a list is
+    walked by an index.
+    """
+    value: object = static
+    remaining = field_path
+    while remaining:
+        if isinstance(value, list):
+            index, _, rest = remaining.partition('.')
+            if not index.isdigit() or int(index) >= len(value):
+                raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
+            value, remaining = value[int(index)], rest
+            continue
+        if not isinstance(value, dict):
+            raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
+        parts = remaining.split('.')
+        for i in range(len(parts), 0, -1):
+            key = '.'.join(parts[:i])
+            if key in value:
+                value, remaining = value[key], '.'.join(parts[i:])
+                break
+        else:
+            raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
+    return value
+
+
 @app.get('/api/episode/{episode_id}/static/{field_path:path}')
 @require_dataset
 async def api_episode_static_field(episode_id: int, field_path: str):
@@ -541,25 +566,7 @@ async def api_episode_static_field(episode_id: int, field_path: str):
     except IndexError as e:
         raise HTTPException(status_code=404, detail='Episode not found') from e
 
-    # Navigate dotted path, greedily matching dict keys (handles keys with dots like "link0.stl")
-    value = episode.static
-    remaining = field_path
-    while remaining:
-        if not isinstance(value, dict):
-            raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
-        # Try the full remaining path first, then progressively shorter prefixes
-        parts = remaining.split('.')
-        matched = False
-        for i in range(len(parts), 0, -1):
-            key = '.'.join(parts[:i])
-            if key in value:
-                value = value[key]
-                remaining = '.'.join(parts[i:])
-                matched = True
-                break
-        if not matched:
-            raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
-
+    value = _static_field(episode.static, field_path)
     filename = field_path.rsplit('.', 1)[-1] if '.' in field_path else field_path
     if isinstance(value, bytes):
         return Response(

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -357,8 +357,9 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
         yield key_path
 
 
-def has_download(static: dict, key_path: tuple[str, ...]) -> bool:
-    """Whether `static` holds a value a page links as a download at `key_path`, a list item by its index."""
+def download_at(static: dict, key_path: tuple[str, ...]) -> bytes | str | None:
+    """The value a page links as a download at `key_path` into `static`, a list item by its index; None where
+    `static` holds no download there."""
     value: object = static
     for key in key_path:
         if isinstance(value, dict) and key in value:
@@ -366,8 +367,20 @@ def has_download(static: dict, key_path: tuple[str, ...]) -> bool:
         elif isinstance(value, list) and key.isdigit() and str(int(key)) == key and int(key) < len(value):
             value = value[int(key)]
         else:
-            return False
-    return is_download(value)
+            return None
+    return cast(bytes | str, value) if is_download(value) else None
+
+
+@dataclass(frozen=True)
+class DownloadMetadata:
+    """What a page says about a download beside its link: `bytes` or `text`, and its size."""
+
+    type: str
+    size: int
+
+
+def download_metadata(value: bytes | str) -> DownloadMetadata:
+    return DownloadMetadata('bytes' if isinstance(value, bytes) else 'text', len(value))
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -389,7 +402,7 @@ async def episode_viewer(request: Request, episode_id: int):
     def _make_serializable(obj, key_path=()):
         if is_download(obj):
             link = links[key_path]
-            return {DOWNLOAD_LINK: link, 'size': len(obj), 'type': 'bytes' if isinstance(obj, bytes) else 'text'}
+            return {DOWNLOAD_LINK: link, **asdict(download_metadata(obj))}
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, dict):
@@ -667,8 +680,9 @@ def _static_at(static: dict, key_path: Sequence[str]) -> object:
 
 
 def _content_disposition(disposition: str, filename: str) -> str:
-    """The `Content-Disposition` value naming a download `filename`; a name outside plain ASCII is percent-encoded."""
-    encoded = quote(filename)
+    """The `Content-Disposition` value naming a download `filename`; a name outside the plain ASCII characters,
+    a `/` included, is percent-encoded."""
+    encoded = quote(filename, safe='')
     if encoded == filename:
         return f'{disposition}; filename="{filename}"'
     return f"{disposition}; filename*=utf-8''{encoded}"

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -208,11 +208,13 @@ def normalized_base_href(value: str) -> str:
     """`value` with the trailing slash a relative link needs.
 
     Only a path at the server root: a relative one, a netloc, a query or a fragment each send a
-    relative link somewhere other than the prefix. A browser resolves a dot segment and a backslash
-    before it reads the `<base>`, so a path holding one names a different prefix than it shows.
+    relative link somewhere other than the prefix, and so does a path opening with two slashes, which
+    a browser reads as a host. A browser resolves a dot segment and a backslash before it reads the
+    `<base>`, so a path holding one names a different prefix than it shows.
     """
     parts = urlsplit(value)
-    if parts.scheme or parts.netloc or parts.query or parts.fragment or not parts.path.startswith('/'):
+    rooted = parts.path.startswith('/') and not parts.path.startswith('//')
+    if parts.scheme or parts.netloc or parts.query or parts.fragment or not rooted:
         raise ValueError(f'base_href must be a path at the server root and nothing else, got {value!r}')
     if '\\' in parts.path or any(unquote(segment) in ('.', '..') for segment in parts.path.split('/')):
         raise ValueError(f'base_href must hold no dot segment and no backslash, got {value!r}')

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -59,6 +59,9 @@ class PageConfig:
     static_export: bool = False
 
 
+# The app state's key for the `PageConfig` every page reads.
+_PAGE_CONFIG_KEY = 'pages'
+
 # Global app state
 app_state: dict[str, object] = {
     'dataset': None,
@@ -70,7 +73,7 @@ app_state: dict[str, object] = {
     'max_hz': DEFAULT_MAX_HZ,
     'group_tables_cfg': {},
     'home_page': None,  # None = episodes, or group name like 'tasks'
-    'pages': PageConfig(),
+    _PAGE_CONFIG_KEY: PageConfig(),
 }
 
 
@@ -149,7 +152,7 @@ FILTER_VALUES = 'values'
 
 
 def _page_config() -> PageConfig:
-    return cast(PageConfig, app_state['pages'])
+    return cast(PageConfig, app_state[_PAGE_CONFIG_KEY])
 
 
 def _shown_root() -> str:
@@ -295,7 +298,7 @@ def configure_pages(
     the header text, the dataset root when empty. `show_paths` says whether a page reports where the
     dataset lives. `static_export` makes the pages read the files a static export writes.
     """
-    app_state['pages'] = PageConfig(
+    app_state[_PAGE_CONFIG_KEY] = PageConfig(
         base_href=normalized_base_href(base_href), title=title, show_paths=show_paths, static_export=static_export
     )
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -354,6 +354,19 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
         yield key_path
 
 
+def has_download(static: dict, key_path: tuple[str, ...]) -> bool:
+    """Whether `static` holds a value a page links as a download at `key_path`, a list item by its index."""
+    value: object = static
+    for key in key_path:
+        if isinstance(value, dict) and key in value:
+            value = value[key]
+        elif isinstance(value, list) and key.isdigit() and str(int(key)) == key and int(key) < len(value):
+            value = value[int(key)]
+        else:
+            return False
+    return is_download(value)
+
+
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
 @require_dataset
 async def episode_viewer(request: Request, episode_id: int):

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -220,6 +220,15 @@ async def episodes_view(request: Request):
     return templates.TemplateResponse(request, 'index.html', {**_page_context(), 'current_page': 'episodes'})
 
 
+def static_export_url_path(path: str, params: Mapping[str, str] | None = None) -> str:
+    """The path a browser asks for the `static_export_key` file at.
+
+    A host decodes a URL path before it looks the file up, so a name that carries a percent escape
+    is reached by escaping its own `%` again.
+    """
+    return static_export_key(path, params).replace('%', '%25')
+
+
 def _cacheable_api_path(suffix: str) -> str:
     """`api/<suffix>`, under the build id when the pages read a static export.
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -138,6 +138,9 @@ async def cache_rerun_assets(request: Request, call_next):
 # What `encodeURIComponent` leaves unescaped, so app.js and this module name one file alike.
 _QUERY_SAFE = "!*'()"
 
+# The name an empty filter set takes, which the export writer and the browser must spell alike.
+_UNFILTERED_NAME = 'all'
+
 
 def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str:
     """The file name a static export writes an API response to.
@@ -153,7 +156,7 @@ def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str
         return f'{path}.json'
     pairs = sorted((key, value) for key, value in params.items() if value)
     query = '&'.join(f'{quote(k, safe=_QUERY_SAFE)}={quote(v, safe=_QUERY_SAFE)}' for k, v in pairs)
-    return f'{path}/{query or "all"}.json'
+    return f'{path}/{query or _UNFILTERED_NAME}.json'
 
 
 def _shown_root() -> str:

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -165,9 +165,9 @@ def episode_rrd_link(episode_id: int) -> str:
 def download_link(episode_id: int, field_path: str) -> str:
     """The download's path; the field path is one percent-encoded segment, so a `?`, a `/` or a space stays in it.
 
-    A browser reads a segment of dots as a step in the path, encoded or not, so `.` and `..` are refused.
+    A browser reads a segment of dots as a step in the path, encoded or not, so a `.` or `..` segment is refused.
     """
-    if field_path in ('.', '..'):
+    if any(part in ('.', '..') for part in field_path.split('/')):
         raise ValueError(f'a static value named {field_path!r} has no link a browser keeps')
     return _route(api_episode_static_field, episode_id=str(episode_id), field_path=quote(field_path, safe=''))
 
@@ -803,7 +803,10 @@ def configure_tables(
     max_resolution: int,
     max_hz: float,
 ) -> None:
-    """Set what the tables show and how a recording is built; see `main` for what each value does."""
+    """Set what the tables show and how a recording is built; see `main` for what each value does.
+
+    A table response cached under the previous settings is dropped.
+    """
     for name in group_tables or {}:
         if not name or name in ('.', '..') or quote(name, safe='') != name:
             raise ValueError(f'a group name is one URL path segment (letters, digits, "_", "-", "."), got {name!r}')
@@ -816,6 +819,7 @@ def configure_tables(
     app_state['max_resolution'] = max_resolution
     app_state['max_hz'] = max_hz
     app_state['home_page'] = home_page
+    _api_cache.clear()
 
 
 @cfn.config(

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -35,7 +35,7 @@ import positronic.cfg.ds
 from pimm.logging import init_logging
 from positronic import keys
 from positronic.dataset import CachedDataset, Dataset, Episode
-from positronic.dataset.episode import META_UID
+from positronic.dataset.episode import META_PATH, META_UID
 from positronic.dataset.local_dataset import LocalDataset
 from positronic.server.dataset_utils import (
     DEFAULT_MAX_HZ,
@@ -270,7 +270,7 @@ async def episode_viewer(request: Request, episode_id: int):
             'rerun_version': rr.__version__,
             'task': episode.static.get(keys.TASK, None),
             'rrd_path': _cacheable_api_path(f'episode_rrd/{episode_id}'),
-            'episode_path': meta.get('path'),
+            'episode_path': meta.get(META_PATH),
             'episode_size_mb': size_mb_display,
             'static_data': _make_serializable(episode.static),
             **_page_context(),

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import threading
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -145,6 +145,36 @@ def _shown_root() -> str:
     return str(app_state['root']) if app_state['show_paths'] else ''
 
 
+def _route(endpoint: Callable, **params: str) -> str:
+    """The path `endpoint` answers at, relative to the base href."""
+    return app.url_path_for(endpoint.__name__, **params).removeprefix('/')
+
+
+def episodes_link() -> str:
+    return _route(episodes_view)
+
+
+def episode_link(episode_id: int) -> str:
+    return _route(episode_viewer, episode_id=str(episode_id))
+
+
+def episode_rrd_link(episode_id: int) -> str:
+    return _route(api_episode_rrd, episode_id=str(episode_id))
+
+
+def download_link(episode_id: int, field_path: str) -> str:
+    """The download's path; the field path is percent-encoded, so a `?`, a `#` or a space stays in the path."""
+    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=quote(field_path, safe='/'))
+
+
+def group_link(name: str) -> str:
+    return _route(grouped_view, suffix=name)
+
+
+def group_api_link(name: str) -> str:
+    return _route(api_groups, suffix=name)
+
+
 def _page_context() -> dict[str, Any]:
     """The template context every page shares."""
     home_page = app_state.get('home_page')
@@ -162,7 +192,7 @@ def _page_context() -> dict[str, Any]:
     for group_name in group_tables.keys():
         if group_name == home_page:
             continue  # Already added as home
-        url = f'groups/{group_name}'
+        url = group_link(group_name)
         label = group_name.replace('_', ' ').title()
         nav_items.append({'name': group_name, 'url': url, 'label': label})
 
@@ -192,7 +222,7 @@ async def index(request: Request):
         return templates.TemplateResponse(
             request,
             'grouped.html',
-            {'api_endpoint': f'api/groups/{home_page}', **_page_context(), 'current_page': home_page},
+            {'api_endpoint': group_api_link(str(home_page)), **_page_context(), 'current_page': home_page},
         )
     # Default: render episodes
     return templates.TemplateResponse(request, 'index.html', {**_page_context(), 'current_page': 'episodes'})
@@ -292,7 +322,7 @@ async def episode_viewer(request: Request, episode_id: int):
     def _make_serializable(obj, path=''):
         if is_download(obj):
             return {
-                DOWNLOAD_LINK: f'api/episode/{episode_id}/static/{path}',
+                DOWNLOAD_LINK: download_link(episode_id, path),
                 'size': len(obj),
                 'type': 'bytes' if isinstance(obj, bytes) else 'text',
             }
@@ -312,7 +342,7 @@ async def episode_viewer(request: Request, episode_id: int):
             'num_episodes': len(ds),
             'viewer_path': f'/static/rerun/{rr.__version__}/index.html',
             'task': episode.static.get(keys.TASK, None),
-            'rrd_path': f'api/episode_rrd/{episode_id}',
+            'rrd_path': episode_rrd_link(episode_id),
             'episode_path': meta.get(META_PATH),
             'episode_size_mb': size_mb_display,
             'static_data': _make_serializable(episode.static),
@@ -540,7 +570,7 @@ async def api_groups(request: Request, suffix: str):
 @app.get('/groups/{suffix}', response_class=HTMLResponse)
 async def grouped_view(request: Request, suffix: str):
     return templates.TemplateResponse(
-        request, 'grouped.html', {'api_endpoint': f'api/groups/{suffix}', **_page_context(), 'current_page': suffix}
+        request, 'grouped.html', {'api_endpoint': group_api_link(suffix), **_page_context(), 'current_page': suffix}
     )
 
 
@@ -769,6 +799,11 @@ def configure_tables(
     max_hz: float,
 ) -> None:
     """Set what the tables show and how a recording is built; see `main` for what each value does."""
+    for name in group_tables or {}:
+        if name in ('.', '..') or quote(name, safe='') != name:
+            raise ValueError(f'a group name is one URL path segment (letters, digits, "_", "-", "."), got {name!r}')
+    if home_page and home_page not in (group_tables or {}):
+        raise ValueError(f'home_page {home_page!r} names no group table; the tables are {sorted(group_tables or {})}')
     app_state['root'] = root
     app_state['cache_dir'] = cache_dir
     app_state['episode_table_cfg'] = ep_table_cfg or {}

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -190,11 +190,22 @@ def _download_segment(key: str) -> str:
     return encoded
 
 
+# The object key limit of an S3-style host; with an output directory in front it stays within a filesystem's path limit.
+_MAX_DOWNLOAD_PATH_BYTES = 1024
+
+
+def _download_path(field_path: tuple[str, ...]) -> str:
+    """`field_path` as the segments of a download link, one percent-encoded segment per key."""
+    encoded = '/'.join(_download_segment(key) for key in field_path)
+    if len(encoded.encode()) > _MAX_DOWNLOAD_PATH_BYTES:
+        raise ValueError(f'a static value at a path of {len(encoded.encode())} encoded bytes has no link a host keeps')
+    return encoded
+
+
 def download_link(episode_id: int, field_path: tuple[str, ...]) -> str:
     """The download's path: one percent-encoded segment per key, so a `.`, `/`, `?` or space inside a key
     stays in its segment and two static values never share a link."""
-    encoded = '/'.join(_download_segment(key) for key in field_path)
-    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=encoded)
+    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=_download_path(field_path))
 
 
 def group_link(name: str) -> str:
@@ -343,11 +354,11 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
     """The key path of every static value an episode page links as a download; a list item by its index.
 
     Each key is one URL segment, so distinct paths never share a link. A key that makes no segment —
-    empty, `.`, `..`, or past a file name's limit once encoded — is refused.
+    empty, `.`, `..`, or past a file name's limit once encoded — is refused, and so is a path past a
+    host's key limit.
     """
     for key_path, _ in _downloads(static, ()):
-        for key in key_path:
-            _download_segment(key)
+        _download_path(key_path)
         yield key_path
 
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -174,16 +174,26 @@ def episode_rrd_link(episode_id: int) -> str:
     return _route(api_episode_rrd, episode_id=str(episode_id))
 
 
+def _download_segment(key: str) -> str:
+    """`key` as one segment of a download link: percent-encoded, and within any filesystem's name limit.
+
+    A browser rewrites a segment that is empty or all dots, and a filesystem refuses a name past its
+    limit, so such a key has no link.
+    """
+    if key in ('', '.', '..'):
+        raise ValueError(f'a static value with a key {key!r} has no link a browser keeps')
+    encoded = quote(key, safe='')
+    if len(encoded.encode()) > _MAX_COMPONENT_BYTES:
+        raise ValueError(
+            f'a static value with a key of {len(encoded.encode())} encoded bytes has no link a file is named by'
+        )
+    return encoded
+
+
 def download_link(episode_id: int, field_path: tuple[str, ...]) -> str:
     """The download's path: one percent-encoded segment per key, so a `.`, `/`, `?` or space inside a key
-    stays in its segment and two static values never share a link.
-
-    A browser rewrites a segment that is empty or all dots, so a key that is `''`, `.` or `..` is refused.
-    """
-    for key in field_path:
-        if key in ('', '.', '..'):
-            raise ValueError(f'a static value with a key {key!r} has no link a browser keeps')
-    encoded = '/'.join(quote(key, safe='') for key in field_path)
+    stays in its segment and two static values never share a link."""
+    encoded = '/'.join(_download_segment(key) for key in field_path)
     return _route(api_episode_static_field, episode_id=str(episode_id), field_path=encoded)
 
 
@@ -332,13 +342,12 @@ def _downloads(value: object, prefix: tuple[str, ...]) -> Iterator[tuple[tuple[s
 def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
     """The key path of every static value an episode page links as a download; a list item by its index.
 
-    Each key is one URL segment, so distinct paths never share a link. A key a browser rewrites in a path
-    — empty, `.` or `..` — is refused.
+    Each key is one URL segment, so distinct paths never share a link. A key that makes no segment —
+    empty, `.`, `..`, or past a file name's limit once encoded — is refused.
     """
     for key_path, _ in _downloads(static, ()):
         for key in key_path:
-            if key in ('', '.', '..'):
-                raise ValueError(f'a static value with a key {key!r} has no link a browser keeps')
+            _download_segment(key)
         yield key_path
 
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -5,15 +5,14 @@ import hashlib
 import ipaddress
 import logging
 import os
-import re
 import shutil
 import socket
 import subprocess
 import tempfile
 import threading
 from collections import defaultdict
-from collections.abc import Mapping
-from contextlib import asynccontextmanager
+from collections.abc import Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from functools import wraps
@@ -64,7 +63,6 @@ app_state: dict[str, object] = {
     'title': '',  # empty = the dataset root
     'show_paths': True,
     'static_export': False,
-    'build_id': '',
 }
 
 
@@ -136,37 +134,10 @@ async def cache_rerun_assets(request: Request, call_next):
     return response
 
 
-# What `encodeURIComponent` leaves unescaped, so app.js and this module name one file alike.
-_QUERY_SAFE = "!*'()"
-
-# The name an empty filter set takes, which the export writer and the browser must spell alike.
-_UNFILTERED_NAME = 'all'
-
-# A digest stands in for a query over the byte budget; app.js spells both numbers too.
-_QUERY_DIGEST_CHARS = 16
-
-
-def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str:
-    """The file name a static export writes an API response to.
-
-    - `params` is None: `<path>.json`, for an endpoint the export writes whole.
-    - `params` is a mapping: `<path>/<query>.json`, for one it writes a file per filter set for.
-      The query holds the parameters that carry a value, percent-encoded and then sorted, and
-      an empty query is named `all`. Sorting the encoded pair compares ASCII in every language.
-    - A query past the byte budget becomes a digest of itself, which no filesystem's name limit
-      rejects. A digest is hexadecimal, so it can never read as a query or as `all`.
-
-    `app.js` builds the same name.
-    """
-    if params is None:
-        return f'{path}.json'
-    pairs = sorted(
-        f'{quote(key, safe=_QUERY_SAFE)}={quote(value, safe=_QUERY_SAFE)}' for key, value in params.items() if value
-    )
-    query = '&'.join(pairs)
-    if len(query.encode()) > _MAX_COMPONENT_BYTES:
-        query = hashlib.sha256(query.encode()).hexdigest()[:_QUERY_DIGEST_CHARS]
-    return f'{path}/{query or _UNFILTERED_NAME}.json'
+# The field a group table's response carries its filters under, and the field of each filter
+# holding its values. The export reads them back to write one file per filter set.
+GROUP_FILTERS = 'group_filters'
+FILTER_VALUES = 'values'
 
 
 def _shown_root() -> str:
@@ -233,15 +204,6 @@ async def episodes_view(request: Request):
     return templates.TemplateResponse(request, 'index.html', {**_page_context(), 'current_page': 'episodes'})
 
 
-def static_export_url_path(path: str, params: Mapping[str, str] | None = None) -> str:
-    """The path a browser asks for the `static_export_key` file at.
-
-    A host decodes a URL path before it looks the file up, so a name that carries a percent escape
-    is reached by escaping its own `%` again.
-    """
-    return static_export_key(path, params).replace('%', '%25')
-
-
 def normalized_base_href(value: str) -> str:
     """`value` with the trailing slash a relative link needs.
 
@@ -257,43 +219,54 @@ def normalized_base_href(value: str) -> str:
     return parts.path if parts.path.endswith('/') else parts.path + '/'
 
 
-_BUILD_ID = re.compile(r'[A-Za-z0-9_-]*')
-
-
-def validated_build_id(value: str) -> str:
-    """`value` when it holds only what `secrets.token_urlsafe` produces; empty names no build.
-
-    A `?` or a `#` would turn the rest of the URL path into a query or a fragment.
-    """
-    if not _BUILD_ID.fullmatch(value):
-        raise ValueError(f'build_id must match {_BUILD_ID.pattern!r}, got {value!r}')
-    return value
-
-
 def configure_pages(
-    *, base_href: str = '/', title: str = '', show_paths: bool = True, static_export: bool = False, build_id: str = ''
+    *, base_href: str = '/', title: str = '', show_paths: bool = True, static_export: bool = False
 ) -> None:
-    """Set where the pages are served and what they show; see `main` for what each value does.
-
-    The one place the five values enter `app_state`, so a crawler in another repository names no
-    key of it and gets the same checks the command line does.
-    """
+    """Set where the pages are served and what they show; see `main` for what each value does."""
     app_state['base_href'] = normalized_base_href(base_href)
     app_state['title'] = title
     app_state['show_paths'] = show_paths
     app_state['static_export'] = static_export
-    app_state['build_id'] = validated_build_id(build_id)
 
 
-def _cacheable_api_path(suffix: str) -> str:
-    """`api/<suffix>`, under the build id when the pages read a static export.
+def install_dataset(dataset: Dataset) -> None:
+    """Serve `dataset` from now on."""
+    app_state['dataset'] = dataset
+    _api_cache.clear()
+    app_state['loading_state'] = False
 
-    Only an export writes such a file: a live server serves no `build/…` route.
-    """
-    build_id = validated_build_id(str(app_state['build_id']))
-    if app_state['static_export'] and build_id:
-        return f'build/{build_id}/api/{suffix}'
-    return f'api/{suffix}'
+
+@contextmanager
+def app_state_restored() -> Iterator[None]:
+    """Give the app its state back on exit, for a caller that composes the app in its own process."""
+    saved = dict(app_state)
+    try:
+        yield
+    finally:
+        app_state.clear()
+        app_state.update(saved)
+        _api_cache.clear()
+
+
+def is_download(value: object) -> bool:
+    """Whether a static value reaches a page as a download link rather than inline."""
+    return isinstance(value, bytes) or (isinstance(value, str) and len(value) > 1024)
+
+
+def download_paths(static: Mapping[str, Any], path: str = '') -> Iterator[str]:
+    """The field path of every static value an episode page links as a download."""
+    for key, value in static.items():
+        field_path = f'{path}.{key}' if path else key
+        if is_download(value):
+            yield field_path
+        elif isinstance(value, dict):
+            yield from download_paths(value, field_path)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    yield from download_paths(item, field_path)
+                elif is_download(item):
+                    yield field_path
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -311,9 +284,9 @@ async def episode_viewer(request: Request, episode_id: int):
     size_mb_display = f'{size_mb:.2f}' if isinstance(size_mb, int | float) else None
 
     def _make_serializable(obj, path=''):
-        if isinstance(obj, bytes) or (isinstance(obj, str) and len(obj) > 1024):
+        if is_download(obj):
             return {
-                '__download__': _cacheable_api_path(f'episode/{episode_id}/static/{path}'),
+                '__download__': f'api/episode/{episode_id}/static/{path}',
                 'size': len(obj),
                 'type': 'bytes' if isinstance(obj, bytes) else 'text',
             }
@@ -333,7 +306,7 @@ async def episode_viewer(request: Request, episode_id: int):
             'num_episodes': len(ds),
             'viewer_path': f'/static/rerun/{rr.__version__}/index.html',
             'task': episode.static.get(keys.TASK, None),
-            'rrd_path': _cacheable_api_path(f'episode_rrd/{episode_id}'),
+            'rrd_path': f'api/episode_rrd/{episode_id}',
             'episode_path': meta.get(META_PATH),
             'episode_size_mb': size_mb_display,
             'static_data': _make_serializable(episode.static),
@@ -518,11 +491,11 @@ async def api_groups(request: Request, suffix: str):  # noqa: C901
             active_filters[filter_key] = filter_value
 
     groups = defaultdict(list)
-    group_filters = {key: {'label': label or key, 'values': set()} for key, label in cfg.group_filter_keys.items()}
+    group_filters = {key: {'label': label or key, FILTER_VALUES: set()} for key, label in cfg.group_filter_keys.items()}
     for episode in ds:
         # Always collect all filter values regardless of active filters
         for filter_key in cfg.group_filter_keys:
-            group_filters[filter_key]['values'].add(episode.static.get(filter_key))
+            group_filters[filter_key][FILTER_VALUES].add(episode.static.get(filter_key))
         # Apply filters for grouping
         match = all(episode.static[key] == value for key, value in active_filters.items())
         if match:
@@ -534,7 +507,7 @@ async def api_groups(request: Request, suffix: str):  # noqa: C901
         rows.append({**key_fields, '__meta__': {'group': key_fields}, **cfg.group_fn(episodes)})
 
     episodes = get_episodes_list(rows, cfg.format_table.keys(), formatters=formatters, defaults=defaults)
-    result = {'columns': columns, 'episodes': episodes, 'group_filters': group_filters}
+    result = {'columns': columns, 'episodes': episodes, GROUP_FILTERS: group_filters}
     if cfg.default_sort:
         result['default_sort'] = asdict(cfg.default_sort)
     _api_cache[cache_key] = result
@@ -744,6 +717,26 @@ def _generate_self_signed_cert(hosts: list[str]) -> _SelfSignedCert:
     return _SelfSignedCert(keyfile, certfile)
 
 
+def configure_tables(
+    *,
+    root: str,
+    cache_dir: Path,
+    ep_table_cfg: TableConfig | None,
+    group_tables: dict[str, GroupTableConfig] | None,
+    home_page: str | None,
+    max_resolution: int,
+    max_hz: float,
+) -> None:
+    """Set what the tables show and how a recording is built; see `main` for what each value does."""
+    app_state['root'] = root
+    app_state['cache_dir'] = cache_dir
+    app_state['episode_table_cfg'] = ep_table_cfg or {}
+    app_state['group_tables_cfg'] = group_tables or {}
+    app_state['max_resolution'] = max_resolution
+    app_state['max_hz'] = max_hz
+    app_state['home_page'] = home_page
+
+
 @cfn.config(
     dataset=positronic.cfg.ds.local_all,
     ep_table_cfg=default_table,
@@ -767,7 +760,6 @@ def main(
     title: str = '',
     show_paths: bool = True,
     static_export: bool = False,
-    build_id: str = '',
 ):
     """Visualize a Dataset with Rerun.
 
@@ -819,8 +811,6 @@ def main(
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives
         static_export: Whether the pages ask for the file names a static export writes
-        build_id: Names one build, in the `secrets.token_urlsafe` alphabet. With static_export,
-            the episode RRD and the static-field downloads sit under it
     """
     root = get_dataset_root(dataset) or 'unknown_dataset'
     deb_level = logging.DEBUG if debug else logging.INFO
@@ -828,17 +818,17 @@ def main(
 
     # configuronic passes this CLI value through uncoerced.
     cache_root = Path(cache_dir).expanduser()
-    app_state['root'] = root
-    app_state['cache_dir'] = cache_root
-    app_state['loading_state'] = True
-    app_state['episode_table_cfg'] = ep_table_cfg or {}
-    app_state['group_tables_cfg'] = group_tables or {}
-    app_state['max_resolution'] = max_resolution
-    app_state['max_hz'] = max_hz
-    app_state['home_page'] = home_page
-    configure_pages(
-        base_href=base_href, title=title, show_paths=show_paths, static_export=static_export, build_id=build_id
+    configure_tables(
+        root=root,
+        cache_dir=cache_root,
+        ep_table_cfg=ep_table_cfg,
+        group_tables=group_tables,
+        home_page=home_page,
+        max_resolution=max_resolution,
+        max_hz=max_hz,
     )
+    configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=static_export)
+    app_state['loading_state'] = True
 
     if reset_cache and cache_root.exists():
         logging.info(f'Clearing RRD cache directory: {cache_root.resolve()}')
@@ -852,9 +842,7 @@ def main(
         try:
             ds = CachedDataset(dataset)
             logging.info(f'Dataset loaded. Episodes: {len(ds)}')
-            app_state['dataset'] = ds
-            _api_cache.clear()
-            app_state['loading_state'] = False
+            install_dataset(ds)
         except Exception as e:
             logging.error(f'Failed to load dataset: {e}', exc_info=True)
             app_state['loading_state'] = False

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import threading
 from collections import defaultdict
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -58,6 +59,11 @@ app_state: dict[str, object] = {
     'max_hz': DEFAULT_MAX_HZ,
     'group_tables_cfg': {},
     'home_page': None,  # None = episodes, or group name like 'tasks'
+    'base_href': '/',
+    'title': '',  # empty = the dataset root
+    'show_paths': True,
+    'static_export': False,
+    'build_id': '',
 }
 
 
@@ -129,24 +135,54 @@ async def cache_rerun_assets(request: Request, call_next):
     return response
 
 
-def _get_nav_context() -> dict[str, Any]:
-    """Build navigation context for templates."""
+# What `encodeURIComponent` leaves unescaped, so app.js and this module name one file alike.
+_QUERY_SAFE = "!*'()"
+
+
+def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str:
+    """The file name a static export writes an API response to, and a browser asks for.
+
+    `<path>.json` names an endpoint the export writes whole, and None asks for that form.
+    `<path>/<query>.json` names one the export writes a file per filter set for: the query holds
+    the parameters that carry a value, sorted by key and percent-encoded, and an empty query is
+    named `all`. `app.js` builds the same name.
+    """
+    if params is None:
+        return f'{path}.json'
+    pairs = sorted((key, value) for key, value in params.items() if value)
+    query = '&'.join(f'{quote(k, safe=_QUERY_SAFE)}={quote(v, safe=_QUERY_SAFE)}' for k, v in pairs)
+    return f'{path}/{query or "all"}.json'
+
+
+def _cacheable_api_path(suffix: str) -> str:
+    """`api/<suffix>` under the build id, so a rebuild never reads a file a browser cached."""
+    build_id = str(app_state['build_id'])
+    return f'build/{build_id}/api/{suffix}' if build_id else f'api/{suffix}'
+
+
+def _shown_root() -> str:
+    """The dataset root the pages report; empty when the viewer hides paths."""
+    return str(app_state['root']) if app_state['show_paths'] else ''
+
+
+def _page_context() -> dict[str, Any]:
+    """The template context every page shares."""
     home_page = app_state.get('home_page')
     group_tables = app_state.get('group_tables_cfg', {})
 
     nav_items = []
-    episodes_url = '/episodes' if home_page else '/'
+    episodes_url = 'episodes' if home_page else '.'
 
     # If home_page is set, it goes first
     if home_page and home_page in group_tables:
         label = home_page.replace('_', ' ').title()
-        nav_items.append({'name': home_page, 'url': '/', 'label': label})
+        nav_items.append({'name': home_page, 'url': '.', 'label': label})
 
     # Other group links
     for group_name in group_tables.keys():
         if group_name == home_page:
             continue  # Already added as home
-        url = f'/groups/{group_name}'
+        url = f'groups/{group_name}'
         label = group_name.replace('_', ' ').title()
         nav_items.append({'name': group_name, 'url': url, 'label': label})
 
@@ -155,9 +191,19 @@ def _get_nav_context() -> dict[str, Any]:
         nav_items.append({'name': 'episodes', 'url': episodes_url, 'label': 'Episodes'})
     else:
         # Episodes is home, insert at beginning
-        nav_items.insert(0, {'name': 'episodes', 'url': '/', 'label': 'Episodes'})
+        nav_items.insert(0, {'name': 'episodes', 'url': '.', 'label': 'Episodes'})
 
-    return {'nav_items': nav_items, 'home_page': home_page, 'episodes_url': episodes_url}
+    base_href = str(app_state['base_href'])
+    return {
+        'nav_items': nav_items,
+        'home_page': home_page,
+        'episodes_url': episodes_url,
+        # A base href without a trailing slash loses its last segment when a relative link resolves.
+        'base_href': base_href if base_href.endswith('/') else base_href + '/',
+        'title': str(app_state['title']) if app_state['title'] else _shown_root(),
+        'show_paths': app_state['show_paths'],
+        'static_export': app_state['static_export'],
+    }
 
 
 @app.get('/', response_class=HTMLResponse)
@@ -168,25 +214,16 @@ async def index(request: Request):
         return templates.TemplateResponse(
             request,
             'grouped.html',
-            {
-                'repo_id': app_state['root'],
-                'api_endpoint': f'/api/groups/{home_page}',
-                **_get_nav_context(),
-                'current_page': home_page,
-            },
+            {'api_endpoint': f'api/groups/{home_page}', **_page_context(), 'current_page': home_page},
         )
     # Default: render episodes
-    return templates.TemplateResponse(
-        request, 'index.html', {'repo_id': app_state['root'], **_get_nav_context(), 'current_page': 'episodes'}
-    )
+    return templates.TemplateResponse(request, 'index.html', {**_page_context(), 'current_page': 'episodes'})
 
 
 @app.get('/episodes', response_class=HTMLResponse)
 async def episodes_view(request: Request):
     """Episodes list view (used when home_page is set to a group)."""
-    return templates.TemplateResponse(
-        request, 'index.html', {'repo_id': app_state['root'], **_get_nav_context(), 'current_page': 'episodes'}
-    )
+    return templates.TemplateResponse(request, 'index.html', {**_page_context(), 'current_page': 'episodes'})
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -204,10 +241,12 @@ async def episode_viewer(request: Request, episode_id: int):
     size_mb_display = f'{size_mb:.2f}' if isinstance(size_mb, int | float) else None
 
     def _make_serializable(obj, path=''):
-        if isinstance(obj, bytes):
-            return {'__download__': f'/api/episode/{episode_id}/static/{path}', 'size': len(obj), 'type': 'bytes'}
-        if isinstance(obj, str) and len(obj) > 1024:
-            return {'__download__': f'/api/episode/{episode_id}/static/{path}', 'size': len(obj), 'type': 'text'}
+        if isinstance(obj, bytes) or (isinstance(obj, str) and len(obj) > 1024):
+            return {
+                '__download__': _cacheable_api_path(f'episode/{episode_id}/static/{path}'),
+                'size': len(obj),
+                'type': 'bytes' if isinstance(obj, bytes) else 'text',
+            }
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, dict):
@@ -224,10 +263,11 @@ async def episode_viewer(request: Request, episode_id: int):
             'num_episodes': len(ds),
             'rerun_version': rr.__version__,
             'task': episode.static.get(keys.TASK, None),
-            'repo_id': app_state['root'],
+            'rrd_path': _cacheable_api_path(f'episode_rrd/{episode_id}'),
             'episode_path': meta.get('path'),
             'episode_size_mb': size_mb_display,
             'static_data': _make_serializable(episode.static),
+            **_page_context(),
         },
     )
 
@@ -235,8 +275,8 @@ async def episode_viewer(request: Request, episode_id: int):
 @app.get('/api/dataset_info')
 @require_dataset
 async def api_dataset_info():
-    ds = app_state.get('dataset')
-    return {'root': app_state['root'], 'num_episodes': len(ds)}
+    ds = cast(Dataset, app_state['dataset'])
+    return {'root': _shown_root(), 'num_episodes': len(ds)}
 
 
 @dataclass
@@ -434,14 +474,7 @@ async def api_groups(request: Request, suffix: str):  # noqa: C901
 @app.get('/groups/{suffix}', response_class=HTMLResponse)
 async def grouped_view(request: Request, suffix: str):
     return templates.TemplateResponse(
-        request,
-        'grouped.html',
-        {
-            'repo_id': app_state['root'],
-            'api_endpoint': f'/api/groups/{suffix}',
-            **_get_nav_context(),
-            'current_page': suffix,
-        },
+        request, 'grouped.html', {'api_endpoint': f'api/groups/{suffix}', **_page_context(), 'current_page': suffix}
     )
 
 
@@ -450,7 +483,7 @@ async def api_dataset_status():
     return {
         'loading': app_state['loading_state'],
         'loaded': app_state.get('dataset', None) is not None,
-        'repo_id': app_state['root'],
+        'repo_id': _shown_root(),
     }
 
 
@@ -660,6 +693,11 @@ def main(
     reset_cache: bool = False,
     group_tables: dict[str, GroupTableConfig] | None = None,
     home_page: str | None = None,
+    base_href: str = '/',
+    title: str = '',
+    show_paths: bool = True,
+    static_export: bool = False,
+    build_id: str = '',
 ):
     """Visualize a Dataset with Rerun.
 
@@ -707,6 +745,11 @@ def main(
                 },
             }
         group_tables: Mapping of group name to GroupTableConfig
+        base_href: Path every page link and API call resolves against
+        title: Header text; the dataset root when empty
+        show_paths: Whether the pages report where the dataset lives
+        static_export: Whether the pages ask for the file names a static export writes
+        build_id: Names one build; the episode RRD and the static-field downloads sit under it
     """
     root = get_dataset_root(dataset) or 'unknown_dataset'
     deb_level = logging.DEBUG if debug else logging.INFO
@@ -722,6 +765,11 @@ def main(
     app_state['max_resolution'] = max_resolution
     app_state['max_hz'] = max_hz
     app_state['home_page'] = home_page
+    app_state['base_href'] = base_href
+    app_state['title'] = title
+    app_state['show_paths'] = show_paths
+    app_state['static_export'] = static_export
+    app_state['build_id'] = build_id
 
     if reset_cache and cache_root.exists():
         logging.info(f'Clearing RRD cache directory: {cache_root.resolve()}')

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import threading
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -238,16 +238,20 @@ def install_dataset(dataset: Dataset) -> None:
     app_state['loading_state'] = False
 
 
+_APP_STATE_HELD = threading.Lock()
+
+
 @contextmanager
 def app_state_restored() -> Iterator[None]:
-    """Give the app its state back on exit, for a caller that composes the app in its own process."""
-    saved = dict(app_state)
-    try:
-        yield
-    finally:
-        app_state.clear()
-        app_state.update(saved)
-        _api_cache.clear()
+    """Hold the app's state for the block and give it back on exit; a second holder waits."""
+    with _APP_STATE_HELD:
+        saved = dict(app_state)
+        try:
+            yield
+        finally:
+            app_state.clear()
+            app_state.update(saved)
+            _api_cache.clear()
 
 
 def is_download(value: object) -> bool:
@@ -427,6 +431,11 @@ def parse_table_cfg(table_cfg: TableConfig) -> tuple:
     return columns, formatters, defaults
 
 
+def filter_spelling(value: object) -> str | None:
+    """The string a page offers a static value as and sends back in a query; None for an absent value."""
+    return None if value is None else str(value)
+
+
 @app.get('/api/episodes')
 @require_dataset
 async def api_episodes(request: Request):
@@ -440,7 +449,7 @@ async def api_episodes(request: Request):
     filters = {k: v for k, v in request.query_params.items() if v}
 
     def matches(ep: Episode) -> bool:
-        return filters is None or all(str(ep.static.get(k)) == v for k, v in filters.items())
+        return all(filter_spelling(ep.static.get(k)) == v for k, v in filters.items())
 
     ep_it = (
         {'__episode_index__': i, '__meta__': ep.meta, '__duration__': ep.duration_ns / 1e9, **ep.static}
@@ -457,9 +466,26 @@ def _group_id(episode: Episode, group_keys: tuple[str, ...]) -> tuple[Any, ...]:
     return tuple(episode.static.get(k) for k in group_keys)
 
 
+def _grouped(
+    ds: Dataset, group_keys: tuple[str, ...], filter_keys: Iterable[str], active_filters: dict[str, str]
+) -> tuple[dict[str, set[str]], dict[tuple[Any, ...], list[Episode]]]:
+    """The values each filter offers, and the episodes that match `active_filters`, by group id."""
+    offered: dict[str, set[str]] = {key: set() for key in filter_keys}
+    groups: dict[tuple[Any, ...], list[Episode]] = defaultdict(list)
+    for episode in ds:
+        # Every value is offered, whichever filters are active
+        for filter_key in offered:
+            spelling = filter_spelling(episode.static.get(filter_key))
+            if spelling is not None:
+                offered[filter_key].add(spelling)
+        if all(filter_spelling(episode.static.get(key)) == value for key, value in active_filters.items()):
+            groups[_group_id(episode, group_keys)].append(episode)
+    return offered, groups
+
+
 @app.get('/api/groups/{suffix}')
 @require_dataset
-async def api_groups(request: Request, suffix: str):  # noqa: C901
+async def api_groups(request: Request, suffix: str):
     cache_key = ('groups', suffix, tuple(sorted(request.query_params.items())))
     if cache_key in _api_cache:
         return _api_cache[cache_key]
@@ -488,17 +514,11 @@ async def api_groups(request: Request, suffix: str):  # noqa: C901
         if filter_value:
             active_filters[filter_key] = filter_value
 
-    groups = defaultdict(list)
-    group_filters = {key: {'label': label or key, FILTER_VALUES: set()} for key, label in cfg.group_filter_keys.items()}
-    for episode in ds:
-        # Always collect all filter values regardless of active filters
-        for filter_key in cfg.group_filter_keys:
-            group_filters[filter_key][FILTER_VALUES].add(episode.static.get(filter_key))
-        # Apply filters for grouping
-        # A query carries a string, and the page offers the value as one.
-        match = all(str(episode.static.get(key)) == value for key, value in active_filters.items())
-        if match:
-            groups[_group_id(episode, group_keys)].append(episode)
+    offered, groups = _grouped(cast(Dataset, ds), group_keys, cfg.group_filter_keys, active_filters)
+    group_filters = {
+        key: {'label': label or key, FILTER_VALUES: sorted(offered[key])}
+        for key, label in cfg.group_filter_keys.items()
+    }
 
     rows = []
     for group_id, episodes in groups.items():
@@ -557,6 +577,14 @@ def _static_field(static: dict, field_path: str) -> object:
     return value
 
 
+def _content_disposition(disposition: str, filename: str) -> str:
+    """The `Content-Disposition` value naming a download `filename`; a name outside plain ASCII is percent-encoded."""
+    encoded = quote(filename)
+    if encoded == filename:
+        return f'{disposition}; filename="{filename}"'
+    return f"{disposition}; filename*=utf-8''{encoded}"
+
+
 @app.get('/api/episode/{episode_id}/static/{field_path:path}')
 @require_dataset
 async def api_episode_static_field(episode_id: int, field_path: str):
@@ -572,13 +600,13 @@ async def api_episode_static_field(episode_id: int, field_path: str):
         return Response(
             content=value,
             media_type='application/octet-stream',
-            headers={'Content-Disposition': f'attachment; filename={filename}'},
+            headers={'Content-Disposition': _content_disposition('attachment', filename)},
         )
     if isinstance(value, str):
         return Response(
             content=value.encode(),
             media_type='text/plain; charset=utf-8',
-            headers={'Content-Disposition': f'inline; filename={filename}.txt'},
+            headers={'Content-Disposition': _content_disposition('inline', f'{filename}.txt')},
         )
     raise HTTPException(status_code=400, detail=f'Field {field_path} is not downloadable')
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -48,6 +48,17 @@ from positronic.server.dataset_utils import (
 # Response cache for api_groups and api_episodes (dataset is immutable once loaded)
 _api_cache: dict[tuple, dict] = {}
 
+
+@dataclass(frozen=True)
+class PageConfig:
+    """The settings every page is rendered with; `configure_pages` fills them."""
+
+    base_href: str = '/'
+    title: str = ''  # empty = the dataset root
+    show_paths: bool = True
+    static_export: bool = False
+
+
 # Global app state
 app_state: dict[str, object] = {
     'dataset': None,
@@ -59,10 +70,7 @@ app_state: dict[str, object] = {
     'max_hz': DEFAULT_MAX_HZ,
     'group_tables_cfg': {},
     'home_page': None,  # None = episodes, or group name like 'tasks'
-    'base_href': '/',
-    'title': '',  # empty = the dataset root
-    'show_paths': True,
-    'static_export': False,
+    'pages': PageConfig(),
 }
 
 
@@ -140,9 +148,13 @@ GROUP_FILTERS = 'group_filters'
 FILTER_VALUES = 'values'
 
 
+def _page_config() -> PageConfig:
+    return cast(PageConfig, app_state['pages'])
+
+
 def _shown_root() -> str:
     """The dataset root the pages report; empty when the viewer hides paths."""
-    return str(app_state['root']) if app_state['show_paths'] else ''
+    return str(app_state['root']) if _page_config().show_paths else ''
 
 
 def _route(endpoint: Callable, **params: str) -> str:
@@ -208,14 +220,15 @@ def _page_context() -> dict[str, Any]:
         # Episodes is home, insert at beginning
         nav_items.insert(0, {'name': 'episodes', 'url': '.', 'label': 'Episodes'})
 
+    pages = _page_config()
     return {
         'nav_items': nav_items,
         'home_page': home_page,
         'episodes_url': episodes_url,
-        'base_href': normalized_base_href(str(app_state['base_href'])),
-        'title': str(app_state['title']) if app_state['title'] else _shown_root(),
-        'show_paths': app_state['show_paths'],
-        'static_export': app_state['static_export'],
+        'base_href': pages.base_href,
+        'title': pages.title or _shown_root(),
+        'show_paths': pages.show_paths,
+        'static_export': pages.static_export,
     }
 
 
@@ -260,10 +273,9 @@ def configure_pages(
     *, base_href: str = '/', title: str = '', show_paths: bool = True, static_export: bool = False
 ) -> None:
     """Set where the pages are served and what they show; see `main` for what each value does."""
-    app_state['base_href'] = normalized_base_href(base_href)
-    app_state['title'] = title
-    app_state['show_paths'] = show_paths
-    app_state['static_export'] = static_export
+    app_state['pages'] = PageConfig(
+        base_href=normalized_base_href(base_href), title=title, show_paths=show_paths, static_export=static_export
+    )
 
 
 def install_dataset(dataset: Dataset) -> None:

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -254,6 +254,10 @@ def app_state_restored() -> Iterator[None]:
             _api_cache.clear()
 
 
+# The field of a static value's sidebar entry that holds its download link, as `app.js` reads it.
+DOWNLOAD_LINK = '__download__'
+
+
 def is_download(value: object) -> bool:
     """Whether a static value reaches a page as a download link rather than inline."""
     return isinstance(value, bytes) or (isinstance(value, str) and len(value) > 1024)
@@ -288,7 +292,7 @@ async def episode_viewer(request: Request, episode_id: int):
     def _make_serializable(obj, path=''):
         if is_download(obj):
             return {
-                '__download__': f'api/episode/{episode_id}/static/{path}',
+                DOWNLOAD_LINK: f'api/episode/{episode_id}/static/{path}',
                 'size': len(obj),
                 'type': 'bytes' if isinstance(obj, bytes) else 'text',
             }

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -272,7 +272,12 @@ def normalized_base_href(value: str) -> str:
 def configure_pages(
     *, base_href: str = '/', title: str = '', show_paths: bool = True, static_export: bool = False
 ) -> None:
-    """Set where the pages are served and what they show; see `main` for what each value does."""
+    """Set where the pages are served and what they show.
+
+    `base_href` is the path at the server root every page link and API call resolves against. `title` is
+    the header text, the dataset root when empty. `show_paths` says whether a page reports where the
+    dataset lives. `static_export` makes the pages read the files a static export writes.
+    """
     app_state['pages'] = PageConfig(
         base_href=normalized_base_href(base_href), title=title, show_paths=show_paths, static_export=static_export
     )
@@ -310,16 +315,31 @@ def is_download(value: object) -> bool:
     return isinstance(value, bytes) or (isinstance(value, str) and len(value) > 1024)
 
 
-def download_paths(value: object, path: str = '') -> Iterator[str]:
-    """The field path of every static value an episode page links as a download; a list item by its index."""
+def _downloads(value: object, path: str) -> Iterator[tuple[str, object]]:
     if is_download(value):
-        yield path
+        yield path, value
     elif isinstance(value, dict):
         for key, item in value.items():
-            yield from download_paths(item, f'{path}.{key}' if path else key)
+            yield from _downloads(item, f'{path}.{key}' if path else key)
     elif isinstance(value, list):
         for index, item in enumerate(value):
-            yield from download_paths(item, f'{path}.{index}' if path else str(index))
+            yield from _downloads(item, f'{path}.{index}' if path else str(index))
+
+
+def download_paths(static: dict) -> Iterator[str]:
+    """The field path of every static value an episode page links as a download; a list item by its index.
+
+    A path the download route does not lead back to its value is refused: an empty key, or a nested
+    value whose path a dotted top-level key also spells.
+    """
+    for path, value in _downloads(static, ''):
+        try:
+            found = _static_field(static, path)
+        except HTTPException:
+            found = None
+        if found is not value:
+            raise ValueError(f'a static value named {path!r} has no link the download route reads back')
+        yield path
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -336,13 +356,11 @@ async def episode_viewer(request: Request, episode_id: int):
     size_mb = meta.get('size_mb')
     size_mb_display = f'{size_mb:.2f}' if isinstance(size_mb, int | float) else None
 
+    links = {path: download_link(episode_id, path) for path in download_paths(episode.static)}
+
     def _make_serializable(obj, path=''):
         if is_download(obj):
-            return {
-                DOWNLOAD_LINK: download_link(episode_id, path),
-                'size': len(obj),
-                'type': 'bytes' if isinstance(obj, bytes) else 'text',
-            }
+            return {DOWNLOAD_LINK: links[path], 'size': len(obj), 'type': 'bytes' if isinstance(obj, bytes) else 'text'}
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, dict):
@@ -662,36 +680,48 @@ async def api_episode_static_field(episode_id: int, field_path: str):
     raise HTTPException(status_code=400, detail=f'Field {field_path} is not downloadable')
 
 
-@app.get('/api/episode_rrd/{episode_id}')
-@require_dataset
-async def api_episode_rrd(episode_id: int):
+def _recording_cache_path(episode_id: int) -> Path:
+    return _get_rrd_cache_path(episode_id, cast(float, app_state['max_hz']), cast(int, app_state['max_resolution']))
+
+
+def _recording_chunks_cached(episode_id: int, cache_path: Path) -> Iterator[bytes]:
+    """The recording's chunks as they are built, written to `cache_path`; the path names a complete file only."""
     ds = cast(Dataset, app_state['dataset'])
     max_hz = cast(float, app_state['max_hz'])
     max_resolution = cast(int, app_state['max_resolution'])
-    cache_path = _get_rrd_cache_path(episode_id, max_hz, max_resolution)
+    fd, name = tempfile.mkstemp(dir=cache_path.parent, prefix=f'{cache_path.name}.', suffix='.partial')
+    partial = Path(name)
+    published = False
+    try:
+        with os.fdopen(fd, 'wb') as cache_file:
+            for chunk in stream_episode_rrd(ds, episode_id, max_hz=max_hz, max_resolution=max_resolution):
+                cache_file.write(chunk)
+                yield chunk
+        os.replace(partial, cache_path)
+        published = True
+    finally:
+        if not published:
+            partial.unlink(missing_ok=True)
 
+
+def episode_rrd_path(episode_id: int) -> Path:
+    """The file the recording route serves for `episode_id`, built when the cache holds none."""
+    cache_path = _recording_cache_path(episode_id)
+    if not cache_path.exists():
+        for _ in _recording_chunks_cached(episode_id, cache_path):
+            pass
+    return cache_path
+
+
+@app.get('/api/episode_rrd/{episode_id}')
+@require_dataset
+async def api_episode_rrd(episode_id: int):
+    cache_path = _recording_cache_path(episode_id)
     if cache_path.exists():
         logging.debug(f'Serving cached RRD for episode {episode_id} from {cache_path}')
         return FileResponse(cache_path, media_type='application/octet-stream', filename=f'episode_{episode_id}.rrd')
-
-    def _stream_and_cache():
-        # The final cache path denotes a complete file.
-        fd, name = tempfile.mkstemp(dir=cache_path.parent, prefix=f'{cache_path.name}.', suffix='.partial')
-        partial = Path(name)
-        published = False
-        try:
-            with os.fdopen(fd, 'wb') as cache_file:
-                for chunk in stream_episode_rrd(ds, episode_id, max_hz=max_hz, max_resolution=max_resolution):
-                    cache_file.write(chunk)
-                    yield chunk
-            os.replace(partial, cache_path)
-            published = True
-        finally:
-            if not published:
-                partial.unlink(missing_ok=True)
-
     return StreamingResponse(
-        _stream_and_cache(),
+        _recording_chunks_cached(episode_id, cache_path),
         media_type='application/octet-stream',
         headers={'Content-Disposition': f'attachment; filename=episode_{episode_id}.rrd'},
     )
@@ -815,9 +845,13 @@ def configure_tables(
     max_resolution: int,
     max_hz: float,
 ) -> None:
-    """Set what the tables show and how a recording is built; see `main` for what each value does.
+    """Set what the tables show and how a recording is built.
 
-    A table response cached under the previous settings is dropped.
+    `ep_table_cfg` maps an episode's static keys to the columns of the episode table. `group_tables` holds
+    each grouped table by name, and `home_page` names the one served at the root, or None for the episodes.
+    A recording's videos are re-encoded down to `max_resolution` on the long side, and its numeric signals
+    are thinned to `max_hz`; 0 keeps every sample. `root` is the dataset path the pages report, and the
+    recordings are cached under `cache_dir`. A table response cached under the previous settings is dropped.
     """
     for name in group_tables or {}:
         if not name or name in ('.', '..') or quote(name, safe='') != name:

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -51,7 +51,7 @@ _api_cache: dict[tuple, dict] = {}
 
 @dataclass(frozen=True)
 class PageConfig:
-    """The settings every page is rendered with; `configure_pages` fills them."""
+    """The settings every page is rendered with."""
 
     base_href: str = '/'
     title: str = ''  # empty = the dataset root

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -221,9 +221,15 @@ async def episodes_view(request: Request):
 
 
 def _cacheable_api_path(suffix: str) -> str:
-    """`api/<suffix>` under the build id, so a rebuild never reads a file a browser cached."""
+    """`api/<suffix>`, under the build id when the pages read a static export.
+
+    A build id keeps one build's files clear of the ones a browser cached from the build before
+    it. Only an export writes such a file: a live server serves no `build/…` route.
+    """
     build_id = str(app_state['build_id'])
-    return f'build/{build_id}/api/{suffix}' if build_id else f'api/{suffix}'
+    if app_state['static_export'] and build_id:
+        return f'build/{build_id}/api/{suffix}'
+    return f'api/{suffix}'
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -749,7 +755,8 @@ def main(
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives
         static_export: Whether the pages ask for the file names a static export writes
-        build_id: Names one build; the episode RRD and the static-field downloads sit under it
+        build_id: Names one build. With static_export, the episode RRD and the static-field
+            downloads sit under it
     """
     root = get_dataset_root(dataset) or 'unknown_dataset'
     deb_level = logging.DEBUG if debug else logging.INFO

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -223,8 +223,7 @@ async def episodes_view(request: Request):
 def _cacheable_api_path(suffix: str) -> str:
     """`api/<suffix>`, under the build id when the pages read a static export.
 
-    A build id keeps one build's files clear of the ones a browser cached from the build before
-    it. Only an export writes such a file: a live server serves no `build/…` route.
+    Only an export writes such a file: a live server serves no `build/…` route.
     """
     build_id = str(app_state['build_id'])
     if app_state['static_export'] and build_id:

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -140,12 +140,14 @@ _QUERY_SAFE = "!*'()"
 
 
 def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str:
-    """The file name a static export writes an API response to, and a browser asks for.
+    """The file name a static export writes an API response to.
 
-    `<path>.json` names an endpoint the export writes whole, and None asks for that form.
-    `<path>/<query>.json` names one the export writes a file per filter set for: the query holds
-    the parameters that carry a value, sorted by key and percent-encoded, and an empty query is
-    named `all`. `app.js` builds the same name.
+    - `params` is None: `<path>.json`, for an endpoint the export writes whole.
+    - `params` is a mapping: `<path>/<query>.json`, for one it writes a file per filter set for.
+      The query holds the parameters that carry a value, sorted by key and percent-encoded, and
+      an empty query is named `all`.
+
+    `app.js` builds the same name.
     """
     if params is None:
         return f'{path}.json'

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import threading
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -174,14 +174,17 @@ def episode_rrd_link(episode_id: int) -> str:
     return _route(api_episode_rrd, episode_id=str(episode_id))
 
 
-def download_link(episode_id: int, field_path: str) -> str:
-    """The download's path; the field path is one percent-encoded segment, so a `?`, a `/` or a space stays in it.
+def download_link(episode_id: int, field_path: tuple[str, ...]) -> str:
+    """The download's path: one percent-encoded segment per key, so a `.`, `/`, `?` or space inside a key
+    stays in its segment and two static values never share a link.
 
-    A browser reads a segment of dots as a step in the path, encoded or not, so a `.` or `..` segment is refused.
+    A browser rewrites a segment that is empty or all dots, so a key that is `''`, `.` or `..` is refused.
     """
-    if any(part in ('.', '..') for part in field_path.split('/')):
-        raise ValueError(f'a static value named {field_path!r} has no link a browser keeps')
-    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=quote(field_path, safe=''))
+    for key in field_path:
+        if key in ('', '.', '..'):
+            raise ValueError(f'a static value with a key {key!r} has no link a browser keeps')
+    encoded = '/'.join(quote(key, safe='') for key in field_path)
+    return _route(api_episode_static_field, episode_id=str(episode_id), field_path=encoded)
 
 
 def group_link(name: str) -> str:
@@ -315,31 +318,28 @@ def is_download(value: object) -> bool:
     return isinstance(value, bytes) or (isinstance(value, str) and len(value) > 1024)
 
 
-def _downloads(value: object, path: str) -> Iterator[tuple[str, object]]:
+def _downloads(value: object, prefix: tuple[str, ...]) -> Iterator[tuple[tuple[str, ...], object]]:
     if is_download(value):
-        yield path, value
+        yield prefix, value
     elif isinstance(value, dict):
         for key, item in value.items():
-            yield from _downloads(item, f'{path}.{key}' if path else key)
+            yield from _downloads(item, prefix + (key,))
     elif isinstance(value, list):
         for index, item in enumerate(value):
-            yield from _downloads(item, f'{path}.{index}' if path else str(index))
+            yield from _downloads(item, prefix + (str(index),))
 
 
-def download_paths(static: dict) -> Iterator[str]:
-    """The field path of every static value an episode page links as a download; a list item by its index.
+def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
+    """The key path of every static value an episode page links as a download; a list item by its index.
 
-    A path the download route does not lead back to its value is refused: an empty key, or a nested
-    value whose path a dotted top-level key also spells.
+    Each key is one URL segment, so distinct paths never share a link. A key a browser rewrites in a path
+    — empty, `.` or `..` — is refused.
     """
-    for path, value in _downloads(static, ''):
-        try:
-            found = _static_field(static, path)
-        except HTTPException:
-            found = None
-        if found is not value:
-            raise ValueError(f'a static value named {path!r} has no link the download route reads back')
-        yield path
+    for key_path, _ in _downloads(static, ()):
+        for key in key_path:
+            if key in ('', '.', '..'):
+                raise ValueError(f'a static value with a key {key!r} has no link a browser keeps')
+        yield key_path
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
@@ -358,15 +358,16 @@ async def episode_viewer(request: Request, episode_id: int):
 
     links = {path: download_link(episode_id, path) for path in download_paths(episode.static)}
 
-    def _make_serializable(obj, path=''):
+    def _make_serializable(obj, key_path=()):
         if is_download(obj):
-            return {DOWNLOAD_LINK: links[path], 'size': len(obj), 'type': 'bytes' if isinstance(obj, bytes) else 'text'}
+            link = links[key_path]
+            return {DOWNLOAD_LINK: link, 'size': len(obj), 'type': 'bytes' if isinstance(obj, bytes) else 'text'}
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, dict):
-            return {k: _make_serializable(v, f'{path}.{k}' if path else k) for k, v in obj.items()}
+            return {k: _make_serializable(v, key_path + (k,)) for k, v in obj.items()}
         if isinstance(obj, list):
-            return [_make_serializable(v, f'{path}.{i}' if path else str(i)) for i, v in enumerate(obj)]
+            return [_make_serializable(v, key_path + (str(i),)) for i, v in enumerate(obj)]
         return obj
 
     return templates.TemplateResponse(
@@ -618,31 +619,22 @@ async def api_dataset_status():
     }
 
 
-def _static_field(static: dict, field_path: str) -> object:
-    """The value at a dotted path into `static`, or an HTTP 404.
+def _static_at(static: dict, key_path: Sequence[str]) -> object:
+    """The value each key of `key_path` names in turn into `static`, or an HTTP 404.
 
-    A dict key is matched greedily, so a key holding a dot (`link0.stl`) is found; a list is
-    walked by an index.
+    Every key is one path segment, so a key holding a dot (`link0.stl`) is one step; a list is walked by
+    an index.
     """
     value: object = static
-    remaining = field_path
-    while remaining:
+    for key in key_path:
         if isinstance(value, list):
-            index, _, rest = remaining.partition('.')
-            if not index.isdigit() or int(index) >= len(value):
-                raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
-            value, remaining = value[int(index)], rest
-            continue
-        if not isinstance(value, dict):
-            raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
-        parts = remaining.split('.')
-        for i in range(len(parts), 0, -1):
-            key = '.'.join(parts[:i])
-            if key in value:
-                value, remaining = value[key], '.'.join(parts[i:])
-                break
+            if not key.isdigit() or int(key) >= len(value):
+                raise HTTPException(status_code=404, detail=f'Field not found: {"/".join(key_path)}')
+            value = value[int(key)]
+        elif isinstance(value, dict) and key in value:
+            value = value[key]
         else:
-            raise HTTPException(status_code=404, detail=f'Field not found: {field_path}')
+            raise HTTPException(status_code=404, detail=f'Field not found: {"/".join(key_path)}')
     return value
 
 
@@ -656,15 +648,19 @@ def _content_disposition(disposition: str, filename: str) -> str:
 
 @app.get('/api/episode/{episode_id}/static/{field_path:path}')
 @require_dataset
-async def api_episode_static_field(episode_id: int, field_path: str):
+async def api_episode_static_field(episode_id: int, field_path: str, request: Request):
     ds = app_state.get('dataset')
     try:
         episode = ds[episode_id]
     except IndexError as e:
         raise HTTPException(status_code=404, detail='Episode not found') from e
 
-    value = _static_field(episode.static, field_path)
-    filename = field_path.rsplit('.', 1)[-1] if '.' in field_path else field_path
+    # The raw path keeps `%2F` apart from a `/` that separates two keys, which the decoded path loses.
+    prefix = '/' + _route(api_episode_static_field, episode_id=str(episode_id), field_path='')
+    tail = request.scope['raw_path'].decode('ascii').split('?', 1)[0].removeprefix(prefix)
+    key_path = [unquote(segment) for segment in tail.split('/')]
+    value = _static_at(episode.static, key_path)
+    filename = key_path[-1]
     if isinstance(value, bytes):
         return Response(
             content=value,
@@ -677,7 +673,7 @@ async def api_episode_static_field(episode_id: int, field_path: str):
             media_type='text/plain; charset=utf-8',
             headers={'Content-Disposition': _content_disposition('inline', f'{filename}.txt')},
         )
-    raise HTTPException(status_code=400, detail=f'Field {field_path} is not downloadable')
+    raise HTTPException(status_code=400, detail=f'Field {"/".join(key_path)} is not downloadable')
 
 
 def _recording_cache_path(episode_id: int) -> Path:
@@ -853,9 +849,17 @@ def configure_tables(
     are thinned to `max_hz`; 0 keeps every sample. `root` is the dataset path the pages report, and the
     recordings are cached under `cache_dir`. A table response cached under the previous settings is dropped.
     """
-    for name in group_tables or {}:
+    episode_columns = set(ep_table_cfg or {})
+    for name, cfg in (group_tables or {}).items():
         if not name or name in ('.', '..') or quote(name, safe='') != name:
             raise ValueError(f'a group name is one URL path segment (letters, digits, "_", "-", "."), got {name!r}')
+        group_keys = (cfg.group_keys,) if isinstance(cfg.group_keys, str) else cfg.group_keys
+        for key in (*group_keys, *cfg.group_filter_keys):
+            if key not in episode_columns:
+                raise ValueError(
+                    f'group table {name!r} sends {key!r} to a View link, and it is no column of the episode '
+                    f'table, so the flat table cannot filter on it; the episode columns are {sorted(episode_columns)}'
+                )
     if home_page and home_page not in (group_tables or {}):
         raise ValueError(f'home_page {home_page!r} names no group table; the tables are {sorted(group_tables or {})}')
     app_state['root'] = root

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -154,12 +154,6 @@ def static_export_key(path: str, params: Mapping[str, str] | None = None) -> str
     return f'{path}/{query or "all"}.json'
 
 
-def _cacheable_api_path(suffix: str) -> str:
-    """`api/<suffix>` under the build id, so a rebuild never reads a file a browser cached."""
-    build_id = str(app_state['build_id'])
-    return f'build/{build_id}/api/{suffix}' if build_id else f'api/{suffix}'
-
-
 def _shown_root() -> str:
     """The dataset root the pages report; empty when the viewer hides paths."""
     return str(app_state['root']) if app_state['show_paths'] else ''
@@ -224,6 +218,12 @@ async def index(request: Request):
 async def episodes_view(request: Request):
     """Episodes list view (used when home_page is set to a group)."""
     return templates.TemplateResponse(request, 'index.html', {**_page_context(), 'current_page': 'episodes'})
+
+
+def _cacheable_api_path(suffix: str) -> str:
+    """`api/<suffix>` under the build id, so a rebuild never reads a file a browser cached."""
+    build_id = str(app_state['build_id'])
+    return f'build/{build_id}/api/{suffix}' if build_id else f'api/{suffix}'
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -132,17 +132,21 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# Static files and templates (packaged relative to this file)
-_static_dir = _pkg_path('static')
-_templates_dir = _pkg_path('templates')
-app.mount('/static', StaticFiles(directory=_static_dir), name='static')
-templates = Jinja2Templates(directory=_templates_dir)
+# The app's own scripts, styles and viewer, served at the host root, so every export a host serves shares one copy.
+ASSET_ROUTE = 'static'
+app.mount(f'/{ASSET_ROUTE}', StaticFiles(directory=_pkg_path(ASSET_ROUTE)), name=ASSET_ROUTE)
+templates = Jinja2Templates(directory=_pkg_path('templates'))
+
+
+def asset_link(name: str) -> str:
+    """The path at the host root the asset file `name` is served at."""
+    return app.url_path_for(ASSET_ROUTE, path=name)
 
 
 @app.middleware('http')
 async def cache_rerun_assets(request: Request, call_next):
     response = await call_next(request)
-    if request.url.path.startswith('/static/rerun/'):
+    if request.url.path.startswith(asset_link('rerun/')):
         response.headers['Cache-Control'] = 'public, max-age=31536000, immutable'
     return response
 
@@ -281,6 +285,7 @@ def _page_context() -> dict[str, Any]:
     return {
         'nav_items': nav_items,
         'server_names': _server_names(),
+        'asset_link': asset_link,
         'home_page': home_page,
         'episodes_url': episodes_url,
         'base_href': pages.base_href,
@@ -474,7 +479,7 @@ async def episode_viewer(request: Request, episode_id: int):
         {
             'episode_id': episode_id,
             'num_episodes': len(ds),
-            'viewer_path': f'/static/rerun/{rr.__version__}/index.html',
+            'viewer_path': asset_link(f'rerun/{rr.__version__}/index.html'),
             'task': episode.static.get(keys.TASK, None),
             'rrd_path': episode_rrd_link(episode_id),
             'episode_path': meta.get(META_PATH),

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -155,7 +155,7 @@ async def cache_rerun_assets(request: Request, call_next):
 # holding its values.
 GROUP_FILTERS = 'group_filters'
 FILTER_VALUES = 'values'
-# A static export holds a group table as one file per filter set, and this index beside them.
+# A static export holds a group table as one file per filter set some episode satisfies, and this index beside them.
 GROUP_INDEX_FILE = 'index.json'
 # A static export holds an API response read whole at the route's path with this suffix.
 API_FILE_SUFFIX = '.json'

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -545,6 +545,8 @@ class ColumnConfig:
         default: Fallback value when the cell is None/missing.
         renderer: Optional custom renderer (badge, icon, …).
         filter: Whether to show a client-side filter dropdown for this column.
+        display: Whether to draw the column. A False column still carries its value to the page and
+            still filters, so a View link filters on it, but the page draws no header, cell or dropdown.
     """
 
     label: str
@@ -553,6 +555,7 @@ class ColumnConfig:
     default: Any = None
     renderer: RendererConfig | None = None
     filter: bool = False
+    display: bool = True
     align: str | None = None
     sortable: bool = True
 
@@ -612,6 +615,9 @@ def parse_table_cfg(table_cfg: TableConfig) -> tuple:
 
         if cfg.filter:
             column['filter'] = cfg.filter
+
+        if not cfg.display:
+            column['display'] = False
 
         if not cfg.sortable:
             column['sortable'] = False

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -134,6 +134,8 @@ app = FastAPI(lifespan=lifespan)
 
 # The app's own scripts, styles and viewer, served at the host root, so every export a host serves shares one copy.
 ASSET_ROUTE = 'static'
+# Every API route sits under this segment; a static export writes each response a page reads whole under it.
+API_ROUTE = 'api'
 app.mount(f'/{ASSET_ROUTE}', StaticFiles(directory=_pkg_path(ASSET_ROUTE)), name=ASSET_ROUTE)
 templates = Jinja2Templates(directory=_pkg_path('templates'))
 
@@ -504,7 +506,7 @@ async def episode_viewer(request: Request, episode_id: int):
     )
 
 
-@app.get('/api/dataset_info')
+@app.get(f'/{API_ROUTE}/dataset_info')
 @require_dataset
 async def api_dataset_info():
     ds = cast(Dataset, app_state['dataset'])
@@ -623,7 +625,7 @@ def filter_spelling(value: object) -> str | None:
     return None if value is None else str(value)
 
 
-@app.get('/api/episodes')
+@app.get(f'/{API_ROUTE}/episodes')
 @require_dataset
 async def api_episodes(request: Request):
     cache_key = ('episodes', tuple(sorted(request.query_params.items())))
@@ -670,7 +672,7 @@ def _grouped(
     return offered, groups
 
 
-@app.get('/api/groups/{suffix}')
+@app.get(f'/{API_ROUTE}' + '/groups/{suffix}')
 @require_dataset
 async def api_groups(request: Request, suffix: str):
     cache_key = ('groups', suffix, tuple(sorted(request.query_params.items())))
@@ -727,7 +729,7 @@ async def grouped_view(request: Request, suffix: str):
     )
 
 
-@app.get('/api/dataset_status')
+@app.get(f'/{API_ROUTE}/dataset_status')
 async def api_dataset_status():
     return {
         'loading': app_state['loading_state'],
@@ -753,7 +755,7 @@ def _content_disposition(disposition: str, filename: str) -> str:
     return f"{disposition}; filename*=utf-8''{encoded}"
 
 
-@app.get('/api/episode/{episode_id}/static/{field_path:path}')
+@app.get(f'/{API_ROUTE}' + '/episode/{episode_id}/static/{field_path:path}')
 @require_dataset
 async def api_episode_static_field(episode_id: int, field_path: str, request: Request):
     ds = app_state.get('dataset')
@@ -816,7 +818,7 @@ def episode_rrd_path(episode_id: int) -> Path:
     return cache_path
 
 
-@app.get('/api/episode_rrd/{episode_id}')
+@app.get(f'/{API_ROUTE}' + '/episode_rrd/{episode_id}')
 @require_dataset
 async def api_episode_rrd(episode_id: int):
     cache_path = _recording_cache_path(episode_id)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -326,14 +326,19 @@ def normalized_base_href(value: str) -> str:
     Only a path at the server root: a relative one, a netloc, a query or a fragment each send a
     relative link somewhere other than the prefix, and so does a path opening with two slashes, which
     a browser reads as a host. A browser resolves a dot segment and a backslash before it reads the
-    `<base>`, so a path holding one names a different prefix than it shows.
+    `<base>`, so a path holding one names a different prefix than it shows. A host decodes an encoded
+    slash or backslash once, so a segment holding one names a different prefix on the host than in the
+    browser.
     """
     parts = urlsplit(value)
     rooted = parts.path.startswith('/') and not parts.path.startswith('//')
     if parts.scheme or parts.netloc or parts.query or parts.fragment or not rooted:
         raise ValueError(f'base_href must be a path at the server root and nothing else, got {value!r}')
-    if '\\' in parts.path or any(unquote(segment) in ('.', '..') for segment in parts.path.split('/')):
-        raise ValueError(f'base_href must hold no dot segment and no backslash, got {value!r}')
+    segments = [unquote(segment) for segment in parts.path.split('/')]
+    if any(segment in ('.', '..') or '/' in segment or '\\' in segment for segment in segments):
+        raise ValueError(
+            f'base_href must hold no dot segment and no slash or backslash inside a segment, got {value!r}'
+        )
     return parts.path if parts.path.endswith('/') else parts.path + '/'
 
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from enum import StrEnum
 from functools import wraps
 from pathlib import Path
 from typing import Any, cast
@@ -371,16 +372,23 @@ def download_at(static: dict, key_path: tuple[str, ...]) -> bytes | str | None:
     return cast(bytes | str, value) if is_download(value) else None
 
 
+class DownloadKind(StrEnum):
+    """What a download is, as the page tells them apart."""
+
+    BYTES = 'bytes'
+    TEXT = 'text'
+
+
 @dataclass(frozen=True)
 class DownloadMetadata:
-    """What a page says about a download beside its link: `bytes` or `text`, and its size."""
+    """What a page says about a download beside its link: its kind, and its size."""
 
-    type: str
+    type: DownloadKind
     size: int
 
 
 def download_metadata(value: bytes | str) -> DownloadMetadata:
-    return DownloadMetadata('bytes' if isinstance(value, bytes) else 'text', len(value))
+    return DownloadMetadata(DownloadKind.BYTES if isinstance(value, bytes) else DownloadKind.TEXT, len(value))
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -157,6 +157,8 @@ GROUP_FILTERS = 'group_filters'
 FILTER_VALUES = 'values'
 # A static export holds a group table as one file per filter set, and this index beside them.
 GROUP_INDEX_FILE = 'index.json'
+# A static export holds an API response read whole at the route's path with this suffix.
+API_FILE_SUFFIX = '.json'
 
 
 @dataclass(frozen=True)
@@ -243,6 +245,7 @@ def _server_names() -> dict[str, str]:
         'dataset_status': _route(api_dataset_status),
         'dataset_info': _route(api_dataset_info),
         'episodes_api': _route(api_episodes),
+        'api_file_suffix': API_FILE_SUFFIX,
         'episode_page_before': before_index,
         'episode_page_after': after_index,
         'group_index_file': GROUP_INDEX_FILE,
@@ -403,6 +406,14 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
 _MISSING = object()
 
 
+def _list_index(key: str, items: list) -> int | None:
+    """The index `key` names into `items`: ASCII digits, no more of them than the length has; None otherwise."""
+    if not (key.isascii() and key.isdigit() and len(key) <= len(str(len(items)))):
+        return None
+    index = int(key)
+    return index if index < len(items) else None
+
+
 def _value_at(static: dict, key_path: Sequence[str]) -> object:
     """The value each key of `key_path` names in turn into `static`, or `_MISSING`.
 
@@ -412,9 +423,10 @@ def _value_at(static: dict, key_path: Sequence[str]) -> object:
     value: object = static
     for key in key_path:
         if isinstance(value, list):
-            if not key.isdigit() or int(key) >= len(value):
+            index = _list_index(key, value)
+            if index is None:
                 return _MISSING
-            value = value[int(key)]
+            value = value[index]
         elif isinstance(value, dict) and key in value:
             value = value[key]
         else:
@@ -451,10 +463,10 @@ def download_metadata(value: bytes | str) -> DownloadMetadata:
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)
 @require_dataset
 async def episode_viewer(request: Request, episode_id: int):
-    ds = app_state.get('dataset')
+    ds = cast(Dataset, app_state.get('dataset'))
 
     try:
-        episode = ds[episode_id]
+        episode = cast(Episode, ds[episode_id])
     except IndexError as e:
         raise HTTPException(status_code=404, detail='Episode not found') from e
 
@@ -479,6 +491,8 @@ async def episode_viewer(request: Request, episode_id: int):
         {
             'episode_id': episode_id,
             'num_episodes': len(ds),
+            'prev_link': episode_link((episode_id - 1) % len(ds)),
+            'next_link': episode_link((episode_id + 1) % len(ds)),
             'viewer_path': asset_link(f'rerun/{rr.__version__}/index.html'),
             'task': episode.static.get(keys.TASK, None),
             'rrd_path': episode_rrd_link(episode_id),

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -13,7 +13,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime
 from enum import StrEnum
 from functools import wraps
@@ -150,6 +150,16 @@ async def cache_rerun_assets(request: Request, call_next):
 # holding its values.
 GROUP_FILTERS = 'group_filters'
 FILTER_VALUES = 'values'
+# A static export holds a group table as one file per filter set, and this index beside them.
+GROUP_INDEX_FILE = 'index.json'
+
+
+@dataclass(frozen=True)
+class GroupFile:
+    """One file of a group table: the filter set it was read with, and its name beside the index."""
+
+    params: dict[str, str]
+    file: str
 
 
 def _page_config() -> PageConfig:
@@ -213,13 +223,35 @@ def group_api_link(name: str) -> str:
     return _route(api_groups, suffix=name)
 
 
+def _episode_page_prefix() -> str:
+    """What every episode page's link opens with; the page adds the episode's index to it."""
+    placeholder = 'INDEX'
+    return _route(episode_viewer, episode_id=placeholder).removesuffix(placeholder)
+
+
+def _server_names() -> dict[str, str]:
+    """Every name the page reads from the server rather than spelling it again: a route, a file, a field."""
+    params, file = (field.name for field in fields(GroupFile))
+    return {
+        'dataset_status': _route(api_dataset_status),
+        'dataset_info': _route(api_dataset_info),
+        'episodes_api': _route(api_episodes),
+        'episode_page_prefix': _episode_page_prefix(),
+        'group_index_file': GROUP_INDEX_FILE,
+        'entry_params': params,
+        'entry_file': file,
+        'group_filters': GROUP_FILTERS,
+        'filter_values': FILTER_VALUES,
+    }
+
+
 def _page_context() -> dict[str, Any]:
     """The template context every page shares."""
     home_page = app_state.get('home_page')
     group_tables = app_state.get('group_tables_cfg', {})
 
     nav_items = []
-    episodes_url = 'episodes' if home_page else '.'
+    episodes_url = episodes_link() if home_page else '.'
 
     # If home_page is set, it goes first
     if home_page and home_page in group_tables:
@@ -244,6 +276,7 @@ def _page_context() -> dict[str, Any]:
     pages = _page_config()
     return {
         'nav_items': nav_items,
+        'server_names': _server_names(),
         'home_page': home_page,
         'episodes_url': episodes_url,
         'base_href': pages.base_href,

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -795,11 +795,10 @@ def _recording_cache_path(episode_id: int) -> Path:
     return _get_rrd_cache_path(episode_id, cast(float, app_state['max_hz']), cast(int, app_state['max_resolution']))
 
 
-def _recording_chunks_cached(episode_id: int, cache_path: Path) -> Iterator[bytes]:
+def _recording_chunks_cached(
+    ds: Dataset, episode_id: int, cache_path: Path, *, max_hz: float, max_resolution: int
+) -> Iterator[bytes]:
     """The recording's chunks as they are built, written to `cache_path`; the path names a complete file only."""
-    ds = cast(Dataset, app_state['dataset'])
-    max_hz = cast(float, app_state['max_hz'])
-    max_resolution = cast(int, app_state['max_resolution'])
     fd, name = tempfile.mkstemp(dir=cache_path.parent, prefix=f'{cache_path.name}.', suffix='.partial')
     partial = Path(name)
     published = False
@@ -815,11 +814,20 @@ def _recording_chunks_cached(episode_id: int, cache_path: Path) -> Iterator[byte
             partial.unlink(missing_ok=True)
 
 
-def episode_rrd_path(episode_id: int) -> Path:
-    """The complete cached recording of `episode_id`, built when the cache holds none."""
+def _recording_settings() -> tuple[Dataset, float, int]:
+    return (
+        cast(Dataset, app_state['dataset']),
+        cast(float, app_state['max_hz']),
+        cast(int, app_state['max_resolution']),
+    )
+
+
+def ensure_episode_rrd(episode_id: int) -> Path:
+    """Build the recording of `episode_id` into the cache when the cache holds none, and answer its path."""
     cache_path = _recording_cache_path(episode_id)
     if not cache_path.exists():
-        for _ in _recording_chunks_cached(episode_id, cache_path):
+        ds, max_hz, max_resolution = _recording_settings()
+        for _ in _recording_chunks_cached(ds, episode_id, cache_path, max_hz=max_hz, max_resolution=max_resolution):
             pass
     return cache_path
 
@@ -831,8 +839,9 @@ async def api_episode_rrd(episode_id: int):
     if cache_path.exists():
         logging.debug(f'Serving cached RRD for episode {episode_id} from {cache_path}')
         return FileResponse(cache_path, media_type='application/octet-stream', filename=f'episode_{episode_id}.rrd')
+    ds, max_hz, max_resolution = _recording_settings()
     return StreamingResponse(
-        _recording_chunks_cached(episode_id, cache_path),
+        _recording_chunks_cached(ds, episode_id, cache_path, max_hz=max_hz, max_resolution=max_resolution),
         media_type='application/octet-stream',
         headers={'Content-Disposition': f'attachment; filename=episode_{episode_id}.rrd'},
     )

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -28,6 +28,7 @@ import rerun as rr
 import uvicorn
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
@@ -223,20 +224,23 @@ def group_api_link(name: str) -> str:
     return _route(api_groups, suffix=name)
 
 
-def _episode_page_prefix() -> str:
-    """What every episode page's link opens with; the page adds the episode's index to it."""
-    placeholder = 'INDEX'
-    return _route(episode_viewer, episode_id=placeholder).removesuffix(placeholder)
+def _episode_page_affixes() -> tuple[str, str]:
+    """What an episode page's link carries before and after the episode's index, read off the route's path."""
+    route = next(r for r in app.routes if isinstance(r, APIRoute) and r.name == episode_viewer.__name__)
+    before, _, rest = route.path.removeprefix('/').partition('{')
+    return before, rest.partition('}')[2]
 
 
 def _server_names() -> dict[str, str]:
     """Every name the page reads from the server rather than spelling it again: a route, a file, a field."""
     params, file = (field.name for field in fields(GroupFile))
+    before_index, after_index = _episode_page_affixes()
     return {
         'dataset_status': _route(api_dataset_status),
         'dataset_info': _route(api_dataset_info),
         'episodes_api': _route(api_episodes),
-        'episode_page_prefix': _episode_page_prefix(),
+        'episode_page_before': before_index,
+        'episode_page_after': after_index,
         'group_index_file': GROUP_INDEX_FILE,
         'entry_params': params,
         'entry_file': file,

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -409,11 +409,11 @@ _MISSING = object()
 
 
 def _list_index(key: str, items: list) -> int | None:
-    """The index `key` names into `items`: ASCII digits, no more of them than the length has; None otherwise."""
+    """The index `key` names into `items`, spelled as `str` spells it and within the length; None otherwise."""
     if not (key.isascii() and key.isdigit() and len(key) <= len(str(len(items)))):
         return None
     index = int(key)
-    return index if index < len(items) else None
+    return index if key == str(index) and index < len(items) else None
 
 
 def _value_at(static: dict, key_path: Sequence[str]) -> object:

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -452,14 +452,16 @@ class DownloadKind(StrEnum):
 
 @dataclass(frozen=True)
 class DownloadMetadata:
-    """What a page says about a download beside its link: its kind, and its size."""
+    """What a page says about a download beside its link: its kind, and its size in bytes."""
 
     type: DownloadKind
     size: int
 
 
 def download_metadata(value: bytes | str) -> DownloadMetadata:
-    return DownloadMetadata(DownloadKind.BYTES if isinstance(value, bytes) else DownloadKind.TEXT, len(value))
+    if isinstance(value, bytes):
+        return DownloadMetadata(DownloadKind.BYTES, len(value))
+    return DownloadMetadata(DownloadKind.TEXT, len(value.encode()))
 
 
 @app.get('/episode/{episode_id}', response_class=HTMLResponse)

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -389,13 +389,13 @@ def _downloads(value: object, prefix: tuple[str, ...]) -> Iterator[tuple[tuple[s
     elif isinstance(value, dict):
         for key, item in value.items():
             yield from _downloads(item, prefix + (key,))
-    elif isinstance(value, list):
+    elif isinstance(value, list | tuple):
         for index, item in enumerate(value):
             yield from _downloads(item, prefix + (str(index),))
 
 
 def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
-    """The key path of every static value an episode page links as a download; a list item by its index.
+    """The key path of every static value an episode page links as a download; a list or tuple item by its index.
 
     Each key is one URL segment, so distinct paths never share a link. A key that makes no segment —
     empty, `.`, `..`, or past a file name's limit once encoded — is refused.
@@ -408,7 +408,7 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
 _MISSING = object()
 
 
-def _list_index(key: str, items: list) -> int | None:
+def _list_index(key: str, items: Sequence[object]) -> int | None:
     """The index `key` names into `items`, spelled as `str` spells it and within the length; None otherwise."""
     if not (key.isascii() and key.isdigit() and len(key) <= len(str(len(items)))):
         return None
@@ -419,12 +419,12 @@ def _list_index(key: str, items: list) -> int | None:
 def _value_at(static: dict, key_path: Sequence[str]) -> object:
     """The value each key of `key_path` names in turn into `static`, or `_MISSING`.
 
-    Every key is one path segment, so a key holding a dot (`link0.stl`) is one step; a list is walked by
-    an index.
+    Every key is one path segment, so a key holding a dot (`link0.stl`) is one step; a list or a tuple is
+    walked by an index.
     """
     value: object = static
     for key in key_path:
-        if isinstance(value, list):
+        if isinstance(value, list | tuple):
             index = _list_index(key, value)
             if index is None:
                 return _MISSING
@@ -437,8 +437,8 @@ def _value_at(static: dict, key_path: Sequence[str]) -> object:
 
 
 def download_at(static: dict, key_path: tuple[str, ...]) -> bytes | str | None:
-    """The value a page links as a download at `key_path` into `static`, a list item by its index; None where
-    `static` holds no download there."""
+    """The value a page links as a download at `key_path` into `static`, a list or tuple item by its index; None
+    where `static` holds no download there."""
     value = _value_at(static, key_path)
     return cast(bytes | str, value) if is_download(value) else None
 
@@ -483,7 +483,7 @@ async def episode_viewer(request: Request, episode_id: int):
             return obj.isoformat()
         if isinstance(obj, dict):
             return {k: _make_serializable(v, key_path + (k,)) for k, v in obj.items()}
-        if isinstance(obj, list):
+        if isinstance(obj, list | tuple):
             return [_make_serializable(v, key_path + (str(i),)) for i, v in enumerate(obj)]
         return obj
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -358,17 +358,32 @@ def download_paths(static: dict) -> Iterator[tuple[str, ...]]:
         yield key_path
 
 
+_MISSING = object()
+
+
+def _value_at(static: dict, key_path: Sequence[str]) -> object:
+    """The value each key of `key_path` names in turn into `static`, or `_MISSING`.
+
+    Every key is one path segment, so a key holding a dot (`link0.stl`) is one step; a list is walked by
+    an index.
+    """
+    value: object = static
+    for key in key_path:
+        if isinstance(value, list):
+            if not key.isdigit() or int(key) >= len(value):
+                return _MISSING
+            value = value[int(key)]
+        elif isinstance(value, dict) and key in value:
+            value = value[key]
+        else:
+            return _MISSING
+    return value
+
+
 def download_at(static: dict, key_path: tuple[str, ...]) -> bytes | str | None:
     """The value a page links as a download at `key_path` into `static`, a list item by its index; None where
     `static` holds no download there."""
-    value: object = static
-    for key in key_path:
-        if isinstance(value, dict) and key in value:
-            value = value[key]
-        elif isinstance(value, list) and key.isdigit() and str(int(key)) == key and int(key) < len(value):
-            value = value[int(key)]
-        else:
-            return None
+    value = _value_at(static, key_path)
     return cast(bytes | str, value) if is_download(value) else None
 
 
@@ -405,12 +420,9 @@ async def episode_viewer(request: Request, episode_id: int):
     size_mb = meta.get('size_mb')
     size_mb_display = f'{size_mb:.2f}' if isinstance(size_mb, int | float) else None
 
-    links = {path: download_link(episode_id, path) for path in download_paths(episode.static)}
-
     def _make_serializable(obj, key_path=()):
         if is_download(obj):
-            link = links[key_path]
-            return {DOWNLOAD_LINK: link, **asdict(download_metadata(obj))}
+            return {DOWNLOAD_LINK: download_link(episode_id, key_path), **asdict(download_metadata(obj))}
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, dict):
@@ -669,21 +681,10 @@ async def api_dataset_status():
 
 
 def _static_at(static: dict, key_path: Sequence[str]) -> object:
-    """The value each key of `key_path` names in turn into `static`, or an HTTP 404.
-
-    Every key is one path segment, so a key holding a dot (`link0.stl`) is one step; a list is walked by
-    an index.
-    """
-    value: object = static
-    for key in key_path:
-        if isinstance(value, list):
-            if not key.isdigit() or int(key) >= len(value):
-                raise HTTPException(status_code=404, detail=f'Field not found: {"/".join(key_path)}')
-            value = value[int(key)]
-        elif isinstance(value, dict) and key in value:
-            value = value[key]
-        else:
-            raise HTTPException(status_code=404, detail=f'Field not found: {"/".join(key_path)}')
+    """The value `key_path` names into `static`, or an HTTP 404 where `static` holds none there."""
+    value = _value_at(static, key_path)
+    if value is _MISSING:
+        raise HTTPException(status_code=404, detail=f'Field not found: {"/".join(key_path)}')
     return value
 
 

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -162,6 +162,7 @@ function syncURL() {
 function readFiltersFromURL(serverFilterKeys, columns, episodes) {
   const params = new URLSearchParams(window.location.search);
   for (const [key, value] of params.entries()) {
+    if (!value) continue;  // the server reads an empty value as no filter; so does the page
     if (serverFilterKeys.has(key)) {
       state.serverFilters[key] = value;
       continue;
@@ -262,10 +263,15 @@ async function initEpisodesTable() {
 // Filtering & sorting
 // ---------------------------------------------------------------------------
 
+// A formatted cell is `[raw, formatted]`; a filter value is the raw one, as the server spells it in a query.
+function rawValue(entity) {
+  return Array.isArray(entity) ? entity[0] : entity;
+}
+
 function columnValues(episodes, index) {
   const values = new Set();
   for (const [, episodeData] of episodes) {
-    const v = episodeData[index];
+    const v = rawValue(episodeData[index]);
     if (v !== null && v !== undefined) values.add(String(v));
   }
   return Array.from(values);
@@ -285,7 +291,7 @@ function getFilteredEpisodes(columns) {
   let result = state.episodes.filter(([, episodeData]) =>
     Object.entries(filters).every(([filterKey, value]) => {
       const colIdx = columns.findIndex((c) => c.key === filterKey);
-      return String(episodeData[colIdx]) === value;
+      return String(rawValue(episodeData[colIdx])) === value;
     })
   );
 

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -94,42 +94,30 @@ function baseScopedKey(name) {
   return `${name}:${document.baseURI}`;
 }
 
-// The name an empty filter set takes, which the export writer and the browser must spell alike.
-const UNFILTERED_NAME = 'all';
+// A static export holds one file per filter set of a group table, and `index.json` beside them says
+// which file holds which set. The unfiltered flat table is one file, filtered in the browser.
+const groupIndexes = new Map();
 
-// A digest stands in for a query over the byte budget; positronic_server.py spells both numbers
-// too, as _MAX_COMPONENT_BYTES and _QUERY_DIGEST_CHARS.
-const MAX_QUERY_BYTES = 200;
-const QUERY_DIGEST_CHARS = 16;
-
-async function sha256Hex(text) {
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
-  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+async function groupIndex(path) {
+  if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/index.json`)));
+  return groupIndexes.get(path);
 }
 
-// The file name a static export writes an API response to; `static_export_key` in
-// positronic_server.py builds the same name — {b: '2', a: 'x y'} on `leaderboard` names
-// api/groups/leaderboard/a=x%20y&b=2.json.
-async function staticExportKey(path, params) {
-  if (!params) return `${path}.json`;
-  let query = Object.keys(params)
-    .filter((key) => params[key])
-    .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
-    .sort()
-    .join('&');
-  if (new TextEncoder().encode(query).length > MAX_QUERY_BYTES) {
-    query = (await sha256Hex(query)).slice(0, QUERY_DIGEST_CHARS);
-  }
-  return `${path}/${query || UNFILTERED_NAME}.json`;
+function sameFilters(a, b) {
+  const keys = Object.keys(a).sort();
+  const other = Object.keys(b).sort();
+  return keys.length === other.length && keys.every((key, i) => key === other[i] && String(a[key]) === String(b[key]));
 }
 
-// The path a browser asks for that file at; `static_export_url_path` says why the escape.
-async function staticExportUrlPath(path, params) {
-  return (await staticExportKey(path, params)).replaceAll('%', '%25');
+async function exportedGroupFile(path, params) {
+  const chosen = Object.fromEntries(Object.entries(params).filter(([, value]) => value));
+  const entry = (await groupIndex(path)).find((item) => sameFilters(item.params, chosen));
+  if (!entry) throw new Error(`the export holds no ${path} file for ${JSON.stringify(chosen)}`);
+  return appUrl(`${path}/${entry.file}`);
 }
 
 async function apiUrl(path, params) {
-  if (window.STATIC_EXPORT) return appUrl(await staticExportUrlPath(path, params));
+  if (window.STATIC_EXPORT) return params ? exportedGroupFile(path, params) : appUrl(`${path}.json`);
   const url = new URL(path, document.baseURI);
   for (const [key, value] of Object.entries(params || {})) url.searchParams.append(key, value);
   return url.href;

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -137,8 +137,6 @@ async function loadDatasetInfo() {
 }
 
 async function loadEpisodes(filters = {}) {
-  // A static export holds one file per filter set of a group table, and one file for the whole
-  // flat table, whose filters then apply in the browser.
   const perFilterSet = !window.STATIC_EXPORT || window.IS_GROUPED_TABLE;
   return fetchJSON(await apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null));
 }

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -114,8 +114,8 @@ async function staticExportKey(path, params) {
   if (!params) return `${path}.json`;
   let query = Object.keys(params)
     .filter((key) => params[key])
-    .sort()
     .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    .sort()
     .join('&');
   if (new TextEncoder().encode(query).length > MAX_QUERY_BYTES) {
     query = (await sha256Hex(query)).slice(0, QUERY_DIGEST_CHARS);
@@ -123,8 +123,7 @@ async function staticExportKey(path, params) {
   return `${path}/${query || UNFILTERED_NAME}.json`;
 }
 
-// The path a browser asks for that file at. A host decodes a URL path before it looks the file
-// up, so a name that carries a percent escape is reached by escaping its own `%` again.
+// The path a browser asks for that file at; `static_export_url_path` says why the escape.
 async function staticExportUrlPath(path, params) {
   return (await staticExportKey(path, params)).replaceAll('%', '%25');
 }

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -85,6 +85,18 @@ function appUrl(path) {
   return new URL(path, document.baseURI).href;
 }
 
+const FILTERED_EPISODE_IDS = 'filteredEpisodeIds';
+const EPISODES_REFERRER_URL = 'episodesReferrerUrl';
+
+// sessionStorage is origin-scoped and one origin serves many exports, so a key names the base
+// href of the export that wrote it.
+function baseScopedKey(name) {
+  return `${name}:${document.baseURI}`;
+}
+
+// The name an empty filter set takes, which the export writer and the browser must spell alike.
+const UNFILTERED_NAME = 'all';
+
 // The file name a static export writes an API response to; `static_export_key` in
 // positronic_server.py builds the same name — {b: '2', a: 'x y'} on `leaderboard` names
 // api/groups/leaderboard/a=x%20y&b=2.json.
@@ -95,7 +107,7 @@ function staticExportKey(path, params) {
     .sort()
     .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
     .join('&');
-  return `${path}/${query || 'all'}.json`;
+  return `${path}/${query || UNFILTERED_NAME}.json`;
 }
 
 // The path a browser asks for that file at. A host decodes a URL path before it looks the file
@@ -462,11 +474,11 @@ function populateTable(columns) {
     const hasFilters = Object.keys(state.serverFilters).length > 0 ||
       filtered.length < state.episodes.length;
     if (hasFilters) {
-      sessionStorage.setItem('filteredEpisodeIds', JSON.stringify(filtered.map(([id]) => id)));
-      sessionStorage.setItem('episodesReferrerUrl', window.location.href);
+      sessionStorage.setItem(baseScopedKey(FILTERED_EPISODE_IDS), JSON.stringify(filtered.map(([id]) => id)));
+      sessionStorage.setItem(baseScopedKey(EPISODES_REFERRER_URL), window.location.href);
     } else {
-      sessionStorage.removeItem('filteredEpisodeIds');
-      sessionStorage.removeItem('episodesReferrerUrl');
+      sessionStorage.removeItem(baseScopedKey(FILTERED_EPISODE_IDS));
+      sessionStorage.removeItem(baseScopedKey(EPISODES_REFERRER_URL));
     }
   }
 }

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -103,8 +103,10 @@ const groupIndexes = new Map();
 const GROUP_INDEX_FILE = 'index.json';
 const ENTRY_PARAMS = 'params';
 const ENTRY_FILE = 'file';
-// The route the dataset's loading status is read from.
+// The routes a page reads whole: the dataset's loading status, its description, and the flat episode table.
 const DATASET_STATUS_ROUTE = 'api/dataset_status';
+const DATASET_INFO_ROUTE = 'api/dataset_info';
+const EPISODES_ROUTE = 'api/episodes';
 
 async function groupIndex(path) {
   if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/${GROUP_INDEX_FILE}`)));
@@ -137,7 +139,7 @@ async function fetchJSON(url) {
 }
 
 async function loadDatasetInfo() {
-  const data = await fetchJSON(await apiUrl('api/dataset_info'));
+  const data = await fetchJSON(await apiUrl(DATASET_INFO_ROUTE));
   if (!data) return;
   document.getElementById('dataset-stats').innerHTML =
     `<p><strong>${data.num_episodes}</strong> episodes.</p>`;
@@ -145,7 +147,7 @@ async function loadDatasetInfo() {
 
 async function loadEpisodes(filters = {}) {
   const perFilterSet = !window.STATIC_EXPORT || window.IS_GROUPED_TABLE;
-  const url = await apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null);
+  const url = await apiUrl(window.API_ENDPOINT || EPISODES_ROUTE, perFilterSet ? filters : null);
   if (!url) return { columns: state.columns, episodes: [] };
   return fetchJSON(url);
 }

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -97,27 +97,40 @@ function baseScopedKey(name) {
 // The name an empty filter set takes, which the export writer and the browser must spell alike.
 const UNFILTERED_NAME = 'all';
 
+// A digest stands in for a query over the byte budget; positronic_server.py spells both numbers
+// too, as _MAX_COMPONENT_BYTES and _QUERY_DIGEST_CHARS.
+const MAX_QUERY_BYTES = 200;
+const QUERY_DIGEST_CHARS = 16;
+
+async function sha256Hex(text) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 // The file name a static export writes an API response to; `static_export_key` in
 // positronic_server.py builds the same name — {b: '2', a: 'x y'} on `leaderboard` names
 // api/groups/leaderboard/a=x%20y&b=2.json.
-function staticExportKey(path, params) {
+async function staticExportKey(path, params) {
   if (!params) return `${path}.json`;
-  const query = Object.keys(params)
+  let query = Object.keys(params)
     .filter((key) => params[key])
     .sort()
     .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
     .join('&');
+  if (new TextEncoder().encode(query).length > MAX_QUERY_BYTES) {
+    query = (await sha256Hex(query)).slice(0, QUERY_DIGEST_CHARS);
+  }
   return `${path}/${query || UNFILTERED_NAME}.json`;
 }
 
 // The path a browser asks for that file at. A host decodes a URL path before it looks the file
 // up, so a name that carries a percent escape is reached by escaping its own `%` again.
-function staticExportUrlPath(path, params) {
-  return staticExportKey(path, params).replaceAll('%', '%25');
+async function staticExportUrlPath(path, params) {
+  return (await staticExportKey(path, params)).replaceAll('%', '%25');
 }
 
-function apiUrl(path, params) {
-  if (window.STATIC_EXPORT) return appUrl(staticExportUrlPath(path, params));
+async function apiUrl(path, params) {
+  if (window.STATIC_EXPORT) return appUrl(await staticExportUrlPath(path, params));
   const url = new URL(path, document.baseURI);
   for (const [key, value] of Object.entries(params || {})) url.searchParams.append(key, value);
   return url.href;
@@ -130,7 +143,7 @@ async function fetchJSON(url) {
 }
 
 async function loadDatasetInfo() {
-  const data = await fetchJSON(apiUrl('api/dataset_info'));
+  const data = await fetchJSON(await apiUrl('api/dataset_info'));
   if (!data) return;
   document.getElementById('dataset-stats').innerHTML =
     `<p><strong>${data.num_episodes}</strong> episodes.</p>`;
@@ -140,7 +153,7 @@ async function loadEpisodes(filters = {}) {
   // A static export holds one file per filter set of a group table, and one file for the whole
   // flat table, whose filters then apply in the browser.
   const perFilterSet = !window.STATIC_EXPORT || window.IS_GROUPED_TABLE;
-  return fetchJSON(apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null));
+  return fetchJSON(await apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null));
 }
 
 // ---------------------------------------------------------------------------
@@ -177,7 +190,7 @@ async function pollUntilLoaded() {
 
   return new Promise((resolve) => {
     const interval = setInterval(async () => {
-      const status = await fetchJSON(apiUrl('api/dataset_status'));
+      const status = await fetchJSON(await apiUrl('api/dataset_status'));
       if (!status || status.loading) return;
       clearInterval(interval);
       statusEl.classList.remove('show');
@@ -193,7 +206,7 @@ async function initEpisodesTable() {
   const loadingEl = container.querySelector('.loading');
 
   // Check if dataset is ready
-  const status = await fetchJSON(apiUrl('api/dataset_status'));
+  const status = await fetchJSON(await apiUrl('api/dataset_status'));
   if (!status) return;
 
   if (status.loading) {

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -99,13 +99,12 @@ function baseScopedKey(name) {
 // filtered in the browser.
 const groupIndexes = new Map();
 
-// The index file, as `GROUP_INDEX_FILE` in export.py writes it, and the fields of an entry in it, as
-// `GroupFile` there writes them.
+// A group's index: a file beside the group's files, listing {params, file} entries, one per filter set.
 const GROUP_INDEX_FILE = 'index.json';
-// The route `api_dataset_status` answers at, as `positronic_server.py` declares it.
-const DATASET_STATUS_ROUTE = 'api/dataset_status';
 const ENTRY_PARAMS = 'params';
 const ENTRY_FILE = 'file';
+// The route the dataset's loading status is read from.
+const DATASET_STATUS_ROUTE = 'api/dataset_status';
 
 async function groupIndex(path) {
   if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/${GROUP_INDEX_FILE}`)));

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -99,8 +99,14 @@ function staticExportKey(path, params) {
   return `${path}/${query || 'all'}.json`;
 }
 
+// The path a browser asks for that file at. A host decodes a URL path before it looks the file
+// up, so a name that carries a percent escape is reached by escaping its own `%` again.
+function staticExportUrlPath(path, params) {
+  return staticExportKey(path, params).replaceAll('%', '%25');
+}
+
 function apiUrl(path, params) {
-  if (window.STATIC_EXPORT) return appUrl(staticExportKey(path, params));
+  if (window.STATIC_EXPORT) return appUrl(staticExportUrlPath(path, params));
   const url = new URL(path, document.baseURI);
   for (const [key, value] of Object.entries(params || {})) url.searchParams.append(key, value);
   return url.href;

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -86,8 +86,7 @@ function appUrl(path) {
 }
 
 // The file name a static export writes an API response to; `static_export_key` in
-// positronic_server.py builds the same name. Pass no parameters for an endpoint the export writes
-// whole. The filter set {b: '2', a: 'x y'} of the group `leaderboard` names
+// positronic_server.py builds the same name — {b: '2', a: 'x y'} on `leaderboard` names
 // api/groups/leaderboard/a=x%20y&b=2.json.
 function staticExportKey(path, params) {
   if (!params) return `${path}.json`;

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -102,6 +102,8 @@ const groupIndexes = new Map();
 // The index file, as `GROUP_INDEX_FILE` in export.py writes it, and the fields of an entry in it, as
 // `GroupFile` there writes them.
 const GROUP_INDEX_FILE = 'index.json';
+// The route `api_dataset_status` answers at, as `positronic_server.py` declares it.
+const DATASET_STATUS_ROUTE = 'api/dataset_status';
 const ENTRY_PARAMS = 'params';
 const ENTRY_FILE = 'file';
 
@@ -169,8 +171,8 @@ function readFiltersFromURL(serverFilterKeys, columns, episodes) {
     }
     const index = columns.findIndex((c) => c.key === key);
     if (index === -1) continue;  // a key that names no column carries no per-episode value to filter on
-    state.filters[key] = value;
     if (!(key in state.filtersData)) state.filtersData[key] = columnValues(episodes, index);
+    if (state.filtersData[key].includes(value)) state.filters[key] = value;  // a value no row carries is no filter
   }
 }
 
@@ -187,7 +189,7 @@ async function pollUntilLoaded() {
 
   return new Promise((resolve) => {
     const interval = setInterval(async () => {
-      const status = await fetchJSON(await apiUrl('api/dataset_status'));
+      const status = await fetchJSON(await apiUrl(DATASET_STATUS_ROUTE));
       if (!status || status.loading) return;
       clearInterval(interval);
       statusEl.classList.remove('show');
@@ -203,7 +205,7 @@ async function initEpisodesTable() {
   const loadingEl = container.querySelector('.loading');
 
   // Check if dataset is ready
-  const status = await fetchJSON(await apiUrl('api/dataset_status'));
+  const status = await fetchJSON(await apiUrl(DATASET_STATUS_ROUTE));
   if (!status) return;
 
   if (status.loading) {

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -94,8 +94,9 @@ function baseScopedKey(name) {
   return `${name}:${document.baseURI}`;
 }
 
-// A static export holds one file per filter set of a group table, and `index.json` beside them says
-// which file holds which set. The unfiltered flat table is one file, filtered in the browser.
+// A static export holds one file per filter set of a group table that some episode satisfies, and
+// `index.json` beside them says which file holds which set. The unfiltered flat table is one file,
+// filtered in the browser.
 const groupIndexes = new Map();
 
 // The index file, as `GROUP_INDEX_FILE` in export.py writes it, and the fields of an entry in it, as
@@ -118,8 +119,7 @@ function sameFilters(a, b) {
 async function exportedGroupFile(path, params) {
   const chosen = Object.fromEntries(Object.entries(params).filter(([, value]) => value));
   const entry = (await groupIndex(path)).find((item) => sameFilters(item[ENTRY_PARAMS], chosen));
-  if (!entry) throw new Error(`the export holds no ${path} file for ${JSON.stringify(chosen)}`);
-  return appUrl(`${path}/${entry[ENTRY_FILE]}`);
+  return entry ? appUrl(`${path}/${entry[ENTRY_FILE]}`) : null;  // no episode satisfies this filter set
 }
 
 async function apiUrl(path, params) {
@@ -144,7 +144,9 @@ async function loadDatasetInfo() {
 
 async function loadEpisodes(filters = {}) {
   const perFilterSet = !window.STATIC_EXPORT || window.IS_GROUPED_TABLE;
-  return fetchJSON(await apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null));
+  const url = await apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null);
+  if (!url) return { columns: state.columns, episodes: [] };
+  return fetchJSON(url);
 }
 
 // ---------------------------------------------------------------------------

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -8,16 +8,17 @@
 //   episode.html  — single episode with Rerun viewer + static data sidebar
 //
 // Templates set window globals before this script's DOMContentLoaded fires:
-//   window.API_ENDPOINT   — override for /api/episodes (grouped.html sets /api/groups/{name})
+//   window.API_ENDPOINT   — override for api/episodes (grouped.html sets api/groups/{name})
 //   window.IS_GROUPED_TABLE — true on grouped.html, changes View link behavior
 //   window.EPISODES_URL   — where View links point on grouped pages
 //   window.VIEW_LABEL     — button text override
+//   window.STATIC_EXPORT  — read the files a static export wrote, not the live API
 //
 // Data flow
 // ---------
 // On DOMContentLoaded, initEpisodesTable() runs:
-//   1. Polls /api/dataset_status until the server finishes loading the dataset
-//   2. Calls loadEpisodes({}) → fetches from API_ENDPOINT (default /api/episodes)
+//   1. Polls api/dataset_status until the server finishes loading the dataset
+//   2. Calls loadEpisodes({}) → fetches from API_ENDPOINT (default api/episodes)
 //      Response shape: { columns, episodes, group_filters?, default_sort? }
 //        columns:  array of {key, label, filter?, renderer?, align?, subtitle?}
 //        episodes: array of [episodeId, [cell0, cell1, ...], groupFilters?]
@@ -68,7 +69,7 @@
 const state = {
   sort: { columnIndex: null, direction: 'desc' },
   filters: {},           // client-side column filters
-  serverFilters: {},     // server-side group filters (sent to /api/episodes)
+  serverFilters: {},     // server-side group filters (sent to api/episodes)
   episodes: [],          // current episode data
   columns: [],           // column definitions from server
   filtersData: {},       // unique values per filterable column
@@ -78,6 +79,33 @@ const state = {
 // Data fetching
 // ---------------------------------------------------------------------------
 
+// Every link resolves against the <base href> the server rendered, so one export serves from
+// whatever prefix it sits under.
+function appUrl(path) {
+  return new URL(path, document.baseURI).href;
+}
+
+// The file name a static export writes an API response to; `static_export_key` in
+// positronic_server.py builds the same name. Pass no parameters for an endpoint the export writes
+// whole. The filter set {b: '2', a: 'x y'} of the group `leaderboard` names
+// api/groups/leaderboard/a=x%20y&b=2.json.
+function staticExportKey(path, params) {
+  if (!params) return `${path}.json`;
+  const query = Object.keys(params)
+    .filter((key) => params[key])
+    .sort()
+    .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    .join('&');
+  return `${path}/${query || 'all'}.json`;
+}
+
+function apiUrl(path, params) {
+  if (window.STATIC_EXPORT) return appUrl(staticExportKey(path, params));
+  const url = new URL(path, document.baseURI);
+  for (const [key, value] of Object.entries(params || {})) url.searchParams.append(key, value);
+  return url.href;
+}
+
 async function fetchJSON(url) {
   const response = await fetch(url);
   if (response.status === 202) return null;  // dataset still loading
@@ -85,18 +113,17 @@ async function fetchJSON(url) {
 }
 
 async function loadDatasetInfo() {
-  const data = await fetchJSON('/api/dataset_info');
+  const data = await fetchJSON(apiUrl('api/dataset_info'));
   if (!data) return;
   document.getElementById('dataset-stats').innerHTML =
     `<p><strong>${data.num_episodes}</strong> episodes.</p>`;
 }
 
 async function loadEpisodes(filters = {}) {
-  const endpoint = new URL(window.API_ENDPOINT || '/api/episodes', window.location.origin);
-  for (const [key, value] of Object.entries(filters)) {
-    endpoint.searchParams.append(key, value);
-  }
-  return fetchJSON(endpoint);
+  // A static export holds one file per filter set of a group table, and one file for the whole
+  // flat table, whose filters then apply in the browser.
+  const perFilterSet = !window.STATIC_EXPORT || window.IS_GROUPED_TABLE;
+  return fetchJSON(apiUrl(window.API_ENDPOINT || 'api/episodes', perFilterSet ? filters : null));
 }
 
 // ---------------------------------------------------------------------------
@@ -133,7 +160,7 @@ async function pollUntilLoaded() {
 
   return new Promise((resolve) => {
     const interval = setInterval(async () => {
-      const status = await fetchJSON('/api/dataset_status');
+      const status = await fetchJSON(apiUrl('api/dataset_status'));
       if (!status || status.loading) return;
       clearInterval(interval);
       statusEl.classList.remove('show');
@@ -149,7 +176,7 @@ async function initEpisodesTable() {
   const loadingEl = container.querySelector('.loading');
 
   // Check if dataset is ready
-  const status = await fetchJSON('/api/dataset_status');
+  const status = await fetchJSON(apiUrl('api/dataset_status'));
   if (!status) return;
 
   if (status.loading) {
@@ -413,10 +440,10 @@ function populateTable(columns) {
     viewLink.className = 'btn btn-primary btn-small';
     if (window.IS_GROUPED_TABLE) {
       const filters = { ...groupFilters, ...state.serverFilters, ...state.filters };
-      const episodesUrl = window.EPISODES_URL || '/';
-      viewLink.href = `${episodesUrl}?${new URLSearchParams(filters).toString()}`;
+      const episodesUrl = window.EPISODES_URL || '.';
+      viewLink.href = appUrl(`${episodesUrl}?${new URLSearchParams(filters).toString()}`);
     } else {
-      viewLink.href = `/episode/${episodeIndex}`;
+      viewLink.href = appUrl(`episode/${episodeIndex}`);
     }
     viewLink.textContent = window.VIEW_LABEL || 'View';
     viewCell.appendChild(viewLink);

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -159,14 +159,17 @@ function syncURL() {
   window.history.replaceState({}, '', url);
 }
 
-function readFiltersFromURL(serverFilterKeys) {
+function readFiltersFromURL(serverFilterKeys, columns, episodes) {
   const params = new URLSearchParams(window.location.search);
   for (const [key, value] of params.entries()) {
     if (serverFilterKeys.has(key)) {
       state.serverFilters[key] = value;
-    } else if (state.filtersData[key]?.includes(value)) {
-      state.filters[key] = value;
+      continue;
     }
+    const index = columns.findIndex((c) => c.key === key);
+    if (index === -1) continue;  // a key that names no column carries no per-episode value to filter on
+    state.filters[key] = value;
+    if (!(key in state.filtersData)) state.filtersData[key] = columnValues(episodes, index);
   }
 }
 
@@ -229,7 +232,7 @@ async function initEpisodesTable() {
 
   // Parse URL into server/client filters
   const serverFilterKeys = groupFilters ? new Set(Object.keys(groupFilters)) : new Set();
-  readFiltersFromURL(serverFilterKeys);
+  readFiltersFromURL(serverFilterKeys, columns, initial.episodes);
 
   // Re-fetch with server filters if any were set from URL
   if (Object.keys(state.serverFilters).length > 0) {
@@ -259,16 +262,19 @@ async function initEpisodesTable() {
 // Filtering & sorting
 // ---------------------------------------------------------------------------
 
+function columnValues(episodes, index) {
+  const values = new Set();
+  for (const [, episodeData] of episodes) {
+    const v = episodeData[index];
+    if (v !== null && v !== undefined) values.add(String(v));
+  }
+  return Array.from(values);
+}
+
 function buildFiltersData(episodes, columns) {
   const result = {};
   for (const [index, column] of Object.entries(columns)) {
-    if (!column.filter) continue;
-    const values = new Set();
-    for (const [, episodeData] of episodes) {
-      const v = episodeData[index];
-      if (v !== null && v !== undefined) values.add(String(v));
-    }
-    result[column.key] = Array.from(values);
+    if (column.filter) result[column.key] = columnValues(episodes, index);
   }
   return result;
 }

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -98,6 +98,10 @@ function baseScopedKey(name) {
 // which file holds which set. The unfiltered flat table is one file, filtered in the browser.
 const groupIndexes = new Map();
 
+// The fields of an index entry, as `GroupFile` in export.py writes them.
+const ENTRY_PARAMS = 'params';
+const ENTRY_FILE = 'file';
+
 async function groupIndex(path) {
   if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/index.json`)));
   return groupIndexes.get(path);
@@ -111,9 +115,9 @@ function sameFilters(a, b) {
 
 async function exportedGroupFile(path, params) {
   const chosen = Object.fromEntries(Object.entries(params).filter(([, value]) => value));
-  const entry = (await groupIndex(path)).find((item) => sameFilters(item.params, chosen));
+  const entry = (await groupIndex(path)).find((item) => sameFilters(item[ENTRY_PARAMS], chosen));
   if (!entry) throw new Error(`the export holds no ${path} file for ${JSON.stringify(chosen)}`);
-  return appUrl(`${path}/${entry.file}`);
+  return appUrl(`${path}/${entry[ENTRY_FILE]}`);
 }
 
 async function apiUrl(path, params) {

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -98,12 +98,14 @@ function baseScopedKey(name) {
 // which file holds which set. The unfiltered flat table is one file, filtered in the browser.
 const groupIndexes = new Map();
 
-// The fields of an index entry, as `GroupFile` in export.py writes them.
+// The index file, as `GROUP_INDEX_FILE` in export.py writes it, and the fields of an entry in it, as
+// `GroupFile` there writes them.
+const GROUP_INDEX_FILE = 'index.json';
 const ENTRY_PARAMS = 'params';
 const ENTRY_FILE = 'file';
 
 async function groupIndex(path) {
-  if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/index.json`)));
+  if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/${GROUP_INDEX_FILE}`)));
   return groupIndexes.get(path);
 }
 

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -403,7 +403,8 @@ function renderTableHeader(columns) {
   const headerRow = document.querySelector('.episodes-table thead tr');
   const headerCells = [];
 
-  for (const [columnIndex, { label, subtitle, align, sortable }] of Object.entries(columns)) {
+  for (const [columnIndex, { label, subtitle, align, sortable, display }] of Object.entries(columns)) {
+    if (display === false) { headerCells.push(null); continue; }  // a hidden column keeps its index, draws no header
     let content;
     if (subtitle) {
       content = document.createElement('span');
@@ -432,7 +433,7 @@ function renderTableHeader(columns) {
     headerCells.push(th);
   }
 
-  headerRow.prepend(...headerCells);
+  headerRow.prepend(...headerCells.filter(Boolean));
 
   if (state.sort.columnIndex !== null) {
     headerCells[state.sort.columnIndex]?.classList.add(`sorted-${state.sort.direction}`);
@@ -465,6 +466,7 @@ function populateTable(columns) {
     const row = document.createElement('tr');
 
     for (const [i, entity] of episodeData.entries()) {
+      if (columns[i].display === false) continue;  // a hidden column carries a value but draws no cell
       const td = createCell(cellValue(entity, columns[i]));
       if (columns[i].align) td.style.textAlign = columns[i].align;
       row.appendChild(td);
@@ -572,6 +574,7 @@ function renderClientFilters(columns) {
 
   for (const [filterKey, values] of Object.entries(state.filtersData)) {
     const column = columns.find((c) => c.key === filterKey);
+    if (column.display === false) continue;  // a hidden column filters from a View link, not a dropdown
     const options = [
       createOption('-1', 'All'),
       ...values.map((v) => createOption(v, column.renderer?.options[v]?.label ?? v)),

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -95,11 +95,9 @@ function baseScopedKey(name) {
   return `${name}:${document.baseURI}`;
 }
 
-// A static export holds a group table as one file per filter set some episode satisfies, listed in
-// the index file beside them; the unfiltered flat table is one file, filtered in the browser.
+// Each group table's index, read once; the unfiltered flat table is one file, filtered in the browser.
 const groupIndexes = new Map();
 
-// Every name the server and the page agree on: a route, a file an export writes, a response field.
 const NAMES = window.SERVER_NAMES;
 
 function episodePageUrl(index) {

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -102,6 +102,10 @@ const groupIndexes = new Map();
 // Every name the server and the page agree on: a route, a file an export writes, a response field.
 const NAMES = window.SERVER_NAMES;
 
+function episodePageUrl(index) {
+  return appUrl(`${NAMES.episode_page_before}${index}${NAMES.episode_page_after}`);
+}
+
 async function groupIndex(path) {
   if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/${NAMES.group_index_file}`)));
   return groupIndexes.get(path);
@@ -120,7 +124,7 @@ async function exportedGroupFile(path, params) {
 }
 
 async function apiUrl(path, params) {
-  if (window.STATIC_EXPORT) return params ? exportedGroupFile(path, params) : appUrl(`${path}.json`);
+  if (window.STATIC_EXPORT) return params ? exportedGroupFile(path, params) : appUrl(`${path}${NAMES.api_file_suffix}`);
   const url = new URL(path, document.baseURI);
   for (const [key, value] of Object.entries(params || {})) url.searchParams.append(key, value);
   return url.href;
@@ -476,7 +480,7 @@ function populateTable(columns) {
       const episodesUrl = window.EPISODES_URL || '.';
       viewLink.href = appUrl(`${episodesUrl}?${new URLSearchParams(filters).toString()}`);
     } else {
-      viewLink.href = appUrl(`${NAMES.episode_page_before}${episodeIndex}${NAMES.episode_page_after}`);
+      viewLink.href = episodePageUrl(episodeIndex);
     }
     viewLink.textContent = window.VIEW_LABEL || 'View';
     viewCell.appendChild(viewLink);

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -476,7 +476,11 @@ function populateTable(columns) {
     const viewLink = document.createElement('a');
     viewLink.className = 'btn btn-primary btn-small';
     if (window.IS_GROUPED_TABLE) {
-      const filters = { ...groupFilters, ...state.serverFilters, ...state.filters };
+      // An absent group value is no filter, as the server spells it.
+      const present = Object.fromEntries(
+        Object.entries(groupFilters).filter(([, value]) => value !== null && value !== undefined)
+      );
+      const filters = { ...present, ...state.serverFilters, ...state.filters };
       const episodesUrl = window.EPISODES_URL || '.';
       viewLink.href = appUrl(`${episodesUrl}?${new URLSearchParams(filters).toString()}`);
     } else {
@@ -574,7 +578,7 @@ function renderClientFilters(columns) {
 
   for (const [filterKey, values] of Object.entries(state.filtersData)) {
     const column = columns.find((c) => c.key === filterKey);
-    if (column.display === false) continue;  // a hidden column filters from a View link, not a dropdown
+    if (column.display === false) continue;  // a hidden column draws no dropdown
     const options = [
       createOption('-1', 'All'),
       ...values.map((v) => createOption(v, column.renderer?.options[v]?.label ?? v)),

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -476,7 +476,7 @@ function populateTable(columns) {
       const episodesUrl = window.EPISODES_URL || '.';
       viewLink.href = appUrl(`${episodesUrl}?${new URLSearchParams(filters).toString()}`);
     } else {
-      viewLink.href = appUrl(`${NAMES.episode_page_prefix}${episodeIndex}`);
+      viewLink.href = appUrl(`${NAMES.episode_page_before}${episodeIndex}${NAMES.episode_page_after}`);
     }
     viewLink.textContent = window.VIEW_LABEL || 'View';
     viewCell.appendChild(viewLink);

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -94,9 +94,8 @@ function baseScopedKey(name) {
   return `${name}:${document.baseURI}`;
 }
 
-// A static export holds one file per filter set of a group table that some episode satisfies, and
-// `index.json` beside them says which file holds which set. The unfiltered flat table is one file,
-// filtered in the browser.
+// A static export holds a group table as one file per filter set some episode satisfies, listed in
+// `index.json` beside them; the unfiltered flat table is one file, filtered in the browser.
 const groupIndexes = new Map();
 
 // A group's index: a file beside the group's files, listing {params, file} entries, one per filter set.

--- a/positronic/server/static/app.js
+++ b/positronic/server/static/app.js
@@ -13,6 +13,7 @@
 //   window.EPISODES_URL   — where View links point on grouped pages
 //   window.VIEW_LABEL     — button text override
 //   window.STATIC_EXPORT  — read the files a static export wrote, not the live API
+//   window.SERVER_NAMES   — the routes, the files an export writes and the response fields, by name
 //
 // Data flow
 // ---------
@@ -95,20 +96,14 @@ function baseScopedKey(name) {
 }
 
 // A static export holds a group table as one file per filter set some episode satisfies, listed in
-// `index.json` beside them; the unfiltered flat table is one file, filtered in the browser.
+// the index file beside them; the unfiltered flat table is one file, filtered in the browser.
 const groupIndexes = new Map();
 
-// A group's index: a file beside the group's files, listing {params, file} entries, one per filter set.
-const GROUP_INDEX_FILE = 'index.json';
-const ENTRY_PARAMS = 'params';
-const ENTRY_FILE = 'file';
-// The routes a page reads whole: the dataset's loading status, its description, and the flat episode table.
-const DATASET_STATUS_ROUTE = 'api/dataset_status';
-const DATASET_INFO_ROUTE = 'api/dataset_info';
-const EPISODES_ROUTE = 'api/episodes';
+// Every name the server and the page agree on: a route, a file an export writes, a response field.
+const NAMES = window.SERVER_NAMES;
 
 async function groupIndex(path) {
-  if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/${GROUP_INDEX_FILE}`)));
+  if (!groupIndexes.has(path)) groupIndexes.set(path, fetchJSON(appUrl(`${path}/${NAMES.group_index_file}`)));
   return groupIndexes.get(path);
 }
 
@@ -120,8 +115,8 @@ function sameFilters(a, b) {
 
 async function exportedGroupFile(path, params) {
   const chosen = Object.fromEntries(Object.entries(params).filter(([, value]) => value));
-  const entry = (await groupIndex(path)).find((item) => sameFilters(item[ENTRY_PARAMS], chosen));
-  return entry ? appUrl(`${path}/${entry[ENTRY_FILE]}`) : null;  // no episode satisfies this filter set
+  const entry = (await groupIndex(path)).find((item) => sameFilters(item[NAMES.entry_params], chosen));
+  return entry ? appUrl(`${path}/${entry[NAMES.entry_file]}`) : null;  // no episode satisfies this filter set
 }
 
 async function apiUrl(path, params) {
@@ -138,7 +133,7 @@ async function fetchJSON(url) {
 }
 
 async function loadDatasetInfo() {
-  const data = await fetchJSON(await apiUrl(DATASET_INFO_ROUTE));
+  const data = await fetchJSON(await apiUrl(NAMES.dataset_info));
   if (!data) return;
   document.getElementById('dataset-stats').innerHTML =
     `<p><strong>${data.num_episodes}</strong> episodes.</p>`;
@@ -146,7 +141,7 @@ async function loadDatasetInfo() {
 
 async function loadEpisodes(filters = {}) {
   const perFilterSet = !window.STATIC_EXPORT || window.IS_GROUPED_TABLE;
-  const url = await apiUrl(window.API_ENDPOINT || EPISODES_ROUTE, perFilterSet ? filters : null);
+  const url = await apiUrl(window.API_ENDPOINT || NAMES.episodes_api, perFilterSet ? filters : null);
   if (!url) return { columns: state.columns, episodes: [] };
   return fetchJSON(url);
 }
@@ -189,7 +184,7 @@ async function pollUntilLoaded() {
 
   return new Promise((resolve) => {
     const interval = setInterval(async () => {
-      const status = await fetchJSON(await apiUrl(DATASET_STATUS_ROUTE));
+      const status = await fetchJSON(await apiUrl(NAMES.dataset_status));
       if (!status || status.loading) return;
       clearInterval(interval);
       statusEl.classList.remove('show');
@@ -205,7 +200,7 @@ async function initEpisodesTable() {
   const loadingEl = container.querySelector('.loading');
 
   // Check if dataset is ready
-  const status = await fetchJSON(await apiUrl(DATASET_STATUS_ROUTE));
+  const status = await fetchJSON(await apiUrl(NAMES.dataset_status));
   if (!status) return;
 
   if (status.loading) {
@@ -229,7 +224,8 @@ async function initEpisodesTable() {
   const initial = await loadEpisodes({});
   if (!initial) return;
 
-  const { columns, group_filters: groupFilters, default_sort: defaultSort } = initial;
+  const { columns, default_sort: defaultSort } = initial;
+  const groupFilters = initial[NAMES.group_filters];
   state.columns = columns;
   state.filtersData = buildFiltersData(initial.episodes, columns);
 
@@ -480,7 +476,7 @@ function populateTable(columns) {
       const episodesUrl = window.EPISODES_URL || '.';
       viewLink.href = appUrl(`${episodesUrl}?${new URLSearchParams(filters).toString()}`);
     } else {
-      viewLink.href = appUrl(`episode/${episodeIndex}`);
+      viewLink.href = appUrl(`${NAMES.episode_page_prefix}${episodeIndex}`);
     }
     viewLink.textContent = window.VIEW_LABEL || 'View';
     viewCell.appendChild(viewLink);
@@ -539,7 +535,7 @@ function renderServerFilters(groupFilters) {
   for (const [filterKey, filterData] of Object.entries(groupFilters)) {
     const options = [
       createOption('-1', 'All'),
-      ...filterData.values.map((v) => createOption(v, v)),
+      ...filterData[NAMES.filter_values].map((v) => createOption(v, v)),
     ];
 
     const container = createFilterDropdown({

--- a/positronic/server/templates/base.html
+++ b/positronic/server/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     {% block head %}
     <meta charset="utf-8" />
+    <base href="{{ base_href }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title_prefix %}Positronic Server{% endblock %} – {% block title %}{% endblock %}</title>
     <meta
@@ -10,6 +11,7 @@
       content="{% block description %}{% endblock %}"
     />
     <link rel="stylesheet" href="/static/styles.css" />
+    {% if static_export %}<script>window.STATIC_EXPORT = true;</script>{% endif %}
     {% endblock %}
 </head>
 <body>

--- a/positronic/server/templates/base.html
+++ b/positronic/server/templates/base.html
@@ -11,6 +11,7 @@
       content="{% block description %}{% endblock %}"
     />
     <link rel="stylesheet" href="/static/styles.css" />
+    <script>window.SERVER_NAMES = {{ server_names | tojson }};</script>
     {% if static_export %}<script>window.STATIC_EXPORT = true;</script>{% endif %}
     {% endblock %}
 </head>

--- a/positronic/server/templates/base.html
+++ b/positronic/server/templates/base.html
@@ -10,7 +10,7 @@
       name="description"
       content="{% block description %}{% endblock %}"
     />
-    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="stylesheet" href="{{ asset_link('styles.css') }}" />
     <script>window.SERVER_NAMES = {{ server_names | tojson }};</script>
     {% if static_export %}<script>window.STATIC_EXPORT = true;</script>{% endif %}
     {% endblock %}
@@ -30,7 +30,7 @@
       {% block footer %}{% endblock %}
     </div>
 
-    <script src="/static/app.js"></script>
+    <script src="{{ asset_link('app.js') }}"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/positronic/server/templates/episode.html
+++ b/positronic/server/templates/episode.html
@@ -130,8 +130,8 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
     // URL params: ?t=<seconds_from_start> or ?ts_ns=<absolute_nanoseconds> to seek on load
     window.addEventListener('load', () => {
         const viewerIframe = document.getElementById('viewer-iframe');
-        const rrdUrl = appUrl('{{ rrd_path }}');
-        const viewerUrl = new URL(appUrl('/static/rerun/{{ rerun_version }}/index.html'));
+        const rrdUrl = appUrl({{ rrd_path | tojson }});
+        const viewerUrl = new URL(appUrl({{ viewer_path | tojson }}));
         viewerUrl.searchParams.set('url', rrdUrl);
         viewerUrl.searchParams.set('hide_welcome_screen', '');
         const params = new URLSearchParams(window.location.search);

--- a/positronic/server/templates/episode.html
+++ b/positronic/server/templates/episode.html
@@ -44,8 +44,8 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
 
         const prevId = ids[(currentIndex - 1 + ids.length) % ids.length];
         const nextId = ids[(currentIndex + 1) % ids.length];
-        document.getElementById('prev-btn').onclick = () => { window.location.href = `/episode/${prevId}`; };
-        document.getElementById('next-btn').onclick = () => { window.location.href = `/episode/${nextId}`; };
+        document.getElementById('prev-btn').onclick = () => { window.location.href = appUrl(`episode/${prevId}`); };
+        document.getElementById('next-btn').onclick = () => { window.location.href = appUrl(`episode/${nextId}`); };
         document.getElementById('episode-count').textContent = ` / ${ids.length}`;
 
         // Add dismiss × and "Filtered" badge inside the nav bar, before "Ep."
@@ -64,9 +64,9 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
             input.dataset.original = currentId;
             input.maxLength = String({{ num_episodes }}).length;
             document.getElementById('episode-count').textContent = ' / {{ num_episodes }}';
-            document.getElementById('prev-btn').onclick = () => { window.location.href = `/episode/{{ (episode_id - 1) % num_episodes }}`; };
-            document.getElementById('next-btn').onclick = () => { window.location.href = `/episode/{{ (episode_id + 1) % num_episodes }}`; };
-            document.getElementById('breadcrumb-root').href = '/';
+            document.getElementById('prev-btn').onclick = () => { window.location.href = appUrl('episode/{{ (episode_id - 1) % num_episodes }}'); };
+            document.getElementById('next-btn').onclick = () => { window.location.href = appUrl('episode/{{ (episode_id + 1) % num_episodes }}'); };
+            document.getElementById('breadcrumb-root').href = appUrl('.');
             filteredIds = null;
             dismiss.remove();
             badge.remove();
@@ -100,13 +100,13 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
                 episodeInput.value = episodeInput.dataset.original;
                 return;
             }
-            window.location.href = `/episode/${filteredIds[value - 1]}`;
+            window.location.href = appUrl(`episode/${filteredIds[value - 1]}`);
         } else {
             if (isNaN(value) || value < 0 || value >= maxEpisodes) {
                 episodeInput.value = episodeInput.dataset.original;
                 return;
             }
-            window.location.href = `/episode/${value}`;
+            window.location.href = appUrl(`episode/${value}`);
         }
     });
 
@@ -130,8 +130,8 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
     // URL params: ?t=<seconds_from_start> or ?ts_ns=<absolute_nanoseconds> to seek on load
     window.addEventListener('load', () => {
         const viewerIframe = document.getElementById('viewer-iframe');
-        const rrdUrl = `${window.location.origin}/api/episode_rrd/{{ episode_id }}`;
-        const viewerUrl = new URL(`/static/rerun/{{ rerun_version }}/index.html`, window.location.origin);
+        const rrdUrl = appUrl('{{ rrd_path }}');
+        const viewerUrl = new URL(appUrl('/static/rerun/{{ rerun_version }}/index.html'));
         viewerUrl.searchParams.set('url', rrdUrl);
         viewerUrl.searchParams.set('hide_welcome_screen', '');
         const params = new URLSearchParams(window.location.search);
@@ -146,17 +146,17 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
 <main class="main main--full-screen">
     <div class="header">
         <div class="breadcrumbs">
-            <a href="/" class="breadcrumb-link" id="breadcrumb-root">{{ repo_id }}</a>
+            <a href="." class="breadcrumb-link" id="breadcrumb-root">{{ title }}</a>
             <span class="breadcrumb-separator">›</span>
             <span id="episode-nav" class="episode-nav">
                 <span class="breadcrumb-text">Ep. </span>
-                <button id="prev-btn" onclick="window.location.href='/episode/{{ (episode_id - 1) % num_episodes }}'"
+                <button id="prev-btn" onclick="window.location.href=appUrl('episode/{{ (episode_id - 1) % num_episodes }}')"
                     class="btn btn-ghost" title="Previous episode">&lt;</button>
                 <form id="episode-form" class="episode-form" style="display: inline; margin: 0;">
                     <input type="text" id="episode-input" class="episode-input" value="{{ episode_id }}"
                         data-original="{{ episode_id }}" maxlength="{{ num_episodes|string|length }}">
                 </form>
-                <button id="next-btn" onclick="window.location.href='/episode/{{ (episode_id + 1) % num_episodes }}'"
+                <button id="next-btn" onclick="window.location.href=appUrl('episode/{{ (episode_id + 1) % num_episodes }}')"
                     class="btn btn-ghost" title="Next episode">&gt;</button>
                 <span class="breadcrumb-text" id="episode-count"> / {{ num_episodes }}</span>
             </span>
@@ -164,7 +164,7 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
         </div>
     </div>
     <div class="episode-info-header">
-        {% if episode_path or episode_size_mb %}
+        {% if show_paths and (episode_path or episode_size_mb) %}
         <div class="episode-path">
             {% if episode_path %}
             <span class="episode-path-label">Episode path:</span>

--- a/positronic/server/templates/episode.html
+++ b/positronic/server/templates/episode.html
@@ -24,7 +24,7 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
      in the template context. That gives stable URLs but requires server and template changes. -->
 <script>
     let filteredIds = (function() {
-        const raw = sessionStorage.getItem('filteredEpisodeIds');
+        const raw = sessionStorage.getItem(baseScopedKey(FILTERED_EPISODE_IDS));
         if (!raw) return null;
 
         let ids;
@@ -57,8 +57,8 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
         dismiss.className = 'filter-dismiss';
         dismiss.textContent = '\u00d7';
         dismiss.onclick = () => {
-            sessionStorage.removeItem('filteredEpisodeIds');
-            sessionStorage.removeItem('episodesReferrerUrl');
+            sessionStorage.removeItem(baseScopedKey(FILTERED_EPISODE_IDS));
+            sessionStorage.removeItem(baseScopedKey(EPISODES_REFERRER_URL));
             nav.classList.remove('episode-nav--filtered');
             input.value = currentId;
             input.dataset.original = currentId;
@@ -74,7 +74,7 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
         nav.prepend(badge);
         nav.prepend(dismiss);
 
-        const referrerUrl = sessionStorage.getItem('episodesReferrerUrl');
+        const referrerUrl = sessionStorage.getItem(baseScopedKey(EPISODES_REFERRER_URL));
         if (referrerUrl) {
             document.getElementById('breadcrumb-root').href = referrerUrl;
         }
@@ -164,9 +164,9 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
         </div>
     </div>
     <div class="episode-info-header">
-        {% if show_paths and (episode_path or episode_size_mb) %}
+        {% if (show_paths and episode_path) or episode_size_mb %}
         <div class="episode-path">
-            {% if episode_path %}
+            {% if show_paths and episode_path %}
             <span class="episode-path-label">Episode path:</span>
             <code class="episode-path-value">{{ episode_path }}</code>
             {% endif %}

--- a/positronic/server/templates/episode.html
+++ b/positronic/server/templates/episode.html
@@ -44,8 +44,8 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
 
         const prevId = ids[(currentIndex - 1 + ids.length) % ids.length];
         const nextId = ids[(currentIndex + 1) % ids.length];
-        document.getElementById('prev-btn').onclick = () => { window.location.href = appUrl(`episode/${prevId}`); };
-        document.getElementById('next-btn').onclick = () => { window.location.href = appUrl(`episode/${nextId}`); };
+        document.getElementById('prev-btn').onclick = () => { window.location.href = episodePageUrl(prevId); };
+        document.getElementById('next-btn').onclick = () => { window.location.href = episodePageUrl(nextId); };
         document.getElementById('episode-count').textContent = ` / ${ids.length}`;
 
         // Add dismiss × and "Filtered" badge inside the nav bar, before "Ep."
@@ -64,8 +64,8 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
             input.dataset.original = currentId;
             input.maxLength = String({{ num_episodes }}).length;
             document.getElementById('episode-count').textContent = ' / {{ num_episodes }}';
-            document.getElementById('prev-btn').onclick = () => { window.location.href = appUrl('episode/{{ (episode_id - 1) % num_episodes }}'); };
-            document.getElementById('next-btn').onclick = () => { window.location.href = appUrl('episode/{{ (episode_id + 1) % num_episodes }}'); };
+            document.getElementById('prev-btn').onclick = () => { window.location.href = appUrl('{{ prev_link }}'); };
+            document.getElementById('next-btn').onclick = () => { window.location.href = appUrl('{{ next_link }}'); };
             document.getElementById('breadcrumb-root').href = appUrl('.');
             filteredIds = null;
             dismiss.remove();
@@ -100,13 +100,13 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
                 episodeInput.value = episodeInput.dataset.original;
                 return;
             }
-            window.location.href = appUrl(`episode/${filteredIds[value - 1]}`);
+            window.location.href = episodePageUrl(filteredIds[value - 1]);
         } else {
             if (isNaN(value) || value < 0 || value >= maxEpisodes) {
                 episodeInput.value = episodeInput.dataset.original;
                 return;
             }
-            window.location.href = appUrl(`episode/${value}`);
+            window.location.href = episodePageUrl(value);
         }
     });
 
@@ -150,13 +150,13 @@ Episode {{ episode_id }} / {{ num_episodes }} - Positronic Dataset Viewer
             <span class="breadcrumb-separator">›</span>
             <span id="episode-nav" class="episode-nav">
                 <span class="breadcrumb-text">Ep. </span>
-                <button id="prev-btn" onclick="window.location.href=appUrl('episode/{{ (episode_id - 1) % num_episodes }}')"
+                <button id="prev-btn" onclick="window.location.href=appUrl('{{ prev_link }}')"
                     class="btn btn-ghost" title="Previous episode">&lt;</button>
                 <form id="episode-form" class="episode-form" style="display: inline; margin: 0;">
                     <input type="text" id="episode-input" class="episode-input" value="{{ episode_id }}"
                         data-original="{{ episode_id }}" maxlength="{{ num_episodes|string|length }}">
                 </form>
-                <button id="next-btn" onclick="window.location.href=appUrl('episode/{{ (episode_id + 1) % num_episodes }}')"
+                <button id="next-btn" onclick="window.location.href=appUrl('{{ next_link }}')"
                     class="btn btn-ghost" title="Next episode">&gt;</button>
                 <span class="breadcrumb-text" id="episode-count"> / {{ num_episodes }}</span>
             </span>

--- a/positronic/server/templates/grouped.html
+++ b/positronic/server/templates/grouped.html
@@ -6,9 +6,9 @@
 
 {% block scripts %}
 <script>
-    window.API_ENDPOINT = "{{ api_endpoint }}";
+    window.API_ENDPOINT = {{ api_endpoint | tojson }};
     window.IS_GROUPED_TABLE = true;
-    window.EPISODES_URL = "{{ episodes_url | default('.') }}";
+    window.EPISODES_URL = {{ episodes_url | default('.') | tojson }};
 </script>
 {% endblock %}
 

--- a/positronic/server/templates/grouped.html
+++ b/positronic/server/templates/grouped.html
@@ -8,7 +8,7 @@
 <script>
     window.API_ENDPOINT = "{{ api_endpoint }}";
     window.IS_GROUPED_TABLE = true;
-    window.EPISODES_URL = "{{ episodes_url | default('/') }}";
+    window.EPISODES_URL = "{{ episodes_url | default('.') }}";
 </script>
 {% endblock %}
 
@@ -16,7 +16,7 @@
 <main class="main">
     <header class="page-header">
         <div class="page-kicker">Group Explorer</div>
-        <h1>{{repo_id}}</h1>
+        <h1>{{ title }}</h1>
         <p id="dataset-stats">Loading dataset information...</p>
         <div class="dataset-info">
             <div id="loading-status" class="loading-status">

--- a/positronic/server/templates/index.html
+++ b/positronic/server/templates/index.html
@@ -10,7 +10,7 @@
 <main class="main">
     <header class="page-header">
         <div class="page-kicker">Run explorer</div>
-        <h1>{{repo_id}}</h1>
+        <h1>{{ title }}</h1>
         <p id="dataset-stats">Loading dataset information...</p>
         <div class="dataset-info">
             <div id="loading-status" class="loading-status">

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -1,19 +1,25 @@
 """What one export writes, where, and what it keeps off a page."""
 
 import json
+from dataclasses import fields
 from pathlib import Path, PurePosixPath
+from typing import cast
 
 import numpy as np
 import pytest
 
 from positronic import keys
+from positronic.dataset import Dataset
+from positronic.dataset.dataset import FilterDataset
 from positronic.dataset.episode import Episode, EpisodeContainer
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.transforms.episode import EpisodeTransform
+from positronic.server import positronic_server
 from positronic.server.export import (
     GROUP_INDEX_FILE,
     UNFILTERED_FILE,
+    GroupFile,
     asset_content_type,
     export_static,
     filter_sets,
@@ -55,23 +61,36 @@ class _KeepStatic(EpisodeTransform):
         return EpisodeContainer({**episode.signals, **static}, meta=episode.meta)
 
 
-@pytest.fixture
-def dataset(tmp_path):
-    """Two episodes; one static value is long enough to become a download, one is hidden."""
-    root = tmp_path / 'dataset'
+def a_dataset(root: Path, *statics: dict) -> Dataset:
+    """One episode per static-value dict, each four joint samples long."""
     with LocalDatasetWriter(root) as writer:
-        for index, object_name in enumerate(OBJECTS):
+        for static in statics:
             with writer.new_episode() as episode:
-                episode.set_static(keys.TASK, 'Put the banana on the plate')
-                episode.set_static(OUTCOME, 'Success' if index == 0 else 'Failure')
-                episode.set_static(OBJECT, object_name)
-                episode.set_static(ATTEMPT, index + 1)
-                episode.set_static('notes', 'n' * 2000)
-                episode.set_static('artifacts', [b'first blob', 'short'])
-                episode.set_static(HIDDEN_KEY, HIDDEN_VALUE)
+                for name, value in static.items():
+                    episode.set_static(name, value)
                 for step in range(4):
                     episode.append(keys.JOINTS, np.zeros(7, dtype=np.float32), ts_ns=10_000 + step * 1_000)
     return load_all_datasets(root)
+
+
+@pytest.fixture
+def dataset(tmp_path):
+    """Two episodes; one static value is long enough to become a download, one is hidden."""
+    return a_dataset(
+        tmp_path / 'dataset',
+        *(
+            {
+                keys.TASK: 'Put the banana on the plate',
+                OUTCOME: 'Success' if index == 0 else 'Failure',
+                OBJECT: object_name,
+                ATTEMPT: index + 1,
+                'notes': 'n' * 2000,
+                'artifacts': [b'first blob', 'short'],
+                HIDDEN_KEY: HIDDEN_VALUE,
+            }
+            for index, object_name in enumerate(OBJECTS)
+        ),
+    )
 
 
 def shown(dataset):
@@ -186,7 +205,7 @@ def test_the_assets_are_written_only_when_asked(dataset, tmp_path):
 
 
 def test_every_filter_set_a_page_can_ask_for_is_listed_with_the_empty_one_first():
-    response = {GROUP_FILTERS: {'b': {FILTER_VALUES: ['2', '1']}, 'a': {FILTER_VALUES: ['x']}}}
+    response = {GROUP_FILTERS: {'b': {FILTER_VALUES: ['1', '2']}, 'a': {FILTER_VALUES: ['x']}}}
 
     assert list(filter_sets(response)) == [
         {},
@@ -196,11 +215,6 @@ def test_every_filter_set_a_page_can_ask_for_is_listed_with_the_empty_one_first(
         {'a': 'x', 'b': '1'},
         {'a': 'x', 'b': '2'},
     ]
-
-
-def test_a_filter_value_no_episode_carries_asks_for_no_file():
-    """The server matches a filter against an episode's own value, and never against an absent one."""
-    assert list(filter_sets({GROUP_FILTERS: {'a': {FILTER_VALUES: [None, 'x']}}})) == [{}, {'a': 'x'}]
 
 
 def test_a_link_is_moved_under_the_build_and_a_value_that_looks_like_one_is_not():
@@ -266,6 +280,57 @@ def test_an_export_leaves_the_app_state_as_it_found_it(dataset, tmp_path):
     an_export(dataset, tmp_path / 'out', base_href='/v/tok/', title='A run')
 
     assert app_state == before
+
+
+def test_a_group_name_that_would_leave_the_output_directory_is_refused(dataset, tmp_path):
+    out = tmp_path / 'out'
+
+    with pytest.raises(ValueError, match='outside'):
+        an_export(dataset, out, group_tables={'../..': GROUPS['outcomes']})
+    assert not (tmp_path / 'index.html').exists()
+
+
+class _Reversed(Dataset):
+    def __init__(self, dataset: Dataset):
+        self._dataset = dataset
+
+    def __len__(self) -> int:
+        return len(self._dataset)
+
+    def _get_episode(self, index: int) -> Episode:
+        return cast(Episode, self._dataset[len(self._dataset) - 1 - index])
+
+
+def test_a_full_dataset_holding_other_episodes_at_the_shown_indexes_is_refused(dataset, tmp_path):
+    with pytest.raises(ValueError, match='uid'):
+        an_export(dataset, tmp_path / 'reversed', full_dataset=_Reversed(dataset))
+    with pytest.raises(ValueError, match='holds 1 episodes'):
+        an_export(
+            dataset, tmp_path / 'shorter', full_dataset=FilterDataset(dataset, lambda ep: ep.static[ATTEMPT] == 1)
+        )
+    assert not (tmp_path / 'reversed').exists() and not (tmp_path / 'shorter').exists()
+
+
+ESCAPED_KEY = 'notes & é'
+
+
+def test_a_download_whose_field_name_a_page_escapes_is_linked_and_written(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', ESCAPED_KEY: 'n' * 2000})
+    out = tmp_path / 'out'
+
+    written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id='bld'))
+
+    assert '"build/bld/api/episode/0/static/notes \\u0026 \\u00e9"' in (out / 'episode/0/index.html').read_text()
+    assert f'build/bld/api/episode/0/static/{ESCAPED_KEY}' in written
+    assert (out / 'build/bld/api/episode/0/static' / ESCAPED_KEY).read_bytes() == b'n' * 2000
+
+
+def test_the_page_script_spells_a_group_index_as_the_export_writes_it():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+    params, file = (field.name for field in fields(GroupFile))
+
+    assert f"const GROUP_INDEX_FILE = '{GROUP_INDEX_FILE}';" in app_js
+    assert f"const ENTRY_PARAMS = '{params}';" in app_js and f"const ENTRY_FILE = '{file}';" in app_js
 
 
 @pytest.mark.parametrize(

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -270,6 +270,14 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
     assert not (tmp_path / 'out').exists()
 
 
+def test_a_static_value_named_with_a_path_step_stops_the_export_before_it_writes(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a/../b': b'a step'})
+
+    with pytest.raises(ValueError, match='no link'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
 def test_the_assets_go_with_the_root_base_href_only(dataset, tmp_path):
     with pytest.raises(ValueError, match='assets'):
         an_export(dataset, tmp_path / 'out', base_href='/v/tok/', assets=True)

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import shutil
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -21,7 +22,7 @@ from positronic.dataset.dataset import FilterDataset
 from positronic.dataset.episode import Episode, EpisodeContainer
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.dataset.transforms import TransformedDataset
-from positronic.dataset.transforms.episode import EpisodeTransform
+from positronic.dataset.transforms.episode import EpisodeTransform, Identity
 from positronic.server import positronic_server
 from positronic.server.export import (
     GROUP_INDEX_FILE,
@@ -193,19 +194,44 @@ def test_without_a_build_id_the_large_files_sit_at_their_routes(dataset, tmp_pat
     assert {'api/episode_rrd/0', 'api/episode_rrd/1', 'api/episode/0/static/notes'} <= written
 
 
-def test_a_recording_is_copied_from_the_cache_file_and_not_read_through_the_client(dataset, tmp_path, monkeypatch):
+def test_a_recording_is_copied_from_the_file_built_under_the_scratch_dir_and_not_read_through_the_client(
+    dataset, tmp_path, monkeypatch
+):
     def fetch_no_recording(client, path, params=None):
         assert 'episode_rrd' not in path, path
         return _fetch(client, path, params)
 
+    copied: dict[Path, Path] = {}
+    copyfile = shutil.copyfile
+
+    def copy_recording(source, target):
+        copied[Path(target)] = Path(source)
+        return copyfile(source, target)
+
     monkeypatch.setattr('positronic.server.export._fetch', fetch_no_recording)
-    cache = tmp_path / 'cache'
+    monkeypatch.setattr(shutil, 'copyfile', copy_recording)
+    scratch = tmp_path / 'scratch'
+    scratch.mkdir()
 
-    files = an_export(dataset, tmp_path / 'out', cache_dir=cache)
+    files = an_export(dataset, tmp_path / 'out', scratch_dir=scratch)
 
-    cached = {path.read_bytes() for path in cache.rglob('*.rrd')}
-    written = {(tmp_path / 'out' / path).read_bytes() for path in paths_of(files) if 'episode_rrd' in path}
-    assert len(written) == 2 and written == cached
+    recordings = [tmp_path / 'out' / path for path in paths_of(files) if 'episode_rrd' in path]
+    assert len(recordings) == 2
+    assert all(copied[target].is_relative_to(scratch) and copied[target].suffix == '.rrd' for target in recordings)
+    assert not any(scratch.iterdir())
+
+
+def test_two_views_of_one_dataset_through_one_scratch_dir_each_get_their_own_recording(dataset, tmp_path):
+    """A transformed view keeps the dataset's root and its uids, so nothing but the export tells the two apart."""
+    scratch = tmp_path / 'scratch'
+    scratch.mkdir()
+    whole = paths_of(an_export(dataset, tmp_path / 'whole', scratch_dir=scratch))
+    without_joints = TransformedDataset(dataset, Identity(remove=[keys.JOINTS]))
+    thinned = paths_of(an_export(dataset, tmp_path / 'thinned', scratch_dir=scratch, full_dataset=without_joints))
+
+    recording = next(path for path in whole if 'episode_rrd/0' in path)
+    assert recording in thinned
+    assert (tmp_path / 'whole' / recording).stat().st_size > (tmp_path / 'thinned' / recording).stat().st_size
 
 
 def test_a_recording_is_built_from_the_full_dataset(dataset, tmp_path):
@@ -391,13 +417,16 @@ def test_a_short_key_and_a_slashed_key_that_share_a_prefix_are_written_apart(tmp
     assert (out / 'api/episode/0/static/a%2Fb').read_bytes() == b'2'
 
 
-def test_a_cache_and_an_output_directory_that_overlap_are_refused(dataset, tmp_path):
+def test_a_scratch_dir_inside_the_output_is_refused_and_one_holding_the_output_stands(dataset, tmp_path):
     out = tmp_path / 'out'
 
-    for cache in (out, out / 'cache', tmp_path):
-        with pytest.raises(ValueError, match='outside'):
-            an_export(dataset, out, cache_dir=cache)
+    for scratch in (out, out / 'scratch'):
+        with pytest.raises(ValueError, match='inside'):
+            an_export(dataset, out, scratch_dir=scratch)
     assert not out.exists()
+
+    assert an_export(dataset, out, scratch_dir=tmp_path)
+    assert set(tmp_path.iterdir()) >= {out, tmp_path / 'dataset'} and len(list(tmp_path.iterdir())) == 2
 
 
 def test_the_assets_go_with_the_root_base_href_only(dataset, tmp_path):
@@ -573,6 +602,39 @@ def test_a_group_name_that_is_not_one_url_path_segment_is_refused(dataset, tmp_p
         with pytest.raises(ValueError, match='group name'):
             an_export(dataset, tmp_path / 'out', group_tables={name: GROUPS['outcomes']})
     assert not (tmp_path / 'out').exists()
+
+
+def test_two_group_names_that_are_one_name_on_a_filesystem_folding_case_are_refused_before_a_write(dataset, tmp_path):
+    tables = {'Results': GROUPS['outcomes'], 'results': GROUPS['attempts']}
+    with pytest.raises(ValueError, match='folds case'):
+        an_export(dataset, tmp_path / 'out', group_tables=tables)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_two_group_names_that_differ_past_their_case_are_both_written(dataset, tmp_path):
+    tables = {'results': GROUPS['outcomes'], 'result': GROUPS['attempts']}
+    files = paths_of(an_export(dataset, tmp_path / 'out', group_tables=tables))
+    assert {'groups/results/index.html', 'groups/result/index.html'} <= files
+
+
+def test_two_downloads_of_one_episode_that_are_one_file_on_a_filesystem_folding_case_stop_the_export(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {'Notes': 'n' * 2000, 'notes': 'm' * 2000})
+    with pytest.raises(ValueError, match='folds case'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_download_and_the_directory_of_another_that_fold_to_one_name_stop_the_export(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {'Scene': {'mesh': 'n' * 2000}, 'scene': 'm' * 2000})
+    with pytest.raises(ValueError, match='folds case'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_downloads_of_two_episodes_that_differ_in_case_alone_are_written_apart(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {'Notes': 'n' * 2000}, {'notes': 'm' * 2000})
+    files = paths_of(export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False))
+    assert {'api/episode/0/static/Notes', 'api/episode/1/static/notes'} <= files
 
 
 def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -27,14 +27,7 @@ from positronic.server.export import (
     large_file_links_under,
     validated_build_id,
 )
-from positronic.server.positronic_server import (
-    DOWNLOAD_LINK,
-    FILTER_VALUES,
-    GROUP_FILTERS,
-    ColumnConfig,
-    GroupTableConfig,
-    app_state,
-)
+from positronic.server.positronic_server import DOWNLOAD_LINK, ColumnConfig, GroupTableConfig, app_state
 
 OUTCOME = 'eval.outcome'
 OBJECT = 'eval.object'
@@ -56,6 +49,12 @@ GROUPS = {
         group_fn=lambda episodes: {'count': len(episodes)},
         format_table={OUTCOME: ColumnConfig(label='Outcome'), 'count': ColumnConfig(label='Episodes', format='%d')},
         group_filter_keys={ATTEMPT: 'Attempt'},
+    ),
+    'pairs': GroupTableConfig(
+        group_keys=OUTCOME,
+        group_fn=lambda episodes: {'count': len(episodes)},
+        format_table={OUTCOME: ColumnConfig(label='Outcome'), 'count': ColumnConfig(label='Episodes', format='%d')},
+        group_filter_keys={OBJECT: 'Object', ATTEMPT: 'Attempt'},
     ),
 }
 
@@ -212,17 +211,29 @@ def test_the_assets_are_written_only_when_asked(dataset, tmp_path):
     assert any(path.startswith('static/rerun/') and path.endswith('.wasm') for path in with_assets)
 
 
-def test_every_filter_set_a_page_can_ask_for_is_listed_with_the_empty_one_first():
-    response = {GROUP_FILTERS: {'b': {FILTER_VALUES: ['1', '2']}, 'a': {FILTER_VALUES: ['x']}}}
+def test_every_filter_set_an_episode_satisfies_is_listed_once_with_the_empty_one_first():
+    episodes = [{'a': 'x', 'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
 
-    assert list(filter_sets(response)) == [
-        {},
-        {'b': '1'},
-        {'b': '2'},
-        {'a': 'x'},
-        {'a': 'x', 'b': '1'},
-        {'a': 'x', 'b': '2'},
-    ]
+    assert filter_sets(episodes) == [{}, {'a': 'x'}, {'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
+
+
+def test_a_filter_set_no_episode_satisfies_gets_no_file(dataset, tmp_path):
+    out = tmp_path / 'out'
+    an_export(dataset, out, group_tables=GROUPS)
+
+    index = json.loads((out / 'api/groups/pairs' / GROUP_INDEX_FILE).read_text())
+    assert index[0]['params'] == {}
+    assert sorted(json.dumps(entry['params'], sort_keys=True) for entry in index[1:]) == sorted(
+        json.dumps(params, sort_keys=True)
+        for params in (
+            {OBJECT: OBJECTS[0]},
+            {OBJECT: OBJECTS[1]},
+            {ATTEMPT: '1'},
+            {ATTEMPT: '2'},
+            {OBJECT: OBJECTS[0], ATTEMPT: '1'},
+            {OBJECT: OBJECTS[1], ATTEMPT: '2'},
+        )
+    )
 
 
 def test_a_link_is_moved_in_the_nodes_a_page_carries_it_and_an_equal_value_is_not():
@@ -318,14 +329,6 @@ def test_an_export_leaves_the_app_state_as_it_found_it(dataset, tmp_path):
     assert app_state == before
 
 
-def test_a_group_name_that_would_leave_the_output_directory_is_refused(dataset, tmp_path):
-    out = tmp_path / 'out'
-
-    with pytest.raises(ValueError, match='outside'):
-        an_export(dataset, out, group_tables={'../..': GROUPS['outcomes']})
-    assert not (tmp_path / 'index.html').exists()
-
-
 class _Reversed(Dataset):
     def __init__(self, dataset: Dataset):
         self._dataset = dataset
@@ -347,18 +350,31 @@ def test_a_full_dataset_holding_other_episodes_at_the_shown_indexes_is_refused(d
     assert not (tmp_path / 'reversed').exists() and not (tmp_path / 'shorter').exists()
 
 
-ESCAPED_KEY = 'notes & é'
+ESCAPED_KEY = 'notes & é?'
 
 
-def test_a_download_whose_field_name_a_page_escapes_is_linked_and_written(tmp_path):
+def test_a_download_whose_field_name_a_url_cannot_carry_as_it_is_is_linked_encoded_and_written(tmp_path):
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', ESCAPED_KEY: 'n' * 2000})
     out = tmp_path / 'out'
 
     written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id='bld'))
 
-    assert '"build/bld/api/episode/0/static/notes \\u0026 \\u00e9"' in (out / 'episode/0/index.html').read_text()
+    assert '"build/bld/api/episode/0/static/notes%20%26%20%C3%A9%3F"' in (out / 'episode/0/index.html').read_text()
     assert f'build/bld/api/episode/0/static/{ESCAPED_KEY}' in written
     assert (out / 'build/bld/api/episode/0/static' / ESCAPED_KEY).read_bytes() == b'n' * 2000
+
+
+def test_a_group_name_that_is_not_one_url_path_segment_is_refused(dataset, tmp_path):
+    for name in ('a?b', 'a#b', 'a b', 'a/b', '.', '../..'):
+        with pytest.raises(ValueError, match='group name'):
+            an_export(dataset, tmp_path / 'out', group_tables={name: GROUPS['outcomes']})
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):
+    with pytest.raises(ValueError, match='home_page'):
+        an_export(dataset, tmp_path / 'out', group_tables=GROUPS, home_page='nope')
+    assert not (tmp_path / 'out').exists()
 
 
 def test_the_page_script_spells_a_group_index_as_the_export_writes_it():

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -70,7 +70,7 @@ def dataset(tmp_path):
                 episode.set_static('artifacts', [b'first blob', 'short'])
                 episode.set_static(HIDDEN_KEY, HIDDEN_VALUE)
                 for step in range(4):
-                    episode.append('robot_state.q', np.zeros(7, dtype=np.float32), ts_ns=10_000 + step * 1_000)
+                    episode.append(keys.JOINTS, np.zeros(7, dtype=np.float32), ts_ns=10_000 + step * 1_000)
     return load_all_datasets(root)
 
 

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -1,6 +1,7 @@
 """What one export writes, where, and what it keeps off a page."""
 
 import json
+import os
 import re
 import shutil
 import threading
@@ -699,19 +700,15 @@ def test_a_download_whose_path_on_disk_is_past_a_host_s_key_limit_stops_the_expo
     assert not (tmp_path / 'out').exists()
 
 
-def test_a_path_at_a_host_s_key_limit_is_held_and_one_past_it_is_refused():
-    """On disk the test would need an output directory in front, and macOS caps the whole path at 1024 bytes."""
-    tree = _PortableTree()
-    tree.add(
-        '/'.join(['a' * MAX_COMPONENT_BYTES] * 4) + '/' + 'b' * (export.MAX_PATH_BYTES - 4 * (MAX_COMPONENT_BYTES + 1))
-    )
+def test_a_path_at_a_host_s_key_limit_is_held_and_one_past_it_is_refused(monkeypatch):
+    """The local limit is lifted: on macOS it equals the key limit, so no directory in front leaves room."""
+    monkeypatch.setattr(export, '_path_max', lambda directory: 1 << 16)
+    tree = _PortableTree(Path('out'))
+    stem = '/'.join(['a' * MAX_COMPONENT_BYTES] * 4) + '/'
+    tree.add(PurePosixPath(stem + 'b' * (export.MAX_PATH_BYTES - len(stem))))
 
     with pytest.raises(ValueError, match='key limit'):
-        tree.add(
-            '/'.join(['c' * MAX_COMPONENT_BYTES] * 4)
-            + '/'
-            + 'd' * (export.MAX_PATH_BYTES + 1 - 4 * (MAX_COMPONENT_BYTES + 1))
-        )
+        tree.add(PurePosixPath(stem + 'c' * (export.MAX_PATH_BYTES + 1 - len(stem))))
 
 
 def test_a_group_table_past_the_filter_set_bound_is_refused_before_a_write(dataset, tmp_path, monkeypatch):
@@ -728,6 +725,22 @@ def test_a_group_table_at_the_filter_set_bound_is_written(dataset, tmp_path, mon
     an_export(dataset, out, group_tables={'pairs': GROUPS['pairs']})
 
     assert len(json.loads((out / 'api/groups/pairs' / GROUP_INDEX_FILE).read_text())) == 7
+
+
+def test_a_local_path_at_the_filesystem_s_limit_is_refused_before_a_write_and_one_under_it_is_written(
+    dataset, tmp_path, monkeypatch
+):
+    out = tmp_path / 'out'
+    probe = paths_of(an_export(dataset, tmp_path / 'probe'))
+    longest = max(len(os.fsencode(out.joinpath(*PurePosixPath(path).parts))) for path in probe)
+
+    monkeypatch.setattr(export, '_path_max', lambda directory: longest)
+    with pytest.raises(ValueError, match='path limit'):
+        an_export(dataset, out)
+    assert not out.exists()
+
+    monkeypatch.setattr(export, '_path_max', lambda directory: longest + 1)
+    assert paths_of(an_export(dataset, out)) == probe
 
 
 def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -31,6 +31,7 @@ from positronic.server.export import (
     GroupFile,
     _fetch,
     _Output,
+    _PortableTree,
     asset_content_type,
     export_static,
     filter_sets,
@@ -698,16 +699,19 @@ def test_a_download_whose_path_on_disk_is_past_a_host_s_key_limit_stops_the_expo
     assert not (tmp_path / 'out').exists()
 
 
-def test_a_download_whose_path_on_disk_is_at_a_host_s_key_limit_is_written(tmp_path):
-    build_id = 'b' * MAX_COMPONENT_BYTES
-    static, keys = _download_at(export.MAX_PATH_BYTES, build_id)
-    dataset = a_dataset(tmp_path / 'dataset', static)
-
-    files = export_static(
-        dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id=build_id
+def test_a_path_at_a_host_s_key_limit_is_held_and_one_past_it_is_refused():
+    """On disk the test would need an output directory in front, and macOS caps the whole path at 1024 bytes."""
+    tree = _PortableTree()
+    tree.add(
+        '/'.join(['a' * MAX_COMPONENT_BYTES] * 4) + '/' + 'b' * (export.MAX_PATH_BYTES - 4 * (MAX_COMPONENT_BYTES + 1))
     )
 
-    assert export._on_disk(download_link(0, keys), build_id) in paths_of(files)
+    with pytest.raises(ValueError, match='key limit'):
+        tree.add(
+            '/'.join(['c' * MAX_COMPONENT_BYTES] * 4)
+            + '/'
+            + 'd' * (export.MAX_PATH_BYTES + 1 - 4 * (MAX_COMPONENT_BYTES + 1))
+        )
 
 
 def test_a_group_table_past_the_filter_set_bound_is_refused_before_a_write(dataset, tmp_path, monkeypatch):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -20,13 +20,21 @@ from positronic.server.export import (
     GROUP_INDEX_FILE,
     UNFILTERED_FILE,
     GroupFile,
+    _Output,
     asset_content_type,
     export_static,
     filter_sets,
     large_file_links_under,
     validated_build_id,
 )
-from positronic.server.positronic_server import FILTER_VALUES, GROUP_FILTERS, ColumnConfig, GroupTableConfig, app_state
+from positronic.server.positronic_server import (
+    DOWNLOAD_LINK,
+    FILTER_VALUES,
+    GROUP_FILTERS,
+    ColumnConfig,
+    GroupTableConfig,
+    app_state,
+)
 
 OUTCOME = 'eval.outcome'
 OBJECT = 'eval.object'
@@ -217,16 +225,44 @@ def test_every_filter_set_a_page_can_ask_for_is_listed_with_the_empty_one_first(
     ]
 
 
-def test_a_link_is_moved_under_the_build_and_a_value_that_looks_like_one_is_not():
+def test_a_link_is_moved_in_the_nodes_a_page_carries_it_and_an_equal_value_is_not():
     links = ['api/episode_rrd/3', 'api/episode/3/static/scene']
-    page = 'appUrl("api/episode_rrd/3") "api/episode/3/static/scene" "api/episode/3/static/note" href="episodes"'
+    download = {DOWNLOAD_LINK: 'api/episode/3/static/scene', 'size': 6}
+    values = {'twin': 'api/episode_rrd/3', 'note': 'api/episode/3/static/note'}
+    page = f'appUrl("api/episode_rrd/3") {json.dumps(download)} {json.dumps(values)} href="episodes"'
 
     moved = large_file_links_under(page, links, 'bld')
 
-    assert '"build/bld/api/episode_rrd/3"' in moved
-    assert '"build/bld/api/episode/3/static/scene"' in moved
-    assert '"api/episode/3/static/note"' in moved and 'href="episodes"' in moved
+    assert 'appUrl("build/bld/api/episode_rrd/3")' in moved
+    assert json.dumps({**download, DOWNLOAD_LINK: 'build/bld/api/episode/3/static/scene'}) in moved
+    assert json.dumps(values) in moved and 'href="episodes"' in moved
     assert large_file_links_under(page, links, '') == page
+
+
+def test_a_static_value_equal_to_a_link_stays_as_it_is(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'twin': 'api/episode_rrd/0'})
+    out = tmp_path / 'out'
+
+    export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id='bld')
+
+    page = (out / 'episode/0/index.html').read_text()
+    assert 'appUrl("build/bld/api/episode_rrd/0")' in page
+    assert json.dumps({'twin': 'api/episode_rrd/0'})[1:-1] in page
+
+
+def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(tmp_path):
+    out = _Output(tmp_path / 'out')
+
+    for path in ('../index.html', '..\\..\\index.html', '/index.html'):
+        with pytest.raises(ValueError, match='outside'):
+            out.write(path, b'', 'text/html')
+    assert not (tmp_path / 'out').exists()
+
+
+def test_the_assets_go_with_the_root_base_href_only(dataset, tmp_path):
+    with pytest.raises(ValueError, match='assets'):
+        an_export(dataset, tmp_path / 'out', base_href='/v/tok/', assets=True)
+    assert not (tmp_path / 'out').exists()
 
 
 def test_a_build_id_outside_the_token_alphabet_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -25,6 +25,7 @@ from positronic.dataset.transforms.episode import EpisodeTransform
 from positronic.server import positronic_server
 from positronic.server.export import (
     GROUP_INDEX_FILE,
+    MAX_FILTER_KEYS_PER_GROUP,
     UNFILTERED_FILE,
     GroupFile,
     _fetch,
@@ -35,7 +36,14 @@ from positronic.server.export import (
     large_file_links_under,
     validated_build_id,
 )
-from positronic.server.positronic_server import DOWNLOAD_LINK, ColumnConfig, GroupTableConfig, app_state
+from positronic.server.positronic_server import (
+    _MAX_COMPONENT_BYTES,
+    DOWNLOAD_LINK,
+    ColumnConfig,
+    GroupTableConfig,
+    TableConfig,
+    app_state,
+)
 
 OUTCOME = 'eval.outcome'
 OBJECT = 'eval.object'
@@ -483,6 +491,55 @@ class _Reversed(Dataset):
 
     def _get_episode(self, index: int) -> Episode:
         return cast(Episode, self._dataset[len(self._dataset) - 1 - index])
+
+
+def test_a_full_dataset_without_a_download_the_shown_dataset_links_is_refused_before_a_write(dataset, tmp_path):
+    without_notes = TransformedDataset(dataset, _KeepStatic((keys.TASK, OUTCOME, OBJECT, ATTEMPT, 'artifacts')))
+
+    with pytest.raises(ValueError, match="no download at 'notes'"):
+        an_export(dataset, tmp_path / 'out', full_dataset=without_notes)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_download_whose_key_is_past_a_file_name_s_limit_stops_the_export_before_it_writes(tmp_path):
+    long_key = 'k' * (_MAX_COMPONENT_BYTES + 1)
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', long_key: b'a mesh'})
+
+    with pytest.raises(ValueError, match='no link'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
+def _with_filter_keys(count: int) -> tuple[TableConfig, dict[str, GroupTableConfig]]:
+    """A group table filtering on `count` keys no episode carries, and an episode table holding them as columns."""
+    filter_keys = {f'k{i}': f'K{i}' for i in range(count)}
+    table = {**TABLE, **{key: ColumnConfig(label=label) for key, label in filter_keys.items()}}
+    group = GroupTableConfig(
+        group_keys=OUTCOME,
+        group_fn=lambda episodes: {'count': len(episodes)},
+        format_table={OUTCOME: ColumnConfig(label='Outcome'), 'count': ColumnConfig(label='Episodes', format='%d')},
+        group_filter_keys=filter_keys,
+    )
+    return table, {'wide': group}
+
+
+def test_a_group_table_past_the_filter_key_bound_is_refused_before_a_write(dataset, tmp_path):
+    table, groups = _with_filter_keys(MAX_FILTER_KEYS_PER_GROUP + 1)
+
+    with pytest.raises(ValueError, match='filter keys'):
+        an_export(dataset, tmp_path / 'out', ep_table_cfg=table, group_tables=groups)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_group_table_at_the_filter_key_bound_is_written(dataset, tmp_path):
+    table, groups = _with_filter_keys(MAX_FILTER_KEYS_PER_GROUP)
+    out = tmp_path / 'out'
+
+    an_export(dataset, out, ep_table_cfg=table, group_tables=groups)
+
+    assert json.loads((out / 'api/groups/wide' / GROUP_INDEX_FILE).read_text()) == [
+        {'params': {}, 'file': UNFILTERED_FILE}
+    ]
 
 
 def test_a_full_dataset_holding_other_episodes_at_the_shown_indexes_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -303,6 +303,14 @@ def test_a_static_value_named_with_a_backslash_stops_the_export_before_it_writes
     assert not (tmp_path / 'out').exists()
 
 
+def test_two_downloads_that_would_share_one_file_stop_the_export_before_it_writes(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a/b': b'1', 'a//b': b'2'})
+
+    with pytest.raises(ValueError, match='one file'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
 def test_the_assets_go_with_the_root_base_href_only(dataset, tmp_path):
     with pytest.raises(ValueError, match='assets'):
         an_export(dataset, tmp_path / 'out', base_href='/v/tok/', assets=True)

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -311,6 +311,23 @@ def test_two_downloads_that_would_share_one_file_stop_the_export_before_it_write
     assert not (tmp_path / 'out').exists()
 
 
+def test_a_download_named_as_another_download_s_directory_stops_the_export_before_it_writes(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a': b'1', 'a/b': b'2'})
+
+    with pytest.raises(ValueError, match='directory'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_cache_inside_the_output_directory_is_refused(dataset, tmp_path):
+    out = tmp_path / 'out'
+
+    for cache in (out, out / 'cache'):
+        with pytest.raises(ValueError, match='outside'):
+            an_export(dataset, out, cache_dir=cache)
+    assert not out.exists()
+
+
 def test_the_assets_go_with_the_root_base_href_only(dataset, tmp_path):
     with pytest.raises(ValueError, match='assets'):
         an_export(dataset, tmp_path / 'out', base_href='/v/tok/', assets=True)

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -372,7 +372,16 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
 
     for path in ('../index.html', '..\\..\\index.html', '/index.html'):
         with pytest.raises(ValueError, match='outside'):
-            out.write(path, b'', 'text/html')
+            out.plan([path])
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_write_the_plan_does_not_name_is_refused(tmp_path):
+    out = _Output(tmp_path / 'out')
+    out.plan(['index.html'])
+
+    with pytest.raises(ValueError, match='plan'):
+        out.write('episodes/index.html', b'', 'text/html')
     assert not (tmp_path / 'out').exists()
 
 
@@ -533,6 +542,39 @@ def test_a_full_dataset_without_a_download_the_shown_dataset_links_is_refused_be
     assert not (tmp_path / 'out').exists()
 
 
+class _WithStatic(EpisodeTransform):
+    def __init__(self, **static):
+        self._static = static
+
+    def __call__(self, episode: Episode) -> Episode:
+        return EpisodeContainer({**episode.signals, **episode.static, **self._static}, meta=episode.meta)
+
+
+@pytest.mark.parametrize('shown_notes', ['n' * 2000, b'n' * 1500], ids=['type', 'size'])
+def test_a_full_dataset_whose_download_differs_from_the_shown_one_in_type_or_size_is_refused_before_a_write(
+    tmp_path, shown_notes
+):
+    """The page reports the shown value's type and size beside a link the full value answers."""
+    full = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put it down', 'notes': b'n' * 2000})
+    shown_only = TransformedDataset(full, _WithStatic(notes=shown_notes))
+
+    with pytest.raises(ValueError, match="at 'notes'"):
+        export_static(
+            shown_only, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False, full_dataset=full
+        )
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_full_dataset_whose_download_matches_the_shown_one_in_type_and_size_answers_the_link(tmp_path):
+    full = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put it down', 'notes': 'm' * 2000})
+    shown_only = TransformedDataset(full, _WithStatic(notes='n' * 2000))
+    out = tmp_path / 'out'
+
+    export_static(shown_only, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, full_dataset=full)
+
+    assert (out / 'api/episode/0/static/notes').read_bytes() == b'm' * 2000
+
+
 def test_a_hidden_download_of_the_full_dataset_under_a_key_no_link_carries_is_left_alone(tmp_path):
     """The export links the shown dataset's downloads; the full dataset only has to hold those."""
     full = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put it down', 'notes': 'n' * 2000, '': 'h' * 2000})
@@ -677,7 +719,7 @@ def test_a_download_named_past_a_windows_device_name_is_written(tmp_path):
 
 def _download_at(total_bytes: int, build_id: str) -> tuple[dict, tuple[str, ...]]:
     """A static dict with one download whose path on disk is `total_bytes` long, and that download's key path."""
-    stem = len(export._on_disk(download_link(0, ('k',)), build_id)) - 1
+    stem = len(export._large_file_path(download_link(0, ('k',)), build_id)) - 1
     length = total_bytes - stem
     count = -(-(length + 1) // (MAX_COMPONENT_BYTES + 1))
     letters = length - (count - 1)
@@ -692,7 +734,7 @@ def _download_at(total_bytes: int, build_id: str) -> tuple[dict, tuple[str, ...]
 def test_a_download_whose_path_on_disk_is_past_a_host_s_key_limit_stops_the_export_before_it_writes(tmp_path):
     build_id = 'b' * MAX_COMPONENT_BYTES
     static, keys = _download_at(export.MAX_PATH_BYTES + 1, build_id)
-    assert len(export._on_disk(download_link(0, keys), build_id)) == export.MAX_PATH_BYTES + 1
+    assert len(export._large_file_path(download_link(0, keys), build_id)) == export.MAX_PATH_BYTES + 1
     dataset = a_dataset(tmp_path / 'dataset', static)
 
     with pytest.raises(ValueError, match='key limit'):
@@ -741,6 +783,28 @@ def test_a_local_path_at_the_filesystem_s_limit_is_refused_before_a_write_and_on
 
     monkeypatch.setattr(export, '_path_max', lambda directory: longest + 1)
     assert paths_of(an_export(dataset, out)) == probe
+
+
+def test_the_path_limit_is_windows_s_where_the_platform_reports_none(monkeypatch):
+    monkeypatch.delattr(os, 'pathconf')
+
+    assert export._path_max(Path('out')) == export._WINDOWS_PATH_MAX
+
+
+def test_a_page_or_an_api_file_past_the_filesystem_s_limit_stops_the_export_before_it_writes(tmp_path, monkeypatch):
+    """Every path is planned before a write, the large files alone are not: here the recording fits and the
+    longest path does not."""
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put it down'})
+    out = tmp_path / 'out'
+    probe = paths_of(export_static(dataset, tmp_path / 'probe', ep_table_cfg=TABLE, max_resolution=64, assets=False))
+    local = {path: len(os.fsencode(out.joinpath(*PurePosixPath(path).parts))) for path in probe}
+    longest = max(local.values())
+    assert local['api/episode_rrd/0'] < longest
+
+    monkeypatch.setattr(export, '_path_max', lambda directory: longest)
+    with pytest.raises(ValueError, match='path limit'):
+        export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not out.exists()
 
 
 def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -1,7 +1,7 @@
 """What one export writes, where, and what it keeps off a page."""
 
 import json
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 import numpy as np
 import pytest
@@ -14,6 +14,7 @@ from positronic.dataset.transforms.episode import EpisodeTransform
 from positronic.server.export import (
     GROUP_INDEX_FILE,
     UNFILTERED_FILE,
+    asset_content_type,
     export_static,
     filter_sets,
     large_file_links_under,
@@ -208,3 +209,16 @@ def test_an_export_leaves_the_app_state_as_it_found_it(dataset, tmp_path):
     an_export(dataset, tmp_path / 'out', base_href='/v/tok/', title='A run')
 
     assert app_state == before
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('viewer_bg.wasm', 'application/wasm'),
+        ('episode_0.rrd', 'application/octet-stream'),
+        ('app.js', 'text/javascript'),
+        ('styles.css', 'text/css'),
+    ],
+)
+def test_an_asset_is_served_under_the_type_a_browser_needs(name, expected):
+    assert asset_content_type(Path(name)) == expected

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -21,6 +21,7 @@ from positronic.server.export import (
     GROUP_INDEX_FILE,
     UNFILTERED_FILE,
     GroupFile,
+    _fetch,
     _Output,
     asset_content_type,
     export_static,
@@ -171,6 +172,21 @@ def test_without_a_build_id_the_large_files_sit_at_their_routes(dataset, tmp_pat
     page = (out / 'episode/0/index.html').read_text()
     assert '"api/episode_rrd/0"' in page and 'build/' not in page
     assert {'api/episode_rrd/0', 'api/episode_rrd/1', 'api/episode/0/static/notes'} <= written
+
+
+def test_a_recording_is_copied_from_the_cache_file_and_not_read_through_the_client(dataset, tmp_path, monkeypatch):
+    def fetch_no_recording(client, path, params=None):
+        assert 'episode_rrd' not in path, path
+        return _fetch(client, path, params)
+
+    monkeypatch.setattr('positronic.server.export._fetch', fetch_no_recording)
+    cache = tmp_path / 'cache'
+
+    files = an_export(dataset, tmp_path / 'out', cache_dir=cache)
+
+    cached = {path.read_bytes() for path in cache.rglob('*.rrd')}
+    written = {(tmp_path / 'out' / path).read_bytes() for path in paths_of(files) if 'episode_rrd' in path}
+    assert len(written) == 2 and written == cached
 
 
 def test_a_recording_is_built_from_the_full_dataset(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -531,6 +531,21 @@ def test_a_full_dataset_without_a_download_the_shown_dataset_links_is_refused_be
     assert not (tmp_path / 'out').exists()
 
 
+def test_a_hidden_download_of_the_full_dataset_under_a_key_no_link_carries_is_left_alone(tmp_path):
+    """The export links the shown dataset's downloads; the full dataset only has to hold those."""
+    full = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put it down', 'notes': 'n' * 2000, '': 'h' * 2000})
+    shown_only = TransformedDataset(full, _KeepStatic((keys.TASK, 'notes')))
+
+    files = paths_of(
+        export_static(
+            shown_only, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False, full_dataset=full
+        )
+    )
+
+    assert 'api/episode/0/static/notes' in files
+    assert not any(path.endswith('/static/') or path.endswith('/static') for path in files)
+
+
 def test_a_download_whose_key_is_past_a_file_name_s_limit_stops_the_export_before_it_writes(tmp_path):
     long_key = 'k' * (MAX_COMPONENT_BYTES + 1)
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', long_key: b'a mesh'})

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -37,8 +37,8 @@ from positronic.server.export import (
     validated_build_id,
 )
 from positronic.server.positronic_server import (
-    _MAX_COMPONENT_BYTES,
     DOWNLOAD_LINK,
+    MAX_COMPONENT_BYTES,
     ColumnConfig,
     GroupTableConfig,
     TableConfig,
@@ -502,7 +502,7 @@ def test_a_full_dataset_without_a_download_the_shown_dataset_links_is_refused_be
 
 
 def test_a_download_whose_key_is_past_a_file_name_s_limit_stops_the_export_before_it_writes(tmp_path):
-    long_key = 'k' * (_MAX_COMPONENT_BYTES + 1)
+    long_key = 'k' * (MAX_COMPONENT_BYTES + 1)
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', long_key: b'a mesh'})
 
     with pytest.raises(ValueError, match='no link'):
@@ -600,3 +600,9 @@ def test_the_page_script_spells_a_group_index_as_the_export_writes_it():
 )
 def test_an_asset_is_served_under_the_type_a_browser_needs(name, expected):
     assert asset_content_type(Path(name)) == expected
+
+
+def test_a_build_id_past_a_file_name_s_limit_is_refused_and_one_within_it_stands():
+    assert validated_build_id('b' * MAX_COMPONENT_BYTES) == 'b' * MAX_COMPONENT_BYTES
+    with pytest.raises(ValueError, match='build_id'):
+        validated_build_id('b' * (MAX_COMPONENT_BYTES + 1))

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -1,0 +1,210 @@
+"""What one export writes, where, and what it keeps off a page."""
+
+import json
+from pathlib import PurePosixPath
+
+import numpy as np
+import pytest
+
+from positronic import keys
+from positronic.dataset.episode import Episode, EpisodeContainer
+from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
+from positronic.dataset.transforms import TransformedDataset
+from positronic.dataset.transforms.episode import EpisodeTransform
+from positronic.server.export import (
+    GROUP_INDEX_FILE,
+    UNFILTERED_FILE,
+    export_static,
+    filter_sets,
+    large_file_links_under,
+)
+from positronic.server.positronic_server import FILTER_VALUES, GROUP_FILTERS, ColumnConfig, GroupTableConfig, app_state
+
+OUTCOME = 'eval.outcome'
+OBJECT = 'eval.object'
+HIDDEN_KEY = 'checkpoint_path'
+HIDDEN_VALUE = 's3://internal/checkpoints/step_1000'
+OBJECTS = ('Plastic banana', 'Wooden block')
+
+TABLE = {'__index__': ColumnConfig(label='#', format='%d'), OUTCOME: ColumnConfig(label='Outcome', filter=True)}
+GROUPS = {
+    'outcomes': GroupTableConfig(
+        group_keys=OUTCOME,
+        group_fn=lambda episodes: {'count': len(episodes)},
+        format_table={OUTCOME: ColumnConfig(label='Outcome'), 'count': ColumnConfig(label='Episodes', format='%d')},
+        group_filter_keys={OBJECT: 'Object'},
+    )
+}
+
+
+class _KeepStatic(EpisodeTransform):
+    def __init__(self, kept: tuple[str, ...]):
+        self._kept = frozenset(kept)
+
+    def __call__(self, episode: Episode) -> Episode:
+        static = {name: value for name, value in episode.static.items() if name in self._kept}
+        return EpisodeContainer({**episode.signals, **static}, meta=episode.meta)
+
+
+@pytest.fixture
+def dataset(tmp_path):
+    """Two episodes; one static value is long enough to become a download, one is hidden."""
+    root = tmp_path / 'dataset'
+    with LocalDatasetWriter(root) as writer:
+        for index, object_name in enumerate(OBJECTS):
+            with writer.new_episode() as episode:
+                episode.set_static(keys.TASK, 'Put the banana on the plate')
+                episode.set_static(OUTCOME, 'Success' if index == 0 else 'Failure')
+                episode.set_static(OBJECT, object_name)
+                episode.set_static('notes', 'n' * 2000)
+                episode.set_static(HIDDEN_KEY, HIDDEN_VALUE)
+                for step in range(4):
+                    episode.append('robot_state.q', np.zeros(7, dtype=np.float32), ts_ns=10_000 + step * 1_000)
+    return load_all_datasets(root)
+
+
+def shown(dataset):
+    return TransformedDataset(dataset, _KeepStatic((keys.TASK, OUTCOME, OBJECT, 'notes')))
+
+
+def an_export(dataset, out, **overrides):
+    settings = {'ep_table_cfg': TABLE, 'max_resolution': 64, 'assets': False, 'full_dataset': dataset}
+    return export_static(shown(dataset), out, **{**settings, **overrides})
+
+
+def paths_of(files) -> set[str]:
+    return {str(file.path) for file in files}
+
+
+def test_a_page_is_a_directory_with_an_index_file_and_an_api_response_is_json(dataset, tmp_path):
+    written = paths_of(an_export(dataset, tmp_path / 'out'))
+
+    assert {'index.html', 'episodes/index.html', 'episode/0/index.html', 'episode/1/index.html'} <= written
+    assert {'api/episodes.json', 'api/dataset_info.json', 'api/dataset_status.json'} <= written
+
+
+def test_every_file_named_is_on_disk_and_nothing_else_is(dataset, tmp_path):
+    out = tmp_path / 'out'
+    written = an_export(dataset, out)
+
+    on_disk = {str(PurePosixPath(path.relative_to(out))) for path in out.rglob('*') if path.is_file()}
+    assert on_disk == paths_of(written)
+    assert all(file.size == (out / file.path).stat().st_size for file in written)
+
+
+def test_a_group_table_gets_one_file_per_filter_set_and_an_index_naming_them(dataset, tmp_path):
+    out = tmp_path / 'out'
+    an_export(dataset, out, group_tables=GROUPS)
+
+    index = json.loads((out / 'api/groups/outcomes' / GROUP_INDEX_FILE).read_text())
+    assert index[0] == {'params': {}, 'file': UNFILTERED_FILE}
+    assert [entry['params'] for entry in index[1:]] == [{OBJECT: OBJECTS[0]}, {OBJECT: OBJECTS[1]}]
+    for entry in index:
+        assert (out / 'api/groups/outcomes' / entry['file']).is_file()
+
+
+def test_a_filtered_group_file_holds_only_that_filter_s_episodes(dataset, tmp_path):
+    out = tmp_path / 'out'
+    an_export(dataset, out, group_tables=GROUPS)
+
+    index = json.loads((out / 'api/groups/outcomes' / GROUP_INDEX_FILE).read_text())
+    block = next(entry for entry in index if entry['params'] == {OBJECT: 'Wooden block'})
+    table = json.loads((out / 'api/groups/outcomes' / block['file']).read_text())
+    outcome = [column['key'] for column in table['columns']].index(OUTCOME)
+    assert [row[1][outcome] for row in table['episodes']] == ['Failure']
+
+
+def test_a_build_id_moves_the_recordings_and_the_downloads_under_it(dataset, tmp_path):
+    out = tmp_path / 'out'
+    written = paths_of(an_export(dataset, out, build_id='bld'))
+
+    page = (out / 'episode/0/index.html').read_text()
+    assert '"build/bld/api/episode_rrd/0"' in page
+    assert '"build/bld/api/episode/0/static/notes"' in page
+    assert 'build/bld/api/episode_rrd/0' in written
+    assert 'build/bld/api/episode/0/static/notes' in written
+    assert (out / 'build/bld/api/episode/0/static/notes').read_bytes() == b'n' * 2000
+
+
+def test_without_a_build_id_the_large_files_sit_at_their_routes(dataset, tmp_path):
+    out = tmp_path / 'out'
+    written = paths_of(an_export(dataset, out))
+
+    page = (out / 'episode/0/index.html').read_text()
+    assert '"api/episode_rrd/0"' in page and 'build/' not in page
+    assert {'api/episode_rrd/0', 'api/episode_rrd/1', 'api/episode/0/static/notes'} <= written
+
+
+def test_a_recording_is_built_from_the_full_dataset(dataset, tmp_path):
+    """The recording builder reads an episode's robot model out of its static values."""
+    out = tmp_path / 'out'
+    files = {str(file.path): file for file in an_export(dataset, out)}
+
+    assert files['api/episode_rrd/0'].size > 0
+    assert files['api/episode_rrd/0'].content_type == 'application/octet-stream'
+
+
+def test_a_hidden_static_value_reaches_no_page_and_no_file(dataset, tmp_path):
+    out = tmp_path / 'out'
+    an_export(dataset, out, group_tables=GROUPS)
+
+    for path in out.rglob('*'):
+        if path.is_file() and not str(path).endswith('episode_rrd/0') and not str(path).endswith('episode_rrd/1'):
+            assert HIDDEN_VALUE.encode() not in path.read_bytes(), path
+            assert b'/dataset/' not in path.read_bytes(), path
+
+
+def test_a_prefix_and_a_title_reach_every_page(dataset, tmp_path):
+    out = tmp_path / 'out'
+    an_export(dataset, out, base_href='/v/tok/', title='A run')
+
+    for page in ('index.html', 'episodes/index.html', 'episode/1/index.html'):
+        body = (out / page).read_text()
+        assert '<base href="/v/tok/" />' in body
+        assert 'A run' in body
+        assert 'window.STATIC_EXPORT = true;' in body
+
+
+def test_the_assets_are_written_only_when_asked(dataset, tmp_path):
+    without = paths_of(an_export(dataset, tmp_path / 'bare'))
+    with_assets = paths_of(an_export(dataset, tmp_path / 'whole', assets=True))
+
+    assert not [path for path in without if path.startswith('static/')]
+    assert 'static/app.js' in with_assets and 'static/styles.css' in with_assets
+    assert any(path.startswith('static/rerun/') and path.endswith('.wasm') for path in with_assets)
+
+
+def test_every_filter_set_a_page_can_ask_for_is_listed_with_the_empty_one_first():
+    response = {GROUP_FILTERS: {'b': {FILTER_VALUES: ['2', '1']}, 'a': {FILTER_VALUES: ['x']}}}
+
+    assert list(filter_sets(response)) == [
+        {},
+        {'b': '1'},
+        {'b': '2'},
+        {'a': 'x'},
+        {'a': 'x', 'b': '1'},
+        {'a': 'x', 'b': '2'},
+    ]
+
+
+def test_a_filter_value_no_episode_carries_asks_for_no_file():
+    """The server matches a filter against an episode's own value, and never against an absent one."""
+    assert list(filter_sets({GROUP_FILTERS: {'a': {FILTER_VALUES: [None, 'x']}}})) == [{}, {'a': 'x'}]
+
+
+def test_a_link_is_moved_under_the_build_and_a_page_route_is_not():
+    page = 'appUrl("api/episode_rrd/3") "api/episode/3/static/scene" href="episodes" "api/episodes.json"'
+
+    moved = large_file_links_under(page, 'bld')
+
+    assert '"build/bld/api/episode_rrd/3"' in moved
+    assert '"build/bld/api/episode/3/static/scene"' in moved
+    assert 'href="episodes"' in moved and '"api/episodes.json"' in moved
+    assert large_file_links_under(page, '') == page
+
+
+def test_an_export_leaves_the_app_state_as_it_found_it(dataset, tmp_path):
+    before = dict(app_state)
+    an_export(dataset, tmp_path / 'out', base_href='/v/tok/', title='A run')
+
+    assert app_state == before

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -18,11 +18,13 @@ from positronic.server.export import (
     export_static,
     filter_sets,
     large_file_links_under,
+    validated_build_id,
 )
 from positronic.server.positronic_server import FILTER_VALUES, GROUP_FILTERS, ColumnConfig, GroupTableConfig, app_state
 
 OUTCOME = 'eval.outcome'
 OBJECT = 'eval.object'
+ATTEMPT = 'attempt'
 HIDDEN_KEY = 'checkpoint_path'
 HIDDEN_VALUE = 's3://internal/checkpoints/step_1000'
 OBJECTS = ('Plastic banana', 'Wooden block')
@@ -34,7 +36,13 @@ GROUPS = {
         group_fn=lambda episodes: {'count': len(episodes)},
         format_table={OUTCOME: ColumnConfig(label='Outcome'), 'count': ColumnConfig(label='Episodes', format='%d')},
         group_filter_keys={OBJECT: 'Object'},
-    )
+    ),
+    'attempts': GroupTableConfig(
+        group_keys=OUTCOME,
+        group_fn=lambda episodes: {'count': len(episodes)},
+        format_table={OUTCOME: ColumnConfig(label='Outcome'), 'count': ColumnConfig(label='Episodes', format='%d')},
+        group_filter_keys={ATTEMPT: 'Attempt'},
+    ),
 }
 
 
@@ -57,7 +65,9 @@ def dataset(tmp_path):
                 episode.set_static(keys.TASK, 'Put the banana on the plate')
                 episode.set_static(OUTCOME, 'Success' if index == 0 else 'Failure')
                 episode.set_static(OBJECT, object_name)
+                episode.set_static(ATTEMPT, index + 1)
                 episode.set_static('notes', 'n' * 2000)
+                episode.set_static('artifacts', [b'first blob', 'short'])
                 episode.set_static(HIDDEN_KEY, HIDDEN_VALUE)
                 for step in range(4):
                     episode.append('robot_state.q', np.zeros(7, dtype=np.float32), ts_ns=10_000 + step * 1_000)
@@ -65,7 +75,7 @@ def dataset(tmp_path):
 
 
 def shown(dataset):
-    return TransformedDataset(dataset, _KeepStatic((keys.TASK, OUTCOME, OBJECT, 'notes')))
+    return TransformedDataset(dataset, _KeepStatic((keys.TASK, OUTCOME, OBJECT, ATTEMPT, 'notes', 'artifacts')))
 
 
 def an_export(dataset, out, **overrides):
@@ -193,15 +203,62 @@ def test_a_filter_value_no_episode_carries_asks_for_no_file():
     assert list(filter_sets({GROUP_FILTERS: {'a': {FILTER_VALUES: [None, 'x']}}})) == [{}, {'a': 'x'}]
 
 
-def test_a_link_is_moved_under_the_build_and_a_page_route_is_not():
-    page = 'appUrl("api/episode_rrd/3") "api/episode/3/static/scene" href="episodes" "api/episodes.json"'
+def test_a_link_is_moved_under_the_build_and_a_value_that_looks_like_one_is_not():
+    links = ['api/episode_rrd/3', 'api/episode/3/static/scene']
+    page = 'appUrl("api/episode_rrd/3") "api/episode/3/static/scene" "api/episode/3/static/note" href="episodes"'
 
-    moved = large_file_links_under(page, 'bld')
+    moved = large_file_links_under(page, links, 'bld')
 
     assert '"build/bld/api/episode_rrd/3"' in moved
     assert '"build/bld/api/episode/3/static/scene"' in moved
-    assert 'href="episodes"' in moved and '"api/episodes.json"' in moved
-    assert large_file_links_under(page, '') == page
+    assert '"api/episode/3/static/note"' in moved and 'href="episodes"' in moved
+    assert large_file_links_under(page, links, '') == page
+
+
+def test_a_build_id_outside_the_token_alphabet_is_refused(dataset, tmp_path):
+    for value in ('../../shared', 'k"3', 'k3/n9', 'k3 n9'):
+        with pytest.raises(ValueError, match='build_id'):
+            an_export(dataset, tmp_path / 'out', build_id=value)
+    assert validated_build_id('k3n9_-A') == 'k3n9_-A'
+
+
+def test_an_export_refuses_a_directory_that_holds_something(dataset, tmp_path):
+    out = tmp_path / 'out'
+    out.mkdir()
+    (out / 'episode').mkdir()
+    (out / 'episode' / 'stale').write_text('an older export')
+
+    with pytest.raises(ValueError, match='not empty'):
+        an_export(dataset, out)
+    assert (out / 'episode' / 'stale').read_text() == 'an older export'
+
+
+def test_an_empty_directory_is_exported_into(dataset, tmp_path):
+    out = tmp_path / 'out'
+    out.mkdir()
+
+    assert an_export(dataset, out)
+
+
+def test_a_download_inside_a_list_is_linked_by_its_index_and_served(dataset, tmp_path):
+    out = tmp_path / 'out'
+    written = paths_of(an_export(dataset, out))
+
+    assert '"api/episode/0/static/artifacts.0"' in (out / 'episode/0/index.html').read_text()
+    assert 'api/episode/0/static/artifacts.0' in written
+    assert (out / 'api/episode/0/static/artifacts.0').read_bytes() == b'first blob'
+    assert 'api/episode/0/static/artifacts.1' not in written
+
+
+def test_a_filter_on_a_number_reaches_the_episodes_that_carry_it(dataset, tmp_path):
+    out = tmp_path / 'out'
+    an_export(dataset, out, group_tables=GROUPS)
+
+    index = json.loads((out / 'api/groups/attempts' / GROUP_INDEX_FILE).read_text())
+    second = next(entry for entry in index if entry['params'] == {ATTEMPT: '2'})
+    table = json.loads((out / 'api/groups/attempts' / second['file']).read_text())
+    outcome = [column['key'] for column in table['columns']].index(OUTCOME)
+    assert [row[1][outcome] for row in table['episodes']] == ['Failure']
 
 
 def test_an_export_leaves_the_app_state_as_it_found_it(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -391,10 +391,10 @@ def test_a_short_key_and_a_slashed_key_that_share_a_prefix_are_written_apart(tmp
     assert (out / 'api/episode/0/static/a%2Fb').read_bytes() == b'2'
 
 
-def test_a_cache_inside_the_output_directory_is_refused(dataset, tmp_path):
+def test_a_cache_and_an_output_directory_that_overlap_are_refused(dataset, tmp_path):
     out = tmp_path / 'out'
 
-    for cache in (out, out / 'cache'):
+    for cache in (out, out / 'cache', tmp_path):
         with pytest.raises(ValueError, match='outside'):
             an_export(dataset, out, cache_dir=cache)
     assert not out.exists()

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -1,10 +1,16 @@
 """What one export writes, where, and what it keeps off a page."""
 
 import json
+import re
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import fields
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePosixPath
 from typing import cast
+from urllib.request import urlopen
 
 import numpy as np
 import pytest
@@ -272,6 +278,47 @@ def test_a_link_is_moved_in_the_nodes_a_page_carries_it_and_an_equal_value_is_no
     assert large_file_links_under(page, links, '') == page
 
 
+def test_a_link_with_an_encoded_segment_is_carried_as_a_static_host_resolves_it_to_the_file():
+    links = ['api/episode/3/static/a%2Fb']
+    page = f'{json.dumps({DOWNLOAD_LINK: links[0]})}'
+
+    assert json.dumps({DOWNLOAD_LINK: 'api/episode/3/static/a%252Fb'}) in large_file_links_under(page, links, '')
+    assert json.dumps({DOWNLOAD_LINK: 'build/bld/api/episode/3/static/a%252Fb'}) in large_file_links_under(
+        page, links, 'bld'
+    )
+
+
+@contextmanager
+def a_static_host(directory: Path) -> Iterator[str]:
+    """A local static host over `directory`, which percent-decodes a request path once, as any static host does."""
+    handler = partial(SimpleHTTPRequestHandler, directory=str(directory))
+    server = ThreadingHTTPServer(('127.0.0.1', 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f'http://127.0.0.1:{server.server_address[1]}'
+    finally:
+        server.shutdown()
+        thread.join(5)
+
+
+def test_a_static_host_serves_every_download_at_the_link_the_page_carries(tmp_path):
+    dataset = a_dataset(
+        tmp_path / 'dataset',
+        {keys.TASK: 'Put the banana on the plate', 'a/b': b'slashed', 'a': {'b': b'nested'}, ESCAPED_KEY: 'n' * 2000},
+    )
+    out = tmp_path / 'out'
+    export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id='bld')
+    page = (out / 'episode/0/index.html').read_text()
+    carried = re.findall(r'"__download__": "([^"]+)"', page)
+
+    with a_static_host(out) as host:
+        served = {link: urlopen(f'{host}/{link}').read() for link in carried}
+
+    assert len(carried) == 3
+    assert set(served.values()) == {b'slashed', b'nested', b'n' * 2000}
+
+
 def test_a_static_value_equal_to_a_link_stays_as_it_is(tmp_path):
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'twin': 'api/episode_rrd/0'})
     out = tmp_path / 'out'
@@ -306,7 +353,7 @@ def test_a_static_value_named_with_a_backslash_is_linked_encoded_and_written(tmp
 
     written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False))
 
-    assert '"api/episode/0/static/models%5Cscene"' in (out / 'episode/0/index.html').read_text()
+    assert '"api/episode/0/static/models%255Cscene"' in (out / 'episode/0/index.html').read_text()
     assert 'api/episode/0/static/models%5Cscene' in written
     assert (out / 'api/episode/0/static/models%5Cscene').read_bytes() == b'a mesh'
 
@@ -458,7 +505,8 @@ def test_a_download_whose_field_name_a_url_cannot_carry_as_it_is_is_linked_encod
     written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id='bld'))
 
     encoded = 'notes%20%26%20%C3%A9%3F'
-    assert f'"build/bld/api/episode/0/static/{encoded}"' in (out / 'episode/0/index.html').read_text()
+    asked = 'notes%2520%2526%2520%25C3%25A9%253F'
+    assert f'"build/bld/api/episode/0/static/{asked}"' in (out / 'episode/0/index.html').read_text()
     assert f'build/bld/api/episode/0/static/{encoded}' in written
     assert (out / 'build/bld/api/episode/0/static' / encoded).read_bytes() == b'n' * 2000
 

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -23,7 +23,7 @@ from positronic.dataset.episode import Episode, EpisodeContainer
 from positronic.dataset.local_dataset import LocalDatasetWriter, load_all_datasets
 from positronic.dataset.transforms import TransformedDataset
 from positronic.dataset.transforms.episode import EpisodeTransform, Identity
-from positronic.server import positronic_server
+from positronic.server import export, positronic_server
 from positronic.server.export import (
     GROUP_INDEX_FILE,
     MAX_FILTER_KEYS_PER_GROUP,
@@ -44,6 +44,7 @@ from positronic.server.positronic_server import (
     GroupTableConfig,
     TableConfig,
     app_state,
+    download_link,
 )
 
 OUTCOME = 'eval.outcome'
@@ -635,6 +636,79 @@ def test_downloads_of_two_episodes_that_differ_in_case_alone_are_written_apart(t
     dataset = a_dataset(tmp_path / 'dataset', {'Notes': 'n' * 2000}, {'notes': 'm' * 2000})
     files = paths_of(export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False))
     assert {'api/episode/0/static/Notes', 'api/episode/1/static/notes'} <= files
+
+
+def test_a_group_named_as_a_windows_device_is_refused_before_a_write(dataset, tmp_path):
+    with pytest.raises(ValueError, match='Windows'):
+        an_export(dataset, tmp_path / 'out', group_tables={'CON': GROUPS['outcomes']})
+    assert not (tmp_path / 'out').exists()
+
+
+@pytest.mark.parametrize('key', ['CON', 'nul.txt', 'report.'])
+def test_a_download_named_as_a_windows_device_or_with_a_trailing_dot_stops_the_export_before_it_writes(tmp_path, key):
+    dataset = a_dataset(tmp_path / 'dataset', {key: 'n' * 2000})
+    with pytest.raises(ValueError, match='Windows'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_download_named_past_a_windows_device_name_is_written(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {'console': 'n' * 2000, 'aux2': 'm' * 2000, 'lpt': 'o' * 2000})
+    files = paths_of(export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False))
+    assert {'api/episode/0/static/console', 'api/episode/0/static/aux2', 'api/episode/0/static/lpt'} <= files
+
+
+def _download_at(total_bytes: int, build_id: str) -> tuple[dict, tuple[str, ...]]:
+    """A static dict with one download whose path on disk is `total_bytes` long, and that download's key path."""
+    stem = len(export._on_disk(download_link(0, ('k',)), build_id)) - 1
+    length = total_bytes - stem
+    count = -(-(length + 1) // (MAX_COMPONENT_BYTES + 1))
+    letters = length - (count - 1)
+    sizes = [letters // count + (1 if index < letters % count else 0) for index in range(count)]
+    keys = tuple(chr(ord('a') + index) * size for index, size in enumerate(sizes))
+    value: object = 'n' * 2000
+    for key in reversed(keys):
+        value = {key: value}
+    return cast(dict, value), keys
+
+
+def test_a_download_whose_path_on_disk_is_past_a_host_s_key_limit_stops_the_export_before_it_writes(tmp_path):
+    build_id = 'b' * MAX_COMPONENT_BYTES
+    static, keys = _download_at(export.MAX_PATH_BYTES + 1, build_id)
+    assert len(export._on_disk(download_link(0, keys), build_id)) == export.MAX_PATH_BYTES + 1
+    dataset = a_dataset(tmp_path / 'dataset', static)
+
+    with pytest.raises(ValueError, match='key limit'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id=build_id)
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_download_whose_path_on_disk_is_at_a_host_s_key_limit_is_written(tmp_path):
+    build_id = 'b' * MAX_COMPONENT_BYTES
+    static, keys = _download_at(export.MAX_PATH_BYTES, build_id)
+    dataset = a_dataset(tmp_path / 'dataset', static)
+
+    files = export_static(
+        dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id=build_id
+    )
+
+    assert export._on_disk(download_link(0, keys), build_id) in paths_of(files)
+
+
+def test_a_group_table_past_the_filter_set_bound_is_refused_before_a_write(dataset, tmp_path, monkeypatch):
+    monkeypatch.setattr(export, 'MAX_FILTER_SETS_PER_GROUP', 6)
+    with pytest.raises(ValueError, match='filter sets'):
+        an_export(dataset, tmp_path / 'out', group_tables={'pairs': GROUPS['pairs']})
+    assert not (tmp_path / 'out').exists()
+
+
+def test_a_group_table_at_the_filter_set_bound_is_written(dataset, tmp_path, monkeypatch):
+    monkeypatch.setattr(export, 'MAX_FILTER_SETS_PER_GROUP', 7)
+    out = tmp_path / 'out'
+
+    an_export(dataset, out, group_tables={'pairs': GROUPS['pairs']})
+
+    assert len(json.loads((out / 'api/groups/pairs' / GROUP_INDEX_FILE).read_text())) == 7
 
 
 def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -1,6 +1,7 @@
 """What one export writes, where, and what it keeps off a page."""
 
 import json
+import threading
 from dataclasses import fields
 from pathlib import Path, PurePosixPath
 from typing import cast
@@ -278,6 +279,14 @@ def test_a_static_value_named_with_a_path_step_stops_the_export_before_it_writes
     assert not (tmp_path / 'out').exists()
 
 
+def test_a_static_value_named_with_a_backslash_stops_the_export_before_it_writes(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'models\\scene': b'a mesh'})
+
+    with pytest.raises(ValueError, match='outside'):
+        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
+    assert not (tmp_path / 'out').exists()
+
+
 def test_the_assets_go_with_the_root_base_href_only(dataset, tmp_path):
     with pytest.raises(ValueError, match='assets'):
         an_export(dataset, tmp_path / 'out', base_href='/v/tok/', assets=True)
@@ -307,6 +316,29 @@ def test_an_empty_directory_is_exported_into(dataset, tmp_path):
     out.mkdir()
 
     assert an_export(dataset, out)
+
+
+def test_a_second_export_into_the_directory_of_a_running_one_is_refused(dataset, tmp_path):
+    out = tmp_path / 'out'
+    refusals: list[ValueError] = []
+
+    def second():
+        try:
+            an_export(dataset, out)
+        except ValueError as error:
+            refusals.append(error)
+
+    with positronic_server.app_state_restored():  # the first export, holding the state
+        thread = threading.Thread(target=second)
+        thread.start()
+        thread.join(0.2)
+        out.mkdir()
+        (out / 'index.html').write_text('the first export')
+    thread.join()
+
+    assert [str(error).partition(';')[0] for error in refusals] == [f'{out} is not empty']
+    assert [path.name for path in out.iterdir()] == ['index.html']
+    assert (out / 'index.html').read_text() == 'the first export'
 
 
 def test_a_download_inside_a_list_is_linked_by_its_index_and_served(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -365,7 +365,7 @@ def test_a_download_whose_field_name_a_url_cannot_carry_as_it_is_is_linked_encod
 
 
 def test_a_group_name_that_is_not_one_url_path_segment_is_refused(dataset, tmp_path):
-    for name in ('a?b', 'a#b', 'a b', 'a/b', '.', '../..'):
+    for name in ('', 'a?b', 'a#b', 'a b', 'a/b', '.', '../..'):
         with pytest.raises(ValueError, match='group name'):
             an_export(dataset, tmp_path / 'out', group_tables={name: GROUPS['outcomes']})
     assert not (tmp_path / 'out').exists()

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -38,7 +38,12 @@ HIDDEN_KEY = 'checkpoint_path'
 HIDDEN_VALUE = 's3://internal/checkpoints/step_1000'
 OBJECTS = ('Plastic banana', 'Wooden block')
 
-TABLE = {'__index__': ColumnConfig(label='#', format='%d'), OUTCOME: ColumnConfig(label='Outcome', filter=True)}
+TABLE = {
+    '__index__': ColumnConfig(label='#', format='%d'),
+    OUTCOME: ColumnConfig(label='Outcome', filter=True),
+    OBJECT: ColumnConfig(label='Object', filter=True),
+    ATTEMPT: ColumnConfig(label='Attempt'),
+}
 GROUPS = {
     'outcomes': GroupTableConfig(
         group_keys=OUTCOME,
@@ -287,36 +292,48 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
     assert not (tmp_path / 'out').exists()
 
 
-def test_a_static_value_named_with_a_path_step_stops_the_export_before_it_writes(tmp_path):
-    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a/../b': b'a step'})
+def test_a_static_value_whose_key_a_browser_rewrites_stops_the_export_before_it_writes(tmp_path):
+    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a': {'..': b'a step'}})
 
     with pytest.raises(ValueError, match='no link'):
         export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
     assert not (tmp_path / 'out').exists()
 
 
-def test_a_static_value_named_with_a_backslash_stops_the_export_before_it_writes(tmp_path):
+def test_a_static_value_named_with_a_backslash_is_linked_encoded_and_written(tmp_path):
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'models\\scene': b'a mesh'})
+    out = tmp_path / 'out'
 
-    with pytest.raises(ValueError, match='outside'):
-        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
-    assert not (tmp_path / 'out').exists()
+    written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False))
 
-
-def test_two_downloads_that_would_share_one_file_stop_the_export_before_it_writes(tmp_path):
-    dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a/b': b'1', 'a//b': b'2'})
-
-    with pytest.raises(ValueError, match='one file'):
-        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
-    assert not (tmp_path / 'out').exists()
+    assert '"api/episode/0/static/models%5Cscene"' in (out / 'episode/0/index.html').read_text()
+    assert 'api/episode/0/static/models%5Cscene' in written
+    assert (out / 'api/episode/0/static/models%5Cscene').read_bytes() == b'a mesh'
 
 
-def test_a_download_named_as_another_download_s_directory_stops_the_export_before_it_writes(tmp_path):
+def test_a_dotted_top_level_key_and_a_nested_value_that_spell_alike_are_written_apart(tmp_path):
+    dataset = a_dataset(
+        tmp_path / 'dataset',
+        {keys.TASK: 'Put the banana on the plate', 'scene.mesh': b'top', 'scene': {'mesh': b'nested'}},
+    )
+    out = tmp_path / 'out'
+
+    written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False))
+
+    assert {'api/episode/0/static/scene.mesh', 'api/episode/0/static/scene/mesh'} <= written
+    assert (out / 'api/episode/0/static/scene.mesh').read_bytes() == b'top'
+    assert (out / 'api/episode/0/static/scene/mesh').read_bytes() == b'nested'
+
+
+def test_a_short_key_and_a_slashed_key_that_share_a_prefix_are_written_apart(tmp_path):
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put the banana on the plate', 'a': b'1', 'a/b': b'2'})
+    out = tmp_path / 'out'
 
-    with pytest.raises(ValueError, match='directory'):
-        export_static(dataset, tmp_path / 'out', ep_table_cfg=TABLE, max_resolution=64, assets=False)
-    assert not (tmp_path / 'out').exists()
+    written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False))
+
+    assert {'api/episode/0/static/a', 'api/episode/0/static/a%2Fb'} <= written
+    assert (out / 'api/episode/0/static/a').read_bytes() == b'1'
+    assert (out / 'api/episode/0/static/a%2Fb').read_bytes() == b'2'
 
 
 def test_a_cache_inside_the_output_directory_is_refused(dataset, tmp_path):
@@ -386,10 +403,10 @@ def test_a_download_inside_a_list_is_linked_by_its_index_and_served(dataset, tmp
     out = tmp_path / 'out'
     written = paths_of(an_export(dataset, out))
 
-    assert '"api/episode/0/static/artifacts.0"' in (out / 'episode/0/index.html').read_text()
-    assert 'api/episode/0/static/artifacts.0' in written
-    assert (out / 'api/episode/0/static/artifacts.0').read_bytes() == b'first blob'
-    assert 'api/episode/0/static/artifacts.1' not in written
+    assert '"api/episode/0/static/artifacts/0"' in (out / 'episode/0/index.html').read_text()
+    assert 'api/episode/0/static/artifacts/0' in written
+    assert (out / 'api/episode/0/static/artifacts/0').read_bytes() == b'first blob'
+    assert 'api/episode/0/static/artifacts/1' not in written
 
 
 def test_a_filter_on_a_number_reaches_the_episodes_that_carry_it(dataset, tmp_path):
@@ -440,9 +457,10 @@ def test_a_download_whose_field_name_a_url_cannot_carry_as_it_is_is_linked_encod
 
     written = paths_of(export_static(dataset, out, ep_table_cfg=TABLE, max_resolution=64, assets=False, build_id='bld'))
 
-    assert '"build/bld/api/episode/0/static/notes%20%26%20%C3%A9%3F"' in (out / 'episode/0/index.html').read_text()
-    assert f'build/bld/api/episode/0/static/{ESCAPED_KEY}' in written
-    assert (out / 'build/bld/api/episode/0/static' / ESCAPED_KEY).read_bytes() == b'n' * 2000
+    encoded = 'notes%20%26%20%C3%A9%3F'
+    assert f'"build/bld/api/episode/0/static/{encoded}"' in (out / 'episode/0/index.html').read_text()
+    assert f'build/bld/api/episode/0/static/{encoded}' in written
+    assert (out / 'build/bld/api/episode/0/static' / encoded).read_bytes() == b'n' * 2000
 
 
 def test_a_group_name_that_is_not_one_url_path_segment_is_refused(dataset, tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -7,7 +7,6 @@ import shutil
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import fields
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePosixPath
@@ -29,7 +28,6 @@ from positronic.server.export import (
     GROUP_INDEX_FILE,
     MAX_FILTER_KEYS_PER_GROUP,
     UNFILTERED_FILE,
-    GroupFile,
     _fetch,
     _Output,
     asset_content_type,
@@ -810,14 +808,6 @@ def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):
     with pytest.raises(ValueError, match='home_page'):
         an_export(dataset, tmp_path / 'out', group_tables=GROUPS, home_page='nope')
     assert not (tmp_path / 'out').exists()
-
-
-def test_the_page_script_spells_a_group_index_as_the_export_writes_it():
-    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
-    params, file = (field.name for field in fields(GroupFile))
-
-    assert f"const GROUP_INDEX_FILE = '{GROUP_INDEX_FILE}';" in app_js
-    assert f"const ENTRY_PARAMS = '{params}';" in app_js and f"const ENTRY_FILE = '{file}';" in app_js
 
 
 @pytest.mark.parametrize(

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -372,16 +372,25 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
 
     for path in ('../index.html', '..\\..\\index.html', '/index.html'):
         with pytest.raises(ValueError, match='outside'):
-            out.plan([path])
+            out.plan([PurePosixPath(path)])
     assert not (tmp_path / 'out').exists()
 
 
 def test_a_write_the_plan_does_not_name_is_refused(tmp_path):
     out = _Output(tmp_path / 'out')
-    out.plan(['index.html'])
+    out.plan([PurePosixPath('index.html')])
 
     with pytest.raises(ValueError, match='plan'):
-        out.write('episodes/index.html', b'', 'text/html')
+        out.write(PurePosixPath('episodes/index.html'), b'', 'text/html')
+    assert not (tmp_path / 'out').exists()
+
+
+def test_the_path_limit_is_measured_with_the_working_directory_in_front_of_a_relative_output(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(export, '_path_max', lambda directory: len(os.fsencode(tmp_path / 'out' / 'index.html')))
+
+    with pytest.raises(ValueError, match='path limit'):
+        _Output(Path('out')).plan([PurePosixPath('index.html')])
     assert not (tmp_path / 'out').exists()
 
 

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -32,7 +32,6 @@ from positronic.server.export import (
     GroupFile,
     _fetch,
     _Output,
-    _PortableTree,
     asset_content_type,
     export_static,
     filter_sets,
@@ -276,10 +275,10 @@ def test_the_assets_are_written_only_when_asked(dataset, tmp_path):
     assert any(path.startswith('static/rerun/') and path.endswith('.wasm') for path in with_assets)
 
 
-def test_every_filter_set_an_episode_satisfies_is_listed_once_with_the_empty_one_first():
+def test_every_non_empty_filter_set_an_episode_satisfies_is_listed_once_and_the_shortest_first():
     episodes = [{'a': 'x', 'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
 
-    assert filter_sets(episodes) == [{}, {'a': 'x'}, {'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
+    assert filter_sets(episodes) == [{'a': 'x'}, {'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
 
 
 def test_a_filter_set_no_episode_satisfies_gets_no_file(dataset, tmp_path):
@@ -373,15 +372,6 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
     for path in ('../index.html', '..\\..\\index.html', '/index.html'):
         with pytest.raises(ValueError, match='outside'):
             out.plan([PurePosixPath(path)])
-    assert not (tmp_path / 'out').exists()
-
-
-def test_a_write_the_plan_does_not_name_is_refused(tmp_path):
-    out = _Output(tmp_path / 'out')
-    out.plan([PurePosixPath('index.html')])
-
-    with pytest.raises(ValueError, match='plan'):
-        out.write(PurePosixPath('episodes/index.html'), b'', 'text/html')
     assert not (tmp_path / 'out').exists()
 
 
@@ -754,12 +744,12 @@ def test_a_download_whose_path_on_disk_is_past_a_host_s_key_limit_stops_the_expo
 def test_a_path_at_a_host_s_key_limit_is_held_and_one_past_it_is_refused(monkeypatch):
     """The local limit is lifted: on macOS it equals the key limit, so no directory in front leaves room."""
     monkeypatch.setattr(export, '_path_max', lambda directory: 1 << 16)
-    tree = _PortableTree(Path('out'))
+    out = _Output(Path('out'))
     stem = '/'.join(['a' * MAX_COMPONENT_BYTES] * 4) + '/'
-    tree.add(PurePosixPath(stem + 'b' * (export.MAX_PATH_BYTES - len(stem))))
+    out.plan([PurePosixPath(stem + 'b' * (export.MAX_PATH_BYTES - len(stem)))])
 
     with pytest.raises(ValueError, match='key limit'):
-        tree.add(PurePosixPath(stem + 'c' * (export.MAX_PATH_BYTES + 1 - len(stem))))
+        out.plan([PurePosixPath(stem + 'c' * (export.MAX_PATH_BYTES + 1 - len(stem)))])
 
 
 def test_a_group_table_past_the_filter_set_bound_is_refused_before_a_write(dataset, tmp_path, monkeypatch):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -383,7 +383,7 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
 
 def test_the_path_limit_is_measured_with_the_working_directory_in_front_of_a_relative_output(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(export, '_path_max', lambda directory: len(os.fsencode(tmp_path / 'out' / 'index.html')))
+    monkeypatch.setattr(export, '_path_max', lambda directory: export._path_length(tmp_path / 'out' / 'index.html'))
 
     with pytest.raises(ValueError, match='path limit'):
         _Output(Path('out')).plan([PurePosixPath('index.html')])
@@ -724,7 +724,7 @@ def test_a_download_named_past_a_windows_device_name_is_written(tmp_path):
 
 def _download_at(total_bytes: int, build_id: str) -> tuple[dict, tuple[str, ...]]:
     """A static dict with one download whose path on disk is `total_bytes` long, and that download's key path."""
-    stem = len(export._large_file_path(download_link(0, ('k',)), build_id)) - 1
+    stem = len(str(export._large_file_path(download_link(0, ('k',)), build_id))) - 1
     length = total_bytes - stem
     count = -(-(length + 1) // (MAX_COMPONENT_BYTES + 1))
     letters = length - (count - 1)
@@ -738,8 +738,8 @@ def _download_at(total_bytes: int, build_id: str) -> tuple[dict, tuple[str, ...]
 
 def test_a_download_whose_path_on_disk_is_past_a_host_s_key_limit_stops_the_export_before_it_writes(tmp_path):
     build_id = 'b' * MAX_COMPONENT_BYTES
-    static, keys = _download_at(export.MAX_PATH_BYTES + 1, build_id)
-    assert len(export._large_file_path(download_link(0, keys), build_id)) == export.MAX_PATH_BYTES + 1
+    static, keys = _download_at(export.MAX_KEY_BYTES + 1, build_id)
+    assert len(str(export._large_file_path(download_link(0, keys), build_id))) == export.MAX_KEY_BYTES + 1
     dataset = a_dataset(tmp_path / 'dataset', static)
 
     with pytest.raises(ValueError, match='key limit'):
@@ -752,10 +752,10 @@ def test_a_path_at_a_host_s_key_limit_is_held_and_one_past_it_is_refused(monkeyp
     monkeypatch.setattr(export, '_path_max', lambda directory: 1 << 16)
     out = _Output(Path('out'))
     stem = '/'.join(['a' * MAX_COMPONENT_BYTES] * 4) + '/'
-    out.plan([PurePosixPath(stem + 'b' * (export.MAX_PATH_BYTES - len(stem)))])
+    out.plan([PurePosixPath(stem + 'b' * (export.MAX_KEY_BYTES - len(stem)))])
 
     with pytest.raises(ValueError, match='key limit'):
-        out.plan([PurePosixPath(stem + 'c' * (export.MAX_PATH_BYTES + 1 - len(stem)))])
+        out.plan([PurePosixPath(stem + 'c' * (export.MAX_KEY_BYTES + 1 - len(stem)))])
 
 
 def test_a_group_table_past_the_filter_set_bound_is_refused_before_a_write(dataset, tmp_path, monkeypatch):
@@ -779,7 +779,7 @@ def test_a_local_path_at_the_filesystem_s_limit_is_refused_before_a_write_and_on
 ):
     out = tmp_path / 'out'
     probe = paths_of(an_export(dataset, tmp_path / 'probe'))
-    longest = max(len(os.fsencode(out.joinpath(*PurePosixPath(path).parts))) for path in probe)
+    longest = max(export._path_length(out.joinpath(*PurePosixPath(path).parts)) for path in probe)
 
     monkeypatch.setattr(export, '_path_max', lambda directory: longest)
     with pytest.raises(ValueError, match='path limit'):
@@ -790,10 +790,15 @@ def test_a_local_path_at_the_filesystem_s_limit_is_refused_before_a_write_and_on
     assert paths_of(an_export(dataset, out)) == probe
 
 
-def test_the_path_limit_is_windows_s_where_the_platform_reports_none(monkeypatch):
-    monkeypatch.delattr(os, 'pathconf')
+def test_where_the_platform_reports_no_path_limit_windows_s_holds_and_a_path_is_measured_in_utf_16_units(monkeypatch):
+    monkeypatch.setattr(export, '_REPORTS_PATH_MAX', False)
 
     assert export._path_max(Path('out')) == export._WINDOWS_PATH_MAX
+    assert export._path_length(Path('\u00e9' * 10)) == 10 and export._path_length(Path('\U0001d11e')) == 2
+
+
+def test_where_the_platform_reports_a_path_limit_a_path_is_measured_in_bytes():
+    assert export._path_length(Path('\u00e9' * 10)) == len(os.fsencode('\u00e9' * 10))
 
 
 def test_a_page_or_an_api_file_past_the_filesystem_s_limit_stops_the_export_before_it_writes(tmp_path, monkeypatch):
@@ -802,7 +807,7 @@ def test_a_page_or_an_api_file_past_the_filesystem_s_limit_stops_the_export_befo
     dataset = a_dataset(tmp_path / 'dataset', {keys.TASK: 'Put it down'})
     out = tmp_path / 'out'
     probe = paths_of(export_static(dataset, tmp_path / 'probe', ep_table_cfg=TABLE, max_resolution=64, assets=False))
-    local = {path: len(os.fsencode(out.joinpath(*PurePosixPath(path).parts))) for path in probe}
+    local = {path: export._path_length(out.joinpath(*PurePosixPath(path).parts)) for path in probe}
     longest = max(local.values())
     assert local['api/episode_rrd/0'] < longest
 
@@ -814,7 +819,7 @@ def test_a_page_or_an_api_file_past_the_filesystem_s_limit_stops_the_export_befo
 
 def test_a_base_href_that_leaves_no_room_for_a_key_stops_the_export_before_it_writes(dataset, tmp_path):
     with pytest.raises(ValueError, match='key limit'):
-        an_export(dataset, tmp_path / 'out', base_href='/' + 'p' * (export.MAX_PATH_BYTES - 10) + '/')
+        an_export(dataset, tmp_path / 'out', base_href='/' + 'p' * (export.MAX_KEY_BYTES - 10) + '/')
     assert not (tmp_path / 'out').exists()
 
 

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -804,6 +804,12 @@ def test_a_page_or_an_api_file_past_the_filesystem_s_limit_stops_the_export_befo
     assert not out.exists()
 
 
+def test_a_base_href_that_leaves_no_room_for_a_key_stops_the_export_before_it_writes(dataset, tmp_path):
+    with pytest.raises(ValueError, match='key limit'):
+        an_export(dataset, tmp_path / 'out', base_href='/' + 'p' * (export.MAX_PATH_BYTES - 10) + '/')
+    assert not (tmp_path / 'out').exists()
+
+
 def test_a_home_page_that_names_no_group_table_is_refused(dataset, tmp_path):
     with pytest.raises(ValueError, match='home_page'):
         an_export(dataset, tmp_path / 'out', group_tables=GROUPS, home_page='nope')

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -381,6 +381,15 @@ def test_a_path_with_a_parent_segment_or_a_backslash_is_refused_before_a_write(t
     assert not (tmp_path / 'out').exists()
 
 
+def test_a_write_the_plan_does_not_name_is_refused(tmp_path):
+    out = _Output(tmp_path / 'out')
+    out.plan([PurePosixPath('index.html')])
+
+    with pytest.raises(ValueError, match='plan'):
+        out.write(PurePosixPath('episodes/index.html'), b'', 'text/html')
+    assert not (tmp_path / 'out').exists()
+
+
 def test_the_path_limit_is_measured_with_the_working_directory_in_front_of_a_relative_output(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(export, '_path_max', lambda directory: export._path_length(tmp_path / 'out' / 'index.html'))

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -276,7 +276,15 @@ def test_the_assets_are_written_only_when_asked(dataset, tmp_path):
 def test_every_non_empty_filter_set_an_episode_satisfies_is_listed_once_and_the_shortest_first():
     episodes = [{'a': 'x', 'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
 
-    assert filter_sets(episodes) == [{'a': 'x'}, {'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
+    assert filter_sets(episodes, most=10) == [{'a': 'x'}, {'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
+
+
+def test_filter_sets_past_the_bound_are_refused_before_every_episode_is_read():
+    endless = ({'k': str(n)} for n in range(10_000))
+
+    with pytest.raises(ValueError, match='more than 5 filter sets'):
+        filter_sets(endless, most=5)
+    assert next(endless) == {'k': '6'}  # the sixth value passed the count; the rest were never read
 
 
 def test_a_filter_set_no_episode_satisfies_gets_no_file(dataset, tmp_path):

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -13,7 +13,7 @@ from cryptography.x509.oid import NameOID
 from fastapi.testclient import TestClient
 
 from positronic import keys
-from positronic.dataset.episode import META_UID
+from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
     _MAX_COMPONENT_BYTES,
@@ -228,7 +228,7 @@ def _server_rooted_urls(html: str, base_href: str) -> list[str]:
 
 
 class _StubEpisode:
-    meta = {'path': '/datasets/run-7/episode_3', 'size_mb': 12.5}
+    meta = {META_PATH: '/datasets/run-7/episode_3', 'size_mb': 12.5}
     static = {keys.TASK: 'pick the cube', 'scene': b'a mesh'}
 
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -32,6 +32,7 @@ from positronic.server.positronic_server import (
     app_state,
     app_state_restored,
     configure_pages,
+    download_link,
     download_paths,
     normalized_base_href,
 )
@@ -361,6 +362,16 @@ def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_e
     assert viewer.get('/api/episode/0/static/notes & é').headers['content-disposition'] == (
         "inline; filename*=utf-8''notes%20%26%20%C3%A9.txt"
     )
+
+
+def test_a_download_link_carries_its_field_path_encoded_and_the_route_answers_it(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh'})
+
+    link = download_link(0, 'a?b c')
+
+    assert link == 'api/episode/0/static/a%3Fb%20c'
+    assert viewer.get(f'/{link}').content == b'a mesh'
+    assert f'"{link}"' in viewer.get('/episode/0').text
 
 
 def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_path():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -32,7 +32,9 @@ from positronic.server.positronic_server import (
     _path_component,
     _route,
     _served_addresses,
+    api_dataset_info,
     api_dataset_status,
+    api_episodes,
     app,
     app_state,
     app_state_restored,
@@ -371,6 +373,14 @@ def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_e
     )
 
 
+def test_a_download_name_holding_a_slash_is_percent_encoded_in_the_header(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'café/mesh': b'a mesh'})
+
+    assert viewer.get(f'/{download_link(0, ("café/mesh",))}').headers['content-disposition'] == (
+        "attachment; filename*=utf-8''caf%C3%A9%2Fmesh"
+    )
+
+
 def test_a_download_link_carries_each_key_encoded_and_the_route_answers_it(viewer, monkeypatch):
     monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/b': b'nested'})
 
@@ -464,11 +474,16 @@ def test_a_path_of_any_depth_keeps_its_link_on_the_live_server():
     assert download_link(0, keys_).startswith('api/episode/0/static/')
 
 
-def test_the_page_script_names_the_dataset_status_route_the_server_declares():
+def test_the_page_script_names_each_api_route_once_as_the_server_declares_it():
     app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
 
-    assert f"const DATASET_STATUS_ROUTE = '{_route(api_dataset_status)}';" in app_js
-    assert "apiUrl('api/dataset_status')" not in app_js
+    for name, endpoint in (
+        ('DATASET_STATUS_ROUTE', api_dataset_status),
+        ('DATASET_INFO_ROUTE', api_dataset_info),
+        ('EPISODES_ROUTE', api_episodes),
+    ):
+        assert f"const {name} = '{_route(endpoint)}';" in app_js
+        assert app_js.count(f"'{_route(endpoint)}'") == 1
 
 
 def test_the_flat_table_takes_a_url_filter_only_for_a_value_some_row_carries():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -4,6 +4,7 @@ import re
 import socket
 import threading
 from collections import namedtuple
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -32,6 +33,7 @@ from positronic.server.positronic_server import (
     app_state,
     app_state_restored,
     configure_pages,
+    configure_tables,
     download_link,
     download_paths,
     normalized_base_href,
@@ -365,19 +367,41 @@ def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_e
 
 
 def test_a_download_link_carries_its_field_path_encoded_and_the_route_answers_it(viewer, monkeypatch):
-    monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/../b': b'a step'})
+    monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/b': b'nested'})
 
-    link, stepped = download_link(0, 'a?b c'), download_link(0, 'a/../b')
+    link, nested = download_link(0, 'a?b c'), download_link(0, 'a/b')
 
-    assert (link, stepped) == ('api/episode/0/static/a%3Fb%20c', 'api/episode/0/static/a%2F..%2Fb')
-    assert viewer.get(f'/{link}').content == b'a mesh' and viewer.get(f'/{stepped}').content == b'a step'
+    assert (link, nested) == ('api/episode/0/static/a%3Fb%20c', 'api/episode/0/static/a%2Fb')
+    assert viewer.get(f'/{link}').content == b'a mesh' and viewer.get(f'/{nested}').content == b'nested'
     assert f'"{link}"' in viewer.get('/episode/0').text
 
 
-def test_a_static_value_named_as_a_path_step_gets_no_link():
-    for name in ('.', '..'):
+def test_a_static_value_named_with_a_path_step_gets_no_link():
+    for name in ('.', '..', 'a/../b', 'a/./b'):
         with pytest.raises(ValueError, match='no link'):
             download_link(0, name)
+
+
+def test_reconfiguring_the_tables_drops_a_cached_table_response(grouped):
+    before = grouped.get('/api/groups/by_task').json()
+    renamed = replace(
+        _BY_TASK, format_table={keys.TASK: ColumnConfig(label='Job'), 'count': ColumnConfig(label='Episodes')}
+    )
+
+    with app_state_restored():
+        configure_tables(
+            root='',
+            cache_dir=Path(),
+            ep_table_cfg=None,
+            group_tables={'by_task': renamed},
+            home_page=None,
+            max_resolution=64,
+            max_hz=0,
+        )
+        after = grouped.get('/api/groups/by_task').json()
+
+    assert [column['label'] for column in before['columns']] == ['Task', 'Episodes']
+    assert [column['label'] for column in after['columns']] == ['Job', 'Episodes']
 
 
 def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_path():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -19,6 +19,7 @@ from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
     _MAX_COMPONENT_BYTES,
+    _MAX_DOWNLOAD_PATH_BYTES,
     FILTER_VALUES,
     GROUP_FILTERS,
     ColumnConfig,
@@ -29,7 +30,9 @@ from positronic.server.positronic_server import (
     _get_rrd_cache_path,
     _is_loopback,
     _path_component,
+    _route,
     _served_addresses,
+    api_dataset_status,
     app,
     app_state,
     app_state_restored,
@@ -452,6 +455,35 @@ def test_a_key_within_a_file_name_s_limit_once_encoded_keeps_its_link():
 
     assert list(download_paths({key: b'x'})) == [(key,)]
     assert download_link(0, (key,)) == f'api/episode/0/static/{key}'
+
+
+def test_a_path_past_a_host_s_key_limit_once_encoded_gets_no_link():
+    deep = {'k' * _MAX_COMPONENT_BYTES: b'x'}
+    for _ in range(_MAX_DOWNLOAD_PATH_BYTES // _MAX_COMPONENT_BYTES):
+        deep = {'k' * _MAX_COMPONENT_BYTES: deep}
+
+    with pytest.raises(ValueError, match='no link'):
+        list(download_paths(deep))
+
+
+def test_a_path_within_a_host_s_key_limit_once_encoded_keeps_its_link():
+    keys_ = ('k' * _MAX_COMPONENT_BYTES,) * (_MAX_DOWNLOAD_PATH_BYTES // (_MAX_COMPONENT_BYTES + 1))
+
+    assert download_link(0, keys_).startswith('api/episode/0/static/')
+    assert len('/'.join(keys_).encode()) <= _MAX_DOWNLOAD_PATH_BYTES
+
+
+def test_the_page_script_names_the_dataset_status_route_the_server_declares():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert f"const DATASET_STATUS_ROUTE = '{_route(api_dataset_status)}';" in app_js
+    assert "apiUrl('api/dataset_status')" not in app_js
+
+
+def test_the_flat_table_takes_a_url_filter_only_for_a_value_some_row_carries():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert 'if (state.filtersData[key].includes(value)) state.filters[key] = value;' in app_js
 
 
 def test_a_dotted_key_and_a_nested_value_that_spell_alike_each_keep_their_own_link():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,5 +1,6 @@
 import ipaddress
 import os
+import re
 import socket
 from collections import namedtuple
 from pathlib import Path
@@ -11,6 +12,7 @@ from cryptography import x509
 from cryptography.x509.oid import NameOID
 from fastapi.testclient import TestClient
 
+from positronic import keys
 from positronic.dataset.episode import META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
@@ -23,6 +25,7 @@ from positronic.server.positronic_server import (
     _served_addresses,
     app,
     app_state,
+    static_export_key,
 )
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
@@ -213,3 +216,156 @@ def test_a_stream_that_dies_partway_leaves_no_cached_rrd(rrd_cache, monkeypatch)
     cache_path = rrd_cache(30.0, 640)
     assert not cache_path.exists()
     assert list(cache_path.parent.iterdir()) == []
+
+
+# A URL that starts at the server root, in an attribute or in a script's string.
+_ROOTED_URL = re.compile(r"""["'(`](/[^"'`)\s]*)""")
+
+
+def _server_rooted_urls(html: str, base_href: str) -> list[str]:
+    """Every URL the page pins to the server root, apart from the app-level assets and the base."""
+    return [url for url in _ROOTED_URL.findall(html) if not url.startswith('/static/') and url != base_href]
+
+
+class _StubEpisode:
+    meta = {'path': '/datasets/run-7/episode_3', 'size_mb': 12.5}
+    static = {keys.TASK: 'pick the cube', 'scene': b'a mesh'}
+
+
+class _StubDataset:
+    def __len__(self) -> int:
+        return 4
+
+    def __getitem__(self, index: int) -> _StubEpisode:
+        if index >= len(self):
+            raise IndexError(index)
+        return _StubEpisode()
+
+
+@pytest.fixture
+def viewer(monkeypatch):
+    monkeypatch.setitem(app_state, 'dataset', _StubDataset())
+    monkeypatch.setitem(app_state, 'loading_state', False)
+    monkeypatch.setitem(app_state, 'root', '/datasets/run-7')
+    monkeypatch.setitem(app_state, 'episode_table_cfg', {})
+    monkeypatch.setitem(app_state, 'group_tables_cfg', {'leaderboard': None})
+    return TestClient(app)
+
+
+_PAGES = ['/', '/episodes', '/groups/leaderboard', '/episode/0']
+
+
+@pytest.mark.parametrize('page', _PAGES)
+def test_a_viewer_at_the_server_root_says_so(viewer, page):
+    body = viewer.get(page).text
+
+    assert '<base href="/" />' in body
+    assert 'window.STATIC_EXPORT' not in body
+
+
+@pytest.mark.parametrize('page', _PAGES)
+def test_a_viewer_under_a_prefix_pins_no_page_link_to_the_server_root(viewer, monkeypatch, page):
+    monkeypatch.setitem(app_state, 'base_href', '/v/tok/')
+
+    body = viewer.get(page).text
+
+    assert '<base href="/v/tok/" />' in body
+    assert _server_rooted_urls(body, '/v/tok/') == []
+
+
+def test_a_base_href_gains_the_trailing_slash_a_relative_link_needs(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'base_href', '/v/tok')
+
+    assert '<base href="/v/tok/" />' in viewer.get('/').text
+
+
+def test_a_static_export_tells_the_page_to_read_the_files_it_wrote(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'static_export', True)
+
+    assert 'window.STATIC_EXPORT = true;' in viewer.get('/').text
+
+
+def test_a_title_stands_in_for_the_dataset_root(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'title', 'Runway rollouts, 29 August')
+
+    for page in ['/', '/episode/0']:
+        body = viewer.get(page).text
+        assert 'Runway rollouts, 29 August' in body
+
+
+def test_the_header_falls_back_to_the_dataset_root(viewer):
+    assert '/datasets/run-7' in viewer.get('/').text
+
+
+def test_an_episode_page_hides_where_the_episode_lives(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'show_paths', False)
+
+    body = viewer.get('/episode/0').text
+
+    assert 'Episode path' not in body
+    assert '/datasets/run-7' not in body
+
+
+def test_an_episode_page_shows_where_the_episode_lives_by_default(viewer):
+    body = viewer.get('/episode/0').text
+
+    assert 'Episode path' in body
+    assert '/datasets/run-7/episode_3' in body
+
+
+def test_the_api_reports_no_dataset_root_when_the_viewer_hides_paths(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'show_paths', False)
+
+    assert viewer.get('/api/dataset_info').json()['root'] == ''
+    assert viewer.get('/api/dataset_status').json()['repo_id'] == ''
+
+
+def test_the_api_reports_the_dataset_root_by_default(viewer):
+    assert viewer.get('/api/dataset_info').json()['root'] == '/datasets/run-7'
+    assert viewer.get('/api/dataset_status').json()['repo_id'] == '/datasets/run-7'
+
+
+def test_a_build_id_carries_the_files_a_browser_caches_for_a_year(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'build_id', 'k3n9')
+
+    body = viewer.get('/episode/0').text
+
+    assert 'build/k3n9/api/episode_rrd/0' in body
+    assert 'build/k3n9/api/episode/0/static/scene' in body
+
+
+def test_without_a_build_id_the_same_files_sit_beside_the_other_api_calls(viewer):
+    body = viewer.get('/episode/0').text
+
+    assert 'api/episode_rrd/0' in body
+    assert 'api/episode/0/static/scene' in body
+    assert 'build/' not in body
+
+
+def test_an_endpoint_the_export_writes_whole_takes_one_file():
+    assert static_export_key('api/episodes') == 'api/episodes.json'
+    assert static_export_key('api/dataset_info') == 'api/dataset_info.json'
+
+
+def test_an_endpoint_the_export_writes_per_filter_set_names_an_empty_set_all():
+    assert static_export_key('api/groups/leaderboard', {}) == 'api/groups/leaderboard/all.json'
+    assert static_export_key('api/groups/leaderboard', {'model': ''}) == 'api/groups/leaderboard/all.json'
+
+
+def test_one_filter_set_reaches_one_file_whatever_order_it_arrives_in():
+    forwards = static_export_key('api/groups/g', {'model': 'pi0', 'task': 'pick a cube'})
+    backwards = static_export_key('api/groups/g', {'task': 'pick a cube', 'model': 'pi0'})
+
+    assert forwards == backwards == 'api/groups/g/model=pi0&task=pick%20a%20cube.json'
+
+
+def test_a_filter_value_that_carries_a_separator_stays_in_one_component():
+    key = static_export_key('api/groups/g', {'task': 'a&b=c/d'})
+
+    assert key == 'api/groups/g/task=a%26b%3Dc%2Fd.json'
+
+
+def test_app_js_asks_for_the_file_name_this_module_writes():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert static_export_key('api/groups/leaderboard', {'b': '2', 'a': 'x y'}) in app_js

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -418,6 +418,16 @@ def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_pat
     assert list(download_paths(static)) == ['scene', 'notes', 'nested.blob', 'many.0.a', 'many.1']
 
 
+def test_a_static_value_the_download_route_does_not_read_back_gets_no_link():
+    for static in ({'': b'x'}, {'a': {'': b'x'}}, {'a.b': b'1', 'a': {'b': b'2'}}):
+        with pytest.raises(ValueError, match='no link'):
+            list(download_paths(static))
+
+
+def test_a_dotted_key_beside_an_unrelated_nested_value_keeps_both_links():
+    assert list(download_paths({'a.b': b'1', 'a': {'c': b'2'}})) == ['a.b', 'a.c']
+
+
 def test_a_base_href_that_starts_at_the_server_root_stands():
     assert normalized_base_href('/') == '/'
     assert normalized_base_href('/v//tok/') == '/v//tok/'

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,3 +1,4 @@
+import hashlib
 import ipaddress
 import os
 import re
@@ -17,6 +18,7 @@ from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
     _MAX_COMPONENT_BYTES,
+    _QUERY_DIGEST_CHARS,
     _access_url,
     _generate_self_signed_cert,
     _get_rrd_cache_path,
@@ -25,6 +27,7 @@ from positronic.server.positronic_server import (
     _served_addresses,
     app,
     app_state,
+    normalized_base_href,
     static_export_key,
     static_export_url_path,
 )
@@ -399,6 +402,55 @@ def test_a_name_that_carries_a_percent_escape_is_asked_for_with_that_escape_esca
 def test_a_name_that_needs_no_escape_is_asked_for_as_it_stands():
     for params in (None, {}, {'model': 'pi0'}):
         assert static_export_url_path('api/x', params) == static_export_key('api/x', params)
+
+
+def test_a_filter_set_that_fits_a_file_name_keeps_its_readable_one():
+    value = 'x' * (_MAX_COMPONENT_BYTES - len('model='))
+
+    assert static_export_key('api/groups/g', {'model': value}) == f'api/groups/g/model={value}.json'
+
+
+def test_a_filter_set_too_long_for_a_file_name_takes_a_digest_of_itself():
+    value = 'x' * _MAX_COMPONENT_BYTES
+    name = static_export_key('api/groups/g', {'model': value}).removeprefix('api/groups/g/').removesuffix('.json')
+
+    assert name == hashlib.sha256(f'model={value}'.encode()).hexdigest()[:_QUERY_DIGEST_CHARS]
+    assert len(name.encode()) <= _MAX_COMPONENT_BYTES
+
+
+def test_two_filter_sets_past_the_budget_that_differ_reach_different_files():
+    over = 'x' * _MAX_COMPONENT_BYTES
+
+    assert static_export_key('api/groups/g', {'model': over}) != static_export_key('api/groups/g', {'task': over})
+
+
+def test_app_js_bounds_a_file_name_by_the_same_numbers():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert f'const MAX_QUERY_BYTES = {_MAX_COMPONENT_BYTES};' in app_js
+    assert f'const QUERY_DIGEST_CHARS = {_QUERY_DIGEST_CHARS};' in app_js
+
+
+def test_a_base_href_that_starts_at_the_server_root_stands():
+    assert normalized_base_href('/') == '/'
+    assert normalized_base_href('/v/tok/') == '/v/tok/'
+    assert normalized_base_href('/v/tok') == '/v/tok/'
+
+
+def test_a_base_href_that_does_not_start_at_the_server_root_is_refused():
+    for value in ('shares/run', '', 'https://app.example.com/v/tok/'):
+        with pytest.raises(ValueError, match='server root'):
+            normalized_base_href(value)
+
+
+def test_a_build_id_reaches_the_page_script_as_json(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'static_export', True)
+    monkeypatch.setitem(app_state, 'build_id', 'k3&n9')
+
+    body = viewer.get('/episode/0').text
+
+    assert 'build/k3\\u0026n9/api/episode_rrd/0' in body
+    assert 'k3&amp;n9' not in body
 
 
 def test_app_js_asks_for_the_file_name_this_module_writes():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -307,6 +307,19 @@ def test_an_episode_page_hides_where_the_episode_lives(viewer, monkeypatch):
     assert '/datasets/run-7' not in body
 
 
+def test_an_episode_keeps_its_size_where_the_page_hides_paths(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'show_paths', False)
+
+    assert '12.50 MB' in viewer.get('/episode/0').text
+
+
+def test_two_exports_on_one_origin_keep_their_own_session_state():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert 'return `${name}:${document.baseURI}`' in app_js
+    assert app_js.count("sessionStorage.setItem('") == 0
+
+
 def test_an_episode_page_shows_where_the_episode_lives_by_default(viewer):
     body = viewer.get('/episode/0').text
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -18,10 +18,10 @@ from positronic import keys
 from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
-    _MAX_COMPONENT_BYTES,
     _MAX_DOWNLOAD_PATH_BYTES,
     FILTER_VALUES,
     GROUP_FILTERS,
+    MAX_COMPONENT_BYTES,
     ColumnConfig,
     GroupTableConfig,
     PageConfig,
@@ -209,7 +209,7 @@ def test_a_path_component_is_one_short_injective_name():
     assert _path_component('camera/left') != _path_component('camera_left')
 
     long_name = _path_component('x' * 4000)
-    assert len(long_name.encode()) <= _MAX_COMPONENT_BYTES
+    assert len(long_name.encode()) <= MAX_COMPONENT_BYTES
     # A value short enough to survive encoding can never collide with a hashed one.
     assert _path_component(long_name) != long_name
 
@@ -445,29 +445,29 @@ def test_a_static_value_whose_key_a_browser_rewrites_in_a_path_gets_no_link():
 
 
 def test_a_key_past_a_file_name_s_limit_once_encoded_gets_no_link():
-    for key in ('x' * (_MAX_COMPONENT_BYTES + 1), 'é' * (_MAX_COMPONENT_BYTES // 6 + 1)):  # `é` encodes to 6 bytes
+    for key in ('x' * (MAX_COMPONENT_BYTES + 1), 'é' * (MAX_COMPONENT_BYTES // 6 + 1)):  # `é` encodes to 6 bytes
         with pytest.raises(ValueError, match='no link'):
             list(download_paths({key: b'x'}))
 
 
 def test_a_key_within_a_file_name_s_limit_once_encoded_keeps_its_link():
-    key = 'x' * _MAX_COMPONENT_BYTES
+    key = 'x' * MAX_COMPONENT_BYTES
 
     assert list(download_paths({key: b'x'})) == [(key,)]
     assert download_link(0, (key,)) == f'api/episode/0/static/{key}'
 
 
 def test_a_path_past_a_host_s_key_limit_once_encoded_gets_no_link():
-    deep = {'k' * _MAX_COMPONENT_BYTES: b'x'}
-    for _ in range(_MAX_DOWNLOAD_PATH_BYTES // _MAX_COMPONENT_BYTES):
-        deep = {'k' * _MAX_COMPONENT_BYTES: deep}
+    deep = {'k' * MAX_COMPONENT_BYTES: b'x'}
+    for _ in range(_MAX_DOWNLOAD_PATH_BYTES // MAX_COMPONENT_BYTES):
+        deep = {'k' * MAX_COMPONENT_BYTES: deep}
 
     with pytest.raises(ValueError, match='no link'):
         list(download_paths(deep))
 
 
 def test_a_path_within_a_host_s_key_limit_once_encoded_keeps_its_link():
-    keys_ = ('k' * _MAX_COMPONENT_BYTES,) * (_MAX_DOWNLOAD_PATH_BYTES // (_MAX_COMPONENT_BYTES + 1))
+    keys_ = ('k' * MAX_COMPONENT_BYTES,) * (_MAX_DOWNLOAD_PATH_BYTES // (MAX_COMPONENT_BYTES + 1))
 
     assert download_link(0, keys_).startswith('api/episode/0/static/')
     assert len('/'.join(keys_).encode()) <= _MAX_DOWNLOAD_PATH_BYTES
@@ -644,6 +644,18 @@ def test_a_group_filter_key_that_is_no_episode_column_is_refused():
     ep_table_cfg = {keys.TASK: ColumnConfig(label='Task')}
     with app_state_restored(), pytest.raises(ValueError, match='no column of the episode table'):
         _configure(ep_table_cfg, {'by_task': _BY_TASK})  # _BY_TASK filters on ASSISTED, which is no column here
+
+
+def test_a_group_name_past_a_file_name_s_limit_is_refused():
+    ep_table_cfg = {keys.TASK: ColumnConfig(label='Task'), ASSISTED: ColumnConfig(label='Assisted')}
+    with app_state_restored(), pytest.raises(ValueError, match='group name'):
+        _configure(ep_table_cfg, {'g' * (MAX_COMPONENT_BYTES + 1): _BY_TASK})
+
+
+def test_a_group_name_within_a_file_name_s_limit_is_accepted():
+    ep_table_cfg = {keys.TASK: ColumnConfig(label='Task'), ASSISTED: ColumnConfig(label='Assisted')}
+    with app_state_restored():
+        _configure(ep_table_cfg, {'g' * MAX_COMPONENT_BYTES: _BY_TASK})
 
 
 def test_group_keys_that_are_episode_columns_are_accepted():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -27,6 +27,7 @@ from positronic.server.positronic_server import (
     _served_addresses,
     app,
     app_state,
+    configure_pages,
     normalized_base_href,
     static_export_key,
     static_export_url_path,
@@ -444,6 +445,33 @@ def test_a_base_href_that_is_not_a_path_at_the_server_root_is_refused():
     for value in outside:
         with pytest.raises(ValueError, match='server root'):
             normalized_base_href(value)
+
+
+def test_a_base_href_a_browser_would_resolve_outside_the_prefix_is_refused():
+    """A browser applies a dot segment and a backslash before it reads the `<base>`."""
+    escaping = ('/v/../', '/v/%2e%2e/', '/v/%2E./tok/', '/v/./tok/', '/v/tok/..', '/v\\tok/')
+
+    for value in escaping:
+        with pytest.raises(ValueError, match='dot segment'):
+            normalized_base_href(value)
+
+
+def test_a_base_href_whose_segment_only_contains_dots_stands():
+    for value in ('/v/tok.1/', '/v/..tok/', '/v/tok../', '/v/a.b.c/'):
+        assert normalized_base_href(value) == value
+
+
+def test_configure_pages_checks_what_it_is_given_and_fills_the_state(monkeypatch):
+    for key in ('base_href', 'title', 'show_paths', 'static_export', 'build_id'):
+        monkeypatch.setitem(app_state, key, app_state[key])
+
+    configure_pages(base_href='/v/tok', title='A run', show_paths=False, static_export=True, build_id='k3n9')
+
+    assert app_state['base_href'] == '/v/tok/'
+    assert (app_state['title'], app_state['show_paths'], app_state['static_export']) == ('A run', False, True)
+    assert app_state['build_id'] == 'k3n9'
+    with pytest.raises(ValueError, match='build_id'):
+        configure_pages(build_id='k3/n9')
 
 
 def test_a_build_id_in_the_token_alphabet_stands():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -368,20 +368,30 @@ def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_e
     )
 
 
-def test_a_download_link_carries_its_field_path_encoded_and_the_route_answers_it(viewer, monkeypatch):
+def test_a_download_link_carries_each_key_encoded_and_the_route_answers_it(viewer, monkeypatch):
     monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/b': b'nested'})
 
-    link, nested = download_link(0, 'a?b c'), download_link(0, 'a/b')
+    link, slashed = download_link(0, ('a?b c',)), download_link(0, ('a/b',))
 
-    assert (link, nested) == ('api/episode/0/static/a%3Fb%20c', 'api/episode/0/static/a%2Fb')
-    assert viewer.get(f'/{link}').content == b'a mesh' and viewer.get(f'/{nested}').content == b'nested'
+    assert (link, slashed) == ('api/episode/0/static/a%3Fb%20c', 'api/episode/0/static/a%2Fb')
+    assert viewer.get(f'/{link}').content == b'a mesh' and viewer.get(f'/{slashed}').content == b'nested'
     assert f'"{link}"' in viewer.get('/episode/0').text
 
 
-def test_a_static_value_named_with_a_path_step_gets_no_link():
-    for name in ('.', '..', 'a/../b', 'a/./b'):
+def test_a_nested_value_and_a_dotted_top_level_key_get_apart_links_the_route_tells_apart(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'scene.mesh': b'top', 'scene': {'mesh': b'nested'}})
+
+    top, nested = download_link(0, ('scene.mesh',)), download_link(0, ('scene', 'mesh'))
+
+    assert (top, nested) == ('api/episode/0/static/scene.mesh', 'api/episode/0/static/scene/mesh')
+    assert viewer.get(f'/{top}').content == b'top'
+    assert viewer.get(f'/{nested}').content == b'nested'
+
+
+def test_a_key_a_browser_rewrites_in_a_path_gets_no_link():
+    for keys_ in (('.',), ('..',), ('a', '..', 'b'), ('a', '', 'b')):
         with pytest.raises(ValueError, match='no link'):
-            download_link(0, name)
+            download_link(0, keys_)
 
 
 def test_reconfiguring_the_tables_drops_a_cached_table_response(grouped):
@@ -390,11 +400,12 @@ def test_reconfiguring_the_tables_drops_a_cached_table_response(grouped):
         _BY_TASK, format_table={keys.TASK: ColumnConfig(label='Job'), 'count': ColumnConfig(label='Episodes')}
     )
 
+    ep_table_cfg = {keys.TASK: ColumnConfig(label='Task'), ASSISTED: ColumnConfig(label='Assisted')}
     with app_state_restored():
         configure_tables(
             root='',
             cache_dir=Path(),
-            ep_table_cfg=None,
+            ep_table_cfg=ep_table_cfg,
             group_tables={'by_task': renamed},
             home_page=None,
             max_resolution=64,
@@ -415,17 +426,23 @@ def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_pat
         'many': [{'a': b'x'}, b'y'],
     }
 
-    assert list(download_paths(static)) == ['scene', 'notes', 'nested.blob', 'many.0.a', 'many.1']
+    assert list(download_paths(static)) == [
+        ('scene',),
+        ('notes',),
+        ('nested', 'blob'),
+        ('many', '0', 'a'),
+        ('many', '1'),
+    ]
 
 
-def test_a_static_value_the_download_route_does_not_read_back_gets_no_link():
-    for static in ({'': b'x'}, {'a': {'': b'x'}}, {'a.b': b'1', 'a': {'b': b'2'}}):
+def test_a_static_value_whose_key_a_browser_rewrites_in_a_path_gets_no_link():
+    for static in ({'': b'x'}, {'a': {'': b'x'}}, {'..': b'x'}, {'a': {'.': b'x'}}):
         with pytest.raises(ValueError, match='no link'):
             list(download_paths(static))
 
 
-def test_a_dotted_key_beside_an_unrelated_nested_value_keeps_both_links():
-    assert list(download_paths({'a.b': b'1', 'a': {'c': b'2'}})) == ['a.b', 'a.c']
+def test_a_dotted_key_and_a_nested_value_that_spell_alike_each_keep_their_own_link():
+    assert list(download_paths({'a.b': b'1', 'a': {'b': b'2'}})) == [('a.b',), ('a', 'b')]
 
 
 def test_a_base_href_that_starts_at_the_server_root_stands():
@@ -557,3 +574,43 @@ def test_a_second_holder_of_the_app_state_waits_for_the_first():
     for holder in holders:
         holder.join(5)
     assert second_holds.is_set()
+
+
+def _configure(ep_table_cfg, group_tables):
+    configure_tables(
+        root='',
+        cache_dir=Path(),
+        ep_table_cfg=ep_table_cfg,
+        group_tables=group_tables,
+        home_page=None,
+        max_resolution=64,
+        max_hz=0,
+    )
+
+
+def test_a_group_key_that_is_no_episode_column_is_refused():
+    ep_table_cfg = {keys.TASK: ColumnConfig(label='Task')}
+    group_tables = {'by_object': replace(_BY_TASK, group_keys='object', group_filter_keys={})}
+    with app_state_restored(), pytest.raises(ValueError, match='no column of the episode table'):
+        _configure(ep_table_cfg, group_tables)
+
+
+def test_a_group_filter_key_that_is_no_episode_column_is_refused():
+    ep_table_cfg = {keys.TASK: ColumnConfig(label='Task')}
+    with app_state_restored(), pytest.raises(ValueError, match='no column of the episode table'):
+        _configure(ep_table_cfg, {'by_task': _BY_TASK})  # _BY_TASK filters on ASSISTED, which is no column here
+
+
+def test_group_keys_that_are_episode_columns_are_accepted():
+    ep_table_cfg = {keys.TASK: ColumnConfig(label='Task'), ASSISTED: ColumnConfig(label='Assisted')}
+    with app_state_restored():
+        _configure(ep_table_cfg, {'by_task': _BY_TASK})  # the group key and the filter key are both episode columns
+
+
+def test_the_flat_table_applies_a_url_key_that_names_any_episode_column():
+    """A View link carries a group key; the flat table filters on it when it is a column, not only a filter one."""
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert 'function readFiltersFromURL(serverFilterKeys, columns, episodes)' in app_js
+    assert 'const index = columns.findIndex((c) => c.key === key);' in app_js
+    assert 'state.filters[key] = value;' in app_js

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -23,6 +23,7 @@ from positronic.server.positronic_server import (
     GROUP_FILTERS,
     ColumnConfig,
     GroupTableConfig,
+    PageConfig,
     _access_url,
     _generate_self_signed_cert,
     _get_rrd_cache_path,
@@ -276,7 +277,7 @@ def test_a_viewer_at_the_server_root_says_so(viewer, page):
 
 @pytest.mark.parametrize('page', _PAGES)
 def test_a_viewer_under_a_prefix_pins_no_page_link_to_the_server_root(viewer, monkeypatch, page):
-    monkeypatch.setitem(app_state, 'base_href', '/v/tok/')
+    monkeypatch.setitem(app_state, 'pages', PageConfig(base_href='/v/tok/'))
 
     body = viewer.get(page).text
 
@@ -284,20 +285,21 @@ def test_a_viewer_under_a_prefix_pins_no_page_link_to_the_server_root(viewer, mo
     assert _server_rooted_urls(body, '/v/tok/') == []
 
 
-def test_a_base_href_gains_the_trailing_slash_a_relative_link_needs(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'base_href', '/v/tok')
+def test_a_base_href_gains_the_trailing_slash_a_relative_link_needs(viewer):
+    with app_state_restored():
+        configure_pages(base_href='/v/tok')
 
-    assert '<base href="/v/tok/" />' in viewer.get('/').text
+        assert '<base href="/v/tok/" />' in viewer.get('/').text
 
 
 def test_a_static_export_tells_the_page_to_read_the_files_it_wrote(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'static_export', True)
+    monkeypatch.setitem(app_state, 'pages', PageConfig(static_export=True))
 
     assert 'window.STATIC_EXPORT = true;' in viewer.get('/').text
 
 
 def test_a_title_stands_in_for_the_dataset_root(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'title', 'Runway rollouts, 29 August')
+    monkeypatch.setitem(app_state, 'pages', PageConfig(title='Runway rollouts, 29 August'))
 
     for page in ['/', '/episode/0']:
         body = viewer.get(page).text
@@ -309,7 +311,7 @@ def test_the_header_falls_back_to_the_dataset_root(viewer):
 
 
 def test_an_episode_page_hides_where_the_episode_lives(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'show_paths', False)
+    monkeypatch.setitem(app_state, 'pages', PageConfig(show_paths=False))
 
     body = viewer.get('/episode/0').text
 
@@ -318,7 +320,7 @@ def test_an_episode_page_hides_where_the_episode_lives(viewer, monkeypatch):
 
 
 def test_an_episode_keeps_its_size_where_the_page_hides_paths(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'show_paths', False)
+    monkeypatch.setitem(app_state, 'pages', PageConfig(show_paths=False))
 
     assert '12.50 MB' in viewer.get('/episode/0').text
 
@@ -338,7 +340,7 @@ def test_an_episode_page_shows_where_the_episode_lives_by_default(viewer):
 
 
 def test_the_api_reports_no_dataset_root_when_the_viewer_hides_paths(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'show_paths', False)
+    monkeypatch.setitem(app_state, 'pages', PageConfig(show_paths=False))
 
     assert viewer.get('/api/dataset_info').json()['root'] == ''
     assert viewer.get('/api/dataset_status').json()['repo_id'] == ''
@@ -454,13 +456,11 @@ def test_a_base_href_whose_segment_only_contains_dots_stands():
 
 
 def test_configure_pages_checks_what_it_is_given_and_fills_the_state(monkeypatch):
-    for key in ('base_href', 'title', 'show_paths', 'static_export'):
-        monkeypatch.setitem(app_state, key, app_state[key])
+    monkeypatch.setitem(app_state, 'pages', app_state['pages'])
 
     configure_pages(base_href='/v/tok', title='A run', show_paths=False, static_export=True)
 
-    assert app_state['base_href'] == '/v/tok/'
-    assert (app_state['title'], app_state['show_paths'], app_state['static_export']) == ('A run', False, True)
+    assert app_state['pages'] == PageConfig(base_href='/v/tok/', title='A run', show_paths=False, static_export=True)
     with pytest.raises(ValueError, match='server root'):
         configure_pages(base_href='v/tok')
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -18,7 +18,6 @@ from positronic import keys
 from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
-    _MAX_DOWNLOAD_PATH_BYTES,
     FILTER_VALUES,
     GROUP_FILTERS,
     MAX_COMPONENT_BYTES,
@@ -457,20 +456,11 @@ def test_a_key_within_a_file_name_s_limit_once_encoded_keeps_its_link():
     assert download_link(0, (key,)) == f'api/episode/0/static/{key}'
 
 
-def test_a_path_past_a_host_s_key_limit_once_encoded_gets_no_link():
-    deep = {'k' * MAX_COMPONENT_BYTES: b'x'}
-    for _ in range(_MAX_DOWNLOAD_PATH_BYTES // MAX_COMPONENT_BYTES):
-        deep = {'k' * MAX_COMPONENT_BYTES: deep}
-
-    with pytest.raises(ValueError, match='no link'):
-        list(download_paths(deep))
-
-
-def test_a_path_within_a_host_s_key_limit_once_encoded_keeps_its_link():
-    keys_ = ('k' * MAX_COMPONENT_BYTES,) * (_MAX_DOWNLOAD_PATH_BYTES // (MAX_COMPONENT_BYTES + 1))
+def test_a_path_of_any_depth_keeps_its_link_on_the_live_server():
+    """A host's key limit binds the export alone; the live server links every path its route carries."""
+    keys_ = ('k' * MAX_COMPONENT_BYTES,) * 8
 
     assert download_link(0, keys_).startswith('api/episode/0/static/')
-    assert len('/'.join(keys_).encode()) <= _MAX_DOWNLOAD_PATH_BYTES
 
 
 def test_the_page_script_names_the_dataset_status_route_the_server_declares():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -2,6 +2,7 @@ import ipaddress
 import os
 import re
 import socket
+import threading
 from collections import namedtuple
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,10 @@ from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
     _MAX_COMPONENT_BYTES,
+    FILTER_VALUES,
+    GROUP_FILTERS,
+    ColumnConfig,
+    GroupTableConfig,
     _access_url,
     _generate_self_signed_cert,
     _get_rrd_cache_path,
@@ -25,6 +30,7 @@ from positronic.server.positronic_server import (
     _served_addresses,
     app,
     app_state,
+    app_state_restored,
     configure_pages,
     download_paths,
     normalized_base_href,
@@ -348,6 +354,15 @@ def test_the_episode_page_links_its_recording_and_its_downloads_at_their_routes(
     assert viewer.get('/api/episode/0/static/scene').content == b'a mesh'
 
 
+def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_encoded(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'scene': b'a mesh', 'notes & é': 'n' * 2000})
+
+    assert viewer.get('/api/episode/0/static/scene').headers['content-disposition'] == 'attachment; filename="scene"'
+    assert viewer.get('/api/episode/0/static/notes & é').headers['content-disposition'] == (
+        "inline; filename*=utf-8''notes%20%26%20%C3%A9.txt"
+    )
+
+
 def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_path():
     static = {
         'scene': b'a mesh',
@@ -414,3 +429,80 @@ def test_a_group_name_reaches_the_page_script_as_json(viewer):
 
     assert 'window.API_ENDPOINT = "api/groups/a\\u0026b";' in body
     assert 'a&amp;b' not in body
+
+
+class _Statics:
+    """A dataset of episodes that hold static values and nothing else."""
+
+    def __init__(self, *statics: dict):
+        self._statics = statics
+
+    def __len__(self) -> int:
+        return len(self._statics)
+
+    def __getitem__(self, index: int) -> SimpleNamespace:
+        if index >= len(self):
+            raise IndexError(index)
+        return SimpleNamespace(static=self._statics[index], meta={}, duration_ns=0)
+
+
+ASSISTED = 'assisted'
+_BY_TASK = GroupTableConfig(
+    group_keys=keys.TASK,
+    group_fn=lambda episodes: {'count': len(episodes)},
+    format_table={keys.TASK: ColumnConfig(label='Task'), 'count': ColumnConfig(label='Episodes')},
+    group_filter_keys={ASSISTED: 'Assisted'},
+)
+
+
+@pytest.fixture
+def grouped(monkeypatch):
+    episodes = _Statics(
+        {keys.TASK: 'fold', ASSISTED: True},
+        {keys.TASK: 'fold', ASSISTED: False},
+        {keys.TASK: 'stack', ASSISTED: False},
+        {keys.TASK: 'stack'},
+    )
+    monkeypatch.setitem(app_state, 'dataset', episodes)
+    monkeypatch.setitem(app_state, 'loading_state', False)
+    monkeypatch.setitem(app_state, 'group_tables_cfg', {'by_task': _BY_TASK})
+    monkeypatch.setattr(positronic_server, '_api_cache', {})
+    return TestClient(app)
+
+
+def test_a_group_filter_offers_each_value_as_the_string_a_query_carries_and_no_absent_one(grouped):
+    table = grouped.get('/api/groups/by_task').json()
+
+    assert table[GROUP_FILTERS][ASSISTED][FILTER_VALUES] == ['False', 'True']
+
+
+def test_a_group_filter_matches_the_value_it_offered(grouped):
+    assisted = grouped.get('/api/groups/by_task', params={ASSISTED: 'True'}).json()
+    unassisted = grouped.get('/api/groups/by_task', params={ASSISTED: 'False'}).json()
+
+    assert [row[1][0] for row in assisted['episodes']] == ['fold']
+    assert [row[1][0] for row in unassisted['episodes']] == ['fold', 'stack']
+
+
+def test_a_second_holder_of_the_app_state_waits_for_the_first():
+    first_holds, released, second_holds = threading.Event(), threading.Event(), threading.Event()
+
+    def first():
+        with app_state_restored():
+            first_holds.set()
+            released.wait(5)
+
+    def second():
+        with app_state_restored():
+            second_holds.set()
+
+    holders = [threading.Thread(target=first), threading.Thread(target=second)]
+    holders[0].start()
+    assert first_holds.wait(5)
+    holders[1].start()
+
+    assert not second_holds.wait(0.2)
+    released.set()
+    for holder in holders:
+        holder.join(5)
+    assert second_holds.is_set()

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -326,6 +326,7 @@ def test_the_api_reports_the_dataset_root_by_default(viewer):
 
 
 def test_a_build_id_carries_the_files_a_browser_caches_for_a_year(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'static_export', True)
     monkeypatch.setitem(app_state, 'build_id', 'k3n9')
 
     body = viewer.get('/episode/0').text
@@ -340,6 +341,15 @@ def test_without_a_build_id_the_same_files_sit_beside_the_other_api_calls(viewer
     assert 'api/episode_rrd/0' in body
     assert 'api/episode/0/static/scene' in body
     assert 'build/' not in body
+
+
+def test_a_live_viewer_asks_for_the_routes_it_serves_whatever_the_build_id_says(viewer, monkeypatch):
+    monkeypatch.setitem(app_state, 'build_id', 'k3n9')
+
+    body = viewer.get('/episode/0').text
+
+    assert 'build/' not in body
+    assert viewer.get('/api/episode/0/static/scene').content == b'a mesh'
 
 
 def test_an_endpoint_the_export_writes_whole_takes_one_file():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -365,13 +365,19 @@ def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_e
 
 
 def test_a_download_link_carries_its_field_path_encoded_and_the_route_answers_it(viewer, monkeypatch):
-    monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh'})
+    monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/../b': b'a step'})
 
-    link = download_link(0, 'a?b c')
+    link, stepped = download_link(0, 'a?b c'), download_link(0, 'a/../b')
 
-    assert link == 'api/episode/0/static/a%3Fb%20c'
-    assert viewer.get(f'/{link}').content == b'a mesh'
+    assert (link, stepped) == ('api/episode/0/static/a%3Fb%20c', 'api/episode/0/static/a%2F..%2Fb')
+    assert viewer.get(f'/{link}').content == b'a mesh' and viewer.get(f'/{stepped}').content == b'a step'
     assert f'"{link}"' in viewer.get('/episode/0').text
+
+
+def test_a_static_value_named_as_a_path_step_gets_no_link():
+    for name in ('.', '..'):
+        with pytest.raises(ValueError, match='no link'):
+            download_link(0, name)
 
 
 def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_path():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -26,6 +26,7 @@ from positronic.server.positronic_server import (
     app,
     app_state,
     static_export_key,
+    static_export_url_path,
 )
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
@@ -373,6 +374,18 @@ def test_a_filter_value_that_carries_a_separator_stays_in_one_component():
     key = static_export_key('api/groups/g', {'task': 'a&b=c/d'})
 
     assert key == 'api/groups/g/task=a%26b%3Dc%2Fd.json'
+
+
+def test_a_name_that_carries_a_percent_escape_is_asked_for_with_that_escape_escaped():
+    params = {'task': 'pick a cube'}
+
+    assert static_export_key('api/groups/g', params) == 'api/groups/g/task=pick%20a%20cube.json'
+    assert static_export_url_path('api/groups/g', params) == 'api/groups/g/task=pick%2520a%2520cube.json'
+
+
+def test_a_name_that_needs_no_escape_is_asked_for_as_it_stands():
+    for params in (None, {}, {'model': 'pi0'}):
+        assert static_export_url_path('api/x', params) == static_export_key('api/x', params)
 
 
 def test_app_js_asks_for_the_file_name_this_module_writes():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -354,10 +354,10 @@ def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_pat
         'notes': 'n' * 2000,
         'short': 'ok',
         'nested': {'blob': b'x', 'n': 1},
-        'many': [{'a': b'x'}],
+        'many': [{'a': b'x'}, b'y'],
     }
 
-    assert list(download_paths(static)) == ['scene', 'notes', 'nested.blob', 'many.a']
+    assert list(download_paths(static)) == ['scene', 'notes', 'nested.blob', 'many.0.a', 'many.1']
 
 
 def test_a_base_href_that_starts_at_the_server_root_stands():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -30,6 +30,7 @@ from positronic.server.positronic_server import (
     normalized_base_href,
     static_export_key,
     static_export_url_path,
+    validated_build_id,
 )
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
@@ -437,20 +438,45 @@ def test_a_base_href_that_starts_at_the_server_root_stands():
     assert normalized_base_href('/v/tok') == '/v/tok/'
 
 
-def test_a_base_href_that_does_not_start_at_the_server_root_is_refused():
-    for value in ('shares/run', '', 'https://app.example.com/v/tok/'):
+def test_a_base_href_that_is_not_a_path_at_the_server_root_is_refused():
+    outside = ('shares/run', '', 'https://app.example.com/v/tok/', '//other.example/', '/p?q/', '/p#f/')
+
+    for value in outside:
         with pytest.raises(ValueError, match='server root'):
             normalized_base_href(value)
 
 
-def test_a_build_id_reaches_the_page_script_as_json(viewer, monkeypatch):
+def test_a_build_id_in_the_token_alphabet_stands():
+    assert validated_build_id('') == ''
+    assert validated_build_id('k3n9_-A') == 'k3n9_-A'
+
+
+def test_a_build_id_that_would_cut_a_url_path_short_is_refused():
+    for value in ('k3#n9', 'k3?n9', 'k3/n9', 'k3 n9'):
+        with pytest.raises(ValueError, match='build_id'):
+            validated_build_id(value)
+
+
+def test_a_filter_key_outside_the_basic_plane_orders_by_its_encoding():
+    # Python orders these two by code point and JavaScript by UTF-16 code unit, the other way
+    # about; both languages order their percent-encoded ASCII alike.
+    key = static_export_key('api/groups/g', {'\U0001f600': '1', '\ue000': '2'})
+
+    assert key == 'api/groups/g/%EE%80%80=2&%F0%9F%98%80=1.json'
+
+
+def test_the_rrd_path_reaches_the_page_script_as_json(viewer, monkeypatch):
     monkeypatch.setitem(app_state, 'static_export', True)
-    monkeypatch.setitem(app_state, 'build_id', 'k3&n9')
+    monkeypatch.setitem(app_state, 'build_id', 'k3n9')
 
-    body = viewer.get('/episode/0').text
+    assert 'appUrl("build/k3n9/api/episode_rrd/0")' in viewer.get('/episode/0').text
 
-    assert 'build/k3\\u0026n9/api/episode_rrd/0' in body
-    assert 'k3&amp;n9' not in body
+
+def test_a_group_name_reaches_the_page_script_as_json(viewer):
+    body = viewer.get('/groups/a&b').text
+
+    assert 'window.API_ENDPOINT = "api/groups/a\\u0026b";' in body
+    assert 'a&amp;b' not in body
 
 
 def test_app_js_asks_for_the_file_name_this_module_writes():

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -441,6 +441,19 @@ def test_a_static_value_whose_key_a_browser_rewrites_in_a_path_gets_no_link():
             list(download_paths(static))
 
 
+def test_a_key_past_a_file_name_s_limit_once_encoded_gets_no_link():
+    for key in ('x' * (_MAX_COMPONENT_BYTES + 1), 'é' * (_MAX_COMPONENT_BYTES // 6 + 1)):  # `é` encodes to 6 bytes
+        with pytest.raises(ValueError, match='no link'):
+            list(download_paths({key: b'x'}))
+
+
+def test_a_key_within_a_file_name_s_limit_once_encoded_keeps_its_link():
+    key = 'x' * _MAX_COMPONENT_BYTES
+
+    assert list(download_paths({key: b'x'})) == [(key,)]
+    assert download_link(0, (key,)) == f'api/episode/0/static/{key}'
+
+
 def test_a_dotted_key_and_a_nested_value_that_spell_alike_each_keep_their_own_link():
     assert list(download_paths({'a.b': b'1', 'a': {'b': b'2'}})) == [('a.b',), ('a', 'b')]
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -362,12 +362,21 @@ def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_pat
 
 def test_a_base_href_that_starts_at_the_server_root_stands():
     assert normalized_base_href('/') == '/'
+    assert normalized_base_href('/v//tok/') == '/v//tok/'
     assert normalized_base_href('/v/tok/') == '/v/tok/'
     assert normalized_base_href('/v/tok') == '/v/tok/'
 
 
 def test_a_base_href_that_is_not_a_path_at_the_server_root_is_refused():
-    outside = ('shares/run', '', 'https://app.example.com/v/tok/', '//other.example/', '/p?q/', '/p#f/')
+    outside = (
+        'shares/run',
+        '',
+        'https://app.example.com/v/tok/',
+        '//other.example/',
+        '////other.example/',
+        '/p?q/',
+        '/p#f/',
+    )
 
     for value in outside:
         with pytest.raises(ValueError, match='server root'):

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -614,3 +614,11 @@ def test_the_flat_table_applies_a_url_key_that_names_any_episode_column():
     assert 'function readFiltersFromURL(serverFilterKeys, columns, episodes)' in app_js
     assert 'const index = columns.findIndex((c) => c.key === key);' in app_js
     assert 'state.filters[key] = value;' in app_js
+
+
+def test_the_flat_table_compares_a_url_filter_with_a_cell_s_raw_value():
+    """A formatted cell is `[raw, formatted]`, and a View link carries the raw value as the server spells it."""
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert 'return String(rawValue(episodeData[colIdx])) === value;' in app_js
+    assert 'const v = rawValue(episodeData[index]);' in app_js

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -18,6 +18,7 @@ from positronic import keys
 from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
+    _PAGE_CONFIG_KEY,
     FILTER_VALUES,
     GROUP_FILTERS,
     MAX_COMPONENT_BYTES,
@@ -279,7 +280,7 @@ def test_a_viewer_at_the_server_root_says_so(viewer, page):
 
 @pytest.mark.parametrize('page', _PAGES)
 def test_a_viewer_under_a_prefix_pins_no_page_link_to_the_server_root(viewer, monkeypatch, page):
-    monkeypatch.setitem(app_state, 'pages', PageConfig(base_href='/v/tok/'))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(base_href='/v/tok/'))
 
     body = viewer.get(page).text
 
@@ -295,13 +296,13 @@ def test_a_base_href_gains_the_trailing_slash_a_relative_link_needs(viewer):
 
 
 def test_a_static_export_tells_the_page_to_read_the_files_it_wrote(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'pages', PageConfig(static_export=True))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(static_export=True))
 
     assert 'window.STATIC_EXPORT = true;' in viewer.get('/').text
 
 
 def test_a_title_stands_in_for_the_dataset_root(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'pages', PageConfig(title='Runway rollouts, 29 August'))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(title='Runway rollouts, 29 August'))
 
     for page in ['/', '/episode/0']:
         body = viewer.get(page).text
@@ -313,7 +314,7 @@ def test_the_header_falls_back_to_the_dataset_root(viewer):
 
 
 def test_an_episode_page_hides_where_the_episode_lives(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'pages', PageConfig(show_paths=False))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(show_paths=False))
 
     body = viewer.get('/episode/0').text
 
@@ -322,7 +323,7 @@ def test_an_episode_page_hides_where_the_episode_lives(viewer, monkeypatch):
 
 
 def test_an_episode_keeps_its_size_where_the_page_hides_paths(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'pages', PageConfig(show_paths=False))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(show_paths=False))
 
     assert '12.50 MB' in viewer.get('/episode/0').text
 
@@ -342,7 +343,7 @@ def test_an_episode_page_shows_where_the_episode_lives_by_default(viewer):
 
 
 def test_the_api_reports_no_dataset_root_when_the_viewer_hides_paths(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'pages', PageConfig(show_paths=False))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(show_paths=False))
 
     assert viewer.get('/api/dataset_info').json()['root'] == ''
     assert viewer.get('/api/dataset_status').json()['repo_id'] == ''
@@ -518,11 +519,13 @@ def test_a_base_href_whose_segment_only_contains_dots_stands():
 
 
 def test_configure_pages_checks_what_it_is_given_and_fills_the_state(monkeypatch):
-    monkeypatch.setitem(app_state, 'pages', app_state['pages'])
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, app_state[_PAGE_CONFIG_KEY])
 
     configure_pages(base_href='/v/tok', title='A run', show_paths=False, static_export=True)
 
-    assert app_state['pages'] == PageConfig(base_href='/v/tok/', title='A run', show_paths=False, static_export=True)
+    assert app_state[_PAGE_CONFIG_KEY] == PageConfig(
+        base_href='/v/tok/', title='A run', show_paths=False, static_export=True
+    )
     with pytest.raises(ValueError, match='server root'):
         configure_pages(base_href='v/tok')
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,4 +1,3 @@
-import hashlib
 import ipaddress
 import os
 import re
@@ -18,7 +17,6 @@ from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
     _MAX_COMPONENT_BYTES,
-    _QUERY_DIGEST_CHARS,
     _access_url,
     _generate_self_signed_cert,
     _get_rrd_cache_path,
@@ -28,10 +26,8 @@ from positronic.server.positronic_server import (
     app,
     app_state,
     configure_pages,
+    download_paths,
     normalized_base_href,
-    static_export_key,
-    static_export_url_path,
-    validated_build_id,
 )
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
@@ -344,93 +340,24 @@ def test_the_api_reports_the_dataset_root_by_default(viewer):
     assert viewer.get('/api/dataset_status').json()['repo_id'] == '/datasets/run-7'
 
 
-def test_a_build_id_carries_the_files_a_browser_caches_for_a_year(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'static_export', True)
-    monkeypatch.setitem(app_state, 'build_id', 'k3n9')
-
+def test_the_episode_page_links_its_recording_and_its_downloads_at_their_routes(viewer):
     body = viewer.get('/episode/0').text
 
-    assert 'build/k3n9/api/episode_rrd/0' in body
-    assert 'build/k3n9/api/episode/0/static/scene' in body
-
-
-def test_without_a_build_id_the_same_files_sit_beside_the_other_api_calls(viewer):
-    body = viewer.get('/episode/0').text
-
-    assert 'api/episode_rrd/0' in body
-    assert 'api/episode/0/static/scene' in body
-    assert 'build/' not in body
-
-
-def test_a_live_viewer_asks_for_the_routes_it_serves_whatever_the_build_id_says(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'build_id', 'k3n9')
-
-    body = viewer.get('/episode/0').text
-
-    assert 'build/' not in body
+    assert 'appUrl("api/episode_rrd/0")' in body
+    assert '"api/episode/0/static/scene"' in body
     assert viewer.get('/api/episode/0/static/scene').content == b'a mesh'
 
 
-def test_an_endpoint_the_export_writes_whole_takes_one_file():
-    assert static_export_key('api/episodes') == 'api/episodes.json'
-    assert static_export_key('api/dataset_info') == 'api/dataset_info.json'
+def test_every_static_value_a_page_links_as_a_download_is_named_by_its_field_path():
+    static = {
+        'scene': b'a mesh',
+        'notes': 'n' * 2000,
+        'short': 'ok',
+        'nested': {'blob': b'x', 'n': 1},
+        'many': [{'a': b'x'}],
+    }
 
-
-def test_an_endpoint_the_export_writes_per_filter_set_names_an_empty_set_all():
-    assert static_export_key('api/groups/leaderboard', {}) == 'api/groups/leaderboard/all.json'
-    assert static_export_key('api/groups/leaderboard', {'model': ''}) == 'api/groups/leaderboard/all.json'
-
-
-def test_one_filter_set_reaches_one_file_whatever_order_it_arrives_in():
-    forwards = static_export_key('api/groups/g', {'model': 'pi0', 'task': 'pick a cube'})
-    backwards = static_export_key('api/groups/g', {'task': 'pick a cube', 'model': 'pi0'})
-
-    assert forwards == backwards == 'api/groups/g/model=pi0&task=pick%20a%20cube.json'
-
-
-def test_a_filter_value_that_carries_a_separator_stays_in_one_component():
-    key = static_export_key('api/groups/g', {'task': 'a&b=c/d'})
-
-    assert key == 'api/groups/g/task=a%26b%3Dc%2Fd.json'
-
-
-def test_a_name_that_carries_a_percent_escape_is_asked_for_with_that_escape_escaped():
-    params = {'task': 'pick a cube'}
-
-    assert static_export_key('api/groups/g', params) == 'api/groups/g/task=pick%20a%20cube.json'
-    assert static_export_url_path('api/groups/g', params) == 'api/groups/g/task=pick%2520a%2520cube.json'
-
-
-def test_a_name_that_needs_no_escape_is_asked_for_as_it_stands():
-    for params in (None, {}, {'model': 'pi0'}):
-        assert static_export_url_path('api/x', params) == static_export_key('api/x', params)
-
-
-def test_a_filter_set_that_fits_a_file_name_keeps_its_readable_one():
-    value = 'x' * (_MAX_COMPONENT_BYTES - len('model='))
-
-    assert static_export_key('api/groups/g', {'model': value}) == f'api/groups/g/model={value}.json'
-
-
-def test_a_filter_set_too_long_for_a_file_name_takes_a_digest_of_itself():
-    value = 'x' * _MAX_COMPONENT_BYTES
-    name = static_export_key('api/groups/g', {'model': value}).removeprefix('api/groups/g/').removesuffix('.json')
-
-    assert name == hashlib.sha256(f'model={value}'.encode()).hexdigest()[:_QUERY_DIGEST_CHARS]
-    assert len(name.encode()) <= _MAX_COMPONENT_BYTES
-
-
-def test_two_filter_sets_past_the_budget_that_differ_reach_different_files():
-    over = 'x' * _MAX_COMPONENT_BYTES
-
-    assert static_export_key('api/groups/g', {'model': over}) != static_export_key('api/groups/g', {'task': over})
-
-
-def test_app_js_bounds_a_file_name_by_the_same_numbers():
-    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
-
-    assert f'const MAX_QUERY_BYTES = {_MAX_COMPONENT_BYTES};' in app_js
-    assert f'const QUERY_DIGEST_CHARS = {_QUERY_DIGEST_CHARS};' in app_js
+    assert list(download_paths(static)) == ['scene', 'notes', 'nested.blob', 'many.a']
 
 
 def test_a_base_href_that_starts_at_the_server_root_stands():
@@ -462,42 +389,15 @@ def test_a_base_href_whose_segment_only_contains_dots_stands():
 
 
 def test_configure_pages_checks_what_it_is_given_and_fills_the_state(monkeypatch):
-    for key in ('base_href', 'title', 'show_paths', 'static_export', 'build_id'):
+    for key in ('base_href', 'title', 'show_paths', 'static_export'):
         monkeypatch.setitem(app_state, key, app_state[key])
 
-    configure_pages(base_href='/v/tok', title='A run', show_paths=False, static_export=True, build_id='k3n9')
+    configure_pages(base_href='/v/tok', title='A run', show_paths=False, static_export=True)
 
     assert app_state['base_href'] == '/v/tok/'
     assert (app_state['title'], app_state['show_paths'], app_state['static_export']) == ('A run', False, True)
-    assert app_state['build_id'] == 'k3n9'
-    with pytest.raises(ValueError, match='build_id'):
-        configure_pages(build_id='k3/n9')
-
-
-def test_a_build_id_in_the_token_alphabet_stands():
-    assert validated_build_id('') == ''
-    assert validated_build_id('k3n9_-A') == 'k3n9_-A'
-
-
-def test_a_build_id_that_would_cut_a_url_path_short_is_refused():
-    for value in ('k3#n9', 'k3?n9', 'k3/n9', 'k3 n9'):
-        with pytest.raises(ValueError, match='build_id'):
-            validated_build_id(value)
-
-
-def test_a_filter_key_outside_the_basic_plane_orders_by_its_encoding():
-    # Python orders these two by code point and JavaScript by UTF-16 code unit, the other way
-    # about; both languages order their percent-encoded ASCII alike.
-    key = static_export_key('api/groups/g', {'\U0001f600': '1', '\ue000': '2'})
-
-    assert key == 'api/groups/g/%EE%80%80=2&%F0%9F%98%80=1.json'
-
-
-def test_the_rrd_path_reaches_the_page_script_as_json(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, 'static_export', True)
-    monkeypatch.setitem(app_state, 'build_id', 'k3n9')
-
-    assert 'appUrl("build/k3n9/api/episode_rrd/0")' in viewer.get('/episode/0').text
+    with pytest.raises(ValueError, match='server root'):
+        configure_pages(base_href='v/tok')
 
 
 def test_a_group_name_reaches_the_page_script_as_json(viewer):
@@ -505,9 +405,3 @@ def test_a_group_name_reaches_the_page_script_as_json(viewer):
 
     assert 'window.API_ENDPOINT = "api/groups/a\\u0026b";' in body
     assert 'a&amp;b' not in body
-
-
-def test_app_js_asks_for_the_file_name_this_module_writes():
-    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
-
-    assert static_export_key('api/groups/leaderboard', {'b': '2', 'a': 'x y'}) in app_js

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -46,6 +46,7 @@ from positronic.server.positronic_server import (
     configure_pages,
     configure_tables,
     download_link,
+    download_metadata,
     download_paths,
     episode_link,
     normalized_base_href,
@@ -388,6 +389,12 @@ def test_a_download_is_named_in_the_header_and_a_name_outside_ascii_is_percent_e
     assert viewer.get('/api/episode/0/static/notes & é').headers['content-disposition'] == (
         "inline; filename*=utf-8''notes%20%26%20%C3%A9.txt"
     )
+
+
+def test_a_text_download_reports_the_size_of_the_bytes_the_route_answers(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'notes': 'é' * 3})
+
+    assert download_metadata('é' * 3).size == len(viewer.get('/api/episode/0/static/notes').content) == 6
 
 
 def test_a_download_name_holding_a_slash_is_percent_encoded_in_the_header(viewer, monkeypatch):

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -404,6 +404,10 @@ def test_a_list_index_the_route_cannot_parse_is_a_missing_field(viewer, monkeypa
         assert viewer.get(f'/api/episode/0/static/many/{segment}').status_code == 404
     assert viewer.get('/api/episode/0/static/many/0').content == b'x'
 
+    monkeypatch.setattr(_StubEpisode, 'static', {'many': [b'x'] * 10})
+    assert viewer.get('/api/episode/0/static/many/01').status_code == 404
+    assert viewer.get('/api/episode/0/static/many/1').content == b'x'
+
 
 def test_a_download_link_carries_each_key_encoded_and_the_route_answers_it(viewer, monkeypatch):
     monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/b': b'nested'})

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -420,6 +420,17 @@ def test_a_download_link_carries_each_key_encoded_and_the_route_answers_it(viewe
     assert f'"{link}"' in viewer.get('/episode/0').text
 
 
+def test_a_download_inside_a_tuple_is_linked_by_its_index_like_one_inside_a_list(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'many': (b'x', 'short')})
+
+    link = download_link(0, ('many', '0'))
+
+    assert list(download_paths(_StubEpisode.static)) == [('many', '0')]
+    assert link == 'api/episode/0/static/many/0'
+    assert viewer.get(f'/{link}').content == b'x'
+    assert f'"{link}"' in viewer.get('/episode/0').text
+
+
 def test_a_nested_value_and_a_dotted_top_level_key_get_apart_links_the_route_tells_apart(viewer, monkeypatch):
     monkeypatch.setattr(_StubEpisode, 'static', {'scene.mesh': b'top', 'scene': {'mesh': b'nested'}})
 

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -488,7 +488,7 @@ def test_a_page_hands_the_script_every_route_and_file_it_reads(viewer, page):
     names = json.loads(written.group(1))
     params, file = (field.name for field in fields(GroupFile))
 
-    assert names.pop('episode_page_prefix') + '3' == episode_link(3)
+    assert names.pop('episode_page_before') + '3' + names.pop('episode_page_after') == episode_link(3)
     assert names == {
         'dataset_status': _route(api_dataset_status),
         'dataset_info': _route(api_dataset_info),

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -49,6 +49,7 @@ from positronic.server.positronic_server import (
     download_paths,
     episode_link,
     normalized_base_href,
+    parse_table_cfg,
 )
 
 _Addr = namedtuple('_Addr', 'family address netmask broadcast ptp')
@@ -724,3 +725,60 @@ def test_the_flat_table_compares_a_url_filter_with_a_cell_s_raw_value():
 
     assert 'return String(rawValue(episodeData[colIdx])) === value;' in app_js
     assert 'const v = rawValue(episodeData[index]);' in app_js
+
+
+def test_a_shown_column_carries_no_display_flag_and_a_hidden_one_carries_false():
+    columns, _, _ = parse_table_cfg({
+        keys.TASK: ColumnConfig(label='Task'),
+        'model': ColumnConfig(label='Model', filter=True, display=False),
+    })
+    by_key = {column['key']: column for column in columns}
+
+    assert 'display' not in by_key[keys.TASK]  # a shown column carries no flag
+    assert by_key['model']['display'] is False  # the page reads this and draws nothing
+    assert by_key['model']['filter'] is True  # a hidden column still filters
+
+
+@pytest.fixture
+def flat_with_hidden(monkeypatch):
+    episodes = _Statics({keys.TASK: 'stack', 'model': 'groot'}, {keys.TASK: 'stack', 'model': 'pi0'})
+    ep_table_cfg = {
+        keys.TASK: ColumnConfig(label='Task'),
+        'model': ColumnConfig(label='Model', filter=True, display=False),
+    }
+    monkeypatch.setitem(app_state, 'dataset', episodes)
+    monkeypatch.setitem(app_state, 'loading_state', False)
+    monkeypatch.setitem(app_state, 'episode_table_cfg', ep_table_cfg)
+    monkeypatch.setattr(positronic_server, '_api_cache', {})
+    return TestClient(app)
+
+
+def test_the_flat_table_carries_a_hidden_column_value_to_the_page(flat_with_hidden):
+    table = flat_with_hidden.get('/api/episodes').json()
+    model_index = [column['key'] for column in table['columns']].index('model')
+
+    assert table['columns'][model_index]['display'] is False  # the page knows not to draw it
+    assert [row[1][model_index] for row in table['episodes']] == ['groot', 'pi0']  # the value still ships
+
+
+def test_the_flat_table_filters_on_a_hidden_column(flat_with_hidden):
+    filtered = flat_with_hidden.get('/api/episodes', params={'model': 'groot'}).json()
+
+    assert [row[0] for row in filtered['episodes']] == [0]  # a View link filters on the hidden column
+
+
+def test_a_group_filter_key_that_is_a_hidden_episode_column_is_accepted():
+    ep_table_cfg = {
+        keys.TASK: ColumnConfig(label='Task'),
+        ASSISTED: ColumnConfig(label='Assisted', filter=True, display=False),
+    }
+    with app_state_restored():
+        _configure(ep_table_cfg, {'by_task': _BY_TASK})  # a hidden column is still a column a View link filters on
+
+
+def test_the_page_draws_nothing_for_a_hidden_column():
+    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+
+    assert 'if (display === false) { headerCells.push(null); continue; }' in app_js  # no header
+    assert 'if (columns[i].display === false) continue;' in app_js  # no cell
+    assert 'if (column.display === false) continue;' in app_js  # no dropdown

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -41,6 +41,7 @@ from positronic.server.positronic_server import (
     app,
     app_state,
     app_state_restored,
+    asset_link,
     configure_pages,
     configure_tables,
     download_link,
@@ -361,6 +362,13 @@ def test_the_api_reports_no_dataset_root_when_the_viewer_hides_paths(viewer, mon
 def test_the_api_reports_the_dataset_root_by_default(viewer):
     assert viewer.get('/api/dataset_info').json()['root'] == '/datasets/run-7'
     assert viewer.get('/api/dataset_status').json()['repo_id'] == '/datasets/run-7'
+
+
+def test_a_page_links_its_stylesheet_and_its_script_where_the_app_serves_them(viewer):
+    body = viewer.get('/').text
+
+    assert f'href="{asset_link("styles.css")}"' in body and f'src="{asset_link("app.js")}"' in body
+    assert viewer.get(asset_link('styles.css')).status_code == 200
 
 
 def test_the_episode_page_links_its_recording_and_its_downloads_at_their_routes(viewer):

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -584,6 +584,18 @@ def test_a_base_href_a_browser_would_resolve_outside_the_prefix_is_refused():
             normalized_base_href(value)
 
 
+def test_a_base_href_holding_an_encoded_separator_is_refused():
+    """A host decodes `%2F` and `%5C` once, and a browser sends them as written."""
+    for value in ('/v/%2Ftok/', '/v/%2ftok/', '/v/%5Ctok/', '/v/tok%5C/'):
+        with pytest.raises(ValueError, match='dot segment'):
+            normalized_base_href(value)
+
+
+def test_a_base_href_whose_segment_holds_another_encoded_character_stands():
+    for value in ('/v/caf%C3%A9/', '/v/a%20b/'):
+        assert normalized_base_href(value) == value
+
+
 def test_a_base_href_whose_segment_only_contains_dots_stands():
     for value in ('/v/tok.1/', '/v/..tok/', '/v/tok../', '/v/a.b.c/'):
         assert normalized_base_href(value) == value

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -20,6 +20,7 @@ from positronic.dataset.episode import META_PATH, META_UID
 from positronic.server import positronic_server
 from positronic.server.positronic_server import (
     _PAGE_CONFIG_KEY,
+    API_FILE_SUFFIX,
     FILTER_VALUES,
     GROUP_FILTERS,
     GROUP_INDEX_FILE,
@@ -396,6 +397,14 @@ def test_a_download_name_holding_a_slash_is_percent_encoded_in_the_header(viewer
     )
 
 
+def test_a_list_index_the_route_cannot_parse_is_a_missing_field(viewer, monkeypatch):
+    monkeypatch.setattr(_StubEpisode, 'static', {'many': [b'x']})
+
+    for segment in ('\u00b2', '9' * 5000, '-1', '1_0', '01'):
+        assert viewer.get(f'/api/episode/0/static/many/{segment}').status_code == 404
+    assert viewer.get('/api/episode/0/static/many/0').content == b'x'
+
+
 def test_a_download_link_carries_each_key_encoded_and_the_route_answers_it(viewer, monkeypatch):
     monkeypatch.setattr(_StubEpisode, 'static', {'a?b c': b'a mesh', 'a/b': b'nested'})
 
@@ -501,6 +510,7 @@ def test_a_page_hands_the_script_every_route_and_file_it_reads(viewer, page):
         'dataset_status': _route(api_dataset_status),
         'dataset_info': _route(api_dataset_info),
         'episodes_api': _route(api_episodes),
+        'api_file_suffix': API_FILE_SUFFIX,
         'group_index_file': GROUP_INDEX_FILE,
         'entry_params': params,
         'entry_file': file,

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -1,10 +1,11 @@
 import ipaddress
+import json
 import os
 import re
 import socket
 import threading
 from collections import namedtuple
-from dataclasses import replace
+from dataclasses import fields, replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,8 +22,10 @@ from positronic.server.positronic_server import (
     _PAGE_CONFIG_KEY,
     FILTER_VALUES,
     GROUP_FILTERS,
+    GROUP_INDEX_FILE,
     MAX_COMPONENT_BYTES,
     ColumnConfig,
+    GroupFile,
     GroupTableConfig,
     PageConfig,
     _access_url,
@@ -42,6 +45,7 @@ from positronic.server.positronic_server import (
     configure_tables,
     download_link,
     download_paths,
+    episode_link,
     normalized_base_href,
 )
 
@@ -237,6 +241,9 @@ def test_a_stream_that_dies_partway_leaves_no_cached_rrd(rrd_cache, monkeypatch)
 
 # A URL that starts at the server root, in an attribute or in a script's string.
 _ROOTED_URL = re.compile(r"""["'(`](/[^"'`)\s]*)""")
+
+# The object every page hands the script, as `base.html` writes it.
+_SERVER_NAMES = re.compile(r'window\.SERVER_NAMES = (\{.*?\});')
 
 
 def _server_rooted_urls(html: str, base_href: str) -> list[str]:
@@ -474,16 +481,24 @@ def test_a_path_of_any_depth_keeps_its_link_on_the_live_server():
     assert download_link(0, keys_).startswith('api/episode/0/static/')
 
 
-def test_the_page_script_names_each_api_route_once_as_the_server_declares_it():
-    app_js = (Path(positronic_server.__file__).parent / 'static' / 'app.js').read_text()
+@pytest.mark.parametrize('page', _PAGES)
+def test_a_page_hands_the_script_every_route_and_file_it_reads(viewer, page):
+    written = _SERVER_NAMES.search(viewer.get(page).text)
+    assert written is not None, f'{page} hands the script no names'
+    names = json.loads(written.group(1))
+    params, file = (field.name for field in fields(GroupFile))
 
-    for name, endpoint in (
-        ('DATASET_STATUS_ROUTE', api_dataset_status),
-        ('DATASET_INFO_ROUTE', api_dataset_info),
-        ('EPISODES_ROUTE', api_episodes),
-    ):
-        assert f"const {name} = '{_route(endpoint)}';" in app_js
-        assert app_js.count(f"'{_route(endpoint)}'") == 1
+    assert names.pop('episode_page_prefix') + '3' == episode_link(3)
+    assert names == {
+        'dataset_status': _route(api_dataset_status),
+        'dataset_info': _route(api_dataset_info),
+        'episodes_api': _route(api_episodes),
+        'group_index_file': GROUP_INDEX_FILE,
+        'entry_params': params,
+        'entry_file': file,
+        'group_filters': GROUP_FILTERS,
+        'filter_values': FILTER_VALUES,
+    }
 
 
 def test_the_flat_table_takes_a_url_filter_only_for_a_value_some_row_carries():

--- a/positronic/server/tests/test_sidebar_state.py
+++ b/positronic/server/tests/test_sidebar_state.py
@@ -11,10 +11,13 @@ from pathlib import Path
 
 import pytest
 
+from positronic.server.positronic_server import _server_names
+
 APP_JS = Path(__file__).resolve().parents[1] / 'static' / 'app.js'
 
-# app.js registers listeners when it loads, so the context needs a document. Nothing here runs;
-# the harness calls one function and prints what it returns.
+# app.js registers listeners when it loads, so the context needs a document, and it reads the
+# names the page sets on window, so the context needs a window that carries them. Nothing here
+# runs; the harness calls one function and prints what it returns.
 _HARNESS = """
 const fs = require('fs');
 const vm = require('vm');
@@ -28,6 +31,7 @@ const context = {
   Object,
   console,
   localStorage: {getItem: () => stored, setItem: noop},
+  window: {SERVER_NAMES: JSON.parse(process.argv[3])},
   document: {
     addEventListener: noop,
     querySelector: () => null,
@@ -49,7 +53,11 @@ def load_sidebar_state(stored: str | None) -> dict:
     if node is None:
         pytest.skip('node is required to run the viewer JavaScript')
     result = subprocess.run(
-        [node, '-e', _HARNESS, json.dumps(stored), str(APP_JS)], capture_output=True, text=True, timeout=60, check=False
+        [node, '-e', _HARNESS, json.dumps(stored), str(APP_JS), json.dumps(_server_names())],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
     )
     assert result.returncode == 0, f'app.js raised on stored state {stored!r}:\n{result.stderr}'
     return json.loads(result.stdout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
 [project.scripts]
 positronic="positronic.cli:_internal_main"
 positronic-server="positronic.server.positronic_server:_internal_main"
+positronic-server-export="positronic.server.export:_internal_main"
 positronic-inference="positronic.inference:_internal_main"
 positronic-probe="positronic.probe:_internal_main"
 positronic-data-collection="positronic.data_collection:_internal_main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
 [project.scripts]
 positronic="positronic.cli:_internal_main"
 positronic-server="positronic.server.positronic_server:_internal_main"
-positronic-server-export="positronic.server.export:_internal_main"
 positronic-inference="positronic.inference:_internal_main"
 positronic-probe="positronic.probe:_internal_main"
 positronic-data-collection="positronic.data_collection:_internal_main"


### PR DESCRIPTION
## What

`python -m positronic.server.export <dataset> --out_dir=<dir>` writes the viewer for a dataset as
static files, and `export_static(...)` does the same in-process. The app is read with a test client,
so the export holds what the server answers. The layout: a page at `<route>/index.html`, an API
response at `api/<route>.json`, a group table as one file per filter set some episode satisfies with
`index.json` beside them, the recordings and the downloads under `build/<build_id>/`. A host mounts
the output at `base_href`; the app's assets sit at the host root. The server also gains the page
settings `base_href`, `title`, `show_paths`, and a `static_export` mode the export sets alone.
`base_href` is a path at the server root and nothing else: a dot segment, a backslash, a double
slash or an encoded separator is refused, since a browser or a host reads such a path as another
prefix. Each page sets `window.SERVER_NAMES` with the routes, the export's file names and the
response fields, and app.js reads every such name there, so each is spelled once, on the server. A
group table takes at most six filter keys and 1024 filter sets; each set is one read of the dataset.
`full_dataset`, when given, holds the same episodes in the same order with every download the shown
dataset links, of the type and the size the page reports beside the link; the export checks all of
it before a write. The recordings are built in a scratch directory of the export's own, under
`scratch_dir` when given, and removed at the end, so no export reads another's; a scratch directory
inside the output is refused. The export plans every file before the first write; each planned path fits the 1024-byte key limit
of an S3-style host and the local filesystem, folds to no other path, and holds no component Windows
reads as a device. A path that fails this stops the export, and a write outside the plan is refused.

A static value's download link carries one percent-encoded segment per key: `scene/mesh` for a
nested value, `meshes/link0.stl` for a key that holds a dot, `artifacts/0` for a list item, so no
two downloads share a link. The route splits the raw path on `/` before it unquotes each segment, so a `/`, `?`, space or
non-ASCII character in a key stays in its segment. The export writes the segments as a directory
tree in their encoded spelling, and the page escapes each `%` once more, so a host that decodes a
path once finds the file. A key that is empty, `.`, `..`, or past a file name's limit has no link.

The flat episode table applies every URL key that names one of its columns, so a grouped row's View
link opens the group's episodes on both the live server and the export. A filter compares with a
cell's raw value, which is what the link carries, and a value no row carries is no filter.
`configure_tables` refuses a group key or a filter key that is not a column of the episode table,
since the View link carries those keys to the flat table. A column with `display=False` is such a
column that the page draws nothing for: it carries its value and it filters, so a View link
filters on it, but the reader sees no header, no cell and no dropdown. The stacking table takes
`model` and the phail table takes `equipment` this way, so each View link filters without a
visible column.

On the live server, a download inside a list was linked as the list itself; it is now linked by
its index. A group filter offered a value in one spelling and compared it in another, so a
numeric or a boolean value matched no episode; `filter_spelling` is now the one spelling a filter
offers, matches, and the export reads back.

## Why

A reader of a rollout has no dataset and no server; a static export reaches them anyway. One URL
segment per key keeps a download link unambiguous, so the viewer needs no file name built in the
browser and no collision to detect. A transformed view keeps the dataset's root and its episode uids,
so a shared recording cache cannot tell two views apart; a scratch directory per export can.

## Verification

`positronic/server`: 189 tests pass; the node harness for app.js runs with the names a page sets. A local static host over an export serves every download at the
link its page carries, for a slashed, a nested and a non-ASCII key.

## Refs

Phase 1 of Positronic-Robotics/internal#990. Phase 2 is platform's `shares` distribution, which
calls `export_static`.

<!-- opened-by: posi-agent -->
