### PR TITLE
Ship the participant's GitHub device-flow registration in the client

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -35,6 +35,10 @@ export POSITRONIC_PLATFORM_API_KEY=<the key printed above>
 The token GitHub mints carries `read:user user:email`, so it reads your profile and your verified
 email. The platform reads the account once, mints a key, and keeps no GitHub token.
 
+A second run of the command returns the same account and mints no key, because the platform
+cannot read back the key it issued. `platform-register --rotate` mints a fresh one, which is how
+a machine that no longer holds the key gets one.
+
 `POSITRONIC_PLATFORM_URL` and `--platform-url` name a platform other than the default one, as
 everywhere else in this package.
 

--- a/client/README.md
+++ b/client/README.md
@@ -15,40 +15,38 @@ platform installs it on its own, at the exact version it was written against:
 uv add "positronic-platform-client==0.4.0"
 ```
 
-`platform_client` never imports `positronic`. Registration ships here (below); the commands that
-drive an eval — `positronic eval run` and `positronic account` — ship with `positronic`, which
-depends on this package rather than the other way round.
+`platform_client` never imports `positronic`. The `platform-register` command ships here. The
+commands that drive an eval, `positronic eval run` and `positronic account`, ship with `positronic`,
+which depends on this package.
 
 ## Registering
 
-This package carries one command, `platform-register`, and it mints the API key everything else
-needs. It runs GitHub's device flow: it prints a short code and a URL, waits while you authorize it
-in a browser, and registers the account GitHub then names. Installing the package above puts it on
-your path.
+`platform-register` mints the API key that every other call needs. It runs GitHub's device flow:
+it prints a short code and a URL, waits while you authorize the app in a browser, and registers
+the GitHub account that authorized it. The package install above puts the command on your path.
 
 ```bash
 export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
 platform-register --alias=<display name>
-export POSITRONIC_PLATFORM_API_KEY=<the key printed above>
+export POSITRONIC_PLATFORM_API_KEY=<the key the command printed>
 ```
 
-The token GitHub mints carries `read:user user:email`, so it reads your profile and your verified
-email. The platform reads the account once, mints a key, and keeps no GitHub token.
+The GitHub token carries the scopes `read:user` and `user:email`. The platform reads the account
+once, mints a key, and stores no GitHub token.
 
-A second run of the command returns the same account and mints no key, because the platform
-cannot read back the key it issued. `platform-register --rotate` mints a fresh one, which is how
-a machine that no longer holds the key gets one.
+A second run returns the same account and no key: the platform cannot read back a key it issued.
+Run `platform-register --rotate` to mint a new key on a machine that lost it.
 
-`POSITRONIC_PLATFORM_URL` and `--platform-url` name a platform other than the default one, as
-everywhere else in this package. The command refuses a plain `http` platform that is not loopback;
-the tailnet carries staging with no TLS, so a staging user passes `--plaintext-http`.
+`--platform-url` and `POSITRONIC_PLATFORM_URL` name a platform other than the default. The command
+refuses a plain `http` platform that is not loopback. Staging has no TLS and is reached over the
+tailnet: pass `--plaintext-http` to reach it.
 
 ## From the command line
 
-The rest of the user-facing side is `positronic`, and from a checkout it needs no installation step
-at all. `eval run` runs an eval here when given a policy, and on the platform when given a policy
-image. `account register` registers with a credential you already hold, where `platform-register`
-mints one from GitHub:
+`positronic` carries the other commands, and a checkout needs no installation step. `eval run`
+runs an eval here when given a policy, and on the platform when given a policy image.
+`account register` registers with a credential you already hold; `platform-register` mints one
+from GitHub:
 
 ```bash
 export POSITRONIC_PLATFORM_CREDENTIAL=<the identity to register with>

--- a/client/README.md
+++ b/client/README.md
@@ -40,7 +40,8 @@ cannot read back the key it issued. `platform-register --rotate` mints a fresh o
 a machine that no longer holds the key gets one.
 
 `POSITRONIC_PLATFORM_URL` and `--platform-url` name a platform other than the default one, as
-everywhere else in this package.
+everywhere else in this package. The command refuses a plain `http` platform that is not loopback;
+the tailnet carries staging with no TLS, so a staging user passes `--plaintext-http`.
 
 ## From the command line
 

--- a/client/README.md
+++ b/client/README.md
@@ -12,18 +12,38 @@ The library depends on `pydantic` and `httpx` and nothing else, so a service tha
 platform installs it on its own, at the exact version it was written against:
 
 ```bash
-uv add "positronic-platform-client==0.3.0"
+uv add "positronic-platform-client==0.4.0"
 ```
 
-`platform_client` never imports `positronic`. The commands a user drives it with — `positronic eval
-run` and `positronic account` — ship with `positronic`, which depends on this package rather
-than the other way round.
+`platform_client` never imports `positronic`. Registration ships here (below); the commands that
+drive an eval — `positronic eval run` and `positronic account` — ship with `positronic`, which
+depends on this package rather than the other way round.
+
+## Registering
+
+This package carries one command, `platform-register`, and it mints the API key everything else
+needs. It runs GitHub's device flow: it prints a short code and a URL, waits while you authorize it
+in a browser, and registers the account GitHub then names. Installing the package above puts it on
+your path.
+
+```bash
+export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
+platform-register --alias=<display name>
+export POSITRONIC_PLATFORM_API_KEY=<the key printed above>
+```
+
+The token GitHub mints carries `read:user user:email`, so it reads your profile and your verified
+email. The platform reads the account once, mints a key, and keeps no GitHub token.
+
+`POSITRONIC_PLATFORM_URL` and `--platform-url` name a platform other than the default one, as
+everywhere else in this package.
 
 ## From the command line
 
