### PR TITLE
Document SetControlMode and the impedance control mode

### DIFF
--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -61,6 +61,21 @@ Both take the transform itself — `models.DROID_EE_FRAME` is the one we ship �
 
 A `CartesianDelta` is the one command this cannot convert on its own: a delta has no anchor pose, so it carries `frame` and the driver composes it where the measured pose lives.
 
+## Control mode
+
+`SetControlMode(mode)` sets the control law a chunk executes under. At inference it stamps `mode` on every robot command of the decoded chunk, for every arm. At training it is a pass-through. It composes left of the action decoder: `SetControlMode(mode) | action`. The decoder produces the commands, then the mode lands on them. The implementation is in [`positronic/policy/codec.py`](../positronic/policy/codec.py).
+
+`mode` is one of the two control modes in [`positronic.drivers.roboarm.command`](../positronic/drivers/roboarm/command.py): `Impedance(kq, kqd, kx, kxd)`, the hybrid joint/Cartesian impedance law, or `PositionControl(stiffness=None)`, a position servo. A command without a mode runs under the arm's native law. The driver decides what a mode does: a simulator runs its own law, and a driver that cannot execute the mode raises. [The wire format](connect-your-model.md#actions-server--client) shows the `mode` field a command carries.
+
+A pretrained checkpoint expects the law its training data ran under, so the mode belongs to the checkpoint. Two wrappers in [`positronic/cfg/codecs.py`](../positronic/cfg/codecs.py) apply it to an action codec:
+
+| Wrapper | Expands to | Used by |
+|---------|-----------|---------|
+| `droid_execution(action)` | `SetControlMode(DROID_IMPEDANCE) \| action` — the gains DROID's Franka ran ([`positronic/cfg/hardware/roboarm`](../positronic/cfg/hardware/roboarm/__init__.py)) | the `droid` pipelines of OpenPI, DreamZero and MolmoAct2, and OpenPI's `droid_jointpos` |
+| `phail_v1_execution(action)` | `SetControlMode(PositionControl()) \| action` — the position control PhAIL v1 was trained under | the `phail_v1` pipelines of LeRobot, GR00T, OpenPI and DreamZero |
+
+The wrapper is the `action` argument of `compose`, so it sits inside the `observation & action` pair of the standard composition.
+
 ## Writing custom codecs
 
 Subclass `positronic.policy.codec.Codec` and implement `encode()` and/or `_decode_single()`. The base class returns `{}` from both — observation codecs override `encode()`, action codecs override `_decode_single()`. Middleware codecs that pass data through must explicitly `return data` (e.g. `BinarizeGripTraining`, a pure pass-through at decode that only binarizes via its `training_encoder`); middleware that transforms decoded actions modifies and returns `data` instead (e.g. `BinarizeGripInference`, which thresholds `target_grip` in `_decode_single`). Compose observation and action codecs with `&`, chain middleware with `|`. See the vendor codec files below for reference patterns.

--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -63,18 +63,14 @@ A `CartesianDelta` is the one command this cannot convert on its own: a delta ha
 
 ## Control mode
 
-`SetControlMode(mode)` sets the control law a chunk executes under. At inference it stamps `mode` on every robot command of the decoded chunk, for every arm. At training it is a pass-through. It composes left of the action decoder: `SetControlMode(mode) | action`. The decoder produces the commands, then the mode lands on them. The implementation is in [`positronic/policy/codec.py`](../positronic/policy/codec.py).
+`SetControlMode(mode)` stamps a control mode on every robot command of a decoded chunk, so a checkpoint executes under the law its training data ran under. It composes left of the action decoder: `SetControlMode(mode) | action`. `mode` is `Impedance(kq, kqd, kx, kxd)` or `PositionControl(stiffness=None)` from [`positronic.drivers.roboarm.command`](../positronic/drivers/roboarm/command.py); a command without one runs under the arm's native law (see [the wire format](connect-your-model.md#actions-server--client)). Implementation in [`positronic/policy/codec.py`](../positronic/policy/codec.py).
 
-`mode` is one of the two control modes in [`positronic.drivers.roboarm.command`](../positronic/drivers/roboarm/command.py): `Impedance(kq, kqd, kx, kxd)`, the hybrid joint/Cartesian impedance law, or `PositionControl(stiffness=None)`, a position servo. A command without a mode runs under the arm's native law. The driver decides what a mode does: a simulator runs its own law, and a driver that cannot execute the mode raises. [The wire format](connect-your-model.md#actions-server--client) shows the `mode` field a command carries.
-
-A pretrained checkpoint expects the law its training data ran under, so the mode belongs to the checkpoint. Two wrappers in [`positronic/cfg/codecs.py`](../positronic/cfg/codecs.py) apply it to an action codec:
+Two wrappers in [`positronic/cfg/codecs.py`](../positronic/cfg/codecs.py) apply it to an action codec:
 
 | Wrapper | Expands to | Used by |
 |---------|-----------|---------|
