### PR TITLE
Add a 3-camera DROID config beside the 2-camera one

### DIFF
--- a/positronic/cfg/embodiment.py
+++ b/positronic/cfg/embodiment.py
@@ -12,14 +12,7 @@ from positronic.eval import keys as eval_keys
 @cfn.config(
     robot_arm=positronic.cfg.hardware.roboarm.franka_droid,
     gripper=positronic.cfg.hardware.gripper.robotiq,
-    cameras={
-        keys.WRIST_IMAGE: positronic.cfg.hardware.camera.zed_m.override(
-            view='left', resolution='hd720', fps=30, image_enhancement=True
-        ),
-        keys.EXTERIOR_IMAGE: positronic.cfg.hardware.camera.zed_2i.override(
-            view='left', resolution='hd720', fps=30, image_enhancement=True
-        ),
-    },
+    cameras=positronic.cfg.hardware.camera.droid,
 )
 def droid(robot_arm, gripper, cameras):
     """Real single-arm Franka (DROID) + Robotiq gripper + ZED cameras."""
@@ -42,6 +35,9 @@ def droid(robot_arm, gripper, cameras):
         control_systems=(*cameras.values(), robot_arm, gripper),
         simulated=False,
     )
+
+
+droid_3cam = droid.override(cameras=positronic.cfg.hardware.camera.droid_3cam)
 
 
 @cfn.config(robot_arm=positronic.cfg.hardware.roboarm.yam, cameras={})

--- a/positronic/cfg/hardware/camera.py
+++ b/positronic/cfg/hardware/camera.py
@@ -1,5 +1,7 @@
 import configuronic as cfn
 
+from positronic import keys
+
 
 @cfn.config()
 def linux_video(**kwargs):
@@ -31,6 +33,13 @@ def zed(**kwargs):
 
 zed_m = zed.override(serial_number=17521925)
 zed_2i = zed.override(serial_number=39567055)
+zed_2i_second = zed.override(serial_number=13785037)
+
+_DROID_STREAM = {'view': 'left', 'resolution': 'hd720', 'fps': 30, 'image_enhancement': False}
+
+droid = {keys.WRIST_IMAGE: zed_m.override(**_DROID_STREAM), keys.EXTERIOR_IMAGE: zed_2i.override(**_DROID_STREAM)}
+
+droid_3cam = {**droid, keys.EXTERIOR_IMAGE_2: zed_2i_second.override(**_DROID_STREAM)}
 
 # YAM station (brunello): ZED X overhead + two ZED X One wrist cameras on the ZED Link Duo.
 zed_x_top = zed.override(serial_number=48953814)

--- a/positronic/data_collection.py
+++ b/positronic/data_collection.py
@@ -450,12 +450,12 @@ droid = cfn.Config(
     joints_spread=positronic.cfg.hardware.roboarm.FRANKA_JOINTS_SPREAD,
     webxr=positronic.cfg.webxr.oculus,
     sound=positronic.cfg.sound.sound,
-    cameras={
-        keys.WRIST_IMAGE: positronic.cfg.hardware.camera.zed_m.override(view='left', resolution='hd720', fps=30),
-        keys.EXTERIOR_IMAGE: positronic.cfg.hardware.camera.zed_2i.override(view='left', resolution='hd720', fps=30),
-    },
+    cameras=positronic.cfg.hardware.camera.droid,
     operator_position=OperatorPosition.BACK,
 )
+
+
+droid_3cam = droid.override(cameras=positronic.cfg.hardware.camera.droid_3cam)
 
 
 human = cfn.Config(
@@ -481,6 +481,7 @@ def _internal_main():
         'sim': main_sim,
         'sim_pnp': main_sim.override(loaders=positronic.cfg.simulator.multi_tote_loaders),
         'droid': droid,
+        'droid_3cam': droid_3cam,
         'human': human,
     })
 

--- a/positronic/keys.py
+++ b/positronic/keys.py
@@ -45,6 +45,7 @@ DESCRIPTOR = 'descriptor'
 IMAGE_PREFIX = 'image.'
 WRIST_IMAGE = f'{IMAGE_PREFIX}wrist'
 EXTERIOR_IMAGE = f'{IMAGE_PREFIX}exterior'
+EXTERIOR_IMAGE_2 = f'{IMAGE_PREFIX}exterior_2'
 
 # The harness stamps each observation with the control clock's time (``OBS_TIME_NS``) and the wall
 # clock's (``WALL_TIME_NS``); recording timelines and action scheduling read time back off them.

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -251,3 +251,4 @@ joints_ik_sim = joints_ik.override(**{'action.solver': 'lm'})
 dreamzero_layers = layers.video_context_layers.override(
     history_frames=23, stride=8, keys=(keys.WRIST_IMAGE, keys.EXTERIOR_IMAGE)
 )
+dreamzero_layers_3cam = dreamzero_layers.override(keys=(keys.WRIST_IMAGE, keys.EXTERIOR_IMAGE, keys.EXTERIOR_IMAGE_2))

--- a/positronic/vendors/dreamzero/codecs.py
+++ b/positronic/vendors/dreamzero/codecs.py
@@ -224,6 +224,7 @@ droid = codecs.compose.override(
     action=codecs.droid_execution.override(action=_action),
     fps=15.0,
 )
