### PR TITLE
Give platform-register the platform's OAuth client id as its default

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -12,7 +12,7 @@ The library depends on `pydantic` and `httpx` and nothing else, so a service tha
 platform installs it on its own, at the exact version it was written against:
 
 ```bash
-uv add "positronic-platform-client==0.4.0"
+uv add "positronic-platform-client==0.4.1"
 ```
 
 `platform_client` never imports `positronic`. The `platform-register` command ships here. The
@@ -26,10 +26,12 @@ it prints a short code and a URL, waits while you authorize the app in a browser
 the GitHub account that authorized it. The package install above puts the command on your path.
 
 ```bash
-export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
 platform-register --alias=<display name>
 export POSITRONIC_PLATFORM_API_KEY=<the key the command printed>
 ```
+
+The command registers through the platform's own OAuth app, whose client id it carries as its
+default. `--client-id` and `POSITRONIC_PLATFORM_GITHUB_CLIENT_ID` name another app instead.
 
 The GitHub token carries the scopes `read:user` and `user:email`. The platform reads the account
 once, mints a key, and stores no GitHub token.

--- a/client/platform_client/github_device_flow.py
+++ b/client/platform_client/github_device_flow.py
@@ -4,7 +4,6 @@ It asks GitHub for a device code, shows the user the short code, polls until Git
 hands the access token to `users.register` as its `credential`.
 
 Usage
-  export POSITRONIC_PLATFORM_GITHUB_CLIENT_ID=<the OAuth app's public client id>
   platform-register --alias='<display name>'
   platform-register --client-id=<id> --platform-url=http://127.0.0.1:8080
   platform-register --platform-url=http://staging.internal:8080 --plaintext-http  # a plain http link
@@ -40,7 +39,10 @@ DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
 # writes nothing, so the platform holds no power over the account.
 IDENTITY_SCOPE = 'read:user user:email'
 
-# The platform's OAuth app id. The device flow carries no client secret, so the id is public.
+# The platform's OAuth app `positronic-platform-device-flow`. A device flow carries no client
+# secret, so its client id is public (RFC 8628 section 3.1).
+DEFAULT_GITHUB_CLIENT_ID = 'Ov23liw7qPBHHzUfjfZA'
+
 GITHUB_CLIENT_ID_ENV = 'POSITRONIC_PLATFORM_GITHUB_CLIENT_ID'
 
 # GitHub's spelling of every field this flow reads or writes. The step that writes one and the step
@@ -309,10 +311,15 @@ def main() -> None:
     parser.add_argument(
         '--plaintext-http', action='store_true', help='reach an http platform that is not loopback, on a link you trust'
     )
-    parser.add_argument('--client-id', default=os.environ.get(GITHUB_CLIENT_ID_ENV), help=GITHUB_CLIENT_ID_ENV)
+    parser.add_argument(
+        '--client-id',
+        default=os.environ.get(GITHUB_CLIENT_ID_ENV, DEFAULT_GITHUB_CLIENT_ID),
+        help=f'the OAuth app to register through, else {GITHUB_CLIENT_ID_ENV}, else the platform app',
+    )
     args = parser.parse_args()
     if not args.client_id:
-        raise SystemExit(f'pass --client-id, or set {GITHUB_CLIENT_ID_ENV} to the public OAuth client id')
+        # GitHub answers an empty id with an error that names nothing, so an empty override stops here.
+        raise SystemExit(f'--client-id or {GITHUB_CLIENT_ID_ENV} is empty. Unset it to use the default.')
     try:
         base_url = resolve_base_url(args.platform_url)
         allowed = platform_url_is_allowed(base_url, plaintext_http=args.plaintext_http)

