### PR TITLE
Measure what a frame codec costs the round trip, not only the wire

### DIFF
--- a/positronic/offboard/frame_codec_cost.py
+++ b/positronic/offboard/frame_codec_cost.py
@@ -123,24 +123,29 @@ def costs(frames: list[np.ndarray], camera: str, depth: int, codecs: list[Codec]
     return rows
 
 
+def _row(label: str, group: list[Cost], windows: list[int]) -> str:
+    """One printed line: the median over windows of what the group cost in each window."""
+    per_window = [[row for row in group if row.window == window] for window in windows]
+    return (
+        f'{label:>16}  '
+        f'{statistics.median(sum(row.kib for row in w) for w in per_window):8.0f}  '
+        f'{statistics.median(sum(row.encode_ms for row in w) for w in per_window):10.1f}  '
+        f'{statistics.median(sum(row.decode_ms for row in w) for w in per_window):10.1f}'
+    )
+
+
 def report(rows: list[Cost], depth: int) -> None:
     """Median cost per codec, per camera and summed over the cameras one request carries."""
     names = list(dict.fromkeys(row.codec for row in rows))
     cameras = list(dict.fromkeys(row.camera for row in rows))
-    windows = {row.window for row in rows}
+    windows = sorted({row.window for row in rows})
     print(f'\n{depth} frames, {len(windows)} windows, {len(cameras)} cameras\n')
     print(f'{"codec":>22}  {"camera":>16}  {"KiB":>8}  {"encode ms":>10}  {"decode ms":>10}')
     for name in names:
         of_codec = [row for row in rows if row.codec == name]
-        for camera in cameras + ['every camera']:
-            group = of_codec if camera == 'every camera' else [row for row in of_codec if row.camera == camera]
-            per_window = [[row for row in group if row.window == window] for window in sorted(windows)]
-            print(
-                f'{name:>22}  {camera:>16}  '
-                f'{statistics.median(sum(r.kib for r in w) for w in per_window):8.0f}  '
-                f'{statistics.median(sum(r.encode_ms for r in w) for w in per_window):10.1f}  '
-                f'{statistics.median(sum(r.decode_ms for r in w) for w in per_window):10.1f}'
-            )
+        for camera in cameras:
+            print(f'{name:>22}  {_row(camera, [row for row in of_codec if row.camera == camera], windows)}')
+        print(f'{name:>22}  {_row("every camera", of_codec, windows)}')
 
 
 def main() -> int:

--- a/positronic/offboard/frame_codec_cost.py
+++ b/positronic/offboard/frame_codec_cost.py
@@ -23,8 +23,8 @@ import time
 
 import av
 import numpy as np
-from PIL import Image as PilImage
 
+from positronic.policy.codec import RestrictImageSize
 from positronic.utils.serialization import FRAMES, encode_jpeg, unpack
 
 
@@ -95,8 +95,9 @@ class Cost:
     decode_ms: float
 
 
-def bounded_frames(mp4: pathlib.Path, width: int, height: int, rate_hz: float) -> list[np.ndarray]:
-    """Every frame the stack samples, scaled the way ``RestrictImageSize`` scales it."""
+def bounded_frames(mp4: pathlib.Path, bound: RestrictImageSize, rate_hz: float) -> list[np.ndarray]:
+    """Every frame the stack samples, through the rig's own bound."""
+    key = 'image'
     with av.open(str(mp4), 'r') as container:
         recorded_rate = container.streams.video[0].average_rate
         if recorded_rate is None:
@@ -106,13 +107,7 @@ def bounded_frames(mp4: pathlib.Path, width: int, height: int, rate_hz: float) -
         for index, frame in enumerate(container.decode(video=0)):
             if index % step:
                 continue
-            image = frame.to_ndarray(format='rgb24')
-            source_height, source_width = image.shape[:2]
-            scale = min(1.0, width / source_width, height / source_height)
-            if scale < 1.0:
-                size = (int(source_width * scale), int(source_height * scale))
-                image = np.array(PilImage.fromarray(image).resize(size, PilImage.Resampling.BILINEAR))
-            frames.append(image)
+            frames.append(bound.encode({key: frame.to_ndarray(format='rgb24')})[key])
     return frames
 
 
@@ -160,12 +155,12 @@ def main() -> int:
     parser.add_argument('--json', type=pathlib.Path, help='write every row here')
     args = parser.parse_args()
 
-    width, height = (int(side) for side in args.bound.lower().split('x'))
+    bound = RestrictImageSize(*(int(side) for side in args.bound.lower().split('x')))
     codecs: list[Codec] = [Jpeg()]
     codecs += [H264(spec.split(':')[0], int(spec.split(':')[1])) for spec in args.x264.split(',')]
     rows: list[Cost] = []
     for camera in args.cameras.split(','):
-        frames = bounded_frames(args.episode / f'{camera}.mp4', width, height, args.rate)
+        frames = bounded_frames(args.episode / f'{camera}.mp4', bound, args.rate)
         print(f'{camera}: {len(frames)} sampled frames at {frames[0].shape[1]}x{frames[0].shape[0]}')
         rows += costs(frames, camera, args.frames, codecs, args.windows)
 

--- a/positronic/offboard/frame_codec_cost.py
+++ b/positronic/offboard/frame_codec_cost.py
@@ -1,7 +1,7 @@
 """Measure what one observation window costs per image codec: bytes, encode time, decode time.
 
 Replays a recorded episode's cameras through the rig-side bound, then encodes each temporal-stack
-window as one JPEG per frame, which is what the wire carries, and as one h264 GOP. JPEG encodes
+window as one JPEG per frame, which the wire carries, and as one h264 GOP. JPEG encodes
 single-threaded through ``encode_jpeg``; h264 encodes with x264's own frame threading.
 
 Usage

--- a/positronic/offboard/frame_codec_cost.py
+++ b/positronic/offboard/frame_codec_cost.py
@@ -1,0 +1,174 @@
+"""Measure what one observation window costs per image codec: bytes, encode time, decode time.
+
+Replays a recorded episode's cameras through the rig-side bound, then encodes each temporal-stack
+window two ways — one JPEG per frame, which is what the wire carries today, and one h264 GOP over
+the whole window. h264 sends a fraction of the bytes; this reports what that costs in encode and
+decode time, both of which sit on the round trip.
+
+JPEG runs single-threaded through ``encode_jpeg``, the encoder the wire uses. h264 runs with
+x264's own frame threading, so the comparison is generous to h264.
+
+Usage
+  python -m positronic.offboard.frame_codec_cost --episode <dir holding <camera>.mp4>
+  python -m positronic.offboard.frame_codec_cost --episode <dir> --bound 640x180 --json rows.json
+"""
+
+import argparse
+import dataclasses
+import io
+import json
+import pathlib
+import statistics
+import time
+
+import av
+import numpy as np
+from PIL import Image as PilImage
+
+from positronic.utils.serialization import encode_jpeg, unpack
+
+JPEG = 'jpeg q90'
+
+
+@dataclasses.dataclass(frozen=True)
+class H264:
+    """One x264 setting, named the way the report names it."""
+
+    preset: str
+    crf: int
+
+    @property
+    def name(self) -> str:
+        return f'h264 {self.preset} crf{self.crf}'
+
+
+@dataclasses.dataclass(frozen=True)
+class Cost:
+    """What one window of one camera cost under one codec."""
+
+    codec: str
+    camera: str
+    window: int
+    kib: float
+    encode_ms: float
+    decode_ms: float
+
+
+def bounded_frames(mp4: pathlib.Path, width: int, height: int, rate_hz: float) -> list[np.ndarray]:
+    """Every frame the stack samples, scaled the way ``RestrictImageSize`` scales it."""
+    with av.open(str(mp4), 'r') as container:
+        recorded_rate = container.streams.video[0].average_rate
+        if recorded_rate is None:
+            raise ValueError(f'{mp4} declares no frame rate, so the sampled frames cannot be chosen')
+        step = max(1, round(float(recorded_rate) / rate_hz))
+        frames = []
+        for index, frame in enumerate(container.decode(video=0)):
+            if index % step:
+                continue
+            image = frame.to_ndarray(format='rgb24')
+            source_height, source_width = image.shape[:2]
+            scale = min(1.0, width / source_width, height / source_height)
+            if scale < 1.0:
+                size = (int(source_width * scale), int(source_height * scale))
+                image = np.array(PilImage.fromarray(image).resize(size, PilImage.Resampling.BILINEAR))
+            frames.append(image)
+    return frames
+
+
+def jpeg_cost(window: np.ndarray) -> tuple[int, float, float]:
+    """Bytes, encode ms and decode ms for one window as one JPEG per frame."""
+    start = time.perf_counter()
+    marker = encode_jpeg(window)
+    encode_ms = 1000 * (time.perf_counter() - start)
+
+    start = time.perf_counter()
+    unpack(marker)
+    decode_ms = 1000 * (time.perf_counter() - start)
+    return sum(len(buf) for buf in marker[b'frames']), encode_ms, decode_ms
+
+
+def h264_cost(window: np.ndarray, codec: H264) -> tuple[int, float, float]:
+    """Bytes, encode ms and decode ms for one window as a single h264 GOP."""
+    height, width = window.shape[1:3]
+    buffer = io.BytesIO()
+    start = time.perf_counter()
+    with av.open(buffer, 'w', format='mp4') as container:
+        stream = container.add_stream('libx264', rate=15)
+        stream.width, stream.height, stream.pix_fmt = width, height, 'yuv420p'
+        # One self-contained GOP with no lookahead: a request carries its own window and waits on it.
+        stream.options = {'preset': codec.preset, 'crf': str(codec.crf), 'tune': 'zerolatency', 'g': str(len(window))}
+        for frame in window:
+            container.mux(stream.encode(av.VideoFrame.from_ndarray(frame, format='rgb24')))
+        container.mux(stream.encode(None))
+    encode_ms = 1000 * (time.perf_counter() - start)
+    payload = buffer.getvalue()
+
+    start = time.perf_counter()
+    with av.open(io.BytesIO(payload), 'r') as container:
+        for frame in container.decode(video=0):
+            frame.to_ndarray(format='rgb24')
+    return len(payload), encode_ms, 1000 * (time.perf_counter() - start)
+
+
+def costs(frames: list[np.ndarray], camera: str, depth: int, codecs: list[H264], limit: int) -> list[Cost]:
+    """One row per codec per window, over the windows the episode holds."""
+    starts = list(range(0, len(frames) - depth + 1))[: limit or None]
+    rows = []
+    for window_index, start in enumerate(starts):
+        window = np.stack(frames[start : start + depth])
+        size, encode_ms, decode_ms = jpeg_cost(window)
+        rows.append(Cost(JPEG, camera, window_index, size / 1024, encode_ms, decode_ms))
+        for codec in codecs:
+            size, encode_ms, decode_ms = h264_cost(window, codec)
+            rows.append(Cost(codec.name, camera, window_index, size / 1024, encode_ms, decode_ms))
+    return rows
+
+
+def report(rows: list[Cost], depth: int) -> None:
+    """Median cost per codec, per camera and summed over the cameras one request carries."""
+    names = list(dict.fromkeys(row.codec for row in rows))
+    cameras = list(dict.fromkeys(row.camera for row in rows))
+    windows = {row.window for row in rows}
+    print(f'\n{depth} frames, {len(windows)} windows, {len(cameras)} cameras\n')
+    print(f'{"codec":>22}  {"camera":>16}  {"KiB":>8}  {"encode ms":>10}  {"decode ms":>10}')
+    for name in names:
+        of_codec = [row for row in rows if row.codec == name]
+        for camera in cameras + ['every camera']:
+            group = of_codec if camera == 'every camera' else [row for row in of_codec if row.camera == camera]
+            per_window = [[row for row in group if row.window == window] for window in sorted(windows)]
+            print(
+                f'{name:>22}  {camera:>16}  '
+                f'{statistics.median(sum(r.kib for r in w) for w in per_window):8.0f}  '
+                f'{statistics.median(sum(r.encode_ms for r in w) for w in per_window):10.1f}  '
+                f'{statistics.median(sum(r.decode_ms for r in w) for w in per_window):10.1f}'
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--episode', required=True, type=pathlib.Path, help='directory holding <camera>.mp4')
+    parser.add_argument('--cameras', default='image.exterior,image.wrist')
+    parser.add_argument('--frames', type=int, default=25, help='temporal-stack depth')
+    parser.add_argument('--rate', type=float, default=15.0, help='stack sampling rate, Hz')
+    parser.add_argument('--bound', default='1024x288', help='WxH rig-side bound')
+    parser.add_argument('--x264', default='ultrafast:20,veryfast:20', help='comma-separated preset:crf')
+    parser.add_argument('--windows', type=int, default=100, help='windows per camera, 0 for every one')
+    parser.add_argument('--json', type=pathlib.Path, help='write every row here')
+    args = parser.parse_args()
+
+    width, height = (int(side) for side in args.bound.lower().split('x'))
+    codecs = [H264(spec.split(':')[0], int(spec.split(':')[1])) for spec in args.x264.split(',')]
+    rows: list[Cost] = []
+    for camera in args.cameras.split(','):
+        frames = bounded_frames(args.episode / f'{camera}.mp4', width, height, args.rate)
+        print(f'{camera}: {len(frames)} sampled frames at {frames[0].shape[1]}x{frames[0].shape[0]}')
+        rows += costs(frames, camera, args.frames, codecs, args.windows)
+
+    report(rows, args.frames)
+    if args.json:
+        args.json.write_text(json.dumps([dataclasses.asdict(row) for row in rows]))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/positronic/offboard/frame_codec_cost.py
+++ b/positronic/offboard/frame_codec_cost.py
@@ -25,14 +25,30 @@ import av
 import numpy as np
 from PIL import Image as PilImage
 
-from positronic.utils.serialization import encode_jpeg, unpack
+from positronic.utils.serialization import FRAMES, encode_jpeg, unpack
 
-JPEG = 'jpeg q90'
+
+@dataclasses.dataclass(frozen=True)
+class Jpeg:
+    """One JPEG per frame, at the quality the wire itself encodes at."""
+
+    name = 'jpeg'
+
+    def cost(self, window: np.ndarray) -> tuple[int, float, float]:
+        """Bytes, encode ms and decode ms for one window."""
+        start = time.perf_counter()
+        marker = encode_jpeg(window)
+        encode_ms = 1000 * (time.perf_counter() - start)
+
+        start = time.perf_counter()
+        unpack(marker)
+        decode_ms = 1000 * (time.perf_counter() - start)
+        return sum(len(buf) for buf in marker[FRAMES]), encode_ms, decode_ms
 
 
 @dataclasses.dataclass(frozen=True)
 class H264:
-    """One x264 setting, named the way the report names it."""
+    """One x264 setting, over the whole window as a single GOP."""
 
     preset: str
     crf: int
@@ -40,6 +56,31 @@ class H264:
     @property
     def name(self) -> str:
         return f'h264 {self.preset} crf{self.crf}'
+
+    def cost(self, window: np.ndarray) -> tuple[int, float, float]:
+        """Bytes, encode ms and decode ms for one window."""
+        height, width = window.shape[1:3]
+        buffer = io.BytesIO()
+        start = time.perf_counter()
+        with av.open(buffer, 'w', format='mp4') as container:
+            stream = container.add_stream('libx264', rate=15)
+            stream.width, stream.height, stream.pix_fmt = width, height, 'yuv420p'
+            # One self-contained GOP with no lookahead: a request carries its own window and waits on it.
+            stream.options = {'preset': self.preset, 'crf': str(self.crf), 'tune': 'zerolatency', 'g': str(len(window))}
+            for frame in window:
+                container.mux(stream.encode(av.VideoFrame.from_ndarray(frame, format='rgb24')))
+            container.mux(stream.encode(None))
+        encode_ms = 1000 * (time.perf_counter() - start)
+        payload = buffer.getvalue()
+
+        start = time.perf_counter()
+        with av.open(io.BytesIO(payload), 'r') as container:
+            for frame in container.decode(video=0):
+                frame.to_ndarray(format='rgb24')
+        return len(payload), encode_ms, 1000 * (time.perf_counter() - start)
+
+
+Codec = Jpeg | H264
 
 
 @dataclasses.dataclass(frozen=True)
@@ -75,51 +116,14 @@ def bounded_frames(mp4: pathlib.Path, width: int, height: int, rate_hz: float) -
     return frames
 
 
-def jpeg_cost(window: np.ndarray) -> tuple[int, float, float]:
-    """Bytes, encode ms and decode ms for one window as one JPEG per frame."""
-    start = time.perf_counter()
-    marker = encode_jpeg(window)
-    encode_ms = 1000 * (time.perf_counter() - start)
-
-    start = time.perf_counter()
-    unpack(marker)
-    decode_ms = 1000 * (time.perf_counter() - start)
-    return sum(len(buf) for buf in marker[b'frames']), encode_ms, decode_ms
-
-
-def h264_cost(window: np.ndarray, codec: H264) -> tuple[int, float, float]:
-    """Bytes, encode ms and decode ms for one window as a single h264 GOP."""
-    height, width = window.shape[1:3]
-    buffer = io.BytesIO()
-    start = time.perf_counter()
-    with av.open(buffer, 'w', format='mp4') as container:
-        stream = container.add_stream('libx264', rate=15)
-        stream.width, stream.height, stream.pix_fmt = width, height, 'yuv420p'
-        # One self-contained GOP with no lookahead: a request carries its own window and waits on it.
-        stream.options = {'preset': codec.preset, 'crf': str(codec.crf), 'tune': 'zerolatency', 'g': str(len(window))}
-        for frame in window:
-            container.mux(stream.encode(av.VideoFrame.from_ndarray(frame, format='rgb24')))
-        container.mux(stream.encode(None))
-    encode_ms = 1000 * (time.perf_counter() - start)
-    payload = buffer.getvalue()
-
-    start = time.perf_counter()
-    with av.open(io.BytesIO(payload), 'r') as container:
-        for frame in container.decode(video=0):
-            frame.to_ndarray(format='rgb24')
-    return len(payload), encode_ms, 1000 * (time.perf_counter() - start)
-
-
-def costs(frames: list[np.ndarray], camera: str, depth: int, codecs: list[H264], limit: int) -> list[Cost]:
+def costs(frames: list[np.ndarray], camera: str, depth: int, codecs: list[Codec], limit: int) -> list[Cost]:
     """One row per codec per window, over the windows the episode holds."""
     starts = list(range(0, len(frames) - depth + 1))[: limit or None]
     rows = []
     for window_index, start in enumerate(starts):
         window = np.stack(frames[start : start + depth])
-        size, encode_ms, decode_ms = jpeg_cost(window)
-        rows.append(Cost(JPEG, camera, window_index, size / 1024, encode_ms, decode_ms))
         for codec in codecs:
-            size, encode_ms, decode_ms = h264_cost(window, codec)
+            size, encode_ms, decode_ms = codec.cost(window)
             rows.append(Cost(codec.name, camera, window_index, size / 1024, encode_ms, decode_ms))
     return rows
 
@@ -157,7 +161,8 @@ def main() -> int:
     args = parser.parse_args()
 
     width, height = (int(side) for side in args.bound.lower().split('x'))
-    codecs = [H264(spec.split(':')[0], int(spec.split(':')[1])) for spec in args.x264.split(',')]
+    codecs: list[Codec] = [Jpeg()]
+    codecs += [H264(spec.split(':')[0], int(spec.split(':')[1])) for spec in args.x264.split(',')]
     rows: list[Cost] = []
     for camera in args.cameras.split(','):
         frames = bounded_frames(args.episode / f'{camera}.mp4', width, height, args.rate)

--- a/positronic/offboard/frame_codec_cost.py
+++ b/positronic/offboard/frame_codec_cost.py
@@ -1,12 +1,8 @@
 """Measure what one observation window costs per image codec: bytes, encode time, decode time.
 
 Replays a recorded episode's cameras through the rig-side bound, then encodes each temporal-stack
-window two ways — one JPEG per frame, which is what the wire carries today, and one h264 GOP over
-the whole window. h264 sends a fraction of the bytes; this reports what that costs in encode and
-decode time, both of which sit on the round trip.
-
-JPEG runs single-threaded through ``encode_jpeg``, the encoder the wire uses. h264 runs with
-x264's own frame threading, so the comparison is generous to h264.
+window as one JPEG per frame, which is what the wire carries, and as one h264 GOP. JPEG encodes
+single-threaded through ``encode_jpeg``; h264 encodes with x264's own frame threading.
 
 Usage
   python -m positronic.offboard.frame_codec_cost --episode <dir holding <camera>.mp4>

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -26,7 +26,7 @@ _JPEG = b'__jpeg__'
 _DATA = b'data'
 _DTYPE = b'dtype'
 _SHAPE = b'shape'
-FRAMES = b'frames'  # the wire's own name for the per-frame JPEGs; a reader of a marker needs it
+FRAMES = b'frames'  # the wire's own name for the per-frame JPEGs
 _NDIM = b'ndim'
 
 # JPEG quality for images on the wire. A single HD frame — and especially a (T, H, W, 3) stack — is many

--- a/positronic/utils/serialization.py
+++ b/positronic/utils/serialization.py
@@ -26,7 +26,7 @@ _JPEG = b'__jpeg__'
 _DATA = b'data'
 _DTYPE = b'dtype'
 _SHAPE = b'shape'
-_FRAMES = b'frames'
+FRAMES = b'frames'  # the wire's own name for the per-frame JPEGs; a reader of a marker needs it
 _NDIM = b'ndim'
 
 # JPEG quality for images on the wire. A single HD frame — and especially a (T, H, W, 3) stack — is many
@@ -46,12 +46,12 @@ def encode_jpeg(image: np.ndarray) -> dict[bytes, Any]:
         buf = io.BytesIO()
         PilImage.fromarray(np.ascontiguousarray(frame, dtype=np.uint8)).save(buf, format='JPEG', quality=_JPEG_QUALITY)
         bufs.append(buf.getvalue())
-    return {_JPEG: True, _FRAMES: bufs, _NDIM: int(image.ndim)}
+    return {_JPEG: True, FRAMES: bufs, _NDIM: int(image.ndim)}
 
 
 def _decode_jpeg(marker: dict) -> np.ndarray:
     """Inverse of ``encode_jpeg``: decode per-frame JPEGs and restore the original shape."""
-    frames = np.stack([np.asarray(PilImage.open(io.BytesIO(buf))) for buf in marker[_FRAMES]])
+    frames = np.stack([np.asarray(PilImage.open(io.BytesIO(buf))) for buf in marker[FRAMES]])
     return frames if marker[_NDIM] == 4 else frames[0]
 
 


### PR DESCRIPTION
Runway asked to carry the temporal-stack window as one video GOP instead of one JPEG per
frame, on the grounds that it saves both size and encode time. Bytes are easy to count and
the two times are not, and both the encode and the decode sit on the round trip, so a codec
that thirds the bytes and doubles the encode is a loss.

The probe samples a recorded episode's cameras at the stack's cadence, from the recorded
timestamps in the frames index, through `RestrictImageSize`, the codec that bounds an image
before it reaches the wire. It then encodes each window every way it is given and reports
bytes, encode ms and decode ms per window. Every camera samples one time grid over the span
all of them cover, so every reported window sums complete rows. Each decode ends with the
stacked window the policy reads, on both paths.

On the 8 September curie round, 25 frames at 15 Hz, two cameras, 512x288, 100 windows, on
posi-vm (8-core EPYC-Genoa):

| codec | KiB | encode ms | decode ms |
|---|---|---|---|
| jpeg, the wire today | 940 | 23.2 | 34.8 |
| h264 ultrafast crf20 | 268 | 50.6 | 20.1 |
| h264 veryfast crf20 | 158 | 72.8 | 28.5 |

h264 ultrafast sends 3.5x fewer bytes and costs 2.2x the encode; veryfast sends 5.9x fewer
bytes for 3.1x the encode. The milliseconds are this box's own. The rig that serves those
rounds is not in this table: its earlier figures came from a sampling that kept every seventh
recorded frame, and a re-run there is one command.

The decode column is the same machine decoding what it just encoded, so it bounds what a
decode costs on that hardware and says nothing about what the inference server spends. That
server is somebody else's and was never measured here.

JPEG runs single-threaded through `encode_jpeg`, the encoder the wire uses. h264 runs with
x264's own frame threading and `tune=zerolatency`, so the comparison is generous to h264 on
both counts.

`serialization.FRAMES` becomes public in the same change. The per-frame JPEG buffers sit under
that key by a contract between whoever writes a marker and whoever reads one, and a second
module now reads one, so the key gets a single owning definition rather than a literal each
side spells for itself.

Verified over one episode of that round, 100 windows per camera. Five tests pin the probe:
15 Hz over 30 Hz frames keeps every second recorded frame whatever the video's encode rate, two
cameras of unequal length sample one grid, the frame count is capped to the windows asked for,
an episode shorter than one window is refused, and a window with odd sides encodes.
`pytest positronic/utils/tests positronic/offboard/tests positronic/policy/tests` passes.

Refs: Positronic-Robotics/internal#1168.

<!-- opened-by: posi-agent -->