-Nothing here has a command of its own. The user-facing side is `positronic`, and from a checkout it
-needs no installation step at all. `eval run` runs an eval here when given a policy, and on the
-platform when given a policy image:
+The rest of the user-facing side is `positronic`, and from a checkout it needs no installation step
+at all. `eval run` runs an eval here when given a policy, and on the platform when given a policy
+image. `account register` registers with a credential you already hold, where `platform-register`
+mints one from GitHub:
 
 ```bash
 export POSITRONIC_PLATFORM_CREDENTIAL=<the identity to register with>

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -1,0 +1,289 @@
+"""GitHub's device flow, and the `platform-register` command that runs it.
+
+It asks GitHub for a device code, shows the user the short code, polls until GitHub answers, and
+hands the access token to `users.register` as its `credential`.
+
+Usage
+  export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
+  platform-register --alias='<display name>'
+  platform-register --client-id=<id> --platform-url=http://127.0.0.1:8080
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum, auto
+
+import httpx
+from platform_client.client import API_KEY_ENV, API_URL_ENV, PlatformClient, resolve_base_url
+from platform_client.errors import PlatformError
+from platform_client.requests import RegisterRequest
+from platform_client.responses import RegisterResponse
+
+DEVICE_CODE_URL = 'https://github.com/login/device/code'
+ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
+
+# The grant the token request names (RFC 8628 §3.4).
+DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
+
+# The scope the minted token carries: the profile and the verified email. It reads no repository and
+# writes nothing, so the platform holds no power over the account.
+IDENTITY_SCOPE = 'read:user user:email'
+
+# The platform's OAuth app id. The device flow carries no client secret, so the id is public.
+GITHUB_CLIENT_ID_ENV = 'POSITRONIC_PLATFORM_GITHUB_CLIENT_ID'
+
+# GitHub's spelling of every field this flow reads or writes. The step that writes one and the step
+# that reads it have to agree, so each is named once.
+_CLIENT_ID_FIELD = 'client_id'
+_DEVICE_CODE_FIELD = 'device_code'
+_ERROR_FIELD = 'error'
+_INTERVAL_FIELD = 'interval'
+
+DEFAULT_POLL_INTERVAL_S = 5.0
+DEFAULT_EXPIRES_IN_S = 900.0
+
+# How much a `slow_down` answer raises the poll interval (RFC 8628 §3.5).
+_SLOW_DOWN_STEP_S = 5.0
+
+
+class DeviceFlowError(Exception):
+    """GitHub refused the flow, answered something this code cannot read, or is unreachable."""
+
+
+# One request's phases. httpx bounds inactivity inside each one separately, never the whole request.
+CONNECT_TIMEOUT_S = 5.0
+READ_TIMEOUT_S = 10.0
+WRITE_TIMEOUT_S = 5.0
+POOL_TIMEOUT_S = 5.0
+
+REQUEST_TIMEOUT = httpx.Timeout(
+    connect=CONNECT_TIMEOUT_S, read=READ_TIMEOUT_S, write=WRITE_TIMEOUT_S, pool=POOL_TIMEOUT_S
+)
+
+
+def max_stall_s(timeout: httpx.Timeout) -> float:
+    """The four phase timeouts added up: the longest a request can go with no byte in any one phase.
+
+    Each phase timeout bounds inactivity inside that phase, so a slow but steady response outlives
+    this sum. A phase left unset bounds no stall at all, so it refuses.
+    """
+    connect, read, write, pool = timeout.connect, timeout.read, timeout.write, timeout.pool
+    if connect is None or read is None or write is None or pool is None:
+        raise ValueError(f'{timeout} leaves a phase unbounded, so a request stalled in it never fails')
+    return connect + read + write + pool
+
+
+# The longest one GitHub request can stall, read off the phases so the two cannot drift.
+MAX_REQUEST_STALL_S = max_stall_s(REQUEST_TIMEOUT)
+
+# The gateway's own GitHub reads inside `users.register`: the account, plus the addresses of an
+# account whose address is private. Neither distribution imports the other, so this value is a copy.
+GATEWAY_GITHUB_READS = 2
+
+# The gateway verifies inside the registration call, so the read phase covers its GitHub reads plus
+# one request for its own work. A caller that gives up first leaves behind a user and a key it can
+# never read.
+REGISTER_TIMEOUT = httpx.Timeout(
+    connect=CONNECT_TIMEOUT_S,
+    read=GATEWAY_GITHUB_READS * MAX_REQUEST_STALL_S + MAX_REQUEST_STALL_S,
+    write=WRITE_TIMEOUT_S,
+    pool=POOL_TIMEOUT_S,
+)
+
+
+@dataclass(frozen=True)
+class DeviceAuthorization:
+    """What step one returns: the code the user types, and the code this flow polls with."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    interval: float
+    expires_in: float
+
+
+class PollOutcome(Enum):
+    """What one poll of the token endpoint means for the flow (RFC 8628 §3.5)."""
+
+    GRANTED = auto()
+    PENDING = auto()
+    SLOW_DOWN = auto()
+    DENIED = auto()
+    EXPIRED = auto()
+    UNREADABLE = auto()
+
+
+# GitHub's spelling of each outcome. The set of errors it may send is open, so anything else is a
+# request it could not read.
+_POLL_OUTCOMES = {
+    'authorization_pending': PollOutcome.PENDING,
+    'slow_down': PollOutcome.SLOW_DOWN,
+    'access_denied': PollOutcome.DENIED,
+    'expired_token': PollOutcome.EXPIRED,
+}
+
+# What each terminal outcome leaves the caller with. UNREADABLE carries GitHub's own word instead.
+_TERMINAL_MESSAGES = {
+    PollOutcome.DENIED: 'the user refused the authorization',
+    PollOutcome.EXPIRED: 'the device code expired before it was authorized',
+}
+
+
+def _outcome_of(error: object) -> PollOutcome:
+    """Read GitHub's `error` field. An absent one means the access token is in the answer."""
+    return PollOutcome.GRANTED if error is None else _POLL_OUTCOMES.get(str(error), PollOutcome.UNREADABLE)
+
+
+class GitHubDeviceFlow:
+    """The device of RFC 8628: it asks for a code, and it polls until GitHub answers."""
+
+    def __init__(
+        self,
+        client_id: str,
+        http: httpx.Client,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._client_id = client_id
+        self._http = http
+        self._monotonic = monotonic
+        self._sleep = sleep
+
+    def start_device_authorization(self) -> DeviceAuthorization:
+        """Step one: ask GitHub for a device code, and for the short code the user types."""
+        payload = self._post_form(DEVICE_CODE_URL, {_CLIENT_ID_FIELD: self._client_id, 'scope': IDENTITY_SCOPE})
+        error = payload.get(_ERROR_FIELD)
+        if error is not None:
+            raise DeviceFlowError(f'GitHub refused the device-code request: {error}')
+        return DeviceAuthorization(
+            device_code=_require_str(payload, _DEVICE_CODE_FIELD),
+            user_code=_require_str(payload, 'user_code'),
+            verification_uri=_require_str(payload, 'verification_uri'),
+            interval=_optional_float(payload, _INTERVAL_FIELD, DEFAULT_POLL_INTERVAL_S),
+            expires_in=_optional_float(payload, 'expires_in', DEFAULT_EXPIRES_IN_S),
+        )
+
+    def poll_for_token(self, authorization: DeviceAuthorization) -> str:
+        """Step two: poll the device code until GitHub mints the access token, or until it expires."""
+        interval = authorization.interval
+        deadline = self._monotonic() + authorization.expires_in
+        while True:
+            # RFC 8628 §3.3: the device waits the interval before each poll, the first one included.
+            # A poll that starts at once is answered `slow_down`, which spends the code's lifetime.
+            if self._monotonic() + interval > deadline:
+                raise DeviceFlowError('the device code was not authorized in time')
+            self._sleep(interval)
+            payload = self._post_form(
+                ACCESS_TOKEN_URL,
+                {
+                    _CLIENT_ID_FIELD: self._client_id,
+                    _DEVICE_CODE_FIELD: authorization.device_code,
+                    'grant_type': DEVICE_GRANT_TYPE,
+                },
+            )
+            error = payload.get(_ERROR_FIELD)
+            outcome = _outcome_of(error)
+            if outcome is PollOutcome.GRANTED:
+                return _require_str(payload, 'access_token')
+            if outcome is PollOutcome.SLOW_DOWN:
+                # GitHub repeats the original interval in this answer, so the step raises the rate;
+                # taking the value alone would poll on at the rate GitHub just refused.
+                interval = max(interval + _SLOW_DOWN_STEP_S, _optional_float(payload, _INTERVAL_FIELD, 0.0))
+            elif outcome is not PollOutcome.PENDING:
+                raise DeviceFlowError(_TERMINAL_MESSAGES.get(outcome, f'GitHub refused the device code: {error}'))
+
+    def _post_form(self, url: str, data: Mapping[str, str]) -> Mapping[str, object]:
+        """POST a form and read the JSON answer.
+
+        GitHub reports a device-flow error as HTTP 200 with an `error` field, so the body says
+        whether the flow is still running.
+        """
+        try:
+            response = self._http.request(
+                'POST', url, data=dict(data), headers={'accept': 'application/json'}, timeout=REQUEST_TIMEOUT
+            )
+        except httpx.HTTPError as exc:
+            raise DeviceFlowError('GitHub is unreachable') from exc
+        if response.status_code >= 400:
+            raise DeviceFlowError(f'GitHub is unavailable: HTTP {response.status_code}')
+        try:
+            payload: object = response.json()
+        except ValueError as exc:
+            raise DeviceFlowError('GitHub answered with no JSON') from exc
+        if not isinstance(payload, dict):
+            raise DeviceFlowError('GitHub answered with no JSON object')
+        return payload
+
+
+def _require_str(payload: Mapping[str, object], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value:
+        raise DeviceFlowError(f'GitHub answered without {field}')
+    return value
+
+
+def _optional_float(payload: Mapping[str, object], field: str, default: float) -> float:
+    """A number GitHub may omit. Absent takes the default; present and unreadable is a bad answer."""
+    if field not in payload:
+        return default
+    value = payload[field]
+    # `bool` is an `int`, and `True` as an interval would poll once a second rather than refuse.
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise DeviceFlowError(f'GitHub answered with an unreadable {field}')
+    return float(value)
+
+
+def register_with_github(
+    platform: PlatformClient, flow: GitHubDeviceFlow, *, alias: str | None = None
+) -> RegisterResponse:
+    """Run the whole flow: show the code, poll for the token, register with it as the credential."""
+    authorization = flow.start_device_authorization()
+    print(f'open {authorization.verification_uri} and enter {authorization.user_code}', flush=True)
+    token = flow.poll_for_token(authorization)
+    return platform.register(RegisterRequest(credential=token, alias=alias))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--alias', default=None, help='the display name for this account')
+    parser.add_argument('--platform-url', default=None, help=f'the platform to register with, else {API_URL_ENV}')
+    parser.add_argument('--client-id', default=os.environ.get(GITHUB_CLIENT_ID_ENV), help=GITHUB_CLIENT_ID_ENV)
+    args = parser.parse_args()
+    if not args.client_id:
+        raise SystemExit(f'pass --client-id, or set {GITHUB_CLIENT_ID_ENV} to the public OAuth client id')
+    try:
+        base_url = resolve_base_url(args.platform_url)
+    except ValueError as exc:
+        # An empty or relative platform URL is an argument fault, so it reads like the line above.
+        raise SystemExit(str(exc)) from exc
+
+    github = httpx.Client(timeout=REQUEST_TIMEOUT)
+    gateway = httpx.Client(base_url=base_url, timeout=REGISTER_TIMEOUT)
+    with github, gateway, PlatformClient(client=gateway) as platform:
+        try:
+            response = register_with_github(platform, GitHubDeviceFlow(args.client_id, github), alias=args.alias)
+        except httpx.HTTPError as exc:
+            # The GitHub half wraps its own transport failures, so one arriving here dialled the
+            # gateway. httpx names the cause and not the host, which is the half a reader needs.
+            raise SystemExit(f'the platform at {base_url} is unreachable: {exc}') from exc
+        except (DeviceFlowError, PlatformError) as exc:
+            raise SystemExit(str(exc)) from exc
+    print(f'user {response.user_id} ({response.key_status.name})')
+    print(f'artifacts at {response.artifact_location}')
+    if response.api_key is None:
+        print('no key issued: one is minted on a first registration')
+    else:
+        # The key is opaque, so it may hold whitespace or shell metacharacters; an unquoted export
+        # line would either mangle it or run the rest of it.
+        print(f'export {API_KEY_ENV}={shlex.quote(response.api_key)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -58,8 +58,8 @@ class DeviceFlowError(Exception):
     """GitHub refused the flow, answered something this code cannot read, or is unreachable."""
 
 
-class _PollTimedOut(DeviceFlowError):
-    """One request timed out. The poll loop retries it; every other caller sees a DeviceFlowError."""
+class _RequestTimedOut(DeviceFlowError):
+    """One request to GitHub timed out. `poll_for_token` retries it; every other caller sees a DeviceFlowError."""
 
 
 # One request's phases. httpx bounds inactivity inside each one separately, never the whole request.
@@ -225,7 +225,7 @@ class GitHubDeviceFlow:
                         'grant_type': DEVICE_GRANT_TYPE,
                     },
                 )
-            except _PollTimedOut:
+            except _RequestTimedOut:
                 # RFC 8628 §3.5: a poll that timed out slows the rate and tries again; the code may
                 # already be authorized, and the deadline above ends the flow.
                 interval += slow_down_step_s
@@ -254,7 +254,7 @@ class GitHubDeviceFlow:
                 'POST', url, data=dict(data), headers={'accept': 'application/json'}, timeout=REQUEST_TIMEOUT
             )
         except httpx.TimeoutException as exc:
-            raise _PollTimedOut('GitHub did not answer in time') from exc
+            raise _RequestTimedOut('GitHub did not answer in time') from exc
         except httpx.HTTPError as exc:
             raise DeviceFlowError('GitHub is unreachable') from exc
         if response.status_code >= 400:

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -27,6 +27,7 @@ from platform_client.client import API_KEY_ENV, API_URL_ENV, PlatformClient, res
 from platform_client.errors import PlatformError
 from platform_client.requests import RegisterRequest
 from platform_client.responses import RegisterResponse
+from pydantic import ValidationError
 
 DEVICE_CODE_URL = 'https://github.com/login/device/code'
 ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
@@ -312,6 +313,11 @@ def main() -> None:
             raise SystemExit(f'the platform at {base_url} is unreachable: {exc}') from exc
         except (DeviceFlowError, PlatformError) as exc:
             raise SystemExit(str(exc)) from exc
+        except ValidationError as exc:
+            # A 2xx whose body is not a registration: a proxy page, or a gateway of another version.
+            raise SystemExit(
+                f'the platform at {base_url} answered with no registration: {exc.error_count()} field(s) off'
+            ) from exc
     print(f'user {response.user_id} ({response.key_status.name})')
     print(f'artifacts at {response.artifact_location}')
     if response.api_key is None:

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -58,6 +58,10 @@ class DeviceFlowError(Exception):
     """GitHub refused the flow, answered something this code cannot read, or is unreachable."""
 
 
+class _PollTimedOut(DeviceFlowError):
+    """One request timed out. The poll loop retries it; every other caller sees a DeviceFlowError."""
+
+
 # One request's phases. httpx bounds inactivity inside each one separately, never the whole request.
 CONNECT_TIMEOUT_S = 5.0
 READ_TIMEOUT_S = 10.0
@@ -212,14 +216,20 @@ class GitHubDeviceFlow:
             if self._monotonic() + interval > deadline:
                 raise DeviceFlowError('the device code was not authorized in time')
             self._sleep(interval)
-            payload = self._post_form(
-                ACCESS_TOKEN_URL,
-                {
-                    _CLIENT_ID_FIELD: self._client_id,
-                    _DEVICE_CODE_FIELD: authorization.device_code,
-                    'grant_type': DEVICE_GRANT_TYPE,
-                },
-            )
+            try:
+                payload = self._post_form(
+                    ACCESS_TOKEN_URL,
+                    {
+                        _CLIENT_ID_FIELD: self._client_id,
+                        _DEVICE_CODE_FIELD: authorization.device_code,
+                        'grant_type': DEVICE_GRANT_TYPE,
+                    },
+                )
+            except _PollTimedOut:
+                # RFC 8628 §3.5: a poll that timed out slows the rate and tries again; the code may
+                # already be authorized, and the deadline above ends the flow.
+                interval += slow_down_step_s
+                continue
             error = payload.get(_ERROR_FIELD)
             outcome = self._outcome_of(error)
             if outcome is PollOutcome.GRANTED:
@@ -243,6 +253,8 @@ class GitHubDeviceFlow:
             response = self._http.request(
                 'POST', url, data=dict(data), headers={'accept': 'application/json'}, timeout=REQUEST_TIMEOUT
             )
+        except httpx.TimeoutException as exc:
+            raise _PollTimedOut('GitHub did not answer in time') from exc
         except httpx.HTTPError as exc:
             raise DeviceFlowError('GitHub is unreachable') from exc
         if response.status_code >= 400:

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -333,10 +333,16 @@ def main() -> None:
             response = register_with_github(
                 platform, GitHubDeviceFlow(args.client_id, github), alias=args.alias, rotate=args.rotate
             )
-        except httpx.HTTPError as exc:
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
             # The GitHub half wraps its own transport failures, so one arriving here dialled the
             # gateway. httpx names the cause and not the host, which is the half a reader needs.
             raise SystemExit(f'the platform at {base_url} is unreachable: {exc}') from exc
+        except httpx.HTTPError as exc:
+            # The request may have reached the gateway and minted the key before the answer was lost.
+            raise SystemExit(
+                f'the platform at {base_url} did not answer the registration: {exc}. '
+                'A key may have been minted; run again with --rotate.'
+            ) from exc
         except (DeviceFlowError, PlatformError) as exc:
             raise SystemExit(str(exc)) from exc
         except ValidationError as exc:

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -134,6 +134,30 @@ class GitHubDeviceFlow:
         self._monotonic = monotonic
         self._sleep = sleep
 
+    @staticmethod
+    def _require_str(payload: Mapping[str, object], field: str) -> str:
+        value = payload.get(field)
+        if not isinstance(value, str) or not value:
+            raise DeviceFlowError(f'GitHub answered without {field}')
+        return value
+
+    @staticmethod
+    def _optional_duration_s(payload: Mapping[str, object], field: str, default: float) -> float:
+        """A number of seconds GitHub may omit. Absent takes the default; present must be finite and above zero.
+
+        A negative or NaN value raises inside `time.sleep`, and a zero one polls until the code expires.
+        """
+        if field not in payload:
+            return default
+        value = payload[field]
+        # `bool` is an `int`, so `True` would pass as an interval of one second.
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise DeviceFlowError(f'GitHub answered with an unreadable {field}')
+        seconds = float(value)
+        if not math.isfinite(seconds) or seconds <= 0:
+            raise DeviceFlowError(f'GitHub answered with {field}={seconds}, which is no length of time')
+        return seconds
+
     def start_device_authorization(self) -> DeviceAuthorization:
         """Step one: ask GitHub for a device code, and for the short code the user types."""
         payload = self._post_form(DEVICE_CODE_URL, {_CLIENT_ID_FIELD: self._client_id, 'scope': IDENTITY_SCOPE})
@@ -141,11 +165,11 @@ class GitHubDeviceFlow:
         if error is not None:
             raise DeviceFlowError(f'GitHub refused the device-code request: {error}')
         return DeviceAuthorization(
-            device_code=_require_str(payload, _DEVICE_CODE_FIELD),
-            user_code=_require_str(payload, 'user_code'),
-            verification_uri=_require_str(payload, 'verification_uri'),
-            interval=_optional_duration_s(payload, _INTERVAL_FIELD, DEFAULT_POLL_INTERVAL_S),
-            expires_in=_optional_duration_s(payload, 'expires_in', DEFAULT_EXPIRES_IN_S),
+            device_code=self._require_str(payload, _DEVICE_CODE_FIELD),
+            user_code=self._require_str(payload, 'user_code'),
+            verification_uri=self._require_str(payload, 'verification_uri'),
+            interval=self._optional_duration_s(payload, _INTERVAL_FIELD, DEFAULT_POLL_INTERVAL_S),
+            expires_in=self._optional_duration_s(payload, 'expires_in', DEFAULT_EXPIRES_IN_S),
         )
 
     @staticmethod
@@ -191,11 +215,13 @@ class GitHubDeviceFlow:
             error = payload.get(_ERROR_FIELD)
             outcome = self._outcome_of(error)
             if outcome is PollOutcome.GRANTED:
-                return _require_str(payload, 'access_token')
+                return self._require_str(payload, 'access_token')
             if outcome is PollOutcome.SLOW_DOWN:
                 # GitHub repeats the original interval in this answer, so the step raises the rate;
                 # taking the value alone would poll on at the rate GitHub just refused.
-                interval = max(interval + slow_down_step_s, _optional_duration_s(payload, _INTERVAL_FIELD, interval))
+                interval = max(
+                    interval + slow_down_step_s, self._optional_duration_s(payload, _INTERVAL_FIELD, interval)
+                )
             elif outcome is not PollOutcome.PENDING:
                 raise DeviceFlowError(terminal_messages.get(outcome, f'GitHub refused the device code: {error}'))
 
@@ -220,30 +246,6 @@ class GitHubDeviceFlow:
         if not isinstance(payload, dict):
             raise DeviceFlowError('GitHub answered with no JSON object')
         return payload
-
-
-def _require_str(payload: Mapping[str, object], field: str) -> str:
-    value = payload.get(field)
-    if not isinstance(value, str) or not value:
-        raise DeviceFlowError(f'GitHub answered without {field}')
-    return value
-
-
-def _optional_duration_s(payload: Mapping[str, object], field: str, default: float) -> float:
-    """A number of seconds GitHub may omit. Absent takes the default; present must be finite and above zero.
-
-    A negative or NaN value raises inside `time.sleep`, and a zero one polls until the code expires.
-    """
-    if field not in payload:
-        return default
-    value = payload[field]
-    # `bool` is an `int`, and `True` as an interval would poll once a second rather than refuse.
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        raise DeviceFlowError(f'GitHub answered with an unreadable {field}')
-    seconds = float(value)
-    if not math.isfinite(seconds) or seconds <= 0:
-        raise DeviceFlowError(f'GitHub answered with {field}={seconds}, which is no length of time')
-    return seconds
 
 
 def register_with_github(

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -7,6 +7,7 @@ Usage
   export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
   platform-register --alias='<display name>'
   platform-register --client-id=<id> --platform-url=http://127.0.0.1:8080
+  platform-register --platform-url=http://staging.internal:8080 --plaintext-http  # a plain http link
   platform-register --rotate  # mint a new key for an account that is already registered
 """
 
@@ -268,23 +269,25 @@ def register_with_github(
     return platform.register(RegisterRequest(credential=token, alias=alias, rotate=rotate))
 
 
-# A tailnet address is as private as loopback: the WireGuard link encrypts what `http://` sends
-# over it, and staging is reached that way with no TLS of its own (services/ops/staging).
-_TAILNET = ipaddress.ip_network('100.64.0.0/10')
+def platform_url_is_allowed(base_url: str, *, plaintext_http: bool) -> bool:
+    """https anywhere, http to a loopback address, and any other http only under `plaintext_http`.
 
-
-def token_travels_encrypted(base_url: str) -> bool:
-    """https anywhere, or http to loopback or a tailnet address. Any other http shows the token."""
+    An http platform that is not loopback shows the GitHub token to every host on the path, so the
+    caller names the link it trusts.
+    """
     url = httpx.URL(base_url)
     if url.scheme == 'https':
         return True
     if url.scheme != 'http':
         return False
