### PR TITLE
Let whoever asks for an episode close the rollout it sent

### DIFF
--- a/positronic/cli/eval/run.py
+++ b/positronic/cli/eval/run.py
@@ -65,12 +65,16 @@ class TaskDriver(pimm.ControlSystem):
 
     def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         for task in self._tasks():
-            answer = self.perform_task(Rollout(task, self._policy, self._output_path))
-            while not answer.done():
-                if should_stop.value:
-                    return
-                yield pimm.Yield()  # A sleep here would step the virtual clock on the driver's account.
-            answer.result()  # raises if the episode failed
+            rollout = Rollout(task, self._policy, self._output_path)
+            try:
+                answer = self.perform_task(rollout)
+                while not answer.done():
+                    if should_stop.value:
+                        return
+                    yield pimm.Yield()  # A sleep here would step the virtual clock on the driver's account.
+                answer.result()  # raises if the episode failed
+            finally:
+                rollout.close()
         # Let the recorder commit the final episode before this return brings the world down.
         yield pimm.Sleep(0.5)
 

--- a/positronic/cli/eval/tests/test_run.py
+++ b/positronic/cli/eval/tests/test_run.py
@@ -57,8 +57,7 @@ def test_an_exhausted_trial_plan_ends_the_sweep():
 
 
 class _EpisodeStub(pimm.ControlSystem):
-    """Stands in for the harness: records the task it was asked for, closes the session that came with it,
-    and answers a round later."""
+    """Stands in for the harness: records the task it was asked for, and answers a round later."""
 
     def __init__(self):
         self.asked: list[Task] = []
@@ -70,7 +69,6 @@ class _EpisodeStub(pimm.ControlSystem):
                 self.asked.append(call.request.task)
                 yield pimm.Sleep(0.01)  # an episode takes a round to run
                 assert not list(self.perform_task.incoming()), 'a task was asked for while one was running'
-                call.request.close()
                 call.set_result({})
             yield pimm.Sleep(0.01)
 

--- a/positronic/inference.py
+++ b/positronic/inference.py
@@ -43,6 +43,7 @@ class KeyboardOperator(KeyboardControl):
         self._policy = policy
         self._output_path = output_path
         self._pending: pimm.calls.Answer[dict[str, Any]] | None = None
+        self._rollout: Rollout | None = None
         self.perform_task = pimm.calls.ControlSystemCaller[Rollout, dict[str, Any]](self)
         self.done = pimm.ControlSystemEmitter[dict[str, Any]](self)
 
@@ -58,14 +59,23 @@ class KeyboardOperator(KeyboardControl):
             case 's' if self._pending is not None:
                 logger.warning('An episode is already running: press [p] to stop it')
             case 's':
-                # A model that will not open a session ends the episode, not the run: the operator hears it
-                # and presses again.
-                try:  # rules-allow: swallowed-error — the operator is who this failure is for
-                    self._pending = self.perform_task(Rollout(self._next_task(), self._policy, self._output_path))
-                except Exception as e:
+                if self._rollout is not None:
+                    self._rollout.close()
+                    self._rollout = None
+                try:
+                    self._rollout = Rollout(self._next_task(), self._policy, self._output_path)
+                    self._pending = self.perform_task(self._rollout)
+                except Exception as e:  # rules-allow: swallowed-error — the operator is who this failure is for
                     logger.error(f'Episode failed to open: {e}')
             case 'p':
                 self.done.emit({eval_keys.ENDED_BY: eval_keys.ENDED_BY_OPERATOR})
+
+    def run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock):
+        try:
+            yield from super().run(should_stop, clock)
+        finally:
+            if self._rollout is not None:
+                self._rollout.close()
 
 
 def real(policy, embodiment: Embodiment, next_task: Callable[[], Task], output_dir=None):

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -33,15 +33,14 @@ class Rollout:
     serves the policy's functions to that session, and the path the episode records into.
 
     Whoever asks opens it, and so decides which model runs the trial and where the recording lands. An
