### PR TITLE
Build the export's recordings on worker threads and thin the videos too

### DIFF
--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -367,9 +367,9 @@ def _encode_frames_as_video(entity_path: str, sig, max_resolution: int, max_hz: 
 _DOWNSCALE_OPTIONS = {'crf': '28', 'preset': 'veryfast'}
 
 
-def _mp4_downscaled_to(src: Path, max_resolution: int, kept: np.ndarray | None = None) -> bytes:
-    """Re-encode ``src`` with its long side at most ``max_resolution`` and only the frames at the indexes in
-    ``kept``, or return it unchanged if it fits and ``kept`` is None."""
+def _mp4_reduced_to(src: Path, max_resolution: int, kept: np.ndarray | None = None) -> bytes:
+    """``src`` re-encoded to at most ``max_resolution`` on the long side and to the frames at the indexes in
+    ``kept``; unchanged when it fits and ``kept`` is None."""
     with av.open(str(src)) as inp:
         in_stream = inp.streams.video[0]
         source = (in_stream.codec_context.width, in_stream.codec_context.height)
@@ -410,7 +410,7 @@ def _log_video_signals(
         if isinstance(sig, VideoSignal):
             our_ts = np.asarray(sig.keys(), dtype='datetime64[ns]')
             kept = _decimation_indices(our_ts, max_hz)
-            video_bytes = _mp4_downscaled_to(sig.video_path, max_resolution, kept if len(kept) < len(our_ts) else None)
+            video_bytes = _mp4_reduced_to(sig.video_path, max_resolution, kept if len(kept) < len(our_ts) else None)
             asset = rr.AssetVideo(contents=video_bytes, media_type='video/mp4')
             rr.log(name, asset, static=True)
 

--- a/positronic/server/dataset_utils.py
+++ b/positronic/server/dataset_utils.py
@@ -328,7 +328,7 @@ def _size_capped_to(width: int, height: int, max_resolution: int) -> tuple[int, 
     return max(_MIN_ENCODED_SIDE, int(width * scale) // 2 * 2), max(_MIN_ENCODED_SIDE, int(height * scale) // 2 * 2)
 
 
-def _encode_frames_as_video(entity_path: str, sig, max_resolution: int) -> None:
+def _encode_frames_as_video(entity_path: str, sig, max_resolution: int, max_hz: float) -> None:
     codec = rr.VideoCodec.H265
     container = av.open('/dev/null', 'w', format='hevc')
 
@@ -344,6 +344,7 @@ def _encode_frames_as_video(entity_path: str, sig, max_resolution: int) -> None:
     first_frame = np.asarray(sig[0][0])
     h, w = first_frame.shape[:2]
     width, height = _size_capped_to(w, h, max_resolution)
+    kept = set(_decimation_indices(np.asarray(sig.keys(), dtype='datetime64[ns]'), max_hz).tolist())
     stream = cast(VideoStream, container.add_stream('libx265', rate=30))
     stream.width = width
     stream.height = height
@@ -352,12 +353,12 @@ def _encode_frames_as_video(entity_path: str, sig, max_resolution: int) -> None:
 
     rr.log(entity_path, rr.VideoStream(codec=codec), static=True)
 
-    for index, (val, ts) in enumerate(sig):
+    for position, (val, ts) in enumerate(sample for index, sample in enumerate(sig) if index in kept):
         frame = av.VideoFrame.from_ndarray(np.asarray(val), format='rgb24')
         if (width, height) != (w, h):
             frame = frame.reformat(width=width, height=height)
-        frame.pts, frame.time_base = index, _FRAME_INDEX_TIME_BASE
-        times_by_pts[index] = ts
+        frame.pts, frame.time_base = position, _FRAME_INDEX_TIME_BASE
+        times_by_pts[position] = ts
         _log_encoded(stream.encode(frame))
 
     _log_encoded(stream.encode())
@@ -366,14 +367,16 @@ def _encode_frames_as_video(entity_path: str, sig, max_resolution: int) -> None:
 _DOWNSCALE_OPTIONS = {'crf': '28', 'preset': 'veryfast'}
 
 
-def _mp4_downscaled_to(src: Path, max_resolution: int) -> bytes:
-    """Re-encode ``src`` with its long side at most ``max_resolution``, or return it unchanged if it fits."""
+def _mp4_downscaled_to(src: Path, max_resolution: int, kept: np.ndarray | None = None) -> bytes:
+    """Re-encode ``src`` with its long side at most ``max_resolution`` and only the frames at the indexes in
+    ``kept``, or return it unchanged if it fits and ``kept`` is None."""
     with av.open(str(src)) as inp:
         in_stream = inp.streams.video[0]
         source = (in_stream.codec_context.width, in_stream.codec_context.height)
         # Odd sides pass through; evening them here would re-encode every source that already fits.
-        if max(source) <= max_resolution:
+        if max(source) <= max_resolution and kept is None:
             return src.read_bytes()
+        wanted = None if kept is None else set(kept.tolist())
         width, height = _size_capped_to(*source, max_resolution)
 
         buffer = io.BytesIO()
@@ -387,7 +390,9 @@ def _mp4_downscaled_to(src: Path, max_resolution: int) -> bytes:
             out_stream.max_b_frames = 0
             out_stream.options = dict(_DOWNSCALE_OPTIONS)
 
-            for frame in inp.decode(in_stream):
+            for index, frame in enumerate(inp.decode(in_stream)):
+                if wanted is not None and index not in wanted:
+                    continue
                 scaled = frame.reformat(width=width, height=height, format='yuv420p')
                 scaled.pts, scaled.time_base = frame.pts, frame.time_base
                 out.mux(out_stream.encode(scaled))
@@ -397,25 +402,26 @@ def _mp4_downscaled_to(src: Path, max_resolution: int) -> bytes:
 
 
 def _log_video_signals(
-    ep: Episode, signals: EpisodeSignals, drainer: _BinaryStreamDrainer, max_resolution: int
+    ep: Episode, signals: EpisodeSignals, drainer: _BinaryStreamDrainer, max_resolution: int, max_hz: float
 ) -> Iterator[bytes]:
     """Log video signals as AssetVideo + VideoFrameReference (columnar), or as individual images."""
     for name in signals.videos:
         sig = ep.signals[name]
         if isinstance(sig, VideoSignal):
-            video_bytes = _mp4_downscaled_to(sig.video_path, max_resolution)
+            our_ts = np.asarray(sig.keys(), dtype='datetime64[ns]')
+            kept = _decimation_indices(our_ts, max_hz)
+            video_bytes = _mp4_downscaled_to(sig.video_path, max_resolution, kept if len(kept) < len(our_ts) else None)
             asset = rr.AssetVideo(contents=video_bytes, media_type='video/mp4')
             rr.log(name, asset, static=True)
 
-            our_ts = np.asarray(sig.keys(), dtype='datetime64[ns]')
             frame_pts_ns = asset.read_frame_timestamps_nanos()
             rr.send_columns(
                 name,
-                indexes=[rr.TimeColumn('time', timestamp=our_ts)],
+                indexes=[rr.TimeColumn('time', timestamp=our_ts[kept])],
                 columns=rr.VideoFrameReference.columns_nanos(frame_pts_ns),
             )
         else:
-            _encode_frames_as_video(name, sig, max_resolution)
+            _encode_frames_as_video(name, sig, max_resolution, max_hz)
         yield from drainer.drain()
 
 
@@ -651,7 +657,8 @@ def stream_episode_rrd(
 ) -> Iterator[bytes]:
     """Yield an episode RRD as chunks while it is being generated.
 
-    ``max_hz=0`` with a resolution above the source keeps the recording as it was captured.
+    The videos and the numeric signals are thinned to ``max_hz``; ``max_hz=0`` with a resolution above the
+    source keeps the recording as it was captured.
     """
 
     ep = ds[episode_id]
@@ -675,7 +682,7 @@ def stream_episode_rrd(
         _setup_series_names(signals, ep)
         yield from drainer.drain()
 
-        yield from _log_video_signals(ep, signals, drainer, max_resolution)
+        yield from _log_video_signals(ep, signals, drainer, max_resolution, max_hz)
         pose_data = yield from _log_numeric_signals(ep, signals, drainer, max_hz)
         yield from drainer.drain(force=True)  # flush numerics to client before slow pose trails
         yield from _log_pose_signals(ep, signals, pose_data, drainer)

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -14,6 +14,7 @@ import shutil
 import tempfile
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import asdict, dataclass
+from multiprocessing.pool import ThreadPool
 from pathlib import Path, PurePosixPath
 from typing import cast
 from urllib.parse import quote
@@ -73,6 +74,8 @@ MAX_FILTER_KEYS_PER_GROUP = 6
 MAX_FILTER_SETS_PER_GROUP = 1024
 # The object key limit of an S3-style host.
 MAX_KEY_BYTES = 1024
+# A recording's build holds about two cores, so this many at once fill the machine.
+DEFAULT_WORKERS = max(1, (os.cpu_count() or 2) // 2)
 # Windows reports no path limit; its `MAX_PATH` counts UTF-16 units, the end mark included, unless a machine opts
 # into long paths.
 _REPORTS_PATH_MAX = hasattr(os, 'pathconf')
@@ -386,6 +389,22 @@ def _full_checked_against(full: Dataset, shown: Dataset) -> Dataset:
     return full
 
 
+def _build_recordings(reads: Dataset, workers: int) -> None:
+    """Build the recording of each episode of `reads` into the cache, `workers` at a time, with the app serving
+    `reads`; one worker leaves each recording to the write that copies it.
+
+    The workers are threads: the decoder and the encoder release the interpreter lock, and a forked worker
+    hangs on the threads a recording built earlier in the process leaves behind.
+    """
+    if workers < 1:
+        raise ValueError(f'workers={workers}; a recording is built by at least one')
+    if workers == 1:
+        return
+    install_dataset(reads)
+    with ThreadPool(workers) as pool:
+        pool.map(ensure_episode_rrd, range(len(reads)), chunksize=1)
+
+
 def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
     """Write each of `plans` with the app serving the dataset it reads."""
     serving: Dataset | None = None
@@ -442,14 +461,15 @@ def export_static(
     full_dataset: Dataset | None = None,
     assets: bool = True,
     scratch_dir: Path | None = None,
+    workers: int = DEFAULT_WORKERS,
 ) -> list[ExportedFile]:
     """Write the viewer for `dataset` under `out_dir` and give back every file written.
 
     The pages and the tables read `dataset`. The recordings and the downloads read `full_dataset`
     when given, which holds the same episodes in the same order; the recording builder reads an
-    episode's robot model out of its static values. The recordings are built in a directory of this
-    export's own under `scratch_dir`, the system's temporary directory when None, copied in from
-    there, and the directory is removed at the end. `assets` writes the app's own scripts, styles
+    episode's robot model out of its static values. The recordings are built `workers` at a time in a
+    directory of this export's own under `scratch_dir`, the system's temporary directory when None,
+    copied in from there, and the directory is removed at the end. `assets` writes the app's own scripts, styles
     and viewer under `static/`, which the pages request at the host root, so it goes with the root
     base href only; an export under a prefix shares the host's copy. An export holds the app's state
     for its duration, so a second export in the process waits for it; one into the same directory is
@@ -496,6 +516,7 @@ def export_static(
         ]
         asset_files = _asset_files() if assets else []
         out.plan(itertools.chain((planned.path for planned in plans), (path for path, _ in asset_files)))
+        _build_recordings(full, workers)
         _write_serving(out, plans)
     for path, file in asset_files:
         out.copy(path, file)
@@ -517,6 +538,7 @@ def main(
     show_paths: bool = False,
     build_id: str = '',
     assets: bool = True,
+    workers: int = DEFAULT_WORKERS,
 ):
     """Write the viewer for a Dataset as static files, for any static host.
 
@@ -525,7 +547,7 @@ def main(
         out_dir: Directory the files are written under; it is created
         ep_table_cfg: Columns of the episode table, by static key
         max_resolution: Long side an episode's videos are re-encoded down to
-        max_hz: Rate an episode's numeric signals are thinned to; 0 keeps every sample
+        max_hz: Rate an episode's videos and numeric signals are thinned to; 0 keeps every frame and sample
         group_tables: Grouped tables, by name
         home_page: The group table served at the root, or None for the episodes
         base_href: Path at the host root the export is served under
@@ -533,6 +555,7 @@ def main(
         show_paths: Whether the pages report where the dataset lives
         build_id: Names one build; the recordings and the downloads are written under `build/<build_id>/`
         assets: Whether to write the app's own assets under `static/`; with the root base href only
+        workers: Recordings built at once; half the machine's cores by default
     """
     written = export_static(
         dataset,
@@ -547,6 +570,7 @@ def main(
         show_paths=show_paths,
         build_id=build_id,
         assets=assets,
+        workers=workers,
     )
     logging.info(f'{len(written)} files, {sum(file.size for file in written) / 1e6:.1f} MB, under {out_dir}')
 

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -74,8 +74,17 @@ MAX_FILTER_KEYS_PER_GROUP = 6
 MAX_FILTER_SETS_PER_GROUP = 1024
 # The object key limit of an S3-style host.
 MAX_KEY_BYTES = 1024
+
+
+def _available_cpus() -> int:
+    """The CPUs this process may run on; a cgroup quota without a cpuset is not visible to a process."""
+    if hasattr(os, 'sched_getaffinity'):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 2
+
+
 # A recording's build holds about two cores, so this many at once fill the machine.
-DEFAULT_WORKERS = max(1, (os.cpu_count() or 2) // 2)
+DEFAULT_WORKERS = max(1, _available_cpus() // 2)
 # Windows reports no path limit; its `MAX_PATH` counts UTF-16 units, the end mark included, unless a machine opts
 # into long paths.
 _REPORTS_PATH_MAX = hasattr(os, 'pathconf')
@@ -389,22 +398,6 @@ def _full_checked_against(full: Dataset, shown: Dataset) -> Dataset:
     return full
 
 
-def _build_recordings(reads: Dataset, workers: int) -> None:
-    """Build the recording of each episode of `reads` into the cache, `workers` at a time, with the app serving
-    `reads`; one worker leaves each recording to the write that copies it.
-
-    The workers are threads: the decoder and the encoder release the interpreter lock, and a forked worker
-    hangs on the threads a recording built earlier in the process leaves behind.
-    """
-    if workers < 1:
-        raise ValueError(f'workers={workers}; a recording is built by at least one')
-    if workers == 1:
-        return
-    install_dataset(reads)
-    with ThreadPool(workers) as pool:
-        pool.map(ensure_episode_rrd, range(len(reads)), chunksize=1)
-
-
 def _write_serving(out: _Output, plans: Iterable[_Planned]) -> None:
     """Write each of `plans` with the app serving the dataset it reads."""
     serving: Dataset | None = None
@@ -443,6 +436,24 @@ def _filter_sets_by_group(
                 f'group table {name!r} has {past_bound}; an export reads the dataset once per set'
             ) from None
     return sets_by_group
+
+
+def _build_recordings(reads: Dataset, workers: int) -> None:
+    """Build the recording of each episode of `reads` into the cache, `workers` at a time, with the app serving
+    `reads`; one worker builds them on the calling thread.
+
+    The workers are threads: the decoder and the encoder release the interpreter lock, and a forked worker
+    hangs on the threads a recording built earlier in the process leaves behind.
+    """
+    if workers < 1:
+        raise ValueError(f'workers={workers}; a recording is built by at least one')
+    install_dataset(reads)
+    if workers == 1:
+        for index in range(len(reads)):
+            ensure_episode_rrd(index)
+        return
+    with ThreadPool(workers) as pool:
+        pool.map(ensure_episode_rrd, range(len(reads)), chunksize=1)
 
 
 def export_static(

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -976,9 +976,10 @@ def configure_tables(
 
     `ep_table_cfg` maps an episode's static keys to the columns of the episode table. `group_tables` holds
     each grouped table by name, and `home_page` names the one served at the root, or None for the episodes.
-    A recording's videos are re-encoded down to `max_resolution` on the long side, and its numeric signals
-    are thinned to `max_hz`; 0 keeps every sample. `root` is the dataset path the pages report, and the
-    recordings are cached under `cache_dir`. A table response cached under the previous settings is dropped.
+    A recording's videos are re-encoded down to `max_resolution` on the long side, and its videos and its
+    numeric signals are thinned to `max_hz`; 0 keeps every frame and every sample. `root` is the dataset
+    path the pages report, and the recordings are cached under `cache_dir`. A table response cached under
+    the previous settings is dropped.
     """
     episode_columns = set(ep_table_cfg or {})
     for name, cfg in (group_tables or {}).items():
@@ -1038,7 +1039,7 @@ def main(
     Args:
         dataset: Dataset to visualize
         max_resolution: Long side an episode RRD's videos are re-encoded down to
-        max_hz: Rate an episode RRD's numeric signals are thinned to; 0 keeps every sample
+        max_hz: Rate an episode RRD's videos and numeric signals are thinned to; 0 keeps every frame and sample
         cache_dir: Directory to cache generated RRD files
         host: Server host
         port: Server port

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -15,7 +15,7 @@ from positronic.server.dataset_utils import (
     _MAX_PLOTTED_WIDTH,
     _collect_signal_groups,
     _decimation_indices,
-    _mp4_downscaled_to,
+    _mp4_reduced_to,
     _size_capped_to,
     _unplotted_notice,
     _write_urdf_to_dir,
@@ -235,14 +235,14 @@ def test_a_cap_an_encoder_cannot_carry_is_refused():
 def test_a_video_within_the_cap_is_embedded_as_recorded(tmp_path):
     src = _write_mp4(tmp_path / 'small.mp4', width=320, height=240, frames=12)
 
-    assert _mp4_downscaled_to(src, max_resolution=640) == src.read_bytes()
+    assert _mp4_reduced_to(src, max_resolution=640) == src.read_bytes()
 
 
 def test_a_video_keeps_the_frames_named_at_their_own_times(tmp_path):
     src = _write_mp4(tmp_path / 'small.mp4', width=320, height=240, frames=12)
     kept = np.array([0, 3, 6, 9])
 
-    thinned = _mp4_downscaled_to(src, max_resolution=640, kept=kept)
+    thinned = _mp4_reduced_to(src, max_resolution=640, kept=kept)
 
     source_times = _frame_times(src.read_bytes())
     assert _frame_times(thinned) == pytest.approx([source_times[index] for index in kept], abs=1e-4)
@@ -252,7 +252,7 @@ def test_a_video_keeps_the_frames_named_at_their_own_times(tmp_path):
 def test_a_larger_video_is_re_encoded_frame_for_frame(tmp_path):
     src = _write_mp4(tmp_path / 'big.mp4', width=1280, height=720, frames=12)
 
-    downscaled = _mp4_downscaled_to(src, max_resolution=640)
+    downscaled = _mp4_reduced_to(src, max_resolution=640)
 
     with av.open(io.BytesIO(downscaled), 'r') as container:
         stream = container.streams.video[0]

--- a/positronic/server/tests/test_dataset_utils.py
+++ b/positronic/server/tests/test_dataset_utils.py
@@ -160,6 +160,9 @@ class _RawFrameSignal:
     def __iter__(self):
         return iter(zip(self._frames, self._times, strict=True))
 
+    def keys(self):
+        return np.asarray(self._times, dtype=np.int64)
+
 
 def test_every_encoded_frame_keeps_its_own_episode_time(monkeypatch):
     times = [i * 33_000_000 for i in range(12)]
@@ -168,9 +171,23 @@ def test_every_encoded_frame_keeps_its_own_episode_time(monkeypatch):
     monkeypatch.setattr(dataset_utils, 'set_timeline_time', lambda _timeline, ts: logged.append(ts))
     monkeypatch.setattr(dataset_utils.rr, 'log', lambda *args, **kwargs: None)
 
-    dataset_utils._encode_frames_as_video('/video', _RawFrameSignal(frames, times), max_resolution=640)
+    dataset_utils._encode_frames_as_video('/video', _RawFrameSignal(frames, times), max_resolution=640, max_hz=0)
 
     assert logged == times
+
+
+def test_frames_past_the_rate_cap_are_left_out_of_the_encoding(monkeypatch):
+    times = [i * 10_000_000 for i in range(12)]
+    frames = [np.full((64, 64, 3), i * 20 % 256, dtype=np.uint8) for i in range(12)]
+    logged: list[int] = []
+    monkeypatch.setattr(dataset_utils, 'set_timeline_time', lambda _timeline, ts: logged.append(ts))
+    monkeypatch.setattr(dataset_utils.rr, 'log', lambda *args, **kwargs: None)
+
+    dataset_utils._encode_frames_as_video('/video', _RawFrameSignal(frames, times), max_resolution=640, max_hz=30)
+
+    kept = _decimation_indices(np.asarray(times, dtype='datetime64[ns]'), max_hz=30)
+    assert 1 < len(kept) < len(times)
+    assert logged == [times[index] for index in kept]
 
 
 def _write_mp4(path: Path, width: int, height: int, frames: int) -> Path:
@@ -219,6 +236,17 @@ def test_a_video_within_the_cap_is_embedded_as_recorded(tmp_path):
     src = _write_mp4(tmp_path / 'small.mp4', width=320, height=240, frames=12)
 
     assert _mp4_downscaled_to(src, max_resolution=640) == src.read_bytes()
+
+
+def test_a_video_keeps_the_frames_named_at_their_own_times(tmp_path):
+    src = _write_mp4(tmp_path / 'small.mp4', width=320, height=240, frames=12)
+    kept = np.array([0, 3, 6, 9])
+
+    thinned = _mp4_downscaled_to(src, max_resolution=640, kept=kept)
+
+    source_times = _frame_times(src.read_bytes())
+    assert _frame_times(thinned) == pytest.approx([source_times[index] for index in kept], abs=1e-4)
+    assert thinned != src.read_bytes()
 
 
 def test_a_larger_video_is_re_encoded_frame_for_frame(tmp_path):

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -221,6 +221,42 @@ def test_a_recording_is_copied_from_the_file_built_under_the_scratch_dir_and_not
     assert not any(scratch.iterdir())
 
 
+def _recording_builder_threads(monkeypatch) -> list[int]:
+    """Wrap the recording builder so each call records the thread it runs on."""
+    stream = positronic_server.stream_episode_rrd
+    threads: list[int] = []
+
+    def stream_and_record(ds, episode_id, **kwargs):
+        threads.append(threading.get_ident())
+        yield from stream(ds, episode_id, **kwargs)
+
+    monkeypatch.setattr(positronic_server, 'stream_episode_rrd', stream_and_record)
+    return threads
+
+
+def test_the_recordings_are_built_on_worker_threads_and_the_export_copies_them(dataset, tmp_path, monkeypatch):
+    threads = _recording_builder_threads(monkeypatch)
+
+    files = paths_of(an_export(dataset, tmp_path / 'out', workers=2))
+
+    assert len(threads) == 2
+    assert threading.get_ident() not in threads
+    assert len([path for path in files if 'episode_rrd' in path]) == 2
+
+
+def test_one_worker_builds_each_recording_on_the_export_s_own_thread(dataset, tmp_path, monkeypatch):
+    threads = _recording_builder_threads(monkeypatch)
+
+    an_export(dataset, tmp_path / 'out', workers=1)
+
+    assert threads == [threading.get_ident()] * 2
+
+
+def test_fewer_than_one_worker_is_refused(dataset, tmp_path):
+    with pytest.raises(ValueError):
+        an_export(dataset, tmp_path / 'out', workers=0)
+
+
 def test_two_views_of_one_dataset_through_one_scratch_dir_each_get_their_own_recording(dataset, tmp_path):
     """A transformed view keeps the dataset's root and its uids, so nothing but the export tells the two apart."""
     scratch = tmp_path / 'scratch'


### PR DESCRIPTION
## What changes

- `export_static` and `python -m positronic.server.export` take `workers`, half the CPUs the process may run on by default. The recordings are built `workers` at a time on a thread pool before the write loop copies them from the cache. The decoder and the encoder release the interpreter lock. A forked worker hangs on the threads a recording built earlier in the process leaves behind (a fork pool started after four sequential builds never finished), so the pool is threads.
- `max_hz` now thins a recording's videos as well as its numeric signals, before the encode; 0 keeps every frame and every sample, as before. The frame references are thinned with the frames. The sources of the rollout rounds run at 100 fps, so the default of 30 encodes a third of the frames.

## Measured on posi-vm (8 vCPUs): the DROID three-way round of 2 Sep, 90 episodes

| build | wall |
|---|---|
| one at a time, every frame (before) | 20.6 min |
| 4 workers, videos thinned to 30 fps | 10.6 min |

One episode's CPU with the videos thinned, from one profile: decoding the 1280x720 100 fps sources 50%, encoding 30%, scaling 9%, the robot model and the signals 10%. The decode is paid at any rate. The box gives about four cores of real work and one build already holds two, so the pool's gain here is about 1.3x. About a quarter of a build holds the interpreter lock, which bounds a thread pool at about 4x on a box with the cores for it.

## Tests

Five new: frames past the rate are left out of a raw-frame encoding; a video keeps the frames named at their own times; the recordings are built on worker threads and the export copies them; one worker builds on the export's own thread; fewer than one worker is refused. 194 server tests, ruff, basedpyright and the ratchet are green.

<!-- opened-by: posi-agent -->