+    if plaintext_http:
+        return True
+    if url.host == 'localhost':
+        return True
     try:
-        address = ipaddress.ip_address(url.host)
+        return ipaddress.ip_address(url.host).is_loopback
     except ValueError:
-        return url.host == 'localhost'
-    return address.is_loopback or (address.version == 4 and address in _TAILNET)
+        return False
 
 
 def main() -> None:
@@ -294,6 +297,9 @@ def main() -> None:
         '--rotate', action='store_true', help='mint a new key for an account that is already registered'
     )
     parser.add_argument('--platform-url', default=None, help=f'the platform to register with, else {API_URL_ENV}')
+    parser.add_argument(
+        '--plaintext-http', action='store_true', help='reach an http platform that is not loopback, on a link you trust'
+    )
     parser.add_argument('--client-id', default=os.environ.get(GITHUB_CLIENT_ID_ENV), help=GITHUB_CLIENT_ID_ENV)
     args = parser.parse_args()
     if not args.client_id:
@@ -303,9 +309,10 @@ def main() -> None:
     except ValueError as exc:
         # An empty or relative platform URL is an argument fault, so it reads like the line above.
         raise SystemExit(str(exc)) from exc
-    if not token_travels_encrypted(base_url):
+    if not platform_url_is_allowed(base_url, plaintext_http=args.plaintext_http):
         raise SystemExit(
-            f'{base_url} would carry the GitHub token in the clear: use https, or a loopback or tailnet address'
+            f'{base_url} would carry the GitHub token in the clear: '
+            'use https, a loopback address, or pass --plaintext-http on a link you trust'
         )
 
     github = httpx.Client(timeout=REQUEST_TIMEOUT)

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -13,6 +13,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import math
 import os
 import shlex