-    ``output_path`` of ``None`` records nothing. The Harness closes it: the episode it ran, or the ask it refused.
+    ``output_path`` of ``None`` records nothing. Whoever asks closes it, once its call has answered.
     """
 
     def __init__(self, task: Task, policy: Policy, output_path: Path | None):
         self.task = task
         self.output_path = output_path
-        # The Harness closes this runtime before the session, and charges the trial for the model's time
-        # through it. TODO(#661): the framework takes over closing the chain, and only the charge keeps a
-        # runtime here.
+        # The Harness charges the trial for the model's time through this runtime. TODO(#661): the framework
+        # takes over the chain, and only the charge keeps a runtime here.
         self.rt = Executor(policy.functions)
         try:
             self.session = policy.new_session(rt=self.rt)
@@ -99,9 +98,6 @@ class _EpisodeInference:
         # answers must not also keep the world from coming down.
         while self._rollout.rt.in_flight and not should_stop.value:
             self._rollout.rt.wait(POLL_PERIOD_SEC)
-
-    def close(self) -> None:
-        self._rollout.close()
 
 
 class _EpisodeTelemetry:
@@ -188,8 +184,6 @@ class Harness(pimm.ControlSystem):
         self._inference: _EpisodeInference | None = None
         # The call this episode answers when it ends.
         self._call: pimm.calls.Call[Rollout, dict[str, Any]] | None = None
-        # An inference let go of with a function still running.
-        self._retired: _EpisodeInference | None = None
         # ``task.timeout_sec``, armed per episode; a task without one has no deadline and ends on ``done`` alone.
         self._deadline_ns: int | None = None
         # Wall-clock telemetry for the live rollout, opened under ``--timing`` and inert otherwise.
@@ -240,11 +234,9 @@ class Harness(pimm.ControlSystem):
         meta[keys.TASK] = self._task.instruction
         return meta
 
-    def _emit(self, action: dict[str, Any]) -> None:
-        for name, value in action.items():
-            self.commands[name].emit(value)
-
-    def _ready(self, should_stop: pimm.SignalReceiver, args: dict[str, Any]) -> Generator[pimm.Command, None, None]:
+    def _ready(
+        self, should_stop: pimm.SignalReceiver, clock: pimm.Clock, args: dict[str, Any]
+    ) -> Generator[pimm.Command, None, None]:
         """Ask each device in ``args`` for the value it names, and come back once every one has answered."""
         unknown = sorted(set(args) - set(self.prepare))
         if unknown:
@@ -252,11 +244,9 @@ class Harness(pimm.ControlSystem):
             raise ValueError(f'{unknown} is not something {rig} readies; it readies {sorted(self.prepare)}')
         ready = pimm.calls.all_of([self.prepare[name](arg) for name, arg in args.items()])
         while not ready.done() and not should_stop.value:
-            yield pimm.Yield() if self._embodiment.simulated else pimm.Sleep(POLL_PERIOD_SEC)
-        # An episode must not open on a rig that never got ready, and its asker must hear that rather than wait
-        if not ready.done():
-            raise RuntimeError('The world stopped before every device was ready')
-        ready.result()
+            yield self._pace(clock)
+        if ready.done():
+            ready.result()
 
     def _pace(self, clock: pimm.Clock) -> pimm.Command:
         """Sim: yield, so the simulator's control-period sleep is the sole time-master and the policy reads
@@ -269,17 +259,6 @@ class Harness(pimm.ControlSystem):
             return pimm.Sleep(POLL_PERIOD_SEC)
         return pimm.Sleep(min(POLL_PERIOD_SEC, max(due - clock.now_ns(), 1) / 1e9))
 
-    def _retire_inference(self) -> None:
-        """Let go of this episode's inference, keeping it for ``_reap_inference``: the recording stops and the
-        rig goes back without waiting for a model that hangs."""
-        if self._inference is not None:
-            self._retired, self._inference = self._inference, None
-
-    def _reap_inference(self) -> None:
-        if self._retired is not None:
-            self._retired.close()
-            self._retired = None
-
     def _finalize_recording(
         self, clock: pimm.Clock, payload: dict[str, Any] | None = None
     ) -> Generator[pimm.Command, None, None]:
@@ -290,14 +269,13 @@ class Harness(pimm.ControlSystem):
         self.ds_command.emit(DsWriterCommand.STOP({**self._build_episode_meta(), **(payload or {})}))
         for schedule in self._schedules.values():  # devices hold their last commanded position
             schedule.clear()
-        self._retire_inference()
+        self._inference = None
         virtual_now = clock.now()  # before the round below, whose sim-clock advance belongs to no rollout
-        # Give the recorder a round to commit the STOP before the next START (they share ``ds_command``, where
-        # last-value-wins would drop one) and before the next trial's prepare, so the moves it asks for stay
-        # out of the recording.
+        # The recorder reads only the last ``ds_command`` value. This round lets it read the STOP before the next START.
         yield self._pace(clock)
-        # After that round, so the recorder's STOP-time record.io span still parents to the episode. Skew: a
-        # producer stepping in that shared round charges ≤ one control period to the closing episode.
+        # The episode span must still be open while the recorder writes the STOP, so that write is timed
+        # inside the episode. The other control systems run in that round as well, and the episode is timed
+        # with their work too. The error is not more than one control period.
         self._telemetry.end(virtual_now)
 
     def _set_deadline(self, deadline_ns: int | None) -> None:
