### PR TITLE
Answer a waiting caller when the Franka arm stays in error

### DIFF
--- a/positronic/drivers/roboarm/franka.py
+++ b/positronic/drivers/roboarm/franka.py
@@ -15,7 +15,7 @@ import pimm
 from positronic import geom
 from positronic.drivers import vendor_import
 from positronic.drivers.roboarm import keys as roboarm_keys
-from positronic.drivers.utils import DriverRun, MoveAbandoned, MoveStatus, log_failure
+from positronic.drivers.utils import DriverRun, MoveAbandoned, MoveRefused, MoveStatus, log_failure
 
 from . import RobotStatus, State, command
 from .models import DEFAULT_FRAME, EE_LINK, add_default_frame, attach_robotiq_2f85
@@ -102,6 +102,9 @@ def _revolute_joint_names(urdf_xml):
 _MESH_DIR = Path(__file__).resolve().parent.parent.parent / 'assets/fr3_collision'
 # Where the driver leaves the arm: taking control it travels here, and handing it back it returns here.
 _PARK_JOINTS = np.array([0.0, -0.31, 0.0, -1.65, 0.0, 1.522, 0.0])
+
+# Recovery this long into an unclearing error answers a waiting caller instead of holding it.
+_RECOVERY_GRACE_S = 2.0
 
 # The field Desk answers the safe inputs in.
 SAFE_INPUT_STATE = 'safeInputState'
@@ -235,6 +238,10 @@ class _Arm(DriverRun[command.CommandType]):
         self._refusals = 0
         self._refused = False
         self._quiet_at = 0.0
+        # A sync move that arrived while the arm errors, held until the error clears or the grace runs out.
+        self._deferred: pimm.calls.Call[command.CommandType, None] | None = None
+        self._error_started = 0.0
+        self._q_at_error = np.zeros(len(_PARK_JOINTS))
 
     def __enter__(self) -> '_Arm':
         return self
@@ -250,6 +257,61 @@ class _Arm(DriverRun[command.CommandType]):
         faulted = self.moves.errored or st.error != 0  # the robot reports its own faults; a stall is not one
         self.state.encode(st, RobotStatus.ERROR if faulted else RobotStatus.AVAILABLE)
         self.out.emit(self.state)
+
+    @property
+    def awaiting_recovery(self) -> bool:
+        """A sync move waits on the arm to come out of an error."""
+        return self._deferred is not None
+
+    def note_error_entered(self, st: pf.State) -> None:
+        """Mark where and when the arm entered its current error, for the recovery that follows."""
+        self._error_started, self._q_at_error = self.clock.now(), st.q
+
+    def recover_and_serve(
+        self, st: pf.State, in_error: bool, entered: bool, brakes: '_Brakes'
+    ) -> Generator[pimm.Command, None, bool]:
+        """Drive one recovery tick, and return whether it handled the tick.
+
+        While the arm errors it recovers, drains a jog it cannot move on, and holds one waiting sync move.
+        It answers the held move with ``MoveRefused`` once the error outlasts ``_RECOVERY_GRACE_S``, and
+        serves it once the error clears.
+        """
+        if in_error:
+            cleared = self.robot.recover_from_errors()
+            if entered:
+                logger.info(f'Recovering the arm; recover_from_errors returned {cleared}')
+            self.moves.drain_async()
+            if self._deferred is None:
+                asked = self.moves.next_request()
+                self._deferred = asked if isinstance(asked, pimm.calls.Call) else None
+            if not cleared:
+                self._refuse_if_stuck(st)
+                return True
+            logger.info(f'The arm error cleared after {self.clock.now() - self._error_started:.1f}s')
+        if self._deferred is not None:
+            held, self._deferred = self._deferred, None
+            with brakes.opened():
+                yield from self.sync_move(held)
+            return True
+        return False
+
+    def _refuse_if_stuck(self, st: pf.State) -> None:
+        """Answer a held move with ``MoveRefused`` once recovery has run past the grace without clearing."""
+        if self._deferred is None or self.clock.now() - self._error_started < _RECOVERY_GRACE_S:
+            return
+        moved = float(np.max(np.abs(st.q - self._q_at_error)))
+        logger.warning(
+            f'The arm error persists after {_RECOVERY_GRACE_S}s; refusing the waiting move: '
+            f'{st.error_message}, moved {moved:.3f} rad'
+        )
+        self._deferred.set_exception(MoveRefused(st.error_message, moved))
+        self._deferred = None
+
+    def abandon_deferred(self) -> None:
+        """Answer a held move the world stopped before it could be served."""
+        if self._deferred is not None:
+            self._deferred.set_exception(MoveAbandoned())
+            self._deferred = None
 
     @staticmethod
     def _to_pf_mode(mode: command.ControlModeType | None) -> pf.InternalImpedance | pf.SoftwareImpedance:
