### PR TITLE
Log each layer of an episode's session close

### DIFF
--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -90,12 +90,12 @@ class InferenceSession:
         return typed_commands(response[protocol.RESULT])
 
     def close(self):
-        before = self._websocket.state.name
+        state_before_close = self._websocket.state.name
         self._websocket.close()
         # A close that times out still reaches CLOSED locally; only the close code says the server answered.
         logger.info(
             'InferenceSession.close: state %s -> %s, close code %s',
-            before,
+            state_before_close,
             self._websocket.state.name,
             self._websocket.close_code,
         )

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -90,7 +90,9 @@ class InferenceSession:
         return typed_commands(response[protocol.RESULT])
 
     def close(self):
+        before = self._websocket.protocol.state.name
         self._websocket.close()
+        logger.info('InferenceSession.close: state %s -> %s', before, self._websocket.protocol.state.name)
 
 
 def _session_path(path: str, url: str) -> str:

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -90,12 +90,14 @@ class InferenceSession:
         return typed_commands(response[protocol.RESULT])
 
     def close(self):
-        protocol = self._websocket.protocol
-        before = protocol.state.name
+        before = self._websocket.state.name
         self._websocket.close()
         # A close that times out still reaches CLOSED locally; only the close code says the server answered.
         logger.info(
-            'InferenceSession.close: state %s -> %s, close code %s', before, protocol.state.name, protocol.close_code
+            'InferenceSession.close: state %s -> %s, close code %s',
+            before,
+            self._websocket.state.name,
+            self._websocket.close_code,
         )
 
 

--- a/positronic/offboard/client.py
+++ b/positronic/offboard/client.py
@@ -90,9 +90,13 @@ class InferenceSession:
         return typed_commands(response[protocol.RESULT])
 
     def close(self):
-        before = self._websocket.protocol.state.name
+        protocol = self._websocket.protocol
+        before = protocol.state.name
         self._websocket.close()
-        logger.info('InferenceSession.close: state %s -> %s', before, self._websocket.protocol.state.name)
+        # A close that times out still reaches CLOSED locally; only the close code says the server answered.
+        logger.info(
+            'InferenceSession.close: state %s -> %s, close code %s', before, protocol.state.name, protocol.close_code
+        )
 
 
 def _session_path(path: str, url: str) -> str:

--- a/positronic/policy/harness.py
+++ b/positronic/policy/harness.py
@@ -54,8 +54,11 @@ class Rollout:
 
         Until ``Executor.close`` returns, the function in flight still holds the session's websocket or model.
         """
+        logging.info('Rollout.close: closing the runtime')
         self.rt.close()
+        logging.info('Rollout.close: runtime closed, closing the session')
         self.session.close()
+        logging.info('Rollout.close: session closed')
 
 
 class _EpisodeInference:

--- a/positronic/policy/remote.py
+++ b/positronic/policy/remote.py
@@ -1,4 +1,5 @@
 import collections.abc as cabc
+import logging
 import time
 from typing import Any
 
@@ -15,6 +16,8 @@ from positronic.utils.serialization import encode_jpeg
 from .base import Answer, Layer, Policy, Runtime, Session
 from .recording import Recorder
 from .spec import from_spec
+
+logger = logging.getLogger(__name__)
 
 # The name the wire round trip is served under. A policy whose sessions are ``RemoteSession``s declares it.
 INFER = 'infer'
@@ -103,10 +106,13 @@ class RemoteSession(Session):
         return flatten_dict({policy_keys.TYPE: 'remote', policy_keys.SERVER: self._session.metadata})
 
     def close(self):
-        assert self._answer is None or self._answer.done(), (
+        in_flight = self._answer is not None and not self._answer.done()
+        logger.info('RemoteSession.close: answer_in_flight=%s', in_flight)
+        assert not in_flight, (
             'close the runtime serving this session first: the round trip in flight uses the websocket that this closes'
         )
         self._session.close()
+        logger.info('RemoteSession.close: session closed')
 
 
 class _Endpoint(Policy):


### PR DESCRIPTION
## What a reader gets

`Rollout.close` logs each of its two closes, `RemoteSession.close` logs whether a round trip was still in flight, and `InferenceSession.close` logs the websocket state either side of the close together with the close code. One episode's close now reads:

```
Rollout.close: closing the runtime
Rollout.close: runtime closed, closing the session
RemoteSession.close: answer_in_flight=False
InferenceSession.close: state OPEN -> CLOSED, close code 1000
Rollout.close: session closed
```

The close code carries the handshake outcome. `Connection.close` waits for the peer, but a close that reaches its deadline sets a `TimeoutError`, closes the socket, and leaves the protocol `CLOSED` all the same — so the state pair alone reads `OPEN -> CLOSED` whether the server answered or never saw the frame. A code of 1006 means no close frame came back and the server still holds the session, so the next episode's handshake never completes and the process records one episode against that endpoint.

## Why

Nothing instrumented the session close. A log that carries neither a traceback nor a close is therefore the same log whether the close ran or was never reached, and separating those two costs a day of diagnosis on a rig that is recording one episode per process.

With these lines the answer comes off a log alone. Measured on the rig with them in place: five episodes in one process, each ending with the sequence above, and `Server not ready (cold start?)` — which had repeated every 30 s indefinitely — appearing zero times.

<!-- opened-by: posi-agent -->