@@ -317,7 +295,7 @@ class Harness(pimm.ControlSystem):
         # The episode span opens first, so the prepare and the rollout's other phase spans parent to it.
         self._telemetry.begin(self._task.meta)
         with telemetry.span(telemetry_keys.SPAN_RESET):
-            yield from self._ready(should_stop, self._task.prepare_args)
+            yield from self._ready(should_stop, clock, self._task.prepare_args)
         budget = self._task.timeout_sec
         self._set_deadline(clock.now_ns() + round(budget * 1e9) if budget is not None else None)
         self._telemetry.start_rollout(clock.now())
@@ -328,44 +306,14 @@ class Harness(pimm.ControlSystem):
     def _end_episode(
         self, clock: pimm.Clock, should_stop: pimm.SignalReceiver, payload: dict[str, Any]
     ) -> Generator[pimm.Command, None, None]:
-        """Close the live episode: finalize the recording, put the rig back, close the session, and hand the
-        terminal back to whoever asked for the episode.
-
-        The session is closed after the rig has moved, so a model still inside its function costs the
-        recording and the move nothing.
-        """
+        """Close the live episode: finalize the recording, put the rig back, return the terminal to the caller"""
         yield from self._finalize_recording(clock, payload)
-        # A powered arm holds the policy's last setpoint until the next trial, so each device the trial placed
-        # goes back where it put it — the trial's own args, not a fresh draw. The scene is a person's to set
-        # up, and is not asked again. The terminal waits on the move: a scene the next trial draws rebuilds
-        # the model an unfinished one is still travelling under, which nothing but its timeout would end.
-        yield from self._ready(should_stop, {k: v for k, v in self._task.prepare_args.items() if k != eval_keys.SCENE})
-        # The answer waits until the model is out of this episode's function. An in-process policy is one
-        # model across every episode, so the session that the next ask opens must not overtake it. The move
-        # back above gives the function that time.
-        self._reap_inference()
+        yield from self._ready(  # Move robot back to ready state
+            should_stop, clock, {k: v for k, v in self._task.prepare_args.items() if k != eval_keys.SCENE}
+        )
         assert self._call is not None, 'an episode exists only for the call that asked for it'
         self._call.set_result(payload)
         self._call = None
-
-    def _fail_call(self, exc: BaseException) -> None:
-        """Raise to whoever asked for the live episode, in place of the terminal it will never get."""
-        if self._call is not None:
-            self._call.set_exception(exc)
-            self._call = None
-
-    def _advance_episode(
-        self,
-        inference: _EpisodeInference,
-        done: pimm.Message[dict] | None,
-        clock: pimm.Clock,
-        should_stop: pimm.SignalReceiver,
-    ) -> Generator[pimm.Command, None, None]:
-        """One round of the live episode: end it if it is out of budget or done, else run one inference round."""
-        if (terminal := self._trial_terminal(done, clock)) is not None:
-            yield from self._end_episode(clock, should_stop, terminal)
-        else:
-            self._infer(inference, clock, should_stop)
 
     def _build_obs(self, clock: pimm.Clock) -> dict[str, Any]:
         """Read every observation channel and assemble the policy input dict.
@@ -412,10 +360,6 @@ class Harness(pimm.ControlSystem):
         channel's waypoints; one it omits is cleared and holds. The timestamps are already absolute, stamped
         by the scheduling layer against the harness clock.
         """
-        if self._deadline_ns is not None and clock.now_ns() >= self._deadline_ns:
-            # The world reached the deadline while the function was in flight, so its chunk is dropped rather
-            # than placed past the point the trial advertises it stops at; ``_run`` finishes the trial next round.
-            return
         self._assert_anchored(trajectory, clock.now())
         self._telemetry.step()
         # Layers time actions in float seconds; the schedules and every pimm channel are in ns.
@@ -423,12 +367,8 @@ class Harness(pimm.ControlSystem):
             schedule.clear()
             schedule.extend((int(a[keys.ACTION_TIMESTAMP] * 1e9), a[name]) for a in trajectory if name in a)
 
-    def _play(self, clock: pimm.Clock) -> None:
-        """Emit each channel's command due this round, and nothing on a channel with none.
-
-        A channel with several waypoints due emits the last: exact for an absolute setpoint, lossy for a
-        relative one. Pacing keeps one due per round wherever a round is shorter than the waypoint spacing.
-        """
+    def _issue_due_commands(self, clock: pimm.Clock) -> None:
+        """Emit each channel's due command. Nothing on a channel with none. Last on a channel with multiple."""
         now_ns = clock.now_ns()
         for name, schedule in self._schedules.items():
             value = None