+droid_3cam = droid.override(**{'obs.exterior_camera_2': keys.EXTERIOR_IMAGE_2})
 
 _traj_action = dreamzero_action.override(tgt_joints_key=keys.JOINTS, tgt_grip_key=keys.GRIP)
 joints_traj = codecs.compose.override(obs=dreamzero_obs, action=_traj_action, fps=15.0)

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -383,8 +383,9 @@ joints = pipeline
 joints_traj = pipeline.override(codec=codecs.joints_traj)
 joints_ik = pipeline.override(codec=codecs.joints_ik)
 joints_ik_sim = pipeline.override(codec=codecs.joints_ik_sim)
-# The pretrained DROID model (wan2.1) asserts exactly 320x180 frames.
-droid = pipeline.override(codec=codecs.droid, height=180)
+# The public pretrained DROID checkpoint on the wan2.1 backbone. Asserts 320x180 frames.
+droid = pipeline.override(codec=codecs.droid, height=180, **{'source.model_path': 'GEAR-Dreams/DreamZero-DROID'})
+droid_3cam = droid.override(codec=codecs.droid_3cam)
 
 
 # Every pipeline is a subcommand, and so is every deployment — a pipeline with its checkpoint bound.
@@ -406,9 +407,8 @@ COMMANDS = {
             'pipeline.source.backbone': 'wan2.2',
         },
     ),
-    # Public pretrained DROID checkpoint: wan2.1 backbone (the base default) paired with the DROID
-    # pipeline whose codec feeds its required 320x180 frames.
-    'droid': serve.override(pipeline=droid.override(**{'source.model_path': 'GEAR-Dreams/DreamZero-DROID'})),
+    'droid': serve.override(pipeline=droid),
+    'droid_3cam': serve.override(pipeline=droid_3cam),
 }
 
 

--- a/positronic/vendors/dreamzero/server.py
+++ b/positronic/vendors/dreamzero/server.py
@@ -385,7 +385,7 @@ joints_ik = pipeline.override(codec=codecs.joints_ik)
 joints_ik_sim = pipeline.override(codec=codecs.joints_ik_sim)
 # The public pretrained DROID checkpoint on the wan2.1 backbone. Asserts 320x180 frames.
 droid = pipeline.override(codec=codecs.droid, height=180, **{'source.model_path': 'GEAR-Dreams/DreamZero-DROID'})
-droid_3cam = droid.override(codec=codecs.droid_3cam)
+droid_3cam = droid.override(codec=codecs.droid_3cam, local=codecs.dreamzero_layers_3cam)
 
 
 # Every pipeline is a subcommand, and so is every deployment — a pipeline with its checkpoint bound.

--- a/positronic/vendors/molmoact2/codecs.py
+++ b/positronic/vendors/molmoact2/codecs.py
@@ -59,3 +59,4 @@ _action = codecs.absolute_joints_action.override(tgt_joints_key=keys.TARGET_JOIN
 
 # franka_droid runs at 15 Hz; the model emits a 15-step horizon and compose executes all steps by default.
 droid = codecs.compose.override(obs=molmoact2_obs, action=codecs.droid_execution.override(action=_action), fps=15.0)
+droid_3cam = droid.override(**{'obs.exterior_camera_2': keys.EXTERIOR_IMAGE_2})

--- a/positronic/vendors/molmoact2/server.py
+++ b/positronic/vendors/molmoact2/server.py
@@ -64,11 +64,15 @@ def pipeline(codec: Codec, source: ModelSource):
 
 
 droid = pipeline
+droid_3cam = pipeline.override(codec=molmoact2_codecs.droid_3cam)
 
 
 # Every pipeline is a subcommand; MolmoAct2 pins one checkpoint, so there is no separate deployment.
 # The empty key is the default command, so a no-argument launch starts the server.
-COMMANDS = {k: serve.override(pipeline=droid) for k in ('', 'serve', 'droid')}
+COMMANDS = {
+    **{k: serve.override(pipeline=droid) for k in ('', 'serve', 'droid')},
+    'droid_3cam': serve.override(pipeline=droid_3cam),
+}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Define the DROID camera station once in `positronic.cfg.hardware.camera`: `droid` (wrist + exterior) and `droid_3cam`, which adds the second exterior ZED (serial 13785037)
- Add `keys.EXTERIOR_IMAGE_2` (`image.exterior_2`), the name the second exterior camera takes on the wire. The dreamzero and molmoact2 codecs already accept an `exterior_camera_2` argument
- Point `cfg.embodiment.droid` and `data_collection.droid` at the shared dict, which removes the duplicated camera setup and the `image_enhancement` disagreement between them
- Add the `droid_3cam` variant to both, and register `droid_3cam` in the data collection CLI

Eval keeps the 2-camera embodiment as its default. A 3-camera run passes `--embodiment` on the command line.

## Test plan
- `uv run --locked pytest`
- `uv run --locked ruff check .` and `ruff format --check .`
- Check that each config resolves to the right cameras:
  `uv run --locked python -c "import positronic.cfg.embodiment as e, positronic.data_collection as dc; print({k: v.kwargs['serial_number'] for k, v in e.droid_3cam.kwargs['cameras'].items()})"`
- On the rig: `positronic data-collection droid_3cam` records three video signals