@@ -632,9 +694,11 @@ class Robot(pimm.ControlSystem):
                 in_error, entered_error = _check_error(st.error != 0, in_error)
                 if entered_error:
                     logger.warning(f'Robot error: {st.error_message}')
+                    arm.note_error_entered(st)
 
-                if in_error:
-                    robot.recover_from_errors()
+                if (in_error or arm.awaiting_recovery) and (
+                    yield from arm.recover_and_serve(st, in_error, entered_error, brakes)
+                ):
                     yield arm.limiter.wait()
                     continue
 
@@ -649,6 +713,8 @@ class Robot(pimm.ControlSystem):
                     brakes.close_if_idle(goal)
 
                 yield arm.limiter.wait()
+
+            arm.abandon_deferred()  # the world stopped with a move still held
 
             with brakes.opened():
                 yield from arm.park(at_teardown=True)

--- a/positronic/drivers/roboarm/tests/test_franka.py
+++ b/positronic/drivers/roboarm/tests/test_franka.py
@@ -72,6 +72,8 @@ class FakeArm:
     def __init__(self, q, *, polls_to_reach: int = 2, goal_status: 'franka.pf.GoalStatus | None' = None):
         self.q = np.asarray(q, dtype=np.float64)
         self.error = 0
+        self.error_message = ''
+        self.recovers_error = False  # when set, recover_from_errors clears the fault
         self.calls: list[Call] = []
         self.targets: list[np.ndarray] = []
         self.modes: list[Any] = []
@@ -93,7 +95,7 @@ class FakeArm:
     def state(self) -> _ArmState:
         self._record(Call.STATE)
         pose = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
-        return _ArmState(self.q.copy(), np.zeros(7), pose, np.zeros(6), self.error, '')
+        return _ArmState(self.q.copy(), np.zeros(7), pose, np.zeros(6), self.error, self.error_message)
 
     def goal(self) -> _Goal:
         self._record(Call.GOAL)
@@ -110,8 +112,11 @@ class FakeArm:
         self.targets.append(np.asarray(target, dtype=np.float64))
         self._polls = 0
 
-    def recover_from_errors(self) -> None:
+    def recover_from_errors(self) -> bool:
         self._record(Call.RECOVER_FROM_ERRORS)
+        if self.recovers_error:
+            self.error, self.error_message = 0, ''
+        return self.error == 0
 
     def stop(self) -> None:
         self.calls.append(Call.STOP)
@@ -1077,3 +1082,107 @@ def test_a_command_pinning_no_mode_returns_the_arm_to_its_native_law(desk):
     _drive(loop, clock)
 
     assert isinstance(arm.modes[mark], franka.pf.InternalImpedance)