@@ -440,10 +380,7 @@ class Harness(pimm.ControlSystem):
     def _trial_terminal(self, done: pimm.Message[dict] | None, clock: pimm.Clock) -> dict[str, Any] | None:
         """The terminal static payload if the live trial has ended this round, else ``None``.
 
-        The deadline is hard: a truthy ``done`` within budget records ``eval.terminated`` True plus its
-        payload, the budget passing records False, and a terminal past the deadline is a timeout rather than
-        a late success. A task without a timeout has no budget and ends on ``done`` alone. Only a truthy
-        ``done`` counts, so a producer can clear a stale terminal off the wire with an empty payload.
+        A ``done`` that arrives after the deadline is a timeout, not a late success.
         """
         deadline_ns = self._deadline_ns
         if done is not None and done.data and (deadline_ns is None or done.ts <= deadline_ns):
@@ -456,46 +393,38 @@ class Harness(pimm.ControlSystem):
         try:
             yield from self._run(should_stop, clock)
         except BaseException as exc:
-            # Seal the open span before the exception reaches ``bind``'s exit flush: an unended span never
-            # exports, orphaning its finished children and charging the episode's wall to between_episodes.
             self._telemetry.seal(clock.now())
-            self._fail_call(exc)
+            if self._call is not None:
+                self._call.set_exception(exc)
+                self._call = None
             raise
         finally:
-            # A no-op once the block above has answered: the world coming down under a live episode is the
-            # one way a call goes unanswered, and it is the caller's to hear about.
-            self._fail_call(RuntimeError('The world stopped before the episode ended'))
-            # An episode abandoned by a raise never reaches ``_finalize_recording``, and would leave a
-            # deadline standing that nothing will ever meet.
-            self._set_deadline(None)
-            self._retire_inference()
-            self._reap_inference()
-            # An ask this loop never reached still carries a live session, and the Harness closes what it is
-            # handed. The world answers what is left queued, so these calls are answered here as well.
+            # The world stops under a live episode, so nothing sends its call the terminal it waits for, and
+            # an ask this loop never reached gets no episode at all. Both hear the same stop.
+            if self._call is not None:
+                self._call.set_exception(pimm.calls.HandlerStopped())
             for call in self.perform_task.incoming():
-                call.request.close()
                 call.set_exception(pimm.calls.HandlerStopped())
 
     def _run(self, should_stop: pimm.SignalReceiver, clock: pimm.Clock) -> Iterator[pimm.Command]:
         while not should_stop.value:
-            # One action per round: start the episode a call asks for, finish one that is out of budget or
-            # done, or run one inference round.
             call = next(self.perform_task.incoming(), None)
-            # Read every round so the flag clears mid-episode; a press during a trial is consumed, not replayed.
+            # Consume commands during trial, so only non-trial ones are handled
             manual = pimm.value_updated(self.manual_command)
-            # Read every round for the same reason: a terminal landing between episodes belongs to none of
-            # them, and left on the wire it would end the next one on its first round.
             done = pimm.read_updated(self.done)
             if self._inference is not None:
-                if call is not None:  # the live episode is the one that finishes; a second ask is refused
-                    call.request.close()  # the session came with the ask, and nothing here will run it
+                if call is not None:
                     call.set_exception(RuntimeError('An episode is already running'))
-                yield from self._advance_episode(self._inference, done, clock, should_stop)
+                if (terminal := self._trial_terminal(done, clock)) is not None:
+                    yield from self._end_episode(clock, should_stop, terminal)
+                else:
+                    self._infer(self._inference, clock, should_stop)
             elif call is not None:
                 yield from self._begin_episode(clock, should_stop, call)
             elif manual is not None:
-                self._emit(manual)
-            self._play(clock)
+                for name, value in manual.items():
+                    self.commands[name].emit(value)
+            self._issue_due_commands(clock)
             yield self._pace(clock)
 
         if self._inference is not None:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -245,6 +245,7 @@ class Harness(pimm.ControlSystem):
         ready = pimm.calls.all_of([self.prepare[name](arg) for name, arg in args.items()])
         while not ready.done() and not should_stop.value:
             yield self._pace(clock)
+        # if `should_stop` is set, we don't care what result is
         if ready.done():
             ready.result()
 
@@ -415,6 +416,7 @@ class Harness(pimm.ControlSystem):
             if self._inference is not None:
                 if call is not None:
                     call.set_exception(RuntimeError('An episode is already running'))
+                # Deadline is checked once per harness tick.
                 if (terminal := self._trial_terminal(done, clock)) is not None:
                     yield from self._end_episode(clock, should_stop, terminal)
                 else:

