### PR TITLE
Let a RoboLab run pick its camera set

### DIFF
--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -65,10 +65,11 @@ parameter with a default for the usual one. When everyone must agree on the same
 as a named constant in a shared module.
 
 The same holds for any literal two pieces of code must spell identically — an environment-variable
-name, a filename two processes agree on, a wire field. Hoist it at the first duplication, into the module every
-consumer can import, usually the most constrained of them. Not a third copy neither side imports —
-and where there is no shared module at all, as across languages, name it once on each side, beside
-the code that parses it.
+name, a filename two processes agree on, a wire field. Hoist it when a rename must reach a reader you
+cannot name, into the module every consumer can import, usually the most constrained of them. Not a
+third copy neither side imports — and where there is no shared module at all, as across languages, name
+it once on each side, beside the code that parses it. Where you can name every reader from the file in
+front of you, the constant only adds a step. Leave the literal.
 
 Exception: a name the component itself owns and defines, rather than one it reads from its input.
 
@@ -78,6 +79,9 @@ return {**data, 'ee_pose': change_frame(data['ee_pose'])}
 
 # Good — pose_key is a constructor parameter defaulting to 'ee_pose'
 return {**data, self._pose_key: change_frame(data[self._pose_key])}
+
+# Good — the launcher spells this flag and the subprocess it starts parses it
+command = ['uv', 'run', str(_ENV_SCRIPT), '--host', host, '--cameras', cameras]
 ```
 
 ### overspecific

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -10,7 +10,11 @@ from positronic.simulator.robolab.launcher import serve_robolab
 
 
 @cfn.config(
-    camera_dict={keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera', keys.WRIST_IMAGE: 'wrist_cam'},
+    camera_dict={
+        keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera',
+        keys.EXTERIOR_IMAGE_2: 'over_shoulder_right_camera',
+        keys.WRIST_IMAGE: 'wrist_cam',
+    },
     instruction_type='default',
     trial_count=1,
     timeout=None,

--- a/positronic/cfg/eval/sim/robolab.py
+++ b/positronic/cfg/eval/sim/robolab.py
@@ -9,17 +9,21 @@ from positronic.simulator.robolab.adapter import RobolabAdapter
 from positronic.simulator.robolab.launcher import serve_robolab
 
 
-@cfn.config(
-    camera_dict={
-        keys.EXTERIOR_IMAGE: 'over_shoulder_left_camera',
-        keys.EXTERIOR_IMAGE_2: 'over_shoulder_right_camera',
-        keys.WRIST_IMAGE: 'wrist_cam',
-    },
-    instruction_type='default',
-    trial_count=1,
-    timeout=None,
-)
-def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
+def _camera_dict(cameras: str) -> dict[str, str]:
+    """The wire name each camera of the set takes, keyed as ``camera_dict``.
+
+    A set with one exterior binds it to ``EXTERIOR_IMAGE``, so a two-camera policy reads the same key
+    whichever exterior the run renders.
+    """
+    exteriors = [keys.EXTERIOR_IMAGE, keys.EXTERIOR_IMAGE_2]
+    wire = {}
+    for name in robolab_keys.CAMERA_SETS[cameras]:
+        wire[keys.WRIST_IMAGE if name == robolab_keys.WRIST_CAMERA else exteriors.pop(0)] = name
+    return wire
+
+
+@cfn.config(cameras=robolab_keys.WRIST_LEFT_RIGHT, instruction_type='default', trial_count=1, timeout=None)
+def _robolab_eval(task, instruction_type, trial_count, timeout, cameras):
     """A RoboLab eval: the embodiment proxies a remote RoboLab env, the task carries the scenario.
 
     RoboLab (https://github.com/NVLabs/RoboLab) is NVIDIA's Isaac Lab benchmark: tabletop manipulation
@@ -33,13 +37,17 @@ def _robolab_eval(task, instruction_type, trial_count, timeout, camera_dict):
     when the run starts. The instruction is never pinned: the task reads its language live from the env, which
     reports the resolved instruction in every reset's meta.
 
+    ``cameras`` names the set the run renders, one of ``keys.CAMERA_SETS``: both exteriors and the wrist, or
+    one exterior and the wrist. RoboLab bakes the set into the registered task, so a run holds one set.
+
     positronic launches a single task-agnostic env server in RoboLab's own Isaac Lab interpreter; the proxy
     drives it over the socket and the task name + instruction type ride each trial's reset token. There is no
     per-trial seed: RoboLab's eval path exposes no seed hook, so trial params carry none. The env's live
     subtask progress ``[status, completed, total, score]`` is the privileged ground truth (recorded, never
     fed to the policy).
     """
-    proxy = RemoteEnvControlSystem(RobolabAdapter(camera_dict), serve_robolab())
+    camera_dict = _camera_dict(cameras)
+    proxy = RemoteEnvControlSystem(RobolabAdapter(camera_dict), serve_robolab(cameras))
     # The DROID rig's model (Franka arm + Robotiq 2F-85) rides the env's ``robot_meta`` — the launcher
     # serializes it for the Isaac Lab server, which cannot build it — so nothing model-specific lives here.
     embodiment = remote_franka_embodiment(proxy, camera_dict, descriptor='remote.robolab.droid')

--- a/positronic/simulator/robolab/adapter.py
+++ b/positronic/simulator/robolab/adapter.py
@@ -43,12 +43,6 @@ class RobolabAdapter(WireCommandAdapter):
         state = MujocoFrankaState()
         state.encode(raw_obs['joint_pos'], raw_obs['joint_vel'], ee_pose)
         obs: dict[str, Any] = {keys.ROBOT_STATE: state, keys.GRIP: float(raw_obs['grip'])}
-        # TODO: honour a camera_dict naming any other RoboLab camera. env.py renders only the WRIST_LEFT
-        # preset (over_shoulder_left + wrist) and hard-codes emitting those two, so a request for e.g.
-        # over_shoulder_right_camera raises below. The full fix threads the requested set end-to-end: carry
-        # it in the reset token, have env.py register the matching preset via
-        # ``auto_register_droid_envs(cameras=WRIST_LEFT_RIGHT_HEAD)`` so the extra cameras spawn into
-        # ``image_obs``, and emit ``image_obs`` dynamically instead of the two fixed keys.
         for logical, env_key in self._camera_dict.items():
             if env_key not in raw_obs:
                 rendered = sorted(k for k, v in raw_obs.items() if isinstance(v, np.ndarray) and v.ndim == 3)

--- a/positronic/simulator/robolab/e2e.py
+++ b/positronic/simulator/robolab/e2e.py
@@ -82,7 +82,7 @@ def run_replay(fixture_path: str, *, task: str) -> float:
     """Check the task list, then replay every episode in ``fixture_path``; return the replay success rate."""
     episodes = _load_fixture(fixture_path)
     successes = 0
-    with serve_robolab() as (host, port):
+    with serve_robolab(robolab_keys.WRIST_LEFT) as (host, port):
         conn = EnvConnection(host, port)
         try:
             _check_task_list(conn, task)

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -91,6 +91,7 @@ from robolab.core.environments.factory import get_envs  # noqa: E402
 from robolab.core.environments.runtime import create_env  # noqa: E402
 from robolab.core.logging.results import get_all_env_subtask_infos  # noqa: E402
 from robolab.registrations.droid.auto_env_registrations_jointpos import auto_register_droid_envs  # noqa: E402
+from robolab.registrations.droid.camera_presets import WRIST_LEFT_RIGHT  # noqa: E402
 from robolab.robots.droid import EEF_OFFSET_ROT  # noqa: E402
 
 # Both flags gate recorder construction in the env cfg's ``__post_init__``, so they are set before any
@@ -195,7 +196,7 @@ class RobolabEnv(EnvProtocol):
         if self._env is not None:
             self._env.close()  # release the prior task's env before create_env opens a fresh USD stage
         if task not in self._registered:
-            auto_register_droid_envs(task=[task])
+            auto_register_droid_envs(task=[task], cameras=WRIST_LEFT_RIGHT)
             self._registered.add(task)
         env_name = get_envs(task=task)[0]
         self._env, self._env_cfg = create_env(
@@ -373,8 +374,7 @@ class RobolabEnv(EnvProtocol):
             'eef_pos': proprio['eef_pos'][0].cpu().numpy(),
             'eef_quat': proprio['eef_quat'][0].cpu().numpy(),
             'grip': float(proprio['gripper_pos'][0, 0]),
-            'over_shoulder_left_camera': images['over_shoulder_left_camera'][0].cpu().numpy(),
-            'wrist_cam': images['wrist_cam'][0].cpu().numpy(),
+            **{name: frame[0].cpu().numpy() for name, frame in images.items()},
             'subtask': subtask,
         }
 

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -17,6 +17,9 @@ frame.
 The reset token carries the RoboLab env name and the instruction variant; the env builds that task on the
 first reset and caches it, rebuilding only when the key changes. There is no seed anywhere: RoboLab's eval
 path has no seed hook, so a recorded seed would only mislead.
+
+``--cameras`` names the set in ``keys.CAMERA_SETS`` this server renders. RoboLab bakes the set into the
+registered task, so one server serves one set and the token carries no camera.
 """
 
 import argparse
@@ -28,6 +31,7 @@ from contextlib import AbstractContextManager, nullcontext
 from typing import Any
 
 import cv2  # noqa: F401 -- robolab requires cv2 imported before isaaclab
+import keys
 import numpy as np
 import torch
 from isaaclab.app import AppLauncher
@@ -70,6 +74,7 @@ except ImportError:
 parser = argparse.ArgumentParser(description='Serve RoboLab over the env-server protocol.')
 parser.add_argument('--host', default='localhost')
 parser.add_argument('--port', type=int)
+parser.add_argument('--cameras', default=keys.WRIST_LEFT_RIGHT, choices=sorted(keys.CAMERA_SETS))
 AppLauncher.add_app_launcher_args(parser)
 args, _ = parser.parse_known_args()
 args.enable_cameras = True  # not a CLI flag: every robolab runner forces it (the image obs need rendering)
@@ -90,8 +95,10 @@ import robolab.constants  # noqa: E402
 from robolab.core.environments.factory import get_envs  # noqa: E402
 from robolab.core.environments.runtime import create_env  # noqa: E402
 from robolab.core.logging.results import get_all_env_subtask_infos  # noqa: E402
+
+# robolab resolves from its own uv project at run time, so the checker cannot see this module.
+from robolab.registrations.droid import camera_presets  # noqa: E402  # pyright: ignore[reportMissingImports]
 from robolab.registrations.droid.auto_env_registrations_jointpos import auto_register_droid_envs  # noqa: E402
-from robolab.registrations.droid.camera_presets import WRIST_LEFT_RIGHT  # noqa: E402
 from robolab.robots.droid import EEF_OFFSET_ROT  # noqa: E402
 
 # Both flags gate recorder construction in the env cfg's ``__post_init__``, so they are set before any
@@ -196,7 +203,14 @@ class RobolabEnv(EnvProtocol):
         if self._env is not None:
             self._env.close()  # release the prior task's env before create_env opens a fresh USD stage
         if task not in self._registered:
-            auto_register_droid_envs(task=[task], cameras=WRIST_LEFT_RIGHT)
+            # RoboLab's presets hold the camera cfg classes; ``keys.CAMERA_SETS`` names the same sets on
+            # the wire, and the adapter raises when a run asks for a camera the server does not render.
+            presets = {
+                keys.WRIST_LEFT_RIGHT: camera_presets.WRIST_LEFT_RIGHT,
+                keys.WRIST_LEFT: camera_presets.WRIST_LEFT,
+                keys.WRIST_RIGHT: camera_presets.WRIST_RIGHT,
+            }
+            auto_register_droid_envs(task=[task], cameras=presets[args.cameras])
             self._registered.add(task)
         env_name = get_envs(task=task)[0]
         self._env, self._env_cfg = create_env(

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -74,7 +74,7 @@ except ImportError:
 parser = argparse.ArgumentParser(description='Serve RoboLab over the env-server protocol.')
 parser.add_argument('--host', default='localhost')
 parser.add_argument('--port', type=int)
-parser.add_argument(keys.CAMERAS_FLAG, default=keys.WRIST_LEFT_RIGHT, choices=sorted(keys.CAMERA_SETS))
+parser.add_argument('--cameras', default=keys.WRIST_LEFT_RIGHT, choices=sorted(keys.CAMERA_SETS))
 AppLauncher.add_app_launcher_args(parser)
 args, _ = parser.parse_known_args()
 args.enable_cameras = True  # not a CLI flag: every robolab runner forces it (the image obs need rendering)

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -74,7 +74,7 @@ except ImportError:
 parser = argparse.ArgumentParser(description='Serve RoboLab over the env-server protocol.')
 parser.add_argument('--host', default='localhost')
 parser.add_argument('--port', type=int)
-parser.add_argument('--cameras', default=keys.WRIST_LEFT_RIGHT, choices=sorted(keys.CAMERA_SETS))
+parser.add_argument(keys.CAMERAS_FLAG, default=keys.WRIST_LEFT_RIGHT, choices=sorted(keys.CAMERA_SETS))
 AppLauncher.add_app_launcher_args(parser)
 args, _ = parser.parse_known_args()
 args.enable_cameras = True  # not a CLI flag: every robolab runner forces it (the image obs need rendering)

--- a/positronic/simulator/robolab/env.py
+++ b/positronic/simulator/robolab/env.py
@@ -203,8 +203,6 @@ class RobolabEnv(EnvProtocol):
         if self._env is not None:
             self._env.close()  # release the prior task's env before create_env opens a fresh USD stage
         if task not in self._registered:
-            # RoboLab's presets hold the camera cfg classes; ``keys.CAMERA_SETS`` names the same sets on
-            # the wire, and the adapter raises when a run asks for a camera the server does not render.
             presets = {
                 keys.WRIST_LEFT_RIGHT: camera_presets.WRIST_LEFT_RIGHT,
                 keys.WRIST_LEFT: camera_presets.WRIST_LEFT,

--- a/positronic/simulator/robolab/keys.py
+++ b/positronic/simulator/robolab/keys.py
@@ -1,6 +1,26 @@
-"""The keys of a RoboLab task record and of the trial params the eval config owns."""
+"""The keys of a RoboLab task record, of the trial params the eval config owns, and the env's camera names.
+
+The env server runs in RoboLab's own interpreter and cannot import positronic, so it reads this module as a
+top-level ``keys`` from its own directory. The eval config reads it as ``positronic.simulator.robolab.keys``.
+"""
 
 # The seconds RoboLab gives an episode of this task; the eval config sets the trial's deadline from it.
 EPISODE_LENGTH = 'eval.episode_length'
 # The phrasing of the instruction, which the eval config owns and ``_reset_token`` reads back.
 INSTRUCTION_TYPE = 'eval.instruction_type'
+
+# The cameras RoboLab renders, named as the env's ``image_obs`` group names them.
+OVER_SHOULDER_LEFT_CAMERA = 'over_shoulder_left_camera'
+OVER_SHOULDER_RIGHT_CAMERA = 'over_shoulder_right_camera'
+WRIST_CAMERA = 'wrist_cam'
+
+# The camera sets a run picks from. The env registers one set for its whole life, because RoboLab bakes the
+# set into the registered task, so a change needs a fresh USD stage. The names follow RoboLab's own presets.
+WRIST_LEFT_RIGHT = 'wrist_left_right'
+WRIST_LEFT = 'wrist_left'
+WRIST_RIGHT = 'wrist_right'
+CAMERA_SETS = {
+    WRIST_LEFT_RIGHT: (OVER_SHOULDER_LEFT_CAMERA, OVER_SHOULDER_RIGHT_CAMERA, WRIST_CAMERA),
+    WRIST_LEFT: (OVER_SHOULDER_LEFT_CAMERA, WRIST_CAMERA),
+    WRIST_RIGHT: (OVER_SHOULDER_RIGHT_CAMERA, WRIST_CAMERA),
+}

--- a/positronic/simulator/robolab/keys.py
+++ b/positronic/simulator/robolab/keys.py
@@ -1,7 +1,4 @@
-"""What the eval config, the launcher and the env server must spell the same way.
-
-The keys of a RoboLab task record and of the trial params, the env's camera names and sets, and the flag
-that carries the set to the server.
+"""The keys of a RoboLab task record, of the trial params the eval config owns, and the env's camera names.
 
 The env server runs in RoboLab's own interpreter and cannot import positronic, so it reads this module as a
 top-level ``keys`` from its own directory. The eval config reads it as ``positronic.simulator.robolab.keys``.
@@ -26,6 +23,3 @@ CAMERA_SETS = {
     WRIST_LEFT: (OVER_SHOULDER_LEFT_CAMERA, WRIST_CAMERA),
     WRIST_RIGHT: (OVER_SHOULDER_RIGHT_CAMERA, WRIST_CAMERA),
 }
-
-# The flag the launcher spells and the server parses to carry the set name.
-CAMERAS_FLAG = '--cameras'

--- a/positronic/simulator/robolab/keys.py
+++ b/positronic/simulator/robolab/keys.py
@@ -1,4 +1,7 @@
-"""The keys of a RoboLab task record, of the trial params the eval config owns, and the env's camera names.
+"""What the eval config, the launcher and the env server must spell the same way.
+
+The keys of a RoboLab task record and of the trial params, the env's camera names and sets, and the flag
+that carries the set to the server.
 
 The env server runs in RoboLab's own interpreter and cannot import positronic, so it reads this module as a
 top-level ``keys`` from its own directory. The eval config reads it as ``positronic.simulator.robolab.keys``.
@@ -14,8 +17,7 @@ OVER_SHOULDER_LEFT_CAMERA = 'over_shoulder_left_camera'
 OVER_SHOULDER_RIGHT_CAMERA = 'over_shoulder_right_camera'
 WRIST_CAMERA = 'wrist_cam'
 
-# The camera sets a run picks from. The env registers one set for its whole life, because RoboLab bakes the
-# set into the registered task, so a change needs a fresh USD stage. The names follow RoboLab's own presets.
+# The camera sets a run picks from. The names follow RoboLab's own presets.
 WRIST_LEFT_RIGHT = 'wrist_left_right'
 WRIST_LEFT = 'wrist_left'
 WRIST_RIGHT = 'wrist_right'
@@ -24,3 +26,6 @@ CAMERA_SETS = {
     WRIST_LEFT: (OVER_SHOULDER_LEFT_CAMERA, WRIST_CAMERA),
     WRIST_RIGHT: (OVER_SHOULDER_RIGHT_CAMERA, WRIST_CAMERA),
 }
+
+# The flag the launcher spells and the server parses to carry the set name.
+CAMERAS_FLAG = '--cameras'

--- a/positronic/simulator/robolab/launcher.py
+++ b/positronic/simulator/robolab/launcher.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from positronic.drivers.roboarm.models import bundled_franka_model
 from positronic.simulator.env_server.launcher import ensure_pinned_checkout, serve_subprocess
 from positronic.simulator.env_server.protocol import encode
+from positronic.simulator.robolab import keys as robolab_keys
 
 _ENV_SCRIPT = Path(__file__).parent / 'env.py'
 _ENV_SERVER_DIR = Path(__file__).parents[1] / 'env_server'
@@ -88,7 +89,7 @@ def _spawn(host: str, port: int, cameras: str) -> subprocess.Popen:
         host,
         '--port',
         str(port),
-        '--cameras',
+        robolab_keys.CAMERAS_FLAG,
         cameras,
         '--headless',
     ]

--- a/positronic/simulator/robolab/launcher.py
+++ b/positronic/simulator/robolab/launcher.py
@@ -13,6 +13,7 @@ import subprocess
 import tempfile
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
+from functools import partial
 from pathlib import Path
 
 from positronic.drivers.roboarm.models import bundled_franka_model
@@ -66,7 +67,7 @@ def _checkout_lock() -> Iterator[None]:
         yield
 
 
-def _spawn(host: str, port: int) -> subprocess.Popen:
+def _spawn(host: str, port: int, cameras: str) -> subprocess.Popen:
     with _checkout_lock():
         src = _ensure_robolab_src()
         # Install the dependency stack before spawning: a cold first install (~15 GB of Isaac wheels) far
@@ -87,6 +88,8 @@ def _spawn(host: str, port: int) -> subprocess.Popen:
         host,
         '--port',
         str(port),
+        '--cameras',
+        cameras,
         '--headless',
     ]
     # The DROID rig's model (URDF + meshes + gripper) for the viewer and offline IK. env.py runs in RoboLab's
@@ -109,6 +112,10 @@ def _spawn(host: str, port: int) -> subprocess.Popen:
     return subprocess.Popen(command, env=env)
 
 
-def serve_robolab(host: str = 'localhost') -> AbstractContextManager[tuple[str, int]]:
-    """The RoboLab env server as a ``serve`` context manager (the ``serve_subprocess`` contract)."""
-    return serve_subprocess(_spawn, host)
+def serve_robolab(cameras: str, host: str = 'localhost') -> AbstractContextManager[tuple[str, int]]:
+    """The RoboLab env server as a ``serve`` context manager (the ``serve_subprocess`` contract).
+
+    ``cameras`` names the set in ``keys.CAMERA_SETS`` the server renders; RoboLab bakes it into the
+    registered task, so one server serves one set.
+    """
+    return serve_subprocess(partial(_spawn, cameras=cameras), host)

--- a/positronic/simulator/robolab/launcher.py
+++ b/positronic/simulator/robolab/launcher.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from positronic.drivers.roboarm.models import bundled_franka_model
 from positronic.simulator.env_server.launcher import ensure_pinned_checkout, serve_subprocess
 from positronic.simulator.env_server.protocol import encode
-from positronic.simulator.robolab import keys as robolab_keys
 
 _ENV_SCRIPT = Path(__file__).parent / 'env.py'
 _ENV_SERVER_DIR = Path(__file__).parents[1] / 'env_server'
@@ -89,7 +88,7 @@ def _spawn(host: str, port: int, cameras: str) -> subprocess.Popen:
         host,
         '--port',
         str(port),
-        robolab_keys.CAMERAS_FLAG,
+        '--cameras',
         cameras,
         '--headless',
     ]

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -65,6 +65,7 @@ _OBS_SPECS = {
     'eef_pos': ((3,), np.float32),
     'eef_quat': ((4,), np.float32),
     'over_shoulder_left_camera': ((720, 1280, 3), np.uint8),
+    'over_shoulder_right_camera': ((720, 1280, 3), np.uint8),
     'wrist_cam': ((720, 1280, 3), np.uint8),
     'subtask': ((4,), np.float32),
 }

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -32,7 +32,7 @@ import numpy as np
 import torch
 
 # Importing ``env`` launches the Isaac app — a precondition for every isaaclab/robolab import below.
-from env import RobolabEnv, simulation_app
+from env import RobolabEnv, args, simulation_app
 from isaaclab.utils.math import matrix_from_quat, quat_apply, quat_inv, quat_mul
 
 from robolab.robots.droid import EEF_OFFSET_ROT
@@ -60,14 +60,13 @@ _FLANGE_TO_EEF_QUAT = (-0.707106781, 0.0, 0.0, -0.707106781)
 _FRAME_POS_TOL = 1e-4  # m — float32 body poses, so well above round-off and far below a real geometry change
 _FRAME_ROT_TOL = math.radians(0.05)
 
+# The cameras follow ``--cameras``, so a run of any set checks the set that run renders.
 _OBS_SPECS = {
     'joint_pos': ((7,), np.float32),
     'joint_vel': ((7,), np.float32),
     'eef_pos': ((3,), np.float32),
     'eef_quat': ((4,), np.float32),
-    keys.OVER_SHOULDER_LEFT_CAMERA: ((720, 1280, 3), np.uint8),
-    keys.OVER_SHOULDER_RIGHT_CAMERA: ((720, 1280, 3), np.uint8),
-    keys.WRIST_CAMERA: ((720, 1280, 3), np.uint8),
+    **dict.fromkeys(keys.CAMERA_SETS[args.cameras], ((720, 1280, 3), np.uint8)),
     'subtask': ((4,), np.float32),
 }
 

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -27,6 +27,7 @@ Run on a RoboLab-capable box the same way the launcher runs ``env.py`` (AppLaunc
 import math
 import sys
 
+import keys
 import numpy as np
 import torch
 
@@ -64,9 +65,9 @@ _OBS_SPECS = {
     'joint_vel': ((7,), np.float32),
     'eef_pos': ((3,), np.float32),
     'eef_quat': ((4,), np.float32),
-    'over_shoulder_left_camera': ((720, 1280, 3), np.uint8),
-    'over_shoulder_right_camera': ((720, 1280, 3), np.uint8),
-    'wrist_cam': ((720, 1280, 3), np.uint8),
+    keys.OVER_SHOULDER_LEFT_CAMERA: ((720, 1280, 3), np.uint8),
+    keys.OVER_SHOULDER_RIGHT_CAMERA: ((720, 1280, 3), np.uint8),
+    keys.WRIST_CAMERA: ((720, 1280, 3), np.uint8),
     'subtask': ((4,), np.float32),
 }
 

--- a/positronic/simulator/robolab/validate.py
+++ b/positronic/simulator/robolab/validate.py
@@ -109,9 +109,11 @@ def _check_obs_contract(env: RobolabEnv) -> None:
             assert isinstance(arr, np.ndarray) and arr.shape == shape and arr.dtype == dtype, (
                 f'{key}: {type(arr).__name__} shape={getattr(arr, "shape", None)} dtype={getattr(arr, "dtype", None)}'
             )
+        rendered = {k for k, v in obs.items() if isinstance(v, np.ndarray) and v.ndim == 3}
+        assert rendered == set(keys.CAMERA_SETS[args.cameras]), f'rendered cameras {sorted(rendered)}'
         assert isinstance(obs['grip'], float) and 0.0 <= obs['grip'] <= 1.0, f'grip {obs["grip"]!r}'
         assert abs(float(np.linalg.norm(obs['eef_quat'])) - 1.0) < 1e-3, f'eef_quat norm {obs["eef_quat"]}'
-    print('  obs contract: OK (keys, shapes, dtypes, quat norm, grip range)')
+    print('  obs contract: OK (keys, camera set, shapes, dtypes, quat norm, grip range)')
 
 
 def _check_grip(env: RobolabEnv) -> None:


### PR DESCRIPTION
Supersedes #708, whose head branch lives on a fork this account cannot push to. It carries that PR's commit plus the follow-up that answers both Codex findings.

## Summary
- A RoboLab eval takes `cameras`, one of `keys.CAMERA_SETS`: `wrist_left_right`, `wrist_left` or `wrist_right`. `wrist_left_right` renders both over-shoulder cameras and the wrist; the other two render one exterior and the wrist.
- `serve_robolab` passes the set name to `env.py` as `--cameras`, and `_build` registers the matching RoboLab preset. A two-camera run renders two cameras and sends two frames, instead of rendering three and dropping one client-side.
- `positronic/simulator/robolab/keys.py` names the RoboLab cameras and the sets. The module imports nothing, so `env.py` and `validate.py` read it as a top-level `keys` from their own directory, and the eval config reads it as a package.
- `_observe` emits `image_obs` as the env reports it, so a camera reaches the adapter without a further change here.
- A set with one exterior binds it to `image.exterior`. A two-camera policy therefore reads the same key whichever exterior the run renders. `wrist_left_right` adds `image.exterior_2`, which `keys.EXTERIOR_IMAGE_2` already names for the DROID rig (#710).

A run holds one set: `auto_register_droid_envs` bakes the cameras into the registered task, so a change needs a fresh USD stage. The reset token carries no camera.

## Test plan
- `uv run --locked pytest` — 1809 passed, 8 skipped.
- `uv run --locked ruff check` and `ruff format` — clean.
- `check-rules` over the change: `earn-its-place` and `stranded-definition` findings fixed. `primitive-type` asks for an enum, which `positronic/tests/test_keys.py::test_keys_modules_import_nothing` forbids in a `keys.py`; `instruction_type` is the adjacent three-valued string parameter.
- Two episodes of `.sim.robolab.banana_in_bowl` on an L40S against a MolmoAct2 `droid_3cam` server, on the three-camera set: both reported `eval.success`. Each episode recorded `image.exterior`, `image.exterior_2` and `image.wrist`; the two exteriors share no identical frame (mean absolute difference 79 per pixel over 142 frames), so the second exterior is a separate view.
- Not run: `validate.py` and the two-camera sets on real Isaac Sim.