@@ -258,6 +259,25 @@ def register_with_github(
     return platform.register(RegisterRequest(credential=token, alias=alias, rotate=rotate))
 
 
+# A tailnet address is as private as loopback: the WireGuard link encrypts what `http://` sends
+# over it, and staging is reached that way with no TLS of its own (services/ops/staging).
+_TAILNET = ipaddress.ip_network('100.64.0.0/10')
+
+
+def token_travels_encrypted(base_url: str) -> bool:
+    """https anywhere, or http to loopback or a tailnet address. Any other http shows the token."""
+    url = httpx.URL(base_url)
+    if url.scheme == 'https':
+        return True
+    if url.scheme != 'http':
+        return False
+    try:
+        address = ipaddress.ip_address(url.host)
+    except ValueError:
+        return url.host == 'localhost'
+    return address.is_loopback or (address.version == 4 and address in _TAILNET)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--alias', default=None, help='the display name for this account')
@@ -274,6 +294,10 @@ def main() -> None:
     except ValueError as exc:
         # An empty or relative platform URL is an argument fault, so it reads like the line above.
         raise SystemExit(str(exc)) from exc
+    if not token_travels_encrypted(base_url):
+        raise SystemExit(
+            f'{base_url} would carry the GitHub token in the clear: use https, or a loopback or tailnet address'
+        )
 
     github = httpx.Client(timeout=REQUEST_TIMEOUT)
     gateway = httpx.Client(base_url=base_url, timeout=REGISTER_TIMEOUT)

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -53,6 +53,10 @@ DEFAULT_POLL_INTERVAL_S = 5.0
 DEFAULT_EXPIRES_IN_S = 900.0
 
 
+# A device code lives minutes (RFC 8628 gives 15 min as the example); a day bounds what a poll may sleep.
+_LONGEST_DURATION_S = 24 * 60 * 60
+
+
 class DeviceFlowError(Exception):
     """GitHub refused the flow, answered something this code cannot read, or is unreachable."""
 
@@ -145,9 +149,10 @@ class GitHubDeviceFlow:
 
     @staticmethod
     def _optional_duration_s(payload: Mapping[str, object], field: str, default: float) -> float:
-        """A number of seconds GitHub may omit. Absent takes the default; present must be finite and above zero.
+        """A number of seconds GitHub may omit. Absent takes the default; present must be above zero and sleepable.
 
-        A negative or NaN value raises inside `time.sleep`, and a zero one polls until the code expires.
+        A negative or NaN value raises inside `time.sleep`, a zero one polls until the code expires, and a
+        value past `_LONGEST_DURATION_S` overflows `time.sleep` or `float` itself.
         """
         if field not in payload:
             return default
@@ -155,8 +160,11 @@ class GitHubDeviceFlow:
         # `bool` is an `int`, so `True` would pass as an interval of one second.
         if isinstance(value, bool) or not isinstance(value, int | float):
             raise DeviceFlowError(f'GitHub answered with an unreadable {field}')
-        seconds = float(value)
-        if not math.isfinite(seconds) or seconds <= 0:
+        try:
+            seconds = float(value)
+        except OverflowError:  # an integer past what a float holds is as unsleepable as infinity
+            seconds = math.inf
+        if not math.isfinite(seconds) or seconds <= 0 or seconds > _LONGEST_DURATION_S:
             raise DeviceFlowError(f'GitHub answered with {field}={seconds}, which is no length of time')
         return seconds
 

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -13,6 +13,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import shlex
 import time
@@ -48,9 +49,6 @@ _INTERVAL_FIELD = 'interval'
 
 DEFAULT_POLL_INTERVAL_S = 5.0
 DEFAULT_EXPIRES_IN_S = 900.0
-
-# How much a `slow_down` answer raises the poll interval (RFC 8628 §3.5).
-_SLOW_DOWN_STEP_S = 5.0
 
 
 class DeviceFlowError(Exception):
@@ -120,27 +118,6 @@ class PollOutcome(Enum):
     UNREADABLE = auto()
 
 
-# GitHub's spelling of each outcome. The set of errors it may send is open, so anything else is a
-# request it could not read.
-_POLL_OUTCOMES = {
-    'authorization_pending': PollOutcome.PENDING,
-    'slow_down': PollOutcome.SLOW_DOWN,
-    'access_denied': PollOutcome.DENIED,
-    'expired_token': PollOutcome.EXPIRED,
-}
-
-# What each terminal outcome leaves the caller with. UNREADABLE carries GitHub's own word instead.
-_TERMINAL_MESSAGES = {
-    PollOutcome.DENIED: 'the user refused the authorization',
-    PollOutcome.EXPIRED: 'the device code expired before it was authorized',
-}
-
-
-def _outcome_of(error: object) -> PollOutcome:
-    """Read GitHub's `error` field. An absent one means the access token is in the answer."""
-    return PollOutcome.GRANTED if error is None else _POLL_OUTCOMES.get(str(error), PollOutcome.UNREADABLE)
-
-
 class GitHubDeviceFlow:
     """The device of RFC 8628: it asks for a code, and it polls until GitHub answers."""
 
@@ -167,12 +144,34 @@ class GitHubDeviceFlow:
             device_code=_require_str(payload, _DEVICE_CODE_FIELD),
             user_code=_require_str(payload, 'user_code'),
             verification_uri=_require_str(payload, 'verification_uri'),
-            interval=_optional_float(payload, _INTERVAL_FIELD, DEFAULT_POLL_INTERVAL_S),
-            expires_in=_optional_float(payload, 'expires_in', DEFAULT_EXPIRES_IN_S),
+            interval=_optional_duration_s(payload, _INTERVAL_FIELD, DEFAULT_POLL_INTERVAL_S),
+            expires_in=_optional_duration_s(payload, 'expires_in', DEFAULT_EXPIRES_IN_S),
         )
+
+    @staticmethod
+    def _outcome_of(error: object) -> PollOutcome:
+        """Read GitHub's `error` field. An absent one means the access token is in the answer."""
+        if error is None:
+            return PollOutcome.GRANTED
+        # GitHub's spelling of each outcome. The set of errors it may send is open, so anything else
+        # is a request it could not read.
+        outcomes = {
+            'authorization_pending': PollOutcome.PENDING,
+            'slow_down': PollOutcome.SLOW_DOWN,
+            'access_denied': PollOutcome.DENIED,
+            'expired_token': PollOutcome.EXPIRED,
+        }
+        return outcomes.get(str(error), PollOutcome.UNREADABLE)
 
     def poll_for_token(self, authorization: DeviceAuthorization) -> str:
         """Step two: poll the device code until GitHub mints the access token, or until it expires."""
+        # How much a `slow_down` answer raises the poll interval (RFC 8628 §3.5).
+        slow_down_step_s = 5.0
+        # What each terminal outcome leaves the caller with. UNREADABLE carries GitHub's own word.
+        terminal_messages = {
+            PollOutcome.DENIED: 'the user refused the authorization',
+            PollOutcome.EXPIRED: 'the device code expired before it was authorized',
+        }
         interval = authorization.interval
         deadline = self._monotonic() + authorization.expires_in
         while True:
@@ -190,15 +189,15 @@ class GitHubDeviceFlow:
                 },
             )
             error = payload.get(_ERROR_FIELD)
-            outcome = _outcome_of(error)
+            outcome = self._outcome_of(error)
             if outcome is PollOutcome.GRANTED:
                 return _require_str(payload, 'access_token')
             if outcome is PollOutcome.SLOW_DOWN:
                 # GitHub repeats the original interval in this answer, so the step raises the rate;
                 # taking the value alone would poll on at the rate GitHub just refused.
-                interval = max(interval + _SLOW_DOWN_STEP_S, _optional_float(payload, _INTERVAL_FIELD, 0.0))
+                interval = max(interval + slow_down_step_s, _optional_duration_s(payload, _INTERVAL_FIELD, interval))
             elif outcome is not PollOutcome.PENDING:
-                raise DeviceFlowError(_TERMINAL_MESSAGES.get(outcome, f'GitHub refused the device code: {error}'))
+                raise DeviceFlowError(terminal_messages.get(outcome, f'GitHub refused the device code: {error}'))
 
     def _post_form(self, url: str, data: Mapping[str, str]) -> Mapping[str, object]:
         """POST a form and read the JSON answer.
@@ -230,15 +229,21 @@ def _require_str(payload: Mapping[str, object], field: str) -> str:
     return value
 
 
-def _optional_float(payload: Mapping[str, object], field: str, default: float) -> float:
-    """A number GitHub may omit. Absent takes the default; present and unreadable is a bad answer."""
+def _optional_duration_s(payload: Mapping[str, object], field: str, default: float) -> float:
+    """A number of seconds GitHub may omit. Absent takes the default; present must be finite and above zero.
+
+    A negative or NaN value raises inside `time.sleep`, and a zero one polls until the code expires.
+    """
     if field not in payload:
         return default
     value = payload[field]
     # `bool` is an `int`, and `True` as an interval would poll once a second rather than refuse.
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise DeviceFlowError(f'GitHub answered with an unreadable {field}')
-    return float(value)
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise DeviceFlowError(f'GitHub answered with {field}={seconds}, which is no length of time')
+    return seconds
 
 
 def register_with_github(

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -54,10 +54,6 @@ DEFAULT_POLL_INTERVAL_S = 5.0
 DEFAULT_EXPIRES_IN_S = 900.0
 
 
-# A device code lives minutes (RFC 8628 gives 15 min as the example); a day bounds what a poll may sleep.
-_LONGEST_DURATION_S = 24 * 60 * 60
-
-
 class DeviceFlowError(Exception):
     """GitHub refused the flow, answered something this code cannot read, or is unreachable."""
 
@@ -153,8 +149,9 @@ class GitHubDeviceFlow:
         """A number of seconds GitHub may omit. Absent takes the default; present must be above zero and sleepable.
 
         A negative or NaN value raises inside `time.sleep`, a zero one polls until the code expires, and a