--- a/positronic/policy/tests/test_golden_pipeline.py
+++ b/positronic/policy/tests/test_golden_pipeline.py
@@ -46,7 +46,7 @@ from positronic.policy.base import DelegatingPolicy, DelegatingSession, Policy, 
 from positronic.policy.codec import ActionTiming
 from positronic.policy.harness import Harness
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
-from positronic.tests.testing_coutils import ManualDriver, drive_scheduler, episode_caller
+from positronic.tests.testing_coutils import EpisodeCaller, ManualDriver, drive_scheduler
 
 GOLDEN_FILE = Path(__file__).parent / 'golden_pipeline.json.gz'
 
@@ -212,7 +212,7 @@ def _run_pipeline(tmp_path: Path) -> dict:
         harness = Harness(embodiment)
         ds_agent = wire.wire_embodiment(world, harness, embodiment, TimeMode.MESSAGE)
         world.connect(harness.ds_command, ds_agent.command)
-        perform_task = episode_caller(world, harness, wrapped, tmp_path)
+        perform_task = EpisodeCaller(world, harness, wrapped, tmp_path)
         done_em = world.pair(harness.done)
 
         # Robot/gripper emit state every tick, so the script only drives the

--- a/positronic/policy/tests/test_harness.py
+++ b/positronic/policy/tests/test_harness.py
@@ -29,13 +29,7 @@ from positronic.policy.codec import ActionTimestamp
 from positronic.policy.harness import POLL_PERIOD_SEC, Harness, Rollout, _EpisodeInference
 from positronic.policy.layers import ChunkedSchedule, StopOnFault
 from positronic.policy.remote import INFER, RemoteSession, round_trip
-from positronic.tests.testing_coutils import (
-    ManualDriver,
-    RecordingEmitter,
-    drive_scheduler,
-    drive_until,
-    episode_caller,
-)
+from positronic.tests.testing_coutils import EpisodeCaller, ManualDriver, RecordingEmitter, drive_scheduler, drive_until
 
 POLL_PERIOD_NS = round(POLL_PERIOD_SEC * 1e9)
 
