### PR TITLE
Say that zed_2i_second is a ZED-M placeholder for a second ZED 2i

### DIFF
--- a/positronic/cfg/hardware/camera.py
+++ b/positronic/cfg/hardware/camera.py
@@ -33,12 +33,15 @@ def zed(**kwargs):
 
 zed_m = zed.override(serial_number=17521925)
 zed_2i = zed.override(serial_number=39567055)
+# Serial 13785037 is a ZED-M at present. It stands in for a second ZED 2i, which is on the way. The name is
+# for that ZED 2i; the serial changes to the new camera's when it arrives, and the name stays.
 zed_2i_second = zed.override(serial_number=13785037)
 
 _DROID_STREAM = {'view': 'left', 'resolution': 'hd720', 'fps': 30, 'image_enhancement': False}
 
 droid = {keys.WRIST_IMAGE: zed_m.override(**_DROID_STREAM), keys.EXTERIOR_IMAGE: zed_2i.override(**_DROID_STREAM)}
 
+# `exterior_2` is the ZED-M placeholder for now (see `zed_2i_second`), so its optics differ from `exterior`.
 droid_3cam = {**droid, keys.EXTERIOR_IMAGE_2: zed_2i_second.override(**_DROID_STREAM)}
 
 # YAM station (brunello): ZED X overhead + two ZED X One wrist cameras on the ZED Link Duo.

--- a/positronic/cfg/hardware/camera.py
+++ b/positronic/cfg/hardware/camera.py
@@ -33,15 +33,14 @@ def zed(**kwargs):
 
 zed_m = zed.override(serial_number=17521925)
 zed_2i = zed.override(serial_number=39567055)
-# Serial 13785037 is a ZED-M at present. It stands in for a second ZED 2i, which is on the way. The name is
-# for that ZED 2i; the serial changes to the new camera's when it arrives, and the name stays.
+# Serial 13785037 is a ZED-M, so the name and the hardware disagree (Positronic-Robotics/internal#1297).
 zed_2i_second = zed.override(serial_number=13785037)
 
 _DROID_STREAM = {'view': 'left', 'resolution': 'hd720', 'fps': 30, 'image_enhancement': False}
 
 droid = {keys.WRIST_IMAGE: zed_m.override(**_DROID_STREAM), keys.EXTERIOR_IMAGE: zed_2i.override(**_DROID_STREAM)}
 
-# `exterior_2` is the ZED-M placeholder for now (see `zed_2i_second`), so its optics differ from `exterior`.
+# `exterior_2` runs on `zed_2i_second`, a ZED-M, so its optics differ from `exterior`.
 droid_3cam = {**droid, keys.EXTERIOR_IMAGE_2: zed_2i_second.override(**_DROID_STREAM)}
 
 # YAM station (brunello): ZED X overhead + two ZED X One wrist cameras on the ZED Link Duo.


### PR DESCRIPTION
Serial 13785037 is a ZED-M. The SDK reports model ZED-M for it, its calibration file groups with the wrist ZED-M, and the kernel reports USB product id `2b03:f682`, the ZED-M id. Our config names it `zed_2i_second`.

This change says so, in two comments in `positronic/cfg/hardware/camera.py`: one beside `zed_2i_second`, that the name and the hardware disagree, and one beside `droid_3cam`, that `exterior_2` therefore has a ZED-M's optics and not `exterior`'s. It renames nothing, and it adds no check and no warning.

The name is intended: the slot takes a second ZED 2i, and the ZED-M stands in until that camera arrives. That plan is the ticket's, not the comment's — a comment that predicted the arrival and the serial change would go stale on the day it happened, with nothing bringing a reader back to correct it. So the comments carry only what holds now and cite the ticket, which is where the replacement is tracked.

A policy trained on two matched exterior views does not get them from `droid_3cam`. The second comment tells its consumer so.

**Verification.** `/check-rules` over `origin/main...HEAD`, all 14 rules of `CODE_RULES.md`, one isolated agent each: no findings, no waivers. Codex's `stale-doc` finding on the first pass is fixed and re-checked clean.

Ticket: Positronic-Robotics/internal#1297

<!-- opened-by: posi-agent -->