-        value past `_LONGEST_DURATION_S` overflows `time.sleep` or `float` itself.
+        value past a day overflows `time.sleep` or `float` itself.
         """
+        longest_s = 24 * 60 * 60  # a device code lives minutes (RFC 8628 gives 15 min as the example)
         if field not in payload:
             return default
         value = payload[field]
@@ -165,7 +162,7 @@ class GitHubDeviceFlow:
             seconds = float(value)
         except OverflowError:  # an integer past what a float holds is as unsleepable as infinity
             seconds = math.inf
-        if not math.isfinite(seconds) or seconds <= 0 or seconds > _LONGEST_DURATION_S:
+        if not math.isfinite(seconds) or seconds <= 0 or seconds > longest_s:
             raise DeviceFlowError(f'GitHub answered with {field}={seconds}, which is no length of time')
         return seconds
 
@@ -306,17 +303,19 @@ def main() -> None:
         raise SystemExit(f'pass --client-id, or set {GITHUB_CLIENT_ID_ENV} to the public OAuth client id')
     try:
         base_url = resolve_base_url(args.platform_url)
-    except ValueError as exc:
-        # An empty or relative platform URL is an argument fault, so it reads like the line above.
+        allowed = platform_url_is_allowed(base_url, plaintext_http=args.plaintext_http)
+    except (ValueError, httpx.InvalidURL) as exc:
+        # An empty, relative or malformed platform URL is an argument fault, so it reads like the line above.
         raise SystemExit(str(exc)) from exc
-    if not platform_url_is_allowed(base_url, plaintext_http=args.plaintext_http):
+    if not allowed:
         raise SystemExit(
             f'{base_url} would carry the GitHub token in the clear: '
             'use https, a loopback address, or pass --plaintext-http on a link you trust'
         )
 
     github = httpx.Client(timeout=REQUEST_TIMEOUT)
-    gateway = httpx.Client(base_url=base_url, timeout=REGISTER_TIMEOUT)
+    # An environment proxy would carry a plain-http token off the machine, past the URL gate above.
+    gateway = httpx.Client(base_url=base_url, timeout=REGISTER_TIMEOUT, trust_env=httpx.URL(base_url).scheme == 'https')
     with github, gateway, PlatformClient(client=gateway) as platform:
         try:
             response = register_with_github(

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -7,6 +7,7 @@ Usage
   export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
   platform-register --alias='<display name>'
   platform-register --client-id=<id> --platform-url=http://127.0.0.1:8080
+  platform-register --rotate  # mint a new key for an account that is already registered
 """
 
 from __future__ import annotations
@@ -241,18 +242,21 @@ def _optional_float(payload: Mapping[str, object], field: str, default: float) -
 
 
 def register_with_github(
-    platform: PlatformClient, flow: GitHubDeviceFlow, *, alias: str | None = None
+    platform: PlatformClient, flow: GitHubDeviceFlow, *, alias: str | None = None, rotate: bool = False
 ) -> RegisterResponse:
     """Run the whole flow: show the code, poll for the token, register with it as the credential."""
     authorization = flow.start_device_authorization()
     print(f'open {authorization.verification_uri} and enter {authorization.user_code}', flush=True)
     token = flow.poll_for_token(authorization)
-    return platform.register(RegisterRequest(credential=token, alias=alias))
+    return platform.register(RegisterRequest(credential=token, alias=alias, rotate=rotate))
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--alias', default=None, help='the display name for this account')
+    parser.add_argument(
+        '--rotate', action='store_true', help='mint a new key for an account that is already registered'
+    )
     parser.add_argument('--platform-url', default=None, help=f'the platform to register with, else {API_URL_ENV}')
     parser.add_argument('--client-id', default=os.environ.get(GITHUB_CLIENT_ID_ENV), help=GITHUB_CLIENT_ID_ENV)
     args = parser.parse_args()
@@ -268,7 +272,9 @@ def main() -> None:
     gateway = httpx.Client(base_url=base_url, timeout=REGISTER_TIMEOUT)
     with github, gateway, PlatformClient(client=gateway) as platform:
         try:
-            response = register_with_github(platform, GitHubDeviceFlow(args.client_id, github), alias=args.alias)
+            response = register_with_github(
+                platform, GitHubDeviceFlow(args.client_id, github), alias=args.alias, rotate=args.rotate
+            )
         except httpx.HTTPError as exc:
             # The GitHub half wraps its own transport failures, so one arriving here dialled the
             # gateway. httpx names the cause and not the host, which is the half a reader needs.
@@ -278,7 +284,7 @@ def main() -> None:
     print(f'user {response.user_id} ({response.key_status.name})')
     print(f'artifacts at {response.artifact_location}')
     if response.api_key is None:
-        print('no key issued: one is minted on a first registration')
+        print('no key issued: one is minted on a first registration, or by --rotate')
     else:
         # The key is opaque, so it may hold whitespace or shell metacharacters; an unquoted export
         # line would either mangle it or run the rest of it.

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -577,6 +577,22 @@ def test_the_registration_waits_out_the_gateways_own_github_budget():
     }
 
 