@@ -308,7 +302,7 @@ def _pair_all(world, harness, policy, output_path: Path | None = Path('dataset')
         'frame_em': world.pair(harness.observations[CAM]),
         'robot_em': world.pair(harness.observations[keys.ROBOT_STATE]),
         'grip_em': world.pair(harness.observations[keys.GRIP]),
-        'perform_task': episode_caller(world, harness, policy, output_path),
+        'perform_task': EpisodeCaller(world, harness, policy, output_path),
         'done_em': world.pair(harness.done),
         'command_rx': world.pair(harness.commands[keys.ROBOT_COMMAND]),
         'grip_rx': world.pair(harness.commands['target_grip']),
@@ -369,7 +363,7 @@ def test_harness_emits_cartesian_move(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
@@ -428,7 +422,7 @@ def test_harness_passes_descriptor_to_policy(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -461,7 +455,7 @@ def test_robot_model_stays_out_of_the_observation(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations['grip'])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -485,7 +479,7 @@ def _run_with_model(world, model, static_meta=None):
     harness.commands[keys.ROBOT_COMMAND]._bind(RecordingEmitter())
     harness.commands['target_grip']._bind(RecordingEmitter())
     harness.ds_command._bind(RecordingEmitter())
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
     meta_em = world.pair(harness.robot_meta_in)
 
     steps = [(partial(perform_task, Task(instruction_source='t', timeout_sec=None)), 0.0)]
@@ -536,7 +530,7 @@ def test_harness_waits_for_complete_inputs(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     assert CAM in harness.observations
 
@@ -687,7 +681,7 @@ def test_the_world_stopping_under_a_live_episode_fails_the_call(world):
     answer = p['perform_task'](Task(instruction_source='test', timeout_sec=None))
     drive_scheduler(scheduler, steps=20)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pimm.calls.HandlerStopped):
         answer.result()
 
 
@@ -893,7 +887,7 @@ def test_the_policy_opens_on_the_frame_the_reset_published(world):
     )
     policy = StubPolicy()
     harness = Harness(embodiment)
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
     wire.wire_embodiment(world, harness, embodiment, record=False)
 
     scheduler = world.start([harness, device])
@@ -940,7 +934,7 @@ def test_task_done_terminates_through_wire_embodiment(world):
     harness = Harness(embodiment)
     ds_recorder = RecordingEmitter()
     harness.ds_command._bind(ds_recorder)
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
     wire.wire_embodiment(world, harness, embodiment, record=False, done=device.done)
 
     scheduler = world.start([harness, device])
@@ -1180,35 +1174,6 @@ def test_a_world_stopping_mid_episode_withdraws_the_deadline(world):
 
 
 @pytest.mark.timeout(3.0)
-def test_an_episode_abandoned_by_a_raise_withdraws_the_deadline(world):
-    """An episode a raise abandons withdraws its deadline like any other close."""
-
-    class _BoomSession(Session):
-        def __call__(self, obs, time_ns):
-            raise RuntimeError('inference boom')
-
-    class _BoomPolicy(Policy):
-        def new_session(self, context=None, rt=None):
-            return _BoomSession()
-
-    policy = _BoomPolicy()
-    harness = Harness(make_embodiment())
-    p = _pair_all(world, harness, policy)
-    robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
-
-    driver = ManualDriver([
-        (partial(emit_ready_payload, p['frame_em'], p['robot_em'], p['grip_em'], robot_state), 100.0)
-    ])
-    scheduler = world.start([harness, driver])
-    p['perform_task'](Task(instruction_source='t', timeout_sec=100.0))
-    with pytest.raises(RuntimeError, match='inference boom'):
-        drive_scheduler(scheduler, steps=200)
-
-    assert _deadlines(p)[0] is not None, 'no deadline was ever armed, so nothing here was under test'
-    assert _deadlines(p)[-1] is None
-
-
-@pytest.mark.timeout(3.0)
 def test_a_trial_asking_to_ready_what_the_rig_has_not_got_fails_loudly(world):
     """Only the handlers a task names are asked, so a name matching none of them would go unasked and the
     trial would open on a rig nothing readied."""
@@ -1285,7 +1250,7 @@ def test_timeout_during_inference_drops_the_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
 
@@ -1327,8 +1292,7 @@ def test_a_terminal_landing_while_idle_does_not_end_the_next_episode(world):
 
 @pytest.mark.timeout(3.0)
 def test_a_call_arriving_mid_episode_is_refused(world):
-    """The live episode runs on and the second caller is told why, rather than its ask being dropped. The
-    session that ask carried is closed: it came with the ask, and nothing will run it."""
+    """The live episode runs on and the second caller is told why, rather than its ask being dropped."""
     policy = StubPolicy()
     harness = Harness(make_embodiment())
     p = _pair_all(world, harness, policy)
@@ -1344,13 +1308,11 @@ def test_a_call_arriving_mid_episode_is_refused(world):
     assert not live.done()
     assert _ds_types(p).count(DsWriterCommandType.START_EPISODE) == 1
     assert policy.opened_sessions == 2, 'each ask opens its own session'
-    assert policy.closed_sessions == 1, 'the refused ask left its session open'
 
 
 @pytest.mark.timeout(3.0)
-def test_an_ask_the_world_stops_before_is_closed(world):
-    """A queued ask still carries a live session, so the Harness closes it on the way down rather than
-    leaving the model open for the rest of the process."""
+def test_an_ask_the_world_stops_before_is_answered(world):
+    """A queued ask the loop never reaches hears the stop, so whoever asked knows to close what it sent."""
     policy = StubPolicy()
     harness = Harness(make_embodiment())
     p = _pair_all(world, harness, policy)
@@ -1361,8 +1323,7 @@ def test_an_ask_the_world_stops_before_is_closed(world):
     drive_scheduler(scheduler, steps=5)
 
     assert policy.opened_sessions == 1
-    assert policy.closed_sessions == 1, 'the ask went down with its session open'
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pimm.calls.HandlerStopped):
         answer.result()
 
 
@@ -1437,10 +1398,10 @@ class _AbandonedCallPolicy(ServedPolicy):
 
 
 @pytest.mark.timeout(10.0)
-def test_an_episode_answers_only_once_the_call_it_abandoned_has(world):
+def test_closing_a_rollout_waits_out_the_call_it_abandoned(world):
     """An in-process policy is one model across episodes, so the session the next ask opens must not overtake
-    a function still inside this one. The terminal comes back after that function answers, so a driver that
-    waits for it opens the next session on a free model."""
+    a function still inside this one. Closing the rollout waits that function out, so a driver that closes
+    before it asks again opens the next session on a free model."""
     policy = _AbandonedCallPolicy(wall_sec=0.4)
     harness = Harness(make_embodiment())
     p = _pair_all(world, harness, policy)
@@ -1456,8 +1417,9 @@ def test_an_episode_answers_only_once_the_call_it_abandoned_has(world):
     scheduler = world.start([harness, driver])
     answer = p['perform_task'](Task(instruction_source='ep1', timeout_sec=None))
     drive_until(scheduler, answer.done, max_steps=400)
+    p['perform_task'].close()
 
-    assert policy.events == ['open', 'answered'], f'the episode answered mid-function: {policy.events}'
+    assert policy.events == ['open', 'answered'], f'the close left a function inside the model: {policy.events}'
 
 
 @pytest.mark.timeout(3.0)
@@ -1512,7 +1474,7 @@ def test_finish_stops_playing_the_live_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
     done_em = world.pair(harness.done)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -1556,7 +1518,7 @@ def test_empty_trajectory_leaves_every_channel_holding(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     script = [
@@ -1712,7 +1674,7 @@ def test_shutdown_stops_playing_the_live_chunk(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     # A call + a complete obs schedules a chunk; the driver then ends, which makes the
@@ -1862,6 +1824,7 @@ def test_an_inference_outliving_its_episode_parents_to_it(world, tmp_path):
         scheduler = world.start([harness, producer, _Pacer()])
         p['perform_task'](Task(instruction_source='stack', timeout_sec=0.05, charge_inference_time=True))
         drive_scheduler(scheduler, steps=2000)
+        p['perform_task'].close()
 
     spans = list(telemetry.read_spans(telemetry.spans_path(tmp_path, telemetry_keys.HARNESS_PROCESS)))
     episodes = [s for s in spans if s.name == telemetry_keys.SPAN_EPISODE]
@@ -1974,19 +1937,6 @@ def test_anchored_chunk_passes():
     Harness._assert_anchored([{'timestamp': 1.7e9 - 0.2}, {'timestamp': 1.7e9 + 1.5}], now=1.7e9)
 
 
-@pytest.mark.parametrize(('expired', 'scheduled'), [(True, False), (False, True)])
-def test_a_reply_is_scheduled_only_while_the_trial_still_has_budget(world, expired, scheduled):
-    """A trial advertises the instant it stops at. A chunk answered after the world passed that instant is
-    dropped instead of placed, and ``_run`` finishes the trial on the next round."""
-    harness = Harness(make_embodiment())
-    now_ns = world.clock.now_ns()
-    harness._deadline_ns = now_ns - 1_000_000_000 if expired else now_ns + 1_000_000_000
-
-    harness._reschedule(slow_chunk(), world.clock)
-
-    assert bool(harness._schedules[keys.ROBOT_COMMAND]) is scheduled
-
-
 class _ReplanEarly(Layer):
     """Infers on the first observation and again halfway through the chunk it returned.
 
@@ -2041,7 +1991,7 @@ def _run_episode(
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, wrapped)
+    perform_task = EpisodeCaller(world, harness, wrapped)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -2203,7 +2153,7 @@ def test_every_arm_of_a_bimanual_rig_reports_its_own_status(world):
     left_em = world.pair(harness.observations[left])
     right_em = world.pair(harness.observations[right])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     def emit_states():
         left_em.emit(make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6], status=RobotStatus.BUSY))