+
+
+def test_a_move_waiting_on_an_erroring_arm_is_refused_after_the_grace(desk, world):
+    """The wedge: while the arm errors the driver loops on recovery and never serves a waiting move, so a
+    prepare hangs with no bound. The driver now answers the caller once recovery has not cleared in time."""
+    arm = FakeArm(PARK)
+    driver = _driver(arm)
+    driver.state._bind(RecordingEmitter())
+    move = _mover(world, driver)
+    clock = MockClock()
+    loop = driver.run(StopFlag(), clock)
+
+    for _ in range(3):  # init + the opening move
+        next(loop)
+    arm.error, arm.error_message = 1, '[cartesian_reflex]'  # the arm latches an error between episodes
+    answer = move(command.JointPosition(JOGGED))  # a prepare waits on it
+    for _ in range(3):  # the error is entered and the call is held; the grace has not elapsed
+        next(loop)
+
+    assert not answer.done(), 'the move was refused before the grace elapsed'
+
+    clock.advance(franka._RECOVERY_GRACE_S)
+    next(loop)
+
+    with pytest.raises(franka.MoveRefused) as refused:
+        answer.result()
+    assert refused.value.reasons == '[cartesian_reflex]'
+    assert refused.value.moved_rad == 0.0  # nothing commanded the arm, so it did not move
+
+
+def test_a_move_waiting_on_an_erroring_arm_is_served_once_recovery_clears(desk, world):
+    """A fault the driver's own recovery clears inside the grace lets the waiting move run, with no retry."""
+    arm = FakeArm(PARK)
+    driver = _driver(arm)
+    driver.state._bind(RecordingEmitter())
+    move = _mover(world, driver)
+    clock = MockClock()
+    loop = driver.run(StopFlag(), clock)
+
+    for _ in range(3):  # init + the opening move
+        next(loop)
+    arm.error, arm.recovers_error = 1, True  # the error clears on the first recovery
+    answer = move(command.JointPosition(JOGGED))
+    for _ in range(20):
+        if answer.done():
+            break
+        next(loop)
+
+    answer.result()  # served, not refused
+    np.testing.assert_allclose(arm.targets[-1], JOGGED)
+
+
+def test_a_jog_sent_while_a_move_waits_on_the_erroring_arm_is_dropped(desk, world):
+    """A jog issued during an error reaches an arm that cannot move on it, so the driver drops it rather
+    than applying it once the error clears."""
+    arm = FakeArm(PARK)
+    driver = _driver(arm)
+    driver.state._bind(RecordingEmitter())
+    feed = ManualCommandReceiver()
+    driver.commands._bind(feed)
+    move = _mover(world, driver)
+    clock = MockClock()
+    loop = driver.run(StopFlag(), clock)
+
+    for _ in range(3):  # init + the opening move
+        next(loop)
+    arm.error = 1
+    answer = move(command.JointPosition(PARK))  # a prepare waits, so a call is held
+    next(loop)
+    feed.push(command.JointPosition(positions=JOGGED, mode=IMPEDANCE))  # a jog arrives while it is held
+    next(loop)
+    arm.error, arm.error_message = 0, ''  # the fault clears
+    mark = len(arm.targets)
+    for _ in range(20):
+        if answer.done():
+            break
+        next(loop)
+
+    answer.result()
+    assert not any(np.allclose(target, JOGGED) for target in arm.targets[mark:]), 'a dropped jog was applied'
+
+
+def test_a_move_held_on_an_erroring_arm_is_answered_when_the_world_stops(desk, world):
+    """A held move is pulled out of the handler queue, so the teardown answers it or its caller waits for good."""
+    arm = FakeArm(PARK)
+    driver = _driver(arm)
+    driver.state._bind(RecordingEmitter())
+    move = _mover(world, driver)
+    stop = StopFlag()
+    clock = MockClock()
+    loop = driver.run(stop, clock)
+
+    for _ in range(3):  # init + the opening move
+        next(loop)
+    arm.error = 1
+    answer = move(command.JointPosition(JOGGED))
+    next(loop)  # the call is held on the erroring arm
+    assert not answer.done()
+
+    stop.stopped = True
+    _drive(loop, clock)
+
+    with pytest.raises(MoveAbandoned):
+        answer.result()

--- a/positronic/drivers/utils.py
+++ b/positronic/drivers/utils.py
@@ -32,6 +32,23 @@ class MoveAbandoned(RuntimeError):
         super().__init__(message)
 
 
