### PR TITLE
Use more generic example names

### DIFF
--- a/positronic/probe.py
+++ b/positronic/probe.py
@@ -53,7 +53,7 @@ def _build_wire_obs(sample: dict, task: str | None, now_ns: int, recorded_ts: in
 
 
 def _recording_name(meta: dict) -> str:
-    """A short recording name from server metadata, e.g. ``groot@110000`` / ``gyros@18500``."""
+    """A short recording name from server metadata, e.g. ``groot@110000`` / ``pi05@18500``."""
     server_type = meta.get('server.type', 'model')
     ckpt = meta.get('server.checkpoint_id')
     if not ckpt:

--- a/positronic/server/tests/test_positronic_server.py
+++ b/positronic/server/tests/test_positronic_server.py
@@ -315,11 +315,11 @@ def test_a_static_export_tells_the_page_to_read_the_files_it_wrote(viewer, monke
 
 
 def test_a_title_stands_in_for_the_dataset_root(viewer, monkeypatch):
-    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(title='Runway rollouts, 29 August'))
+    monkeypatch.setitem(app_state, _PAGE_CONFIG_KEY, PageConfig(title='Tote rollouts, 29 August'))
 
     for page in ['/', '/episode/0']:
         body = viewer.get(page).text
-        assert 'Runway rollouts, 29 August' in body
+        assert 'Tote rollouts, 29 August' in body
 
 
 def test_the_header_falls_back_to_the_dataset_root(viewer):


### PR DESCRIPTION
The probe's recording-name docstring and the viewer's title test each carried a project-specific name as their example. Neither example depends on the name it used: the docstring shows the `<server type>@<checkpoint>` shape, and the test asserts that a configured title reaches both pages.

The docstring's second example becomes `pi05@18500`, beside the `groot@110000` it already had. The test's title becomes `Tote rollouts, 29 August`.

Verification: `pytest positronic/server/tests/test_positronic_server.py` — 83 passed.

Ticket: none — an example-name change.

<!-- opened-by: posi-agent -->