@@ -2238,7 +2188,7 @@ def test_a_stop_clears_the_chunk_in_the_round_the_fault_is_seen(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     pose, joints = [0.1, 0.2, 0.3], [0.4, 0.5, 0.6]
     driver = ManualDriver([
@@ -2281,7 +2231,7 @@ def test_finish_does_not_wait_for_the_call_in_flight():
         frame_em = world.pair(harness.observations[CAM])
         robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
         grip_em = world.pair(harness.observations[keys.GRIP])
-        perform_task = episode_caller(world, harness, policy)
+        perform_task = EpisodeCaller(world, harness, policy)
         done_em = world.pair(harness.done)
 
         robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -2322,7 +2272,7 @@ def test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy():
         frame_em = world.pair(harness.observations[CAM])
         robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
         grip_em = world.pair(harness.observations[keys.GRIP])
-        perform_task = episode_caller(world, harness, policy)
+        perform_task = EpisodeCaller(world, harness, policy)
         done_em = world.pair(harness.done)
 
         robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -2333,6 +2283,7 @@ def test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy():
             (None, 0.05),
         ])
         drive_scheduler(world.start([harness, driver]), steps=40)
+        perform_task.close()
 
     assert left_the_model.is_set(), 'the run returned with a function still inside the shared policy'
 
@@ -2368,7 +2319,7 @@ def test_the_session_is_closed_only_once_its_call_has_left_it():
         frame_em = world.pair(harness.observations[CAM])
         robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
         grip_em = world.pair(harness.observations[keys.GRIP])
-        perform_task = episode_caller(world, harness, policy)
+        perform_task = EpisodeCaller(world, harness, policy)
         done_em = world.pair(harness.done)
 
         robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
@@ -2379,6 +2330,7 @@ def test_the_session_is_closed_only_once_its_call_has_left_it():
             (None, 0.05),
         ])
         drive_scheduler(world.start([harness, driver]), steps=40)
+        perform_task.close()
 
     assert inside_at_close == [False], 'the session was closed while its own function was still inside it'
 