--- a/client/platform_client/tests/test_github_device_flow.py
+++ b/client/platform_client/tests/test_github_device_flow.py
@@ -20,9 +20,11 @@ from platform_client.client import PlatformClient
 from platform_client.github_device_flow import (
     ACCESS_TOKEN_URL,
     CONNECT_TIMEOUT_S,
+    DEFAULT_GITHUB_CLIENT_ID,
     DEVICE_CODE_URL,
     DEVICE_GRANT_TYPE,
     GATEWAY_GITHUB_READS,
+    GITHUB_CLIENT_ID_ENV,
     IDENTITY_SCOPE,
     MAX_REQUEST_STALL_S,
     POOL_TIMEOUT_S,
@@ -404,6 +406,66 @@ def test_the_command_asks_for_rotation_only_when_the_flag_is_given(flag: list[st
         github_device_flow.main()
 
     assert asked == [expected]
+
+
+ENVIRONMENT_ID = 'Iv1.fromtheenvironment'
+FLAG_ID = 'Iv1.fromtheflag'
+
+
+@pytest.mark.parametrize(
+    ('flag', 'environment', 'expected'),
+    [
+        ([], None, DEFAULT_GITHUB_CLIENT_ID),
+        ([], ENVIRONMENT_ID, ENVIRONMENT_ID),
+        ([f'--client-id={FLAG_ID}'], ENVIRONMENT_ID, FLAG_ID),
+        ([f'--client-id={FLAG_ID}'], None, FLAG_ID),
+    ],
+    ids=['neither', 'the environment', 'both', 'the flag'],
+)
+def test_the_flag_beats_the_environment_and_both_beat_the_platform_app(
+    flag: list[str], environment: str | None, expected: str
+):
+    """A user who sets nothing registers through the platform's own OAuth app."""
+    asked: list[str] = []
+
+    def register(platform: object, flow: object, *, alias: str | None = None, rotate: bool = False) -> RegisterResponse:
+        return RegisterResponse.model_validate(ScriptedGateway().body)
+
+    def capture(client_id: str, http: httpx.Client) -> GitHubDeviceFlow:
+        asked.append(client_id)
+        return GitHubDeviceFlow(client_id, http)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.delenv(GITHUB_CLIENT_ID_ENV, raising=False)
+        if environment is not None:
+            patch.setenv(GITHUB_CLIENT_ID_ENV, environment)
+        patch.setattr(github_device_flow, 'register_with_github', register)
+        patch.setattr(github_device_flow, 'GitHubDeviceFlow', capture)
+        patch.setattr(sys, 'argv', ['platform-register', '--platform-url=https://gateway.example', *flag])
+
+        github_device_flow.main()
+
+    assert asked == [expected]
+
+
+@pytest.mark.parametrize('flag', [['--client-id='], []], ids=['the flag', 'the environment'])
+def test_an_override_emptied_rather_than_unset_stops_before_github(flag: list[str]):
+    """An empty value overrides the default with nothing, and GitHub reads an empty id as a bad request."""
+    reached: list[str] = []
+
+    def capture(client_id: str, http: httpx.Client) -> GitHubDeviceFlow:
+        reached.append(client_id)
+        return GitHubDeviceFlow(client_id, http)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv(GITHUB_CLIENT_ID_ENV, '')
+        patch.setattr(github_device_flow, 'GitHubDeviceFlow', capture)
+        patch.setattr(sys, 'argv', ['platform-register', '--platform-url=https://gateway.example', *flag])
+
+        with pytest.raises(SystemExit) as raised:
+            github_device_flow.main()
+
+    assert GITHUB_CLIENT_ID_ENV in str(raised.value) and reached == []
 
 
 @pytest.mark.parametrize(

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "positronic-platform-client"
-version = "0.4.0"
+version = "0.4.1"
 description = "Typed wire contract and HTTP client for the Positronic evaluation platform API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # (.github/workflows/release.yaml). Pinned exactly, because that package guarantees no
     # backwards compatibility: a floating requirement would let a fresh install of THIS release
     # resolve a contract it was never built against.
-    "positronic-platform-client==0.4.0",
+    "positronic-platform-client==0.4.1",
     "psutil",  # `positronic-server` enumerates local interfaces to name a wildcard bind's addresses
     "pyarrow",
     "pydantic",

--- a/uv.lock
+++ b/uv.lock
@@ -5095,7 +5095,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/45/029c72cffe797d826
 
 [[package]]
 name = "positronic-platform-client"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

`platform-register` carries the public client id of the platform's GitHub OAuth app, `positronic-platform-device-flow`, as its default. A participant runs the command with no flag and no environment variable. `--client-id` overrides the default, and `POSITRONIC_PLATFORM_GITHUB_CLIENT_ID` overrides it when the flag is absent. An override that is set and empty stops the command before it asks GitHub for a device code, with a line that names the empty override.

The client version is 0.4.1; the root pin and the lockfile follow it.

## Why

A device-flow client id is public by design (RFC 8628): the flow carries no secret, and GitHub answers for the account that authorized the app. Asking every participant to find and export the id was one more setup step for a value that never changes. The app lives on the v-positronic account today; GitHub keeps an app's client id across a transfer to the organisation, so the default survives that move (Positronic-Robotics/internal#1105).

## Verification

`uv run pytest client positronic/cli/tests/test_fresh_install.py positronic/cli/tests/test_vocabulary.py`: 356 passed. Four tests pin the precedence: neither set takes the default; the environment overrides the default; the flag overrides the environment; the flag alone overrides the default. Two pin that an emptied override stops before any flow is built. The first case fails without the change.

Refs: Positronic-Robotics/internal#939

<!-- opened-by: posi-agent -->