### PR TITLE
Export the app assets under a directory the caller names

### DIFF
--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -59,6 +59,7 @@ from positronic.server.positronic_server import (
     group_link,
     install_dataset,
     normalized_base_href,
+    validated_asset_dir,
 )
 
 logger = logging.getLogger(__name__)
@@ -369,11 +370,12 @@ def _large_file_plans(client: TestClient, reads: Dataset, links: _EpisodeLinks, 
     ]
 
 
-def asset_files() -> list[tuple[PurePosixPath, Path]]:
-    """The app's own scripts, styles and viewer, each as its path under `static/` and the file to copy from."""
+def asset_files(asset_dir: str = ASSET_ROUTE) -> list[tuple[PurePosixPath, Path]]:
+    """The app's own scripts, styles and viewer, each as its path under `asset_dir` and the file to copy from."""
+    directory = PurePosixPath(validated_asset_dir(asset_dir))
     static_dir = Path(__file__).resolve().parent / ASSET_ROUTE
     files = sorted(p for p in static_dir.rglob('*') if p.is_file())
-    return [(PurePosixPath(ASSET_ROUTE) / file.relative_to(static_dir).as_posix(), file) for file in files]
+    return [(directory / file.relative_to(static_dir).as_posix(), file) for file in files]
 
 
 def _whole_api_routes() -> list[str]:
@@ -489,6 +491,7 @@ def export_static(
     build_id: str = '',
     full_dataset: Dataset | None = None,
     assets: bool = True,
+    asset_dir: str = ASSET_ROUTE,
     scratch_dir: Path | None = None,
     workers: int = DEFAULT_WORKERS,
 ) -> list[ExportedFile]:
@@ -499,10 +502,11 @@ def export_static(
     episode's robot model out of its static values. The recordings are built `workers` at a time in a
     directory of this export's own under `scratch_dir`, the system's temporary directory when None,
     copied in from there, and the directory is removed at the end. `assets` writes the app's own scripts, styles
-    and viewer under `static/`, which the pages request at the host root, so it goes with the root
-    base href only; an export under a prefix shares the host's copy. An export holds the app's state
-    for its duration, so a second export in the process waits for it; one into the same directory is
-    then refused, as the directory holds the first.
+    and viewer under `asset_dir`, a directory under `static/` the pages request at the host root, so it goes
+    with the root base href only; an export under a prefix shares the host's copy. A host that serves several
+    exports names a directory per set of assets, so an export never overwrites the assets another export's
+    pages read. An export holds the app's state for its duration, so a second export in the process waits for
+    it; one into the same directory is then refused, as the directory holds the first.
     """
     out = _Output(Path(out_dir), normalized_base_href(base_href).removeprefix('/'))
     if scratch_dir is not None and Path(scratch_dir).resolve().is_relative_to(out.directory.resolve()):
@@ -512,6 +516,7 @@ def export_static(
     if assets and normalized_base_href(base_href) != '/':
         raise ValueError('assets sit under static/ at the host root; an export under a prefix takes assets=False')
     validated_build_id(build_id)
+    validated_asset_dir(asset_dir)
     shown = CachedDataset(dataset)
     sets_by_group = _filter_sets_by_group(shown, group_tables)
     full = _full_checked_against(CachedDataset(full_dataset), shown) if full_dataset is not None else shown
@@ -529,7 +534,9 @@ def export_static(
             max_resolution=max_resolution,
             max_hz=max_hz,
         )
-        configure_pages(base_href=base_href, title=title, show_paths=show_paths, static_export=True)
+        configure_pages(
+            base_href=base_href, title=title, show_paths=show_paths, static_export=True, asset_dir=asset_dir
+        )
         client = TestClient(app)
         # Past `configure_tables`, every group name is one segment the route builders spell.
         plans = [
@@ -543,7 +550,7 @@ def export_static(
             ),
             *itertools.chain.from_iterable(_large_file_plans(client, full, links, build_id) for links in episodes),
         ]
-        assets_to_copy = asset_files() if assets else []
+        assets_to_copy = asset_files(asset_dir) if assets else []
         out.plan(itertools.chain((planned.path for planned in plans), (path for path, _ in assets_to_copy)))
         _build_recordings(full, workers)
         _write_serving(out, plans)
@@ -567,6 +574,7 @@ def main(
     show_paths: bool = False,
     build_id: str = '',
     assets: bool = True,
+    asset_dir: str = ASSET_ROUTE,
     workers: int = DEFAULT_WORKERS,
 ):
     """Write the viewer for a Dataset as static files, for any static host.
@@ -583,7 +591,8 @@ def main(
         title: Header text; the dataset root when empty
         show_paths: Whether the pages report where the dataset lives
         build_id: Names one build; the recordings and the downloads are written under `build/<build_id>/`
-        assets: Whether to write the app's own assets under `static/`; with the root base href only
+        assets: Whether to write the app's own assets under `asset_dir`; with the root base href only
+        asset_dir: Directory under `static/` the assets sit in, so a host holds one per set of assets
         workers: Recordings built at once; half the machine's cores by default
     """
     written = export_static(
@@ -599,6 +608,7 @@ def main(
         show_paths=show_paths,
         build_id=build_id,
         assets=assets,
+        asset_dir=asset_dir,
         workers=workers,
     )
     logging.info(f'{len(written)} files, {sum(file.size for file in written) / 1e6:.1f} MB, under {out_dir}')

--- a/positronic/server/export.py
+++ b/positronic/server/export.py
@@ -35,6 +35,7 @@ from positronic.server.positronic_server import (
     API_FILE_SUFFIX,
     API_ROUTE,
     ASSET_ROUTE,
+    DEFAULT_ASSET_DIR,
     DOWNLOAD_LINK,
     GROUP_INDEX_FILE,
     MAX_COMPONENT_BYTES,
@@ -370,9 +371,9 @@ def _large_file_plans(client: TestClient, reads: Dataset, links: _EpisodeLinks, 
     ]
 
 
-def asset_files(asset_dir: str = ASSET_ROUTE) -> list[tuple[PurePosixPath, Path]]:
+def asset_files(asset_dir: PurePosixPath = DEFAULT_ASSET_DIR) -> list[tuple[PurePosixPath, Path]]:
     """The app's own scripts, styles and viewer, each as its path under `asset_dir` and the file to copy from."""
-    directory = PurePosixPath(validated_asset_dir(asset_dir))
+    directory = validated_asset_dir(asset_dir)
     static_dir = Path(__file__).resolve().parent / ASSET_ROUTE
     files = sorted(p for p in static_dir.rglob('*') if p.is_file())
     return [(directory / file.relative_to(static_dir).as_posix(), file) for file in files]
@@ -491,7 +492,7 @@ def export_static(
     build_id: str = '',
     full_dataset: Dataset | None = None,
     assets: bool = True,
-    asset_dir: str = ASSET_ROUTE,
+    asset_dir: PurePosixPath = DEFAULT_ASSET_DIR,
     scratch_dir: Path | None = None,
     workers: int = DEFAULT_WORKERS,
 ) -> list[ExportedFile]:
@@ -608,7 +609,7 @@ def main(
         show_paths=show_paths,
         build_id=build_id,
         assets=assets,
-        asset_dir=asset_dir,
+        asset_dir=PurePosixPath(asset_dir),
         workers=workers,
     )
     logging.info(f'{len(written)} files, {sum(file.size for file in written) / 1e6:.1f} MB, under {out_dir}')

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime
 from enum import StrEnum
 from functools import wraps
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, cast
 from urllib.parse import quote, unquote, urlsplit
 
@@ -52,6 +52,8 @@ _api_cache: dict[tuple, dict] = {}
 
 # The app's own scripts, styles and viewer sit under this route at the host root.
 ASSET_ROUTE = 'static'
+# The directory of assets a page reads when nothing names another.
+DEFAULT_ASSET_DIR = PurePosixPath(ASSET_ROUTE)
 
 
 @dataclass(frozen=True)
@@ -62,7 +64,7 @@ class PageConfig:
     title: str = ''  # empty = the dataset root
     show_paths: bool = True
     static_export: bool = False
-    asset_dir: str = ASSET_ROUTE
+    asset_dir: PurePosixPath = DEFAULT_ASSET_DIR
 
 
 # The app state's key for the `PageConfig` every page reads.
@@ -156,16 +158,16 @@ templates = Jinja2Templates(directory=_pkg_path('templates'))
 VIEWER_DIR = 'rerun'
 
 
-def validated_asset_dir(value: str) -> str:
+def validated_asset_dir(value: PurePosixPath) -> PurePosixPath:
     """`value` when it names a directory of assets under the asset route."""
-    route, *segments = value.split('/')
+    route, *segments = value.parts
     if route != ASSET_ROUTE:
-        raise ValueError(f'an asset directory sits under {ASSET_ROUTE!r}, got {value!r}')
+        raise ValueError(f'an asset directory sits under {ASSET_ROUTE!r}, got {str(value)!r}')
     for segment in segments:
         if not _is_one_path_segment(segment):
             raise ValueError(
                 f'an asset directory is URL path segments of at most {MAX_COMPONENT_BYTES} letters, digits, "_", '
-                f'"-" and ".", got {value!r}'
+                f'"-" and ".", got {str(value)!r}'
             )
     return value
 
@@ -378,7 +380,7 @@ def configure_pages(
     title: str = '',
     show_paths: bool = True,
     static_export: bool = False,
-    asset_dir: str = ASSET_ROUTE,
+    asset_dir: PurePosixPath = DEFAULT_ASSET_DIR,
 ) -> None:
     """Set where the pages are served and what they show.
 

--- a/positronic/server/positronic_server.py
+++ b/positronic/server/positronic_server.py
@@ -50,6 +50,9 @@ from positronic.server.dataset_utils import (
 # Response cache for api_groups and api_episodes (dataset is immutable once loaded)
 _api_cache: dict[tuple, dict] = {}
 
+# The app's own scripts, styles and viewer sit under this route at the host root.
+ASSET_ROUTE = 'static'
+
 
 @dataclass(frozen=True)
 class PageConfig:
@@ -59,6 +62,7 @@ class PageConfig:
     title: str = ''  # empty = the dataset root
     show_paths: bool = True
     static_export: bool = False
+    asset_dir: str = ASSET_ROUTE
 
 
 # The app state's key for the `PageConfig` every page reads.
@@ -101,6 +105,16 @@ def require_dataset(func):
 MAX_COMPONENT_BYTES = 200
 
 
+def _is_one_path_segment(value: str) -> bool:
+    """Whether a URL path and a filename both carry `value` as one segment, as it is written."""
+    return (
+        bool(value)
+        and value not in ('.', '..')
+        and quote(value, safe='') == value
+        and len(value) <= MAX_COMPONENT_BYTES
+    )
+
+
 def _path_component(value: str) -> str:
     """``value`` as one filename component, injectively and within any filesystem's name limit."""
     encoded = quote(value, safe='')
@@ -132,21 +146,33 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# The app's own scripts, styles and viewer, served at the host root, so every export a host serves shares one copy.
-ASSET_ROUTE = 'static'
 # Every API route sits under this segment; a static export writes each response a page reads whole under it.
 API_ROUTE = 'api'
 app.mount(f'/{ASSET_ROUTE}', StaticFiles(directory=_pkg_path(ASSET_ROUTE)), name=ASSET_ROUTE)
 templates = Jinja2Templates(directory=_pkg_path('templates'))
 
 
-# The rerun viewer sits under `static/rerun/<release>/`, one directory per release.
+# The rerun viewer sits under `<asset directory>/rerun/<release>/`, one directory per release.
 VIEWER_DIR = 'rerun'
+
+
+def validated_asset_dir(value: str) -> str:
+    """`value` when it names a directory of assets under the asset route."""
+    route, *segments = value.split('/')
+    if route != ASSET_ROUTE:
+        raise ValueError(f'an asset directory sits under {ASSET_ROUTE!r}, got {value!r}')
+    for segment in segments:
+        if not _is_one_path_segment(segment):
+            raise ValueError(
+                f'an asset directory is URL path segments of at most {MAX_COMPONENT_BYTES} letters, digits, "_", '
+                f'"-" and ".", got {value!r}'
+            )
+    return value
 
 
 def asset_link(name: str) -> str:
     """The path at the host root the asset file `name` is served at."""
-    return app.url_path_for(ASSET_ROUTE, path=name)
+    return f'/{_page_config().asset_dir}/{name}'
 
 
 @app.middleware('http')
@@ -347,16 +373,26 @@ def normalized_base_href(value: str) -> str:
 
 
 def configure_pages(
-    *, base_href: str = '/', title: str = '', show_paths: bool = True, static_export: bool = False
+    *,
+    base_href: str = '/',
+    title: str = '',
+    show_paths: bool = True,
+    static_export: bool = False,
+    asset_dir: str = ASSET_ROUTE,
 ) -> None:
     """Set where the pages are served and what they show.
 
     `base_href` is the path at the server root every page link and API call resolves against. `title` is
     the header text, the dataset root when empty. `show_paths` says whether a page reports where the
-    dataset lives. `static_export` makes the pages read the files a static export writes.
+    dataset lives. `static_export` makes the pages read the files a static export writes. `asset_dir` is
+    the directory under the asset route the pages read the app's own scripts, styles and viewer from.
     """
     app_state[_PAGE_CONFIG_KEY] = PageConfig(
-        base_href=normalized_base_href(base_href), title=title, show_paths=show_paths, static_export=static_export
+        base_href=normalized_base_href(base_href),
+        title=title,
+        show_paths=show_paths,
+        static_export=static_export,
+        asset_dir=validated_asset_dir(asset_dir),
     )
 
 
@@ -987,7 +1023,7 @@ def configure_tables(
     """
     episode_columns = set(ep_table_cfg or {})
     for name, cfg in (group_tables or {}).items():
-        if not name or name in ('.', '..') or quote(name, safe='') != name or len(name) > MAX_COMPONENT_BYTES:
+        if not _is_one_path_segment(name):
             raise ValueError(
                 f'a group name is one URL path segment of at most {MAX_COMPONENT_BYTES} letters, digits, "_", "-" '
                 f'and ".", got {name!r}'

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -345,7 +345,7 @@ def test_the_assets_of_an_export_that_names_no_directory_sit_at_the_asset_route(
 
 
 def test_an_export_writes_its_assets_under_the_directory_it_is_given_and_its_pages_read_them_there(dataset, tmp_path):
-    out, directory = tmp_path / 'out', 'static/a1b2c3d4e5f6a7b8'
+    out, directory = tmp_path / 'out', PurePosixPath('static/a1b2c3d4e5f6a7b8')
     written = an_export(dataset, out, assets=True, asset_dir=directory)
 
     at_directory = sorted(str(file.path) for file in written if file.kind is FileKind.ASSET)
@@ -356,10 +356,10 @@ def test_an_export_writes_its_assets_under_the_directory_it_is_given_and_its_pag
     assert f'/{directory}/{VIEWER_DIR}/{rr.__version__}/index.html' in (out / 'episode/0/index.html').read_text()
 
 
-@pytest.mark.parametrize('directory', ['assets', 'static/../etc', 'static/a b', 'static//pair', 'static/.'])
+@pytest.mark.parametrize('directory', ['assets', '/static/rooted', 'static/../etc', 'static/a b'])
 def test_an_asset_directory_outside_the_asset_route_or_past_one_segment_each_is_refused(directory, dataset, tmp_path):
     with pytest.raises(ValueError, match='asset directory'):
-        an_export(dataset, tmp_path / 'out', asset_dir=directory)
+        an_export(dataset, tmp_path / 'out', asset_dir=PurePosixPath(directory))
 
 
 def test_every_non_empty_filter_set_an_episode_satisfies_is_listed_once_and_the_shortest_first():

--- a/positronic/server/tests/test_export.py
+++ b/positronic/server/tests/test_export.py
@@ -333,6 +333,35 @@ def test_the_asset_list_holds_the_viewer_of_the_release_the_pages_load():
     assert all(file.is_file() for _, file in listed)
 
 
+def test_the_assets_of_an_export_that_names_no_directory_sit_at_the_asset_route(dataset, tmp_path):
+    out = tmp_path / 'out'
+    written = an_export(dataset, out, assets=True)
+
+    assert sorted(str(file.path) for file in written if file.kind is FileKind.ASSET) == sorted(
+        str(path) for path, _ in asset_files()
+    )
+    assert 'href="/static/styles.css"' in (out / 'index.html').read_text()
+    assert f'/static/{VIEWER_DIR}/{rr.__version__}/index.html' in (out / 'episode/0/index.html').read_text()
+
+
+def test_an_export_writes_its_assets_under_the_directory_it_is_given_and_its_pages_read_them_there(dataset, tmp_path):
+    out, directory = tmp_path / 'out', 'static/a1b2c3d4e5f6a7b8'
+    written = an_export(dataset, out, assets=True, asset_dir=directory)
+
+    at_directory = sorted(str(file.path) for file in written if file.kind is FileKind.ASSET)
+    assert at_directory == sorted(str(path) for path, _ in asset_files(directory))
+    assert all(path.startswith(f'{directory}/') for path in at_directory)
+    assert f'{directory}/{VIEWER_DIR}/{rr.__version__}/index.html' in at_directory
+    assert f'href="/{directory}/styles.css"' in (out / 'index.html').read_text()
+    assert f'/{directory}/{VIEWER_DIR}/{rr.__version__}/index.html' in (out / 'episode/0/index.html').read_text()
+
+
+@pytest.mark.parametrize('directory', ['assets', 'static/../etc', 'static/a b', 'static//pair', 'static/.'])
+def test_an_asset_directory_outside_the_asset_route_or_past_one_segment_each_is_refused(directory, dataset, tmp_path):
+    with pytest.raises(ValueError, match='asset directory'):
+        an_export(dataset, tmp_path / 'out', asset_dir=directory)
+
+
 def test_every_non_empty_filter_set_an_episode_satisfies_is_listed_once_and_the_shortest_first():
     episodes = [{'a': 'x', 'b': '1'}, {'b': '2'}, {'a': 'x', 'b': '1'}]
 


### PR DESCRIPTION
`export_static` and `asset_files` take `asset_dir`, a directory under `static/`. The export writes the app's own scripts, styles and viewer there, and the pages of that export link them there, the rerun viewer path included. `configure_pages` carries the same directory to `PageConfig`, which `asset_link` reads. `asset_files(asset_dir)` answers the `(key, file)` pairs of that tree, so a caller that uploads the assets itself stages what those pages read. The default is `static/`, so the live app, the CLI and every current caller keep the behaviour they have.

The export wrote those files at fixed keys under `static/` and every page read them there. A host that serves several exports built from different positronic versions therefore overwrote them on each export, and an older export then served its pages against newer assets. The intended caller, the `shares` service, names the directory by a content digest of the asset files: two exports with the same assets share one directory, an export with other assets gets a new one, and nothing is overwritten.

The directory is a `PurePosixPath` through the whole API, and `DEFAULT_ASSET_DIR` is its default. Only `main` holds a string, because the CLI hands its own token through uncoerced; it builds the path at the call. `ASSET_ROUTE` stays a string, as the FastAPI mount and the file-kind table read it as one. `validated_asset_dir` answers a path it has checked: it refuses a directory outside the asset route, and refuses a segment a URL path or a filename cannot carry as it is written. `_is_one_path_segment` holds that test, which the group-name check already spelled out inline.

`assets` still needs the root base href: the pages request the assets at the host root, whichever directory holds them.

Verification: `uv run pytest positronic/server/tests` (202 passed), ruff, and the basedpyright ratchet, which is unchanged. Three tests were added — an export under a named directory writes its assets there and its pages read them there, an export that names no directory writes them at the asset route, and a directory outside the route, rooted, or holding a segment past one path component is refused.

Refs: Positronic-Robotics/internal#990

opened-by: posi-agent