-| `droid_execution(action)` | `SetControlMode(DROID_IMPEDANCE) \| action` — the gains DROID's Franka ran ([`positronic/cfg/hardware/roboarm`](../positronic/cfg/hardware/roboarm/__init__.py)) | the `droid` pipelines of OpenPI, DreamZero and MolmoAct2, and OpenPI's `droid_jointpos` |
-| `phail_v1_execution(action)` | `SetControlMode(PositionControl()) \| action` — the position control PhAIL v1 was trained under | the `phail_v1` pipelines of LeRobot, GR00T, OpenPI and DreamZero |
-
-The wrapper is the `action` argument of `compose`, so it sits inside the `observation & action` pair of the standard composition.
+| `droid_execution(action)` | `SetControlMode(DROID_IMPEDANCE) \| action` ([the DROID gains](../positronic/cfg/hardware/roboarm/__init__.py)) | the `droid` pipelines of OpenPI, DreamZero and MolmoAct2, and OpenPI's `droid_jointpos` |
+| `phail_v1_execution(action)` | `SetControlMode(PositionControl()) \| action` | the `phail_v1` pipelines of LeRobot, GR00T, OpenPI and DreamZero |
 
 ## Writing custom codecs
 

--- a/docs/connect-your-model.md
+++ b/docs/connect-your-model.md
@@ -143,6 +143,9 @@ Every command also takes an optional `mode`, the control law it asks to execute 
 `PositionControl(stiffness=...)` for a position servo, or `Impedance(kq, kqd, kx, kxd)` for the hybrid
 joint/Cartesian law. Omit it — the default — and the arm runs its native law. What a pinned mode does is the
 driver's: a simulator runs its own law regardless, and a driver that cannot execute the mode raises.
+A server built on positronic sets the mode with the `SetControlMode` codec, composed left of the action
+decoder; `codecs.droid_execution` and `codecs.phail_v1_execution` wrap an action codec that way. See
+[Control mode](codecs.md#control-mode) in the Codec Guide.
 
 Which command your model produces is decided by its codec.
 

--- a/positronic/vendors/dreamzero/README.md
+++ b/positronic/vendors/dreamzero/README.md
@@ -182,7 +182,9 @@ that decodes to a `JointPosition` command. They differ only in how **training la
 
 Each codec has a same-named serving pipeline (see [`server.py`](./server.py)), selected as the serve
 subcommand. Since the four `joints*` codecs decode inference identically, `joints` serves any of their
-checkpoints; the `droid` pipeline pairs the pretrained DROID model with its required 320×180 frames.
+checkpoints; the `droid` pipeline pairs the pretrained DROID model with its required 320×180 frames and
+executes each chunk under DROID's impedance gains (`codecs.droid_execution`; see
+[Control mode](../../../docs/codecs.md#control-mode)).
 
 ## Session parameters
 

--- a/positronic/vendors/molmoact2/README.md
+++ b/positronic/vendors/molmoact2/README.md
@@ -73,7 +73,8 @@ ships one, `droid` (source: [`codecs.py`](./codecs.py)):
 ## Technical details
 
 - **Action space**: absolute joint positions (7) + gripper (1), decoded straight into a `JointPosition`
-  command (no IK at runtime).
+  command (no IK at runtime). Each chunk executes under DROID's impedance gains (`codecs.droid_execution`;
+  see [Control mode](../../../docs/codecs.md#control-mode)).
 - **Observation**: 3 cameras (2 exterior + 1 wrist) + 8-D state + language prompt.
 - **Inference**: `norm_tag='franka_droid'`, continuous action mode; the model emits a 15-step action chunk at
   15 Hz, executed in full by the client's declared `ChunkedSchedule`.

--- a/positronic/vendors/openpi/README.md
+++ b/positronic/vendors/openpi/README.md
@@ -25,6 +25,8 @@ OpenPI supports multiple codecs for different use cases:
 - **`droid`**: Inference-only codec for pretrained DROID checkpoints. The model predicts per-step joint velocities; the codec scales each into a `JointDelta` command (grip binarized) and truncates each chunk to DROID's 8-step open-loop horizon. The driver applies each delta to the live measured joints (`set_target_joints(st.q + delta)`), reproducing the DROID controller. Serve with `droid` and run inference normally.
 - **`droid_jointpos`**: Inference-only codec for openpi's `*_droid_jointpos` checkpoints — the policies RoboLab's leaderboard evaluates. The model emits absolute joint-position chunks; the codec decodes each step into a `JointPosition` command (grip binarized at 0.5) and executes the whole chunk before replanning, matching RoboLab's client cadence (`open_loop_horizon` = the model's `action_horizon`). Serve with `droid_jointpos`.
 
+Both DROID codecs execute each chunk under DROID's impedance gains (`codecs.droid_execution`; see [Control mode](../../../docs/codecs.md#control-mode)).
+
 ## 1. Prepare Data
 
 Positronic datasets must be converted into the LeRobot format using an OpenPI codec.


### PR DESCRIPTION
Docs only. No code changes.

The codec guide gets a "Control mode" section. It names `SetControlMode`, the two control modes (`Impedance`, `PositionControl`), the composition order, and the two config wrappers `droid_execution` and `phail_v1_execution` with the pipelines that use them.

The `mode` paragraph of the wire format in `docs/connect-your-model.md` points at that section.

The OpenPI, DreamZero and MolmoAct2 READMEs say that their DROID pipelines execute each chunk under DROID's impedance gains, with a link to the section.

`positronic/offboard/README.md` already documents the `mode` field of a command. It is unchanged.

Ticket: Positronic-Robotics/internal#1071

<!-- opened-by: posi-agent -->