### PR TITLE
Add the unchecked-field-name rule to CODE_RULES.md

### DIFF
--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -372,6 +372,9 @@ Keep a typed value typed to the end: copy the model and assign the field, which 
 reads. Where a set of names is needed, derive it from the type (`model_fields`,
 `dataclasses.fields`) or pin it with a test that fails when the model renames or gains a field.
 
+A frozen model refuses the assignment. There `model_copy(update=…)` stays, and a test pins each
+name to `model_fields`, so a rename fails the suite instead of the run.
+
 Exception: a name that is the wire — a JSON key two deploys exchange, an environment variable, a
 third-party object's attribute. There the string is the contract (`hardcoded-keys`).
 

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -372,8 +372,9 @@ Keep a typed value typed to the end: copy the model and assign the field, which 
 reads. Where a set of names is needed, derive it from the type (`model_fields`,
 `dataclasses.fields`) or pin it with a test that fails when the model renames or gains a field.
 
-A frozen model, or a field marked frozen, refuses the assignment. There `model_copy(update=…)`
-stays, and a test pins each name to `model_fields`, so a rename fails the suite instead of the run.
+A model that refuses or validates the assignment — frozen, a frozen field, `validate_assignment` —
+keeps `model_copy(update=…)`, and a test pins each name to `model_fields`, so a rename fails the
+suite instead of the run.
 
 Exception: a name that is the wire — a JSON key two deploys exchange, an environment variable, a
 third-party object's attribute. There the string is the contract (`hardcoded-keys`).

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -359,3 +359,28 @@ reason: an import that cannot resolve gets `# pyright: ignore[reportMissingImpor
 other diagnostic in that file live. Where the gate compares per-file counts rather than entries —
 `.basedpyright/baseline.json` is one such baseline — re-anchoring line numbers can absorb a new
 finding without it noticing, so check that yourself.
+
+### unchecked-field-name
+
+Don't address a typed object's field by a string the type checker never sees. `obj.field` is
+checked, and `getattr(obj, 'field')` raises on a rename. The dict side of a model is neither:
+`model_dump(exclude=…)`, `model_copy(update=…)`, `getattr(obj, 'field', default)` and a filter
+over `.items()` take names pydantic never compares against the model, so a rename passes every
+gate and changes what the code does at run time.
+
+Keep a typed value typed to the end: copy the model and assign the field, which the type checker
+reads. Where a set of names is needed, derive it from the type (`model_fields`,
+`dataclasses.fields`) or pin it with a test that fails when the model renames or gains a field.
+
+Exception: a name that is the wire — a JSON key two deploys exchange, an environment variable, a
+third-party object's attribute. There the string is the contract (`hardcoded-keys`).
+
+```python
+# Bad — pydantic checks none of these names, so a rename is silent
+data.update({k: v for k, v in ended.model_dump().items() if k not in ('active', 'phase')})
+attempt = spec.model_copy(update={'artifact_location': moved})
+
+# Good — the type checker reads the assignment
+attempt = spec.model_copy()
+attempt.artifact_location = moved
+```

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -372,8 +372,8 @@ Keep a typed value typed to the end: copy the model and assign the field, which 
 reads. Where a set of names is needed, derive it from the type (`model_fields`,
 `dataclasses.fields`) or pin it with a test that fails when the model renames or gains a field.
 
-A frozen model refuses the assignment. There `model_copy(update=…)` stays, and a test pins each
-name to `model_fields`, so a rename fails the suite instead of the run.
+A frozen model, or a field marked frozen, refuses the assignment. There `model_copy(update=…)`
+stays, and a test pins each name to `model_fields`, so a rename fails the suite instead of the run.
 
 Exception: a name that is the wire — a JSON key two deploys exchange, an environment variable, a
 third-party object's attribute. There the string is the contract (`hardcoded-keys`).


### PR DESCRIPTION
## What

`CODE_RULES.md` gains `unchecked-field-name`. A typed object's field is never addressed by a string the type checker does not see. The rule states the safe path (keep the value typed; derive or pin a name set) and the exception (a name that is a wire contract).

## Why

A typed pydantic model was dumped to a dict and filtered by a tuple of field-name strings. pydantic checks none of `model_dump(exclude=…)`, `model_copy(update=…)`, the three-argument `getattr` or a filter over a dumped dict, so a rename passes every gate and changes behaviour at run time. ruff B009/B010 flag only the two-argument forms, which raise. A sweep found 57 such sites in platform, 13 of them in production code that writes persisted records; positronic and os hold none.

`hardcoded-keys` does not cover it. A named constant is as unchecked as the literal; only the type, or a test against the type, ties a name to the model. A pre-commit checker for the three syntactic shapes lands in platform separately. This rule covers the shapes no checker sees.

## Verification

A documentation-only change. pre-commit passed on the commit.

<!-- opened-by: posi-agent -->