@@ -2419,7 +2371,7 @@ def test_a_rescheduled_trajectory_clears_the_channels_it_omits(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
     driver = ManualDriver([
@@ -2467,7 +2419,7 @@ def test_finishing_discards_a_call_that_is_still_in_flight(world):
     frame_em = world.pair(harness.observations[CAM])
     robot_em = world.pair(harness.observations[keys.ROBOT_STATE])
     grip_em = world.pair(harness.observations[keys.GRIP])
-    perform_task = episode_caller(world, harness, policy)
+    perform_task = EpisodeCaller(world, harness, policy)
     done_em = world.pair(harness.done)
 
     robot_state = make_robot_state([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])

--- a/positronic/tests/testing_coutils.py
+++ b/positronic/tests/testing_coutils.py
@@ -58,17 +58,24 @@ def scripted_driver(*steps: ScriptStep) -> ManualDriver:
     return ManualDriver(script=steps)
 
 
-def episode_caller(
-    world: pimm.World, harness: Harness, policy: Policy, output_path: Path | None = Path('dataset')
-) -> Callable[[Task], pimm.calls.Answer[dict[str, Any]]]:
-    """A caller that asks ``harness`` for a task the way a driver does: it opens the session that runs it and
-    names the path it records into. Nothing writes there unless the test runs a recorder of its own."""
-    perform_task = world.pair(harness.perform_task)
+class EpisodeCaller:
+    """Asks ``harness`` for a task the way a driver does: it opens the session that runs it and names the
+    path it records into. Nothing writes there unless the test runs a recorder of its own."""
 
-    def ask(task: Task):
-        return perform_task(Rollout(task, policy, output_path))
+    def __init__(self, world: pimm.World, harness: Harness, policy: Policy, output_path: Path | None = Path('dataset')):
+        self._perform_task = world.pair(harness.perform_task)
+        self._policy = policy
+        self._output_path = output_path
+        self._rollouts: list[Rollout] = []
 
-    return ask
+    def __call__(self, task: Task) -> pimm.calls.Answer[dict[str, Any]]:
+        rollout = Rollout(task, self._policy, self._output_path)
+        self._rollouts.append(rollout)
+        return self._perform_task(rollout)
+
+    def close(self) -> None:
+        while self._rollouts:
+            self._rollouts.pop().close()
 
 
 class RecordingEmitter(pimm.SignalEmitter[T]):


### PR DESCRIPTION
## Summary

The `Harness` closed a session and a runtime that it did not open. A caller
builds a `Rollout`, which opens both from the policy, and hands it over. This
moves the close back to the caller.

- The `Harness` answers every call it takes, and the answer is its last touch
  on the rollout. `_EpisodeInference.close`, `_retire_inference`,
  `_reap_inference` and both `call.request.close()` calls are gone.
- `TaskDriver` closes in a `finally`, so an early return on `should_stop`
  closes too, and the close lands before the next task builds its rollout.
- `KeyboardOperator` closes the last rollout on the next press, and closes a
  live one when the run returns.
- `EpisodeCaller` replaces the `episode_caller` function in the test helpers.
  It keeps the rollouts it opened and closes them on `close()`.

Two ordering points move with it. The answer no longer waits for the model, so
the caller must close before it asks again — both callers do. An episode that a
raise abandons hands the caller the real exception from `run`, not a plain
stop.

Cleanups in the same files:

- Inline `_advance_episode` and `_emit`, each of which had one caller.
- `_ready` takes the clock and yields `_pace`, instead of branching on
  `simulated` a second time.
- `_ready` returns when the world stops instead of raising. The episode
  finished, so its terminal is honest.
- Drop the deadline guard in `_reschedule`. `_trial_terminal` checks the
  deadline once per round, before `_infer` runs.

## Test plan

`uv run --locked pytest` — 1807 passed, 8 skipped.

Six tests changed subject because the property moved to the caller:

| Test | Change |
|---|---|
| `test_a_call_arriving_mid_episode_is_refused` | dropped the `closed_sessions` assertion |
| `test_an_ask_the_world_stops_before_is_closed` | renamed `..._is_answered`, asserts `HandlerStopped` |
| `test_an_episode_answers_only_once_the_call_it_abandoned_has` | renamed `test_closing_a_rollout_waits_out_the_call_it_abandoned` |
| `test_the_run_ends_only_once_the_call_it_abandoned_is_out_of_the_policy` | closes the caller before the world exits |
| `test_the_session_is_closed_only_once_its_call_has_left_it` | same |
| `test_an_inference_outliving_its_episode_parents_to_it` | closes inside the telemetry bind, so the span is written |

Two deleted, because the code they pinned is gone:
`test_an_episode_abandoned_by_a_raise_withdraws_the_deadline` and
`test_a_reply_is_scheduled_only_while_the_trial_still_has_budget`.

Two gaps stay open: nothing checks that `TaskDriver` closes each rollout, and
nothing checks that it closes rollout N before it builds rollout N+1.