+class MoveRefused(RuntimeError):
+    """A move the arm would not take: it holds an error the driver could not clear in time.
+
+    ``reasons`` is the arm's own error message. ``moved_rad`` is the largest joint motion the arm made
+    while the driver tried to recover; a caller reads it to judge whether the path is blocked.
+    """
+
+    def __init__(self, reasons: str, moved_rad: float):
+        self.reasons = reasons
+        self.moved_rad = moved_rad
+        super().__init__(f'the arm refused the move: {reasons}; moved {moved_rad:.3f} rad while recovering')
+
+    # An exception crosses the process boundary rebuilt from this call, so both fields survive it.
+    def __reduce__(self):
+        return (MoveRefused, (self.reasons, self.moved_rad))
+
+
 class Moves(Generic[T]):
     """Both ways a device is asked to move, and the move it has in flight.
 
@@ -90,6 +107,10 @@ class Moves(Generic[T]):
         if (call := next(self._sync_move.incoming(), None)) is not None:
             return call
         return pimm.value_updated(self._async_move)
+
+    def drain_async(self) -> None:
+        """Discard any streamed setpoint waiting. A jog the device cannot move on is dropped, not applied later."""
+        pimm.value_updated(self._async_move)
 
     def accept(
         self, call: pimm.calls.Call[T, None], target: np.ndarray | float, tol: float, now: float, timeout_s: float


### PR DESCRIPTION
## The defect

The Franka run loop looped on `recover_from_errors()` while the arm held an error and reached `moves.next_request()` only after the error cleared (`franka.py`, the `in_error` branch). A sync move that arrived while the arm errored sat in the handler queue, unanswered, for as long as the error stood. On 2026-09-11 a `cartesian_reflex` stood fourteen minutes under continuous recovery, so a prepare hung with no bound and the console wedged. Diagnosis: Positronic-Robotics/internal#1285.

## What this ships

The driver now holds one waiting sync move while it recovers, on `_Arm`:

- It recovers each tick and drains a jog issued while the arm cannot move on it.
- It serves the held move once the error clears, so a fault that clears inside the grace costs no retry.
- It answers the held move with `MoveRefused(reasons, moved_rad)` once recovery has not cleared the error in `_RECOVERY_GRACE_S` (2 s). `reasons` is the arm's own error message; `moved_rad` is the largest joint motion during recovery.
- It logs the recovery result, and whether the error cleared or persists.
- The world stopping with a move still held answers that move with `MoveAbandoned`.

`MoveRefused` is a new exception in `drivers/utils.py`. It is the retriable signal the harness retry (P1, `internal#1285`) will catch; this PR only introduces it and raises it.

## Scope

- It needs no type or signal from positronic#678 (the refused-move-reason PR), so it does not branch off it. The two touch nearby lines in `run()`; positronic#678 landed first and this branch is rebased onto it (below).
- P2 in the plan. P1 (the harness retry) waits on this.

## Tests

Driver-level, no rig, through the `FakeArm` and a `MockClock`: a move waiting on an erroring arm is refused after the grace and not before; it is served once recovery clears; a jog issued while a move is held is dropped; a held move is answered when the world stops. The refusal test fails without the fix, because the call is never answered.

`uv run --locked pytest positronic/drivers/roboarm/tests/test_franka.py` is green (36 passed). `pre-commit` (ruff, ruff format, basedpyright) passed on commit.

The thresholds in the plan (2 s, and the 0.02 rad path-blocked bound in P1) have no data behind them and are used as given.

The `check-rules` fan-out is skipped this pass to keep the shared box free while other agents work; the rules check is due before merge.

## Rebased onto positronic#678 2026-09-12

positronic#678 merged as `8ea1eb5d` and took the `run()` lines this branch warned it would. Rebased onto that sha; head `2de067c5` -> `418738d3`.

Two conflicts, both the same shape — two independent insertions at one point — so both sides are kept: positronic#678's `SAFE_INPUT_STATE`/`_Reading`/`_SafeInputs` beside this branch's `_RECOVERY_GRACE_S`, and positronic#678's `safe_inputs`/`_refusals`/`_refused`/`_quiet_at` beside its `_deferred`/`_error_started`/`_q_at_error`.

The composition was checked rather than assumed. `note_refusals(goal)` runs at the top of every tick, BEFORE the error branch, so the `continue` inside `recover_and_serve` does not skip positronic#678's refusal logging; `close_if_idle(goal)` keeps its new signature. The diff against main deletes exactly five lines, all of them ones this commit deliberately replaces, and every positronic#678 marker is still in the file.

`test_franka.py` 52 passed on the rebased head (36 this branch's, the rest positronic#678's, now running together). ruff, ruff format and basedpyright clean.

One thing the rebase deliberately did not settle: positronic#678's `note_refusals` names a move libfranka rejects on a triggered safe input, and this PR's `MoveRefused` answers a caller when an error outlasts the grace. They are distinct mechanisms that now sit in one file. Whether a safe-input refusal should also answer a waiting caller is a design question, not a merge conflict.

The `check-rules` fan-out is still owed before merge.

<!-- opened-by: posi-agent -->