+def test_an_answer_lost_after_the_request_names_rotate_as_the_recovery():
+    """The gateway may have minted the key before the connection dropped, so a plain retry finds no key."""
+
+    def drop(*_args: object, **_kwargs: object) -> RegisterResponse:
+        raise httpx.ReadError('connection reset')
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'register_with_github', drop)
+        patch.setattr(sys, 'argv', ['platform-register', '--client-id=x', '--platform-url=https://gateway.example'])
+
+        with pytest.raises(SystemExit) as raised:
+            github_device_flow.main()
+
+    assert isinstance(raised.value.code, str) and '--rotate' in raised.value.code
+
+
 def test_a_refused_gateway_ends_the_command_rather_than_raising():
     """A dial the gateway refuses is a transport error, which no other layer here converts."""
 

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -420,6 +420,44 @@ def test_the_flag_admits_any_http_and_no_other_scheme(base_url: str, allowed: bo
     assert github_device_flow.platform_url_is_allowed(base_url, plaintext_http=True) is allowed
 
 
+def test_a_malformed_platform_url_exits_with_one_line():
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            sys, 'argv', ['platform-register', '--client-id=x', '--platform-url=https://gateway.example:notaport']
+        )
+
+        with pytest.raises(SystemExit) as raised:
+            github_device_flow.main()
+
+    assert 'notaport' in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ('platform_url', 'trusts_env'), [('http://127.0.0.1:8080', False), ('https://gateway.example', True)]
+)
+def test_a_plain_http_gateway_client_ignores_an_environment_proxy(platform_url: str, trusts_env: bool):
+    """`HTTP_PROXY` with no matching `NO_PROXY` would carry a plain-http token off the machine."""
+    clients: list[dict[str, object]] = []
+    real_client = httpx.Client
+
+    def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
+        return RegisterResponse.model_validate(ScriptedGateway().body)
+
+    def capture(**kwargs: object) -> httpx.Client:
+        clients.append(kwargs)
+        return real_client(**kwargs)  # pyright: ignore[reportArgumentType]
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'register_with_github', record)
+        patch.setattr(httpx, 'Client', capture)
+        patch.setattr(sys, 'argv', ['platform-register', '--client-id=x', f'--platform-url={platform_url}'])
+
+        github_device_flow.main()
+
+    gateway = next(c for c in clients if c.get('base_url') == platform_url)
+    assert gateway['trust_env'] is trusts_env
+
+
 def test_the_command_refuses_a_platform_that_would_show_the_token():
     """A shared-address http platform never sees the GitHub token: the command stops before the code."""
     reached: list[object] = []

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -386,6 +386,40 @@ def test_the_command_asks_for_rotation_only_when_the_flag_is_given(flag: list[st
     assert asked == [expected]
 
 
+@pytest.mark.parametrize(
+    ('base_url', 'encrypted'),
+    [
+        ('https://gateway.example', True),
+        ('http://127.0.0.1:8080', True),
+        ('http://localhost:8080', True),
+        ('http://100.64.7.9:8080', True),
+        ('http://203.0.113.5:8080', False),
+        ('http://gateway.example', False),
+        ('http://10.0.0.5:8080', False),
+    ],
+)
+def test_the_token_travels_only_over_https_loopback_or_the_tailnet(base_url: str, encrypted: bool):
+    assert github_device_flow.token_travels_encrypted(base_url) is encrypted
+
+
+def test_the_command_refuses_a_platform_that_would_show_the_token():
+    """A public http address never sees the GitHub token: the command stops before the device code."""
+    reached: list[object] = []
+
+    def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
+        reached.append(flow)
+        return RegisterResponse.model_validate(ScriptedGateway().body)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'register_with_github', record)
+        patch.setattr(sys, 'argv', ['platform-register', '--client-id=x', '--platform-url=http://203.0.113.5:8080'])
+
+        with pytest.raises(SystemExit) as raised:
+            github_device_flow.main()
+
+    assert 'https' in str(raised.value) and reached == []
+
+
 def test_the_user_is_shown_the_code_before_the_poll_starts(capsys):
     """Only the short code has to reach the user while the flow runs."""
     github = ScriptedGitHub(polls=[dict(GRANTED)])

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -1,0 +1,412 @@
+"""The user's half of the GitHub device flow, driven against a scripted transport.
+
+No test reaches GitHub. An injected sleep records the intervals and advances a fake monotonic clock,
+so the poll runs at full speed and the suite waits on nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+from platform_client import github_device_flow, routes
+from platform_client.client import PlatformClient
+from platform_client.github_device_flow import (
+    ACCESS_TOKEN_URL,
+    CONNECT_TIMEOUT_S,
+    DEVICE_CODE_URL,
+    DEVICE_GRANT_TYPE,
+    GATEWAY_GITHUB_READS,
+    IDENTITY_SCOPE,
+    MAX_REQUEST_STALL_S,
+    POOL_TIMEOUT_S,
+    REGISTER_TIMEOUT,
+    REQUEST_TIMEOUT,
+    WRITE_TIMEOUT_S,
+    DeviceAuthorization,
+    DeviceFlowError,
+    GitHubDeviceFlow,
+    max_stall_s,
+    register_with_github,
+)
+from platform_client.responses import RegisterResponse
+
+CLIENT_ID = 'Iv1.testclientid'
+DEVICE_CODE = 'dev-code-1'
+TOKEN = 'gho_token'
+DEVICE_ANSWER: dict[str, object] = {
+    'device_code': DEVICE_CODE,
+    'user_code': 'WDJB-MJHT',
+    'verification_uri': 'https://github.com/login/device',
+    'interval': 5,
+    'expires_in': 900,
+}
+GRANTED = {'access_token': TOKEN, 'token_type': 'bearer', 'scope': IDENTITY_SCOPE}
+
+# rules-allow: hardcoded-keys — `positronic/cli/conftest.py` holds the same value, and this package
+# may not import from `positronic`: the dependency runs the other way, and the client installs alone.
+MINTED_KEY = 'pk_live_secret'
+
+
+@dataclass
+class ScriptedGitHub:
+    """One scripted answer per token poll, taken in order, plus the device-code endpoint."""
+
+    polls: list[dict[str, object]] = field(default_factory=list)
+    device: dict[str, object] = field(default_factory=lambda: dict(DEVICE_ANSWER))
+    status: int = 200  # every endpoint's HTTP status; the flow reports its own errors in the body
+    requests: list[httpx.Request] = field(default_factory=list)
+    # Every wait and every poll, in the order they happened: the order is what RFC 8628 §3.3 fixes.
+    events: list[str] = field(default_factory=list)
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        self.events.append('poll')
+        url = str(request.url)
+        if url == DEVICE_CODE_URL:
+            return httpx.Response(self.status, json=self.device)
+        if url == ACCESS_TOKEN_URL:
+            return httpx.Response(self.status, json=self.polls.pop(0))
+        raise AssertionError(f'the flow reached an endpoint it has no business at: {url}')
+
+    def form(self, url: str) -> dict[str, str]:
+        """The last form this endpoint received, read back off the recorded request."""
+        sent = [r for r in self.requests if str(r.url) == url]
+        return dict(httpx.QueryParams(sent[-1].content.decode()))
+
+
+@dataclass
+class RecordedSleep:
+    """A sleep the test reads back, advancing the clock the poll measures its deadline against."""
+
+    events: list[str]
+    seconds: list[float] = field(default_factory=list)
+    now: float = 0.0
+
+    def __call__(self, seconds: float) -> None:
+        self.seconds.append(seconds)
+        self.events.append(f'wait {seconds}')
+        self.now += seconds
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _flow(github: ScriptedGitHub) -> tuple[GitHubDeviceFlow, RecordedSleep]:
+    sleep = RecordedSleep(github.events)
+    http = httpx.Client(transport=httpx.MockTransport(github.handle))
+    return GitHubDeviceFlow(CLIENT_ID, http, monotonic=sleep.monotonic, sleep=sleep), sleep
+
+
+def _authorization(*, interval: float = 5.0, expires_in: float = 900.0) -> DeviceAuthorization:
+    return DeviceAuthorization(
+        device_code=DEVICE_CODE,
+        user_code=str(DEVICE_ANSWER['user_code']),
+        verification_uri=str(DEVICE_ANSWER['verification_uri']),
+        interval=interval,
+        expires_in=expires_in,
+    )
+
+
+# --- step one: the device code ------------------------------------------------
+
+
+def test_the_device_code_request_asks_for_identity_scope_only():
+    github = ScriptedGitHub()
+    flow, _ = _flow(github)
+
+    authorization = flow.start_device_authorization()
+
+    assert github.form(DEVICE_CODE_URL) == {'client_id': CLIENT_ID, 'scope': IDENTITY_SCOPE}
+    assert authorization.device_code == DEVICE_CODE
+    assert authorization.user_code == DEVICE_ANSWER['user_code']
+    assert authorization.verification_uri == DEVICE_ANSWER['verification_uri']
+    assert authorization.interval == 5.0 and authorization.expires_in == 900.0
+
+
+def test_a_device_code_answer_without_an_interval_polls_at_the_default_rate():
+    github = ScriptedGitHub(device={k: v for k, v in DEVICE_ANSWER.items() if k not in ('interval', 'expires_in')})
+    flow, _ = _flow(github)
+
+    authorization = flow.start_device_authorization()
+
+    assert authorization.interval == 5.0 and authorization.expires_in == 900.0
+
+
+def test_an_unreadable_interval_is_a_bad_answer_rather_than_the_default():
+    """An absent field takes the default; a present one GitHub cannot have meant is a bad answer."""
+    flow, _ = _flow(ScriptedGitHub(device=dict(DEVICE_ANSWER) | {'interval': 'five'}))
+
+    with pytest.raises(DeviceFlowError, match='unreadable interval'):
+        flow.start_device_authorization()
+
+
+def test_a_boolean_interval_is_a_bad_answer():
+    """`bool` is an `int`, so the plain numeric test would take `True` as a one-second interval."""
+    flow, _ = _flow(ScriptedGitHub(device=dict(DEVICE_ANSWER) | {'interval': True}))
+
+    with pytest.raises(DeviceFlowError, match='unreadable interval'):
+        flow.start_device_authorization()
+
+
+def test_a_refused_device_code_request_names_what_github_answered():
+    github = ScriptedGitHub(device={'error': 'incorrect_client_credentials'})
+    flow, _ = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='incorrect_client_credentials'):
+        flow.start_device_authorization()
+
+
+def test_a_device_code_answer_missing_a_field_is_unreadable():
+    github = ScriptedGitHub(device={k: v for k, v in DEVICE_ANSWER.items() if k != 'user_code'})
+    flow, _ = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='user_code'):
+        flow.start_device_authorization()
+
+
+# --- step two: the poll -------------------------------------------------------
+
+
+def test_an_authorized_device_code_yields_the_access_token():
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, sleep = _flow(github)
+
+    assert flow.poll_for_token(_authorization()) == TOKEN
+    assert sleep.seconds == [5.0]  # the wait GitHub asks for, then the poll that answers
+
+
+def test_the_first_poll_waits_the_interval_github_asked_for():
+    """RFC 8628 §3.3. A poll that starts at once is answered `slow_down`, which costs the code."""
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+
+    flow.poll_for_token(_authorization(interval=7.0))
+
+    assert github.events == ['wait 7.0', 'poll']
+
+
+def test_the_token_request_names_the_device_grant_and_the_client():
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+
+    flow.poll_for_token(_authorization())
+
+    assert github.form(ACCESS_TOKEN_URL) == {
+        'client_id': CLIENT_ID,
+        'device_code': DEVICE_CODE,
+        'grant_type': DEVICE_GRANT_TYPE,
+    }
+
+
+def test_a_pending_authorization_is_polled_until_the_user_finishes():
+    pending = {'error': 'authorization_pending'}
+    github = ScriptedGitHub(polls=[dict(pending), dict(pending), dict(GRANTED)])
+    flow, sleep = _flow(github)
+
+    assert flow.poll_for_token(_authorization()) == TOKEN
+    assert sleep.seconds == [5.0, 5.0, 5.0]  # GitHub's own interval, held while it asks for no change
+
+
+def test_slow_down_raises_the_interval_every_time_it_arrives():
+    slow = {'error': 'slow_down', 'interval': 5}
+    github = ScriptedGitHub(polls=[slow, slow, dict(GRANTED)])
+    flow, sleep = _flow(github)
+
+    flow.poll_for_token(_authorization())
+
+    assert sleep.seconds == [5.0, 10.0, 15.0]  # the asked-for wait, then each raise it answers with
+
+
+def test_an_expired_device_code_leaves_the_user_unauthorized():
+    github = ScriptedGitHub(polls=[{'error': 'expired_token'}])
+    flow, _ = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='expired'):
+        flow.poll_for_token(_authorization())
+
+
+def test_a_refused_authorization_leaves_the_user_unauthorized():
+    github = ScriptedGitHub(polls=[{'error': 'authorization_pending'}, {'error': 'access_denied'}])
+    flow, _ = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='refused the authorization'):
+        flow.poll_for_token(_authorization())
+
+
+def test_the_poll_stops_when_the_device_code_expires():
+    """GitHub sets the lifetime, and a user who never authorizes runs it out."""
+    github = ScriptedGitHub(polls=[{'error': 'authorization_pending'} for _ in range(100)])
+    flow, sleep = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='not authorized in time'):
+        flow.poll_for_token(_authorization(expires_in=12.0))
+
+    assert sleep.seconds == [5.0, 5.0]  # a third wait would pass 12 seconds, so it never starts
+
+
+def test_an_unreadable_device_code_names_what_github_answered():
+    """An error that is neither a refusal nor an expiry says GitHub could not read the request."""
+    github = ScriptedGitHub(polls=[{'error': 'unsupported_grant_type'}])
+    flow, _ = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='unsupported_grant_type'):
+        flow.poll_for_token(_authorization())
+
+
+def test_a_github_outage_is_reported_as_unavailable():
+    github = ScriptedGitHub(polls=[dict(GRANTED)], status=503)
+    flow, _ = _flow(github)
+
+    with pytest.raises(DeviceFlowError, match='unavailable'):
+        flow.poll_for_token(_authorization())
+
+
+def test_an_unreachable_github_is_reported_as_unreachable():
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('connection refused', request=request)
+
+    http = httpx.Client(transport=httpx.MockTransport(refuse))
+    flow = GitHubDeviceFlow(CLIENT_ID, http, monotonic=lambda: 0.0, sleep=lambda _: None)
+
+    with pytest.raises(DeviceFlowError, match='unreachable'):
+        flow.poll_for_token(_authorization())
+
+
+def test_an_answer_that_is_not_a_json_object_is_unreadable():
+    def answer_a_list(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    http = httpx.Client(transport=httpx.MockTransport(answer_a_list))
+    flow = GitHubDeviceFlow(CLIENT_ID, http, monotonic=lambda: 0.0, sleep=lambda _: None)
+
+    with pytest.raises(DeviceFlowError, match='no JSON object'):
+        flow.start_device_authorization()
+
+
+# --- step three: the registration --------------------------------------------
+
+
+@dataclass
+class ScriptedGateway:
+    """`users.register`, answering one scripted body and recording what reached it."""
+
+    body: dict[str, object] = field(
+        default_factory=lambda: {
+            'user_id': 'a1',
+            'artifact_location': 's3://artifacts/a1',
+            'api_key': MINTED_KEY,
+            'key_status': 'created',
+        }
+    )
+    requests: list[httpx.Request] = field(default_factory=list)
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url='https://gateway.example', transport=httpx.MockTransport(self.handle), timeout=REGISTER_TIMEOUT
+        )
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(200, json=self.body)
+
+
+def test_the_registration_carries_the_access_token_as_the_credential():
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+    gateway = ScriptedGateway()
+
+    with PlatformClient(client=gateway.client()) as platform:
+        response = register_with_github(platform, flow, alias='team-rocket')
+
+    sent = gateway.requests[0]
+    assert str(sent.url) == f'https://gateway.example{routes.USERS_REGISTER}'
+    assert json.loads(sent.content) == {'credential': TOKEN, 'alias': 'team-rocket', 'rotate': False}
+    assert response.api_key == MINTED_KEY
+
+
+def test_the_user_is_shown_the_code_before_the_poll_starts(capsys):
+    """Only the short code has to reach the user while the flow runs."""
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+
+    with PlatformClient(client=ScriptedGateway().client()) as platform:
+        register_with_github(platform, flow)
+
+    shown = capsys.readouterr().out
+    assert str(DEVICE_ANSWER['user_code']) in shown and str(DEVICE_ANSWER['verification_uri']) in shown
+
+
+def test_the_registration_keeps_the_key_the_gateway_minted():
+    """The flow leaves the client authenticated, so a caller registering in Python reads on."""
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+
+    with PlatformClient(client=ScriptedGateway().client()) as platform:
+        register_with_github(platform, flow)
+        assert platform.api_key == MINTED_KEY
+
+
+def test_the_registration_waits_out_the_gateways_own_github_budget():
+    gateway = ScriptedGateway()
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+
+    with PlatformClient(client=gateway.client()) as platform:
+        register_with_github(platform, flow)
+
+    assert gateway.requests[0].extensions['timeout'] == {
+        'connect': CONNECT_TIMEOUT_S,
+        'read': GATEWAY_GITHUB_READS * MAX_REQUEST_STALL_S + MAX_REQUEST_STALL_S,
+        'write': WRITE_TIMEOUT_S,
+        'pool': POOL_TIMEOUT_S,
+    }
+
+
+def test_a_refused_gateway_ends_the_command_rather_than_raising():
+    """A dial the gateway refuses is a transport error, which no other layer here converts."""
+
+    def refuse(*_args: object, **_kwargs: object) -> RegisterResponse:
+        raise httpx.ConnectError('connection refused')
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'register_with_github', refuse)
+        patch.setattr(sys, 'argv', ['platform-register', '--client-id=x', '--platform-url=https://gateway.example'])
+
+        with pytest.raises(SystemExit) as raised:
+            github_device_flow.main()
+
+    # A string exit code prints and exits 1, which is how the argument faults report too.
+    assert isinstance(raised.value.code, str) and 'gateway.example' in raised.value.code
+
+
+# --- the timeout policy -------------------------------------------------------
+
+
+def test_every_phase_of_a_github_request_carries_a_bound():
+    assert max_stall_s(REQUEST_TIMEOUT) == MAX_REQUEST_STALL_S
+
+
+def test_every_phase_of_a_registration_carries_a_bound():
+    assert max_stall_s(REGISTER_TIMEOUT) > MAX_REQUEST_STALL_S
+
+
+def test_a_timeout_that_leaves_a_phase_open_bounds_no_stall():
+    open_pool = httpx.Timeout(connect=1.0, read=1.0, write=1.0, pool=None)
+
+    with pytest.raises(ValueError, match='unbounded'):
+        max_stall_s(open_pool)
+
+
+def test_the_flow_sets_no_bare_number_as_a_timeout():
+    """The mechanical half of the rule above: a bare number reads as a deadline and is not one."""
+    source = Path(github_device_flow.__file__).read_text()
+    # `timeout=` followed by a digit: the bare-number form, which httpx applies to every phase.
+    offending = [line.strip() for line in source.splitlines() if re.search(r'timeout\s*=\s*[\d.]', line)]
+
+    assert offending == []

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -154,6 +154,31 @@ def test_a_boolean_interval_is_a_bad_answer():
         flow.start_device_authorization()
 
 
+@pytest.mark.parametrize('field', ['interval', 'expires_in'])
+@pytest.mark.parametrize('value', [-1, 0, float('nan'), float('inf')])
+def test_a_timing_field_that_is_no_length_of_time_is_a_bad_answer(field: str, value: float):
+    """A negative or NaN value raises inside `time.sleep`. Zero polls in a tight loop, and infinity never returns."""
+    # `json` writes NaN and Infinity, which httpx's own encoder refuses, so the body is written here.
+    body = json.dumps(dict(DEVICE_ANSWER) | {field: value})
+
+    def answer(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body, headers={'content-type': 'application/json'})
+
+    http = httpx.Client(transport=httpx.MockTransport(answer))
+    flow = GitHubDeviceFlow(CLIENT_ID, http, monotonic=lambda: 0.0, sleep=lambda _: None)
+
+    with pytest.raises(DeviceFlowError, match=f'{field}=.*no length of time'):
+        flow.start_device_authorization()
+
+
+@pytest.mark.parametrize('value', [5, 5.0, 0.5, 3600])
+def test_a_positive_interval_is_taken_as_github_sent_it(value: float):
+    """The guard above refuses nothing GitHub can have meant, whole seconds or a fraction of one."""
+    flow, _ = _flow(ScriptedGitHub(device=dict(DEVICE_ANSWER) | {'interval': value}))
+
+    assert flow.start_device_authorization().interval == float(value)
+
+
 def test_a_refused_device_code_request_names_what_github_answered():
     github = ScriptedGitHub(device={'error': 'incorrect_client_credentials'})
     flow, _ = _flow(github)

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -155,9 +155,10 @@ def test_a_boolean_interval_is_a_bad_answer():
 
 
 @pytest.mark.parametrize('field', ['interval', 'expires_in'])
-@pytest.mark.parametrize('value', [-1, 0, float('nan'), float('inf')])
+@pytest.mark.parametrize('value', [-1, 0, float('nan'), float('inf'), 1e100, 10**1000])
 def test_a_timing_field_that_is_no_length_of_time_is_a_bad_answer(field: str, value: float):
-    """A negative or NaN value raises inside `time.sleep`. Zero polls in a tight loop, and infinity never returns."""
+    """A negative or NaN value raises inside `time.sleep`, zero polls in a tight loop, and a value past a day
+    overflows `time.sleep` or `float` itself."""
     # `json` writes NaN and Infinity, which httpx's own encoder refuses, so the body is written here.
     body = json.dumps(dict(DEVICE_ANSWER) | {field: value})
 
@@ -171,7 +172,7 @@ def test_a_timing_field_that_is_no_length_of_time_is_a_bad_answer(field: str, va
         flow.start_device_authorization()
 
 
-@pytest.mark.parametrize('value', [5, 5.0, 0.5, 3600])
+@pytest.mark.parametrize('value', [5, 5.0, 0.5, 3600, 24 * 60 * 60])
 def test_a_positive_interval_is_taken_as_github_sent_it(value: float):
     """The guard above refuses nothing GitHub can have meant, whole seconds or a fraction of one."""
     flow, _ = _flow(ScriptedGitHub(device=dict(DEVICE_ANSWER) | {'interval': value}))

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -369,7 +369,7 @@ def test_the_registration_asks_the_gateway_to_rotate_when_told_to():
 
 @pytest.mark.parametrize(('flag', 'expected'), [(['--rotate'], True), ([], False)])
 def test_the_command_asks_for_rotation_only_when_the_flag_is_given(flag: list[str], expected: bool):
-    """Without the flag the command registers as it always did, and the account keeps its key."""
+    """Without the flag the command sends `rotate=False`, and the account keeps the key it holds."""
     asked: list[bool] = []
 
     def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -420,6 +420,32 @@ def test_the_command_refuses_a_platform_that_would_show_the_token():
     assert 'https' in str(raised.value) and reached == []
 
 
+def test_a_success_that_is_no_registration_exits_with_one_line():
+    """A 2xx from a proxy page or another gateway version ends the command without a traceback."""
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    gateway = ScriptedGateway(body={'unexpected': 'page'})
+    flow, _ = _flow(github)  # built before the patch below, so GitHub keeps its own transport
+
+    def flow_for(client_id: str, http: httpx.Client) -> GitHubDeviceFlow:
+        return flow
+
+    real_client = httpx.Client
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'GitHubDeviceFlow', flow_for)
+        # Every client main opens answers as the gateway; the GitHub one is replaced above.
+        patch.setattr(
+            httpx,
+            'Client',
+            lambda **kwargs: real_client(**{**kwargs, 'transport': httpx.MockTransport(gateway.handle)}),
+        )
+        patch.setattr(sys, 'argv', ['platform-register', '--client-id=x', '--platform-url=https://gateway.example'])
+
+        with pytest.raises(SystemExit) as raised:
+            github_device_flow.main()
+
+    assert 'no registration' in str(raised.value)
+
+
 def test_the_user_is_shown_the_code_before_the_poll_starts(capsys):
     """Only the short code has to reach the user while the flow runs."""
     github = ScriptedGitHub(polls=[dict(GRANTED)])

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -330,6 +330,37 @@ def test_the_registration_carries_the_access_token_as_the_credential():
     assert response.api_key == MINTED_KEY
 
 
+def test_the_registration_asks_the_gateway_to_rotate_when_told_to():
+    """The account exists and this machine no longer holds its key, so a fresh one is minted."""
+    github = ScriptedGitHub(polls=[dict(GRANTED)])
+    flow, _ = _flow(github)
+    gateway = ScriptedGateway()
+
+    with PlatformClient(client=gateway.client()) as platform:
+        register_with_github(platform, flow, rotate=True)
+
+    assert json.loads(gateway.requests[0].content)['rotate'] is True
+
+
+@pytest.mark.parametrize(('flag', 'expected'), [(['--rotate'], True), ([], False)])
+def test_the_command_asks_for_rotation_only_when_the_flag_is_given(flag: list[str], expected: bool):
+    """Without the flag the command registers as it always did, and the account keeps its key."""
+    asked: list[bool] = []
+
+    def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
+        asked.append(rotate)
+        return RegisterResponse.model_validate(ScriptedGateway().body)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'register_with_github', record)
+        argv = ['platform-register', '--client-id=x', '--platform-url=https://gateway.example', *flag]
+        patch.setattr(sys, 'argv', argv)
+
+        github_device_flow.main()
+
+    assert asked == [expected]
+
+
 def test_the_user_is_shown_the_code_before_the_poll_starts(capsys):
     """Only the short code has to reach the user while the flow runs."""
     github = ScriptedGitHub(polls=[dict(GRANTED)])

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -11,6 +11,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -293,6 +294,24 @@ def test_a_github_outage_is_reported_as_unavailable():
         flow.poll_for_token(_authorization())
 
 
+def test_a_poll_that_times_out_is_retried_at_a_slower_rate():
+    """RFC 8628 §3.5: a timed-out poll slows down and tries again; the code may already be authorized."""
+    answers = iter([None, dict(GRANTED)])
+    slept: list[float] = []
+
+    def answer(request: httpx.Request) -> httpx.Response:
+        body = next(answers)
+        if body is None:
+            raise httpx.ReadTimeout('no answer in time', request=request)
+        return httpx.Response(200, json=body)
+
+    http = httpx.Client(transport=httpx.MockTransport(answer))
+    flow = GitHubDeviceFlow(CLIENT_ID, http, monotonic=lambda: 0.0, sleep=slept.append)
+
+    assert flow.poll_for_token(_authorization()) == GRANTED['access_token']
+    assert slept == [_authorization().interval, _authorization().interval + 5.0]
+
+
 def test_an_unreachable_github_is_reported_as_unreachable():
     def refuse(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError('connection refused', request=request)
@@ -443,9 +462,9 @@ def test_a_plain_http_gateway_client_ignores_an_environment_proxy(platform_url: 
     def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
         return RegisterResponse.model_validate(ScriptedGateway().body)
 
-    def capture(**kwargs: object) -> httpx.Client:
+    def capture(**kwargs: Any) -> httpx.Client:
         clients.append(kwargs)
-        return real_client(**kwargs)  # pyright: ignore[reportArgumentType]
+        return real_client(**kwargs)
 
     with pytest.MonkeyPatch.context() as patch:
         patch.setattr(github_device_flow, 'register_with_github', record)

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -388,23 +388,40 @@ def test_the_command_asks_for_rotation_only_when_the_flag_is_given(flag: list[st
 
 
 @pytest.mark.parametrize(
-    ('base_url', 'encrypted'),
+    ('base_url', 'allowed'),
     [
         ('https://gateway.example', True),
         ('http://127.0.0.1:8080', True),
+        ('http://127.1.2.3:8080', True),
+        ('http://[::1]:8080', True),
         ('http://localhost:8080', True),
-        ('http://100.64.7.9:8080', True),
+        ('http://100.64.7.9:8080', False),
         ('http://203.0.113.5:8080', False),
         ('http://gateway.example', False),
         ('http://10.0.0.5:8080', False),
+        ('ftp://gateway.example', False),
     ],
 )
-def test_the_token_travels_only_over_https_loopback_or_the_tailnet(base_url: str, encrypted: bool):
-    assert github_device_flow.token_travels_encrypted(base_url) is encrypted
+def test_only_https_and_a_loopback_address_pass_without_the_flag(base_url: str, allowed: bool):
+    assert github_device_flow.platform_url_is_allowed(base_url, plaintext_http=False) is allowed
+
+
+@pytest.mark.parametrize(
+    ('base_url', 'allowed'),
+    [
+        ('http://100.64.7.9:8080', True),
+        ('http://203.0.113.5:8080', True),
+        ('http://gateway.example', True),
+        ('https://gateway.example', True),
+        ('ftp://gateway.example', False),
+    ],
+)
+def test_the_flag_admits_any_http_and_no_other_scheme(base_url: str, allowed: bool):
+    assert github_device_flow.platform_url_is_allowed(base_url, plaintext_http=True) is allowed
 
 
 def test_the_command_refuses_a_platform_that_would_show_the_token():
-    """A public http address never sees the GitHub token: the command stops before the device code."""
+    """A shared-address http platform never sees the GitHub token: the command stops before the code."""
     reached: list[object] = []
 
     def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
@@ -418,7 +435,25 @@ def test_the_command_refuses_a_platform_that_would_show_the_token():
         with pytest.raises(SystemExit) as raised:
             github_device_flow.main()
 
-    assert 'https' in str(raised.value) and reached == []
+    assert '--plaintext-http' in str(raised.value) and reached == []
+
+
+def test_the_flag_admits_a_platform_the_command_would_otherwise_refuse():
+    """A staging user reaches an http platform off this machine, so the flow runs."""
+    reached: list[object] = []
+
+    def record(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
+        reached.append(flow)
+        return RegisterResponse.model_validate(ScriptedGateway().body)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(github_device_flow, 'register_with_github', record)
+        argv = ['platform-register', '--client-id=x', '--platform-url=http://203.0.113.5:8080', '--plaintext-http']
+        patch.setattr(sys, 'argv', argv)
+
+        github_device_flow.main()
+
+    assert len(reached) == 1
 
 
 def test_a_success_that_is_no_registration_exits_with_one_line():

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "positronic-platform-client"
-version = "0.3.0"
+version = "0.4.0"
 description = "Typed wire contract and HTTP client for the Positronic evaluation platform API"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -11,6 +11,9 @@ dependencies = [
     "pydantic>=2.7",
     "httpx>=0.27",
 ]
+
+[project.scripts]
+platform-register = "platform_client.github_device_flow:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # (.github/workflows/release.yaml). Pinned exactly, because that package guarantees no
     # backwards compatibility: a floating requirement would let a fresh install of THIS release
     # resolve a contract it was never built against.
-    "positronic-platform-client==0.3.0",
+    "positronic-platform-client==0.4.0",
     "psutil",  # `positronic-server` enumerates local interfaces to name a wildcard bind's addresses
     "pyarrow",
     "pydantic",

--- a/uv.lock
+++ b/uv.lock
@@ -5095,7 +5095,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/45/029c72cffe797d826
 
 [[package]]
 name = "positronic-platform-client"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What it ships

`platform-register`, a console script on `positronic-platform-client`, and the module behind it
(`platform_client/github_device_flow.py`). It asks GitHub for a device code with the platform's
OAuth client id, prints the `user_code` and the `verification_uri`, then polls
`POST https://github.com/login/oauth/access_token` at the `interval` — `slow_down` adds 5 s, and the
poll stops at `expires_in`. It hands the access token to `users.register` as its `credential` and
prints `user_id`, `key_status`, `artifact_location`, and a shell-quoted `export` line carrying the key.

`--rotate` sets the `rotate` field of `RegisterRequest`, the field `positronic account register`
already sets. The platform cannot read back the key it issued, so a repeat registration answers
`existing` and mints nothing; a machine that lost the plaintext key uses the flag to get a fresh one.

`--plaintext-http` admits an http platform that is not loopback. The command otherwise takes https
anywhere and http to a loopback address, and refuses the rest before it asks GitHub for a code.
Staging is reached over the tailnet with no TLS, so a staging user passes the flag.

The client id comes from `--client-id` or `POSITRONIC_PLATFORM_GITHUB_CLIENT_ID`, the gateway from
`--platform-url` or `POSITRONIC_PLATFORM_URL`. The token GitHub mints carries `read:user user:email`.

## Why it lives here

The device polls and the gateway waits for nothing (RFC 8628 §3.5), so registration never occupies a
gateway request thread. The caller runs the poll loop **before** `positronic` is installed, and
`positronic` depends on this package, so the command ships in the distribution installed first.

- **Every httpx phase carries a bound.** A bare number sets each of the four separately, so a budget
  built on one understates what a request costs. `REQUEST_TIMEOUT` names all four, and
  `MAX_REQUEST_STALL_S` is read off them.
- **The registration outwaits the gateway's own GitHub budget.** The gateway verifies the account
  inside `users.register`, so that call's read phase is the gateway's GitHub budget plus one request.
  A caller that gives up first leaves a user and a key it can never read.
- **A timing field GitHub sends is a length of time.** `interval` and `expires_in` reach `time.sleep`
  and the poll deadline, so the reader takes a finite number above zero and at most a day. A negative
  or NaN value raises inside `time.sleep`, a zero interval polls until the code dies, and a huge one
  overflows the sleep. The deadline is monotonic, so a clock step cannot end the poll early.
- **A success that is no registration exits with one line.** A proxy page, or a gateway of another
  version, answers 2xx with a body pydantic refuses; the command names the platform and the field
  count, with no traceback.

The transport rule reads the URL and nothing else, and a shared address range says nothing about who
else is on it, so only loopback passes unasked.

What it does not cover: the README documents the installed `platform-register …`, so the command
stays outside `test_fresh_install.py`, whose gate reads `uv run …` lines only. Covering it there
needs GitHub's URLs redirectable at a fake.

`positronic account register` is unchanged: it registers with a credential you already hold.

## Verification

- `uv run pytest client --no-cov -q` — 304 passed.
- `test_vocabulary.py` and `test_fresh_install.py` judge it from outside `client/` — 41 passed.
- `uv run pre-commit run --from-ref origin/main --to-ref HEAD` — every hook passes, basedpyright
  included, with the type baseline untouched.
- Ran the command: `--help` lists both flags, and `--platform-url=http://100.64.7.9:8080` refuses
  and names `--plaintext-http`.
- The transport rule is pinned both ways: ten cases without the flag, five with it.

## Refs

- Positronic-Robotics/internal#939
- Positronic-Robotics/platform#325 — the gateway side, which waits on this command

<!-- opened-by: posi-agent -->