### PR TITLE
Render the over-shoulder right camera for RoboLab evals

### DIFF
--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -151,7 +151,11 @@ def _resolve_tasks(task) -> list[str]:
 
 
 @cfn.config(
-    camera_dict={keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera', keys.WRIST_IMAGE: 'wrist_cam'},
+    camera_dict={
+        keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera',
+        keys.EXTERIOR_RIGHT_IMAGE: 'over_shoulder_right_camera',
+        keys.WRIST_IMAGE: 'wrist_cam',
+    },
     instruction_type='default',
     trial_count=1,
     timeout=None,

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -52,6 +52,8 @@ DESCRIPTOR = 'descriptor'
 IMAGE_PREFIX = 'image.'
 WRIST_IMAGE = f'{IMAGE_PREFIX}wrist'
 EXTERIOR_IMAGE = f'{IMAGE_PREFIX}exterior'
+# A rig with a second exterior view names it this way; the DROID rig and RoboLab both carry one.
+EXTERIOR_RIGHT_IMAGE = f'{IMAGE_PREFIX}exterior_right'
 
 # The harness stamps each observation with the control clock's time (``OBS_TIME_NS``) and the wall
 # clock's (``WALL_TIME_NS``); recording timelines and action scheduling read time back off them.

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -35,12 +35,6 @@ class RobolabAdapter(WireCommandAdapter):
         state = MujocoFrankaState()
         state.encode(raw_obs['joint_pos'], raw_obs['joint_vel'], ee_pose)
         obs: dict[str, Any] = {keys.ROBOT_STATE: state, keys.GRIP: float(raw_obs['grip'])}
-        # TODO: honour a camera_dict naming any other RoboLab camera. env.py renders only the WRIST_LEFT
-        # preset (over_shoulder_left + wrist) and hard-codes emitting those two, so a request for e.g.
-        # over_shoulder_right_camera raises below. The full fix threads the requested set end-to-end: carry
-        # it in the reset token, have env.py register the matching preset via
-        # ``auto_register_droid_envs(cameras=WRIST_LEFT_RIGHT_HEAD)`` so the extra cameras spawn into
-        # ``image_obs``, and emit ``image_obs`` dynamically instead of the two fixed keys.
         for logical, env_key in self._camera_dict.items():
             if env_key not in raw_obs:
                 rendered = sorted(k for k, v in raw_obs.items() if isinstance(v, np.ndarray) and v.ndim == 3)

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -90,6 +90,7 @@ from robolab.core.environments.factory import get_envs  # noqa: E402
 from robolab.core.environments.runtime import create_env  # noqa: E402
 from robolab.core.logging.results import get_all_env_subtask_infos  # noqa: E402
 from robolab.registrations.droid.auto_env_registrations_jointpos import auto_register_droid_envs  # noqa: E402
+from robolab.registrations.droid.camera_presets import WRIST_LEFT_RIGHT  # noqa: E402
 from robolab.robots.droid import EEF_OFFSET_ROT  # noqa: E402
 
 # Both flags gate recorder construction in the env cfg's ``__post_init__``, so they are set before any
@@ -157,7 +158,7 @@ class RobolabEnv(EnvProtocol):
         if self._env is not None:
             self._env.close()  # release the prior task's env before create_env opens a fresh USD stage
         if task not in self._registered:
-            auto_register_droid_envs(task=[task])
+            auto_register_droid_envs(task=[task], cameras=WRIST_LEFT_RIGHT)
             self._registered.add(task)
         env_name = get_envs(task=task)[0]
         self._env, self._env_cfg = create_env(
@@ -335,8 +336,7 @@ class RobolabEnv(EnvProtocol):
             'eef_pos': proprio['eef_pos'][0].cpu().numpy(),
             'eef_quat': proprio['eef_quat'][0].cpu().numpy(),
             'grip': float(proprio['gripper_pos'][0, 0]),
-            'over_shoulder_left_camera': images['over_shoulder_left_camera'][0].cpu().numpy(),
-            'wrist_cam': images['wrist_cam'][0].cpu().numpy(),
+            **{name: frame[0].cpu().numpy() for name, frame in images.items()},
             'subtask': subtask,
         }
 

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -65,6 +65,7 @@ _OBS_SPECS = {
     'eef_pos': ((3,), np.float32),
     'eef_quat': ((4,), np.float32),
     'over_shoulder_left_camera': ((720, 1280, 3), np.uint8),
+    'over_shoulder_right_camera': ((720, 1280, 3), np.uint8),
     'wrist_cam': ((720, 1280, 3), np.uint8),
     'subtask': ((4,), np.float32),
 }


### PR DESCRIPTION
## Changes
- Register the `WRIST_LEFT_RIGHT` camera preset in `simulator/robolab/env.py`, so RoboLab spawns the over-shoulder right camera alongside left and wrist
- Emit `image_obs` dynamically in `_observe` instead of two hard-coded keys, so any registered camera reaches the adapter without a further code change
- Add `keys.EXTERIOR_RIGHT_IMAGE` (`image.exterior_right`) and map it to `over_shoulder_right_camera` in the default `camera_dict`
- Assert the third camera in `validate.py`'s observation contract
- Remove the TODO at `simulator/robolab/adapter.py:38`, which described this change

## Why
`env.py` registered the `WRIST_LEFT` preset and `_observe` emitted exactly `over_shoulder_left_camera` and `wrist_cam`, so a `camera_dict` naming any other camera raised in `RobolabAdapter.observations`. The deleted TODO describes the fix implemented here.

We hit this serving a DROID policy through `positronic eval run`: it takes three views — wrist plus both over-shoulder exteriors — and has no two-camera variant. Duplicating or blanking the third panel is not a workaround for us, because it feeds the backbone a frame it never saw in pretraining, inside the single conditioning latent the policy reads.

## Unit Testing
No new unit tests. The behaviour lives behind Isaac Lab, which the pytest suite cannot import; `validate.py` is the on-box contract test for this code and it was extended to cover the new camera.

## Integration Testing

### `sim/`
- [x] `uv run --project <robolab checkout> positronic/simulator/robolab/validate.py --headless` against real Isaac Sim: **ALL CHECKS PASSED**.
  - tiled cameras list `over_shoulder_left_camera` and `over_shoulder_right_camera`, both `(720, 1280, 3)`
  - `obs contract: OK (keys, shapes, dtypes, quat norm, grip range)` — now covering the third camera
  - `joint_pos` bit-identical pass-through, converged to 0.0002 rad; `joint_vel` anchoring exact
  - flange to `eef_frame` 0.0000 mm / 0.0000 deg; all 12 Cartesian tracking cases pass; `cartesian_delta` 0.06 mm / 0.00 deg
- [x] 10 rollouts of `.sim.robolab.banana_in_bowl` driven by an external policy over this branch, all three camera streams recorded per episode

## Notes for reviewers
**On the camera name.** `image.exterior_right` is additive: `WRIST_IMAGE` and `EXTERIOR_IMAGE` keep their spellings and their bindings, so existing configs and recorded datasets are unaffected. If you would rather spell it differently — `image.exterior_2`, or something matching the `image.wrist_left` / `image.wrist_right` pair already used in `cfg/embodiment.py` — it is one constant in `keys.py` and one entry in the default `camera_dict`. Happy to change it to whatever you prefer.

**On depth of fix.** This pins the preset in `env.py`, so every RoboLab eval now renders three cameras whether or not the caller wants them. Your deleted TODO described the more general form — threading the requested set through the reset token so `camera_dict` becomes a request rather than a filter. That is the better fix and we are happy to do it instead; we kept this one minimal to be easy to review. The cost of the current shape is one extra tiled render and one extra frame on the wire per step for callers that only want two cameras.

**Not covered.** The real DROID embodiment (`cfg/embodiment.py`) binds only `image.wrist` and `image.exterior`, so this change affects the RoboLab sim path only. Wiring a second exterior on the physical rigs is separate, and we understand you are